### PR TITLE
[BUGFIX] Fallback to native implementation of RNN when use_sequence_length=True

### DIFF
--- a/src/operator/nn/mkldnn/mkldnn_rnn-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_rnn-inl.h
@@ -473,6 +473,11 @@ inline bool SupportMKLDNNRnn(const int input_dtype) {
   return false;
 }
 
+inline bool SupportMKLDNNRnn(const RNNParam &param, const int input_dtype) {
+  if (param.use_sequence_length) return false;
+  return SupportMKLDNNRnn(input_dtype);
+}
+
 }  // namespace op
 }  // namespace mxnet
 

--- a/src/operator/rnn.cc
+++ b/src/operator/rnn.cc
@@ -198,7 +198,7 @@ inline static bool RNNStorageType(const nnvm::NodeAttrs& attrs,
                                   std::vector<int> *in_attrs,
                                   std::vector<int> *out_attrs) {
   const RNNParam& param = nnvm::get<RNNParam>(attrs.parsed);
-  const bool support_mkldnn_rnn = 
+  const bool support_mkldnn_rnn =
       !param.use_sequence_length && dmlc::GetEnv("MXNET_USE_MKLDNN_RNN", 1);
   return MKLDNNStorageType(attrs, dev_mask, support_mkldnn_rnn,
                            dispatch_mode, in_attrs, out_attrs);

--- a/src/operator/rnn.cc
+++ b/src/operator/rnn.cc
@@ -197,7 +197,9 @@ inline static bool RNNStorageType(const nnvm::NodeAttrs& attrs,
                                   DispatchMode* dispatch_mode,
                                   std::vector<int> *in_attrs,
                                   std::vector<int> *out_attrs) {
-  const bool support_mkldnn_rnn = dmlc::GetEnv("MXNET_USE_MKLDNN_RNN", 1);
+  const RNNParam& param = nnvm::get<RNNParam>(attrs.parsed);
+  const bool support_mkldnn_rnn = 
+      !param.use_sequence_length && dmlc::GetEnv("MXNET_USE_MKLDNN_RNN", 1);
   return MKLDNNStorageType(attrs, dev_mask, support_mkldnn_rnn,
                            dispatch_mode, in_attrs, out_attrs);
 }
@@ -244,7 +246,7 @@ static OpStatePtr CreateRNNState(const nnvm::NodeAttrs &attrs,
   }
 
 #if MXNET_USE_MKLDNN == 1
-  if (ctx.dev_type == kCPU && SupportMKLDNNRnn(in_types[rnn_enum::kData])) {
+  if (ctx.dev_type == kCPU && SupportMKLDNNRnn(param, in_types[rnn_enum::kData])) {
     const mxnet::TShape& data_shape = in_shapes[rnn_enum::kData];
     state = OpStatePtr::Create<MKLDNNRnnOp>(param, data_shape[0],
         data_shape[1], data_shape[2]);


### PR DESCRIPTION
## Description ##
This PR is addressing https://github.com/apache/incubator-mxnet/issues/19323. I've added additional check for `use_sequence_length` parameter when choosing kernel to run. oneDNN does not support variable sequence length so the code right now raises an error.

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [x] Fallback to native RNN implementation when `use_sequence_length` parameter is set to `true`

## Comments ##
- No further comments from my side.
