### PR TITLE
Fix uninitialized variable in RTC path

### DIFF
--- a/src/common/cuda/rtc/half-inl.h
+++ b/src/common/cuda/rtc/half-inl.h
@@ -29,7 +29,7 @@ namespace rtc {
 
 const char fp16_support_string[] = R"code(
 struct __align__(2) __half {
-  __host__ __device__ __half() { }
+  __host__ __device__ __half() : __x(0) { }
   unsigned short __x;
 };
 /* Definitions of intrinsics */

--- a/src/common/cuda/rtc/vectorization-inl.h
+++ b/src/common/cuda/rtc/vectorization-inl.h
@@ -207,6 +207,8 @@ class VectorizedAccessor {
           if (reinterpret_cast<size_t>(ptr) >= reinterpret_cast<size_t>(unaligned_ptr_) &&
               reinterpret_cast<size_t>(ptr) < reinterpret_cast<size_t>(unaligned_ptr_ + N)) {
             storage_.scratch_.separate[j] = *ptr;
+          } else {
+            storage_.scratch_.separate[j] = DType();
           }
         }
       }


### PR DESCRIPTION
## Description ##
This is a small fix to remove the uninitialized variable from half and vectorized loader in RTC.
