### PR TITLE
Fix HLS2RGBConvert

### DIFF
--- a/src/operator/image/image_random-inl.h
+++ b/src/operator/image/image_random-inl.h
@@ -860,7 +860,8 @@ inline void HLS2RGBConvert(const float& src_h,
 
     if (h < 0) {
       do { h += 6; } while (h < 0);
-    } else if (h >= 6) {
+    }
+    if (h >= 6) {  // h + 6 >= 6 holds true for some h < 0
       do { h -= 6; } while (h >= 6);
     }
 

--- a/tests/python/unittest/test_numpy_contrib_gluon_data_vision.py
+++ b/tests/python/unittest/test_numpy_contrib_gluon_data_vision.py
@@ -131,7 +131,6 @@ class TestImage(unittest.TestCase):
         ]
 
     @use_np
-    @pytest.mark.skipif(sys.platform == "win32", reason='https://github.com/apache/incubator-mxnet/issues/18986')
     def test_bbox_augmenters(self):
         # only test if all augmenters will work
         im_list = [_generate_objects() + [x] for x in self.IMAGES]


### PR DESCRIPTION
For small h (eg. -2.22524022E-7), h += 6 will yield a h == 6. But
c_HlsSectorData[6] is invalid memory leading to segmentation fault. We need to
decrement to 0.

Can be reproduced (prior to this commit via):

  MXNET_TEST_SEED=1492532915 python3.8 -m pytest tests/python/unittest/test_numpy_contrib_gluon_data_vision.py::TestImage::test_bbox_augmenters

Fixes https://github.com/apache/incubator-mxnet/issues/18986