### PR TITLE
Check if backend memory has been freed in check_leak_ndarray pytest fixture

### DIFF
--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -62,7 +62,7 @@ def check_leak_ndarray(request):
             pass
 
         if isinstance(element, mx.nd._internal.NDArrayBase):
-            return True
+            return element._alive  # We only care about catching NDArray's that haven't been freed in the backend yet
         elif isinstance(element, mx.sym._internal.SymbolBase):
             return False
         elif hasattr(element, '__dict__'):

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -58,7 +58,7 @@ def check_leak_ndarray(request):
             if element in seen:
                 return False
             seen.add(element)
-        except (TypeError, ValueError):  # unhashable
+        except (TypeError, ValueError, NotImplementedError):  # unhashable
             pass
 
         if isinstance(element, mx.nd._internal.NDArrayBase):


### PR DESCRIPTION
Make use of the `_alive` attribute introduced in https://github.com/apache/incubator-mxnet/pull/19475 to make check_leak_ndarray pytest fixture more robust and precise.

Also handle NotImplementedError in `__hash__` in check_leak_ndarray fixture. MXNet ndarray throws NotImplementedError in `__hash__` Prior to the Segfault fix in https://github.com/apache/incubator-mxnet/pull/19475, this was causing Segfault https://github.com/apache/incubator-mxnet/issues/19473 as PyTest would try to print the array.

See https://jenkins.mxnet-ci.amazon-ml.com/blue/rest/organizations/jenkins/pipelines/mxnet-validation/pipelines/unix-cpu/branches/leezu-patch-3/runs/3/nodes/286/steps/425/log/?start=0 for NotImplementedError