### PR TITLE
Always skip test_bbox_augmenters

### DIFF
--- a/tests/python/unittest/test_numpy_contrib_gluon_data_vision.py
+++ b/tests/python/unittest/test_numpy_contrib_gluon_data_vision.py
@@ -131,7 +131,7 @@ class TestImage(unittest.TestCase):
         ]
 
     @use_np
-    @pytest.mark.skipif(sys.platform == "win32", reason='https://github.com/apache/incubator-mxnet/issues/18986')
+    @pytest.mark.skip(reason='https://github.com/apache/incubator-mxnet/issues/18986')
     def test_bbox_augmenters(self):
         # only test if all augmenters will work
         im_list = [_generate_objects() + [x] for x in self.IMAGES]


### PR DESCRIPTION
```
DEBUG    root:conftest.py:213 Setting np/mx/python random seeds to 1492532915. Use MXNET_TEST_SEED=1492532915 to reproduce.
[...]
../tests/python/unittest/test_numpy_contrib_gluon_data_vision.py Fatal Python error: Segmentation fault

Thread 0x00007fe28613e3c0 (most recent call first):
  File "/home/ubuntu/src/mxnet-master/python/mxnet/numpy/multiarray.py", line 152 in _new_alloc_handle
  File "/home/ubuntu/src/mxnet-master/python/mxnet/numpy/multiarray.py", line 2480 in empty
  File "/home/ubuntu/src/mxnet-master/python/mxnet/numpy/multiarray.py", line 2557 in array
  File "/home/ubuntu/src/mxnet-master/python/mxnet/gluon/contrib/data/vision/dataloader.py", line 521 in forward
  File "/home/ubuntu/src/mxnet-master/python/mxnet/gluon/block.py", line 713 in __call__
  File "/home/ubuntu/src/mxnet-master/python/mxnet/gluon/nn/basic_layers.py", line 58 in forward
  File "/home/ubuntu/src/mxnet-master/python/mxnet/gluon/block.py", line 713 in __call__
  File "/home/ubuntu/src/mxnet-master/python/mxnet/gluon/data/dataset.py", line 236 in __getitem__
  File "/home/ubuntu/src/mxnet-master/python/mxnet/gluon/data/dataloader.py", line 674 in <listcomp>
  File "/home/ubuntu/src/mxnet-master/python/mxnet/gluon/data/dataloader.py", line 674 in same_process_iter
  File "/home/ubuntu/src/mxnet-master/tests/python/unittest/test_numpy_contrib_gluon_data_vision.py", line 144 in test_bbox_augmenters
  File "/home/ubuntu/src/mxnet-master/python/mxnet/util.py", line 480 in _with_np_array
  File "/home/ubuntu/src/mxnet-master/python/mxnet/util.py", line 299 in _with_np_shape
  File "/home/ubuntu/.pyenv/versions/3.8.5/lib/python3.8/unittest/case.py", line 633 in _callTestMethod
[...]
zsh: segmentation fault (core dumped)  MXNET_TEST_SEED=1492532915 python3.8 -m pytest  --log-level=DEBUG
```

https://github.com/apache/incubator-mxnet/issues/18986