### PR TITLE
Unique names for nodes in imperative mode

### DIFF
--- a/src/imperative/imperative.cc
+++ b/src/imperative/imperative.cc
@@ -233,7 +233,8 @@ void Imperative::RecordOp(
 
   nnvm::ObjectPtr node = nnvm::Node::Create();
   node->attrs = std::move(attrs);
-  if (node->attrs.name == "") {
+  // if node name is empty or node name is equal to op name - name it with unique name
+  if (node->attrs.name == "" || node->attrs.op->name == node->attrs.name) {
     node->attrs.name = "node_" + std::to_string(node_count_++);
   } else {
     node_count_++;
@@ -326,7 +327,8 @@ void Imperative::RecordDeferredCompute(nnvm::NodeAttrs &&attrs,
   }
   node->attrs = std::move(attrs);
   // Need to support NameManager in imperative API to better name node->attrs.name
-  if (node->attrs.name == "") {
+  // if node name is empty or node name is equal to op name - name it with unique name
+  if (node->attrs.name == "" || node->attrs.op->name == node->attrs.name) {
     node->attrs.name = "node_" + std::to_string(node_count_++);
   } else {
     node_count_++;


### PR DESCRIPTION
## Description ##
Graph recorded in imperative mode doesn't have unique nodes name.
```
 {
      "op": "FullyConnected", 
      "name": "FullyConnected", 
      "attrs": {
        "__profiler_scope__": "<unk>:", 
        "flatten": "False", 
        "no_bias": "False", 
        "num_hidden": "768"
      }, 
      "inputs": [[98, 0, 0], [99, 0, 0], [100, 0, 0]]
    }, 
    {
      "op": "Dropout", 
      "name": "Dropout", 
      "attrs": {
        "__profiler_scope__": "<unk>:", 
        "axes": "()", 
        "cudnn_off": "False", 
        "p": "0.1"
      }, 
      "inputs": [[101, 0, 0]]
    }, 
```

E.g. every FC layer has the same name "FullyConnected". Because of this user is not able to identify nodes when using monitor callback (register_op_hook).

This PR changes node name to unique name if op name is equal to node name

@leezu @sxjscience 
