### PR TITLE
[DOC] Fix markdown syntax for link to community guide

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -20,7 +20,7 @@ Contributors of Apache MXNet (incubating)
 Apache MXNet adopts the Apache way and governs by merit. We believe that it is important to create
 an inclusive community where everyone can use, contribute to, and influence the direction of
 the project. We actively invite contributors who have earned the merit to be part of the
-development community. See [MXNet Community Guide][https://mxnet.apache.org/community/community].
+development community. See [MXNet Community Guide](https://mxnet.apache.org/community/community).
 
 
 PPMC


### PR DESCRIPTION
## Description ##
Fix markdown syntax for link to community guide

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- Fix markdown syntax for link to community guide


## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
