### PR TITLE
Mark test_batchnorm_with_type as flaky

### DIFF
--- a/tests/python/gpu/test_operator_gpu.py
+++ b/tests/python/gpu/test_operator_gpu.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from __future__ import print_function
 import sys
 import os
 import time
@@ -372,6 +371,7 @@ def test_preloaded_multi_sgd():
 
 
 @pytest.mark.serial
+@pytest.mark.flaky
 def test_batchnorm_with_type():
   ctx_list_v2_2D = [
     {'ctx': mx.cpu(0), 'norm_data': (5, 2, 5, 5), 'type_dict': {'norm_data': np.float32}},


### PR DESCRIPTION
```
[2020-11-06T21:37:09.831Z]       # V2, 1D
[2020-11-06T21:37:09.831Z]       for fix_gamma, cudnn_off in itertools.product(bools, bools):
[2020-11-06T21:37:09.831Z]           sym = mx.sym.BatchNorm(name='norm', fix_gamma=fix_gamma, cudnn_off=cudnn_off)
[2020-11-06T21:37:09.831Z] >         check_consistency(sym, ctx_list_v2_1D)
[...]
[2020-11-06T21:37:09.831Z] E       AssertionError: 
[2020-11-06T21:37:09.831Z] E       Items are not equal:
[2020-11-06T21:37:09.831Z] E       Error 8317.657381 exceeds tolerance rtol=1.000000e-05, atol=1.000000e-20 (mismatch 50.000000%).
[2020-11-06T21:37:09.831Z] E       Location of maximum error: (0,), a=-0.00000000, b=-0.00000000
[2020-11-06T21:37:09.831Z] E        ACTUAL: array([ -0.        , -39.62720511])
[2020-11-06T21:37:09.831Z] E        DESIRED: array([ -0.        , -39.62720511])
```