### PR TITLE
Disable ENABLE_TESTCOVERAGE on CentOS 7 build

### DIFF
--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -263,7 +263,6 @@ build_centos7_cpu() {
     export CXXFLAGS="-fabi-version=11 -fabi-compat-version=7"
     cmake \
         -DCMAKE_BUILD_TYPE="RelWithDebInfo" \
-        -DENABLE_TESTCOVERAGE=ON \
         -DUSE_MKL_IF_AVAILABLE=OFF \
         -DUSE_MKLDNN=OFF \
         -DUSE_DIST_KVSTORE=ON \

--- a/ci/jenkins/Jenkins_steps.groovy
+++ b/ci/jenkins/Jenkins_steps.groovy
@@ -280,7 +280,7 @@ def compile_centos7_cpu(lib_name) {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.init_git()
             utils.docker_run('centos7_cpu', 'build_centos7_cpu', false)
-            utils.pack_lib(lib_name, mx_lib, true)
+            utils.pack_lib(lib_name, mx_lib)
           }
         }
       }
@@ -866,7 +866,7 @@ def test_centos7_python3_cpu(lib_name) {
         ws('workspace/build-centos7-cpu') {
           timeout(time: max_time, unit: 'MINUTES') {
             try {
-              utils.unpack_and_init(lib_name, mx_lib, true)
+              utils.unpack_and_init(lib_name, mx_lib)
               utils.docker_run('centos7_cpu', 'unittest_centos7_cpu', false)
               utils.publish_test_coverage()
             } finally {


### PR DESCRIPTION
Causes significant slowdown in connection with the system (devtoolset) provided OpenMP libraries.
https://github.com/apache/incubator-mxnet/pull/17559 starts pulling in the system OpenMP in addition to the `3rdparty/openmp` causing the slowdown to materialize after the merge of https://github.com/apache/incubator-mxnet/pull/17559.

Fixes https://github.com/apache/incubator-mxnet/issues/19502

Let's still fix the issue of intgemm pulling a second openmp @kpuatamazon


With this PR


```
[2020-11-10T00:14:44.881Z] ============================= slowest 50 durations =============================

[2020-11-10T00:14:44.881Z] 467.92s call     tests/python/unittest/test_random.py::test_random

[2020-11-10T00:14:44.881Z] 74.58s call     tests/python/unittest/test_operator.py::test_image_normalize

[2020-11-10T00:14:44.881Z] 74.46s call     tests/python/unittest/test_random.py::test_randint_generator

[2020-11-10T00:14:44.881Z] 53.77s call     tests/python/unittest/test_random.py::test_shuffle

[2020-11-10T00:14:44.881Z] 29.70s call     tests/python/unittest/test_gluon.py::test_slice_pooling2d_slice_pooling2d

[2020-11-10T00:14:44.881Z] 19.73s call     tests/python/unittest/test_random.py::test_dirichlet

[2020-11-10T00:14:44.881Z] 15.36s call     tests/python/unittest/test_sparse_operator.py::test_sparse_mathematical_core

[2020-11-10T00:14:44.881Z] 10.90s call     tests/python/unittest/test_gluon.py::test_slice_pooling2d

[2020-11-10T00:14:44.881Z] 10.63s call     tests/python/unittest/test_operator.py::test_big_transpose

[2020-11-10T00:14:44.881Z] 10.30s call     tests/python/unittest/test_sparse_operator.py::test_sparse_square_sum

```
Without this PR
```
[2020-11-09T22:46:33.281Z] ============================= slowest 50 durations =============================

[2020-11-09T22:46:33.281Z] 599.70s call     tests/python/unittest/test_gluon.py::test_slice_pooling2d_slice_pooling2d

[2020-11-09T22:46:33.281Z] 246.20s call     tests/python/unittest/test_random.py::test_randint_generator

[2020-11-09T22:46:33.281Z] 219.33s call     tests/python/unittest/test_gluon.py::test_slice_pooling2d

[2020-11-09T22:46:33.281Z] 182.46s call     tests/python/unittest/test_random.py::test_random

[2020-11-09T22:46:33.281Z] 143.63s call     tests/python/unittest/test_sparse_operator.py::test_cast_storage_ex

[2020-11-09T22:46:33.281Z] 125.78s call     tests/python/unittest/test_sparse_operator.py::test_sparse_square_sum

[2020-11-09T22:46:33.281Z] 88.98s call     tests/python/unittest/test_random.py::test_negative_binomial_generator

[2020-11-09T22:46:33.281Z] 69.17s call     tests/python/unittest/test_random.py::test_poisson_generator

[2020-11-09T22:46:33.281Z] 63.23s call     tests/python/unittest/test_gluon.py::test_slice_batchnorm

[2020-11-09T22:46:33.281Z] 62.36s call     tests/python/unittest/test_gluon.py::test_slice_batchnorm_reshape_batchnorm

```