### PR TITLE
[FEATURE]Allow eliminating common subexpressions when temp space is used

### DIFF
--- a/src/imperative/eliminate_common_expr_pass.cc
+++ b/src/imperative/eliminate_common_expr_pass.cc
@@ -88,7 +88,15 @@ bool NodeEqual(const Node* n, const Node* m) {
   // to be eligible
   static auto& resource_request = Op::GetAttr<FResourceRequest>("FResourceRequest");
   static auto& resource_request_ex = Op::GetAttr<FResourceRequestEx>("FResourceRequestEx");
-  if (resource_request.get(n->op(), nullptr) != nullptr) return false;
+  const auto fresource_request = resource_request.get(n->op(), nullptr);
+  if (fresource_request != nullptr) {
+    const auto& requests = fresource_request(n->attrs);
+    for (const auto& req : requests) {
+      if (req.type != ResourceRequest::kTempSpace) {
+        return false;
+      }
+    }
+  }
   if (resource_request_ex.get(n->op(), nullptr) != nullptr) return false;
 
   return true;


### PR DESCRIPTION
## Description ##
As noted in #19316, currently common subexpression elimination is not allowed for any operators that requests resources (since they could request random resource). But if the operator requests just temporary workspace, it still should be eligible for elimination.

@leezu @szha

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
