### PR TITLE
disable graph partition by default

### DIFF
--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -913,7 +913,7 @@ class HybridBlock(Block):
         self._monitor_all = False
         self._backend = None
         self._backend_opts = {}
-        self._partition_if_dynamic = True
+        self._partition_if_dynamic = False
         self._first_forward = True
 
     def __setattr__(self, name, value):


### PR DESCRIPTION
## Description ##
Temporarily disabling graph partitioning by default until the gluon backward bug #18823 is fixed. This should fix #19524 .

Once #18823 is fixed, this PR should be reverted.