### PR TITLE
Mark test_gluon_bernoulli_v1 as flaky

### DIFF
--- a/tests/python/unittest/test_gluon_probability_v1.py
+++ b/tests/python/unittest/test_gluon_probability_v1.py
@@ -1261,6 +1261,7 @@ def test_gluon_binomial_v1():
 
 
 @use_np
+@pytest.mark.flaky
 def test_gluon_bernoulli_v1():
     class TestBernoulli(HybridBlock):
         def __init__(self, func, is_logit=False):


### PR DESCRIPTION
[2020-11-10T12:43:48.119Z]             mx_out = net(param, sample).asnumpy()
[2020-11-10T12:43:48.119Z]             np_out = _np.log(ss.bernoulli.pmf(sample.asnumpy(), prob.asnumpy()))
[2020-11-10T12:43:48.119Z]             assert_almost_equal(mx_out, np_out, atol=1e-4,
[2020-11-10T12:43:48.119Z] >                               rtol=1e-3, use_broadcast=False)
[...]
[2020-11-10T12:43:48.120Z] >       raise AssertionError(msg)
[2020-11-10T12:43:48.120Z] E       AssertionError: 
[2020-11-10T12:43:48.120Z] E       Items are not equal:
[2020-11-10T12:43:48.120Z] E       Error 5.229716 exceeds tolerance rtol=1.000000e-03, atol=1.000000e-04 (mismatch 16.666667%).
[2020-11-10T12:43:48.120Z] E       Location of maximum error: (0, 0), a=-13.99647522, b=-14.07058334
[2020-11-10T12:43:48.120Z] E        ACTUAL: array([[-13.996475  ,  -0.20232847,  -0.6910891 ],
[2020-11-10T12:43:48.120Z] E              [ -0.63558733,  -1.0058423 ,  -1.4756919 ]], dtype=float32)
[2020-11-10T12:43:48.120Z] E        DESIRED: array([[-14.07058334,  -0.20232854,  -0.69108912],
[2020-11-10T12:43:48.120Z] E              [ -0.63558742,  -1.00584236,  -1.47569192]])

https://jenkins.mxnet-ci.amazon-ml.com/blue/rest/organizations/jenkins/pipelines/mxnet-validation/pipelines/unix-gpu/branches/PR-19509/runs/1/nodes/279/steps/374/log/?start=0