### PR TITLE
[COMMUNITY] Add Zhaoqi Zhu as a new committer

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -132,6 +132,7 @@ healthy project. The PPMC actively seeks to appoint new committers from the list
 * [Yuxi Hu](https://github.com/yuxihu)
 * [Zach Kimberg](https://github.com/zachgk)
   - Zach is one of the major maintainers of the MXNet Scala package.
+* [Zhaoqi Zhu](https://github.com/Zha0q1)
 
 
 List of Contributors


### PR DESCRIPTION
## Description ##
Please join me in welcoming Zhaoqi Zhu (@Zha0q1) as a new committer of Apache MXNet!
Zhaoqi has been of great help in the community, has made many contributions towards the
large-tensor support effort, worked on optimizing the argmin/argmax operators,
Operator Profiling Enhancements as well as his help with fixing parts of our Jenkins
automation time-to-time when they broke down.

Congratulations to @Zha0q1!