### PR TITLE
Enable coverage reports for PR diffs

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,4 +1,5 @@
 # Codecov.io configuration file
+# See https://docs.codecov.io/docs/codecovyml-reference
 codecov:
   notify:
     require_ci_to_pass: yes
@@ -6,7 +7,7 @@ codecov:
 coverage:
   status:
     project: off
-    patch: off
+    patch: on
   precision: 2
   round: down
   range: "70...100"
@@ -20,7 +21,6 @@ parsers:
       macro: no
 
 ignore:
- - "cpp-package/example/**/*"
  - "tests/**/*"
 
 # Disable comments for now to gather data in the background


### PR DESCRIPTION
The codecov/patch status only measures lines adjusted in the pull request or single commit, if the commit is not in a pull request. This status provides an indication on how well the pull request is tested.

Discussion in https://github.com/apache/incubator-mxnet/pull/17889#issuecomment-615398344 applies with respect to not enabling project level coverage reporting.