### PR TITLE
[v1.x] update cudnn version for cu102

### DIFF
--- a/ci/docker/Dockerfile.build.ubuntu_gpu_cu102
+++ b/ci/docker/Dockerfile.build.ubuntu_gpu_cu102
@@ -65,7 +65,7 @@ COPY install/ubuntu_tutorials.sh /work/
 RUN /work/ubuntu_tutorials.sh
 
 ENV CUDA_VERSION=10.2.89
-ENV CUDNN_VERSION=7.6.5.32
+ENV CUDNN_VERSION=8.0.4.30
 COPY install/ubuntu_cudnn.sh /work/
 RUN /work/ubuntu_cudnn.sh
 


### PR DESCRIPTION
## Description ##
Updating cudnn version from 7.6.5.32 to 8.0.4.30 for the dockerfile for cuda 10.2. This should fix the CD failure for v1.x branch https://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/restricted-mxnet-cd%2Fmxnet-cd-release-job-1.x/detail/mxnet-cd-release-job-1.x/984/pipeline/534