### PR TITLE
[BUGFIX] CheckpointHandler verbose behavior in gluon.contrib.estimator

### DIFF
--- a/python/mxnet/gluon/contrib/estimator/event_handler.py
+++ b/python/mxnet/gluon/contrib/estimator/event_handler.py
@@ -496,13 +496,13 @@ class CheckpointHandler(TrainBegin, BatchEnd, EpochEnd):
                 if self.monitor_op(monitor_value, self.best):
                     prefix = self.model_prefix + '-best'
                     self._save_params_and_trainer(estimator, prefix)
-                    self.best = monitor_value
                     if self.verbose > 0:
                         estimator.logger.info('[Epoch %d] CheckpointHandler: '
                                               '%s improved from %0.5f to %0.5f, '
                                               'updating best model at %s with prefix: %s',
                                               self.current_epoch, monitor_name,
                                               self.best, monitor_value, self.model_dir, prefix)
+                    self.best = monitor_value
                 else:
                     if self.verbose > 0:
                         estimator.logger.info('[Epoch %d] CheckpointHandler: '


### PR DESCRIPTION
## Description ##
fixed CheckpointHandler in gluon.contrib.estimator.event_handler. 
when verbose is enabled, it will not print correct log info.

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [x] fix `CheckpointHandler._save_checkpoint` method

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
