### PR TITLE
Mark test_random_gray as flaky

### DIFF
--- a/tests/python/unittest/test_gluon_data_vision.py
+++ b/tests/python/unittest/test_gluon_data_vision.py
@@ -14,7 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from __future__ import print_function
 from collections import namedtuple
 
 import mxnet as mx
@@ -381,6 +380,7 @@ def test_random_transforms():
     assert counter == pytest.approx(5000, 1e-1)
 
 @xfail_when_nonstandard_decimal_separator
+@pytest.mark.flaky
 def test_random_gray():
     from mxnet.gluon.data.vision import transforms
 

--- a/tests/python/unittest/test_numpy_gluon_data_vision.py
+++ b/tests/python/unittest/test_numpy_gluon_data_vision.py
@@ -340,6 +340,7 @@ def test_random_transforms():
 
 @xfail_when_nonstandard_decimal_separator
 @use_np
+@pytest.mark.flaky
 def test_random_gray():
     from mxnet.gluon.data.vision import transforms
 


### PR DESCRIPTION
```
[2020-11-06T03:30:35.465Z]         for _ in range(iteration):
[2020-11-06T03:30:35.465Z]             out = transform(img)
[2020-11-06T03:30:35.465Z]             if out[0][0][0].asnumpy() != pixel:
[2020-11-06T03:30:35.465Z]                 num_apply += 1
[2020-11-06T03:30:35.465Z] >       assert_almost_equal(num_apply/float(iteration), 0.5, 0.1)
[...]
[2020-11-06T03:30:35.466Z] >       raise AssertionError(msg)
[2020-11-06T03:30:35.466Z] E       AssertionError: 
[2020-11-06T03:30:35.466Z] E       Items are not equal:
[2020-11-06T03:30:35.466Z] E       Error 1.100000 exceeds tolerance rtol=1.000000e-01, atol=1.000000e-20.
[2020-11-06T03:30:35.466Z] E       
[2020-11-06T03:30:35.466Z] E        ACTUAL: 0.445
[2020-11-06T03:30:35.466Z] E        DESIRED: 0.5
```

Fixes https://github.com/apache/incubator-mxnet/issues/19232
(track in source code instead of issue)