### PR TITLE
Enable Numpy Large tensor nightly tests

### DIFF
--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -683,7 +683,7 @@ build_ubuntu_cpu_large_tensor() {
         -DUSE_SIGNAL_HANDLER=ON                 \
         -DUSE_CUDA=OFF                          \
         -DUSE_CUDNN=OFF                         \
-        -DUSE_MKLDNN=OFF                        \
+        -DUSE_MKLDNN=ON                         \
         -DUSE_INT64_TENSOR_SIZE=ON              \
         -G Ninja                                \
         /work/mxnet
@@ -700,7 +700,7 @@ build_ubuntu_gpu_large_tensor() {
         -DUSE_CUDNN=ON                          \
         -DUSE_MKL_IF_AVAILABLE=OFF              \
         -DUSE_MKLML_MKL=OFF                     \
-        -DUSE_MKLDNN=OFF                        \
+        -DUSE_MKLDNN=ON                         \
         -DUSE_DIST_KVSTORE=ON                   \
         -DCMAKE_BUILD_TYPE=Release              \
         -DMXNET_CUDA_ARCH="$CI_CMAKE_CUDA_ARCH" \

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -1036,19 +1036,7 @@ nightly_test_large_tensor() {
     set -ex
     export PYTHONPATH=./python/
     export DMLC_LOG_STACK_TRACE_DEPTH=10
-    pytest tests/nightly/test_large_array.py::test_tensor
-    pytest tests/nightly/test_large_array.py::test_nn
-    pytest tests/nightly/test_large_array.py::test_basic
-}
-
-#Test Large Vectors
-nightly_test_large_vector() {
-    set -ex
-    export PYTHONPATH=./python/
-    export DMLC_LOG_STACK_TRACE_DEPTH=10
-    pytest tests/nightly/test_large_vector.py::test_tensor
-    pytest tests/nightly/test_large_vector.py::test_nn
-    pytest tests/nightly/test_large_vector.py::test_basic
+    pytest --timeout=0 tests/nightly/test_np_large_array.py
 }
 
 #Tests Model backwards compatibility on MXNet

--- a/tests/nightly/JenkinsfileForBinaries
+++ b/tests/nightly/JenkinsfileForBinaries
@@ -64,7 +64,6 @@ core_logic: {
         ws('workspace/large_tensor-cpu') {
             utils.unpack_and_init('cpu_int64', mx_lib)
             utils.docker_run('ubuntu_cpu', 'nightly_test_large_tensor', false)
-            utils.docker_run('ubuntu_cpu', 'nightly_test_large_vector', false)
         }
       }
     },

--- a/tests/nightly/test_np_large_array.py
+++ b/tests/nightly/test_np_large_array.py
@@ -188,7 +188,6 @@ def test_argmin():
     A.attach_grad()
     with mx.autograd.record():
         B = np.argmin(A)
-    print(B)
     assert B == 21
     B.backward()
     assert A.grad.shape == (INT_OVERFLOW, 2)
@@ -202,7 +201,6 @@ def test_argmax():
     A.attach_grad()
     with mx.autograd.record():
         B = np.argmax(A)
-    print(B)
     assert B == 21
     B.backward()
     assert A.grad.shape == (INT_OVERFLOW, 2)
@@ -983,6 +981,7 @@ def test_expm1():
 
 
 @use_np
+@pytest.mark.skip(reason='to be moved to new file and run separately as it takes lot of memory')
 def test_frexp():
     inp = np.ones((2, INT_OVERFLOW))
     inp[-1, -1] = 9
@@ -1090,7 +1089,7 @@ def test_prod():
     assert inp.grad.shape == inp.shape
     assert inp.grad[-1, -1] == 1
     with mx.autograd.record():
-        out2 = np.sum(inp, axis=0)
+        out2 = np.prod(inp, axis=0)
         out2.backward()
     assert out2.shape == (INT_OVERFLOW, )
     assert out2[0] == 2 and out2[-1] == 10
@@ -1654,6 +1653,7 @@ def test_digamma():
 
 
 @use_np
+@pytest.mark.skip(reason='to be moved to new file and run separately as it takes lot of memory')
 def test_rnn_dim_check():
     L_SEQ, BAT, L_INP, L_STA = 2**31, 4, 2**10, 2
     data = np.random.uniform(-1, 1, (L_SEQ, BAT, L_INP))
@@ -1664,6 +1664,7 @@ def test_rnn_dim_check():
 
 
 @use_np
+@pytest.mark.skip(reason='runs without MKLDNN, wtih is not default behavior')
 def test_rnn_vanilla():
     L_SEQ, BAT, L_INP, L_STA = 2**20, 4, 2**10, 2
     def batch_check(x, modes, params):


### PR DESCRIPTION
## Description ##
Replace NDArray tests with Numpy ones

## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

## Testing ##
```
(pytest) ubuntu@ip-172-31-90-243 ~/workspace/incubator-mxnet (lt_nightly) $ python -m pytest -s --exitfirst --timeout=0 --verbose tests/nightly/test_np_large_array.py
=============================================================== test session starts ================================================================
platform linux -- Python 3.6.10, pytest-5.3.5, py-1.8.2, pluggy-0.13.1 -- /home/ubuntu/anaconda3/envs/pytest/bin/python
cachedir: .pytest_cache
rootdir: /home/ubuntu/workspace/incubator-mxnet, inifile: pytest.ini
plugins: timeout-1.4.2
collected 165 items

tests/nightly/test_np_large_array.py::test_gluon_embedding Setting module np/mx/python random seeds, use MXNET_MODULE_SEED=1579558005 to reproduce.
[04:10:03] ../src/storage/storage.cc:199: Using Pooled (Naive) StorageManager for CPU
PASSED
tests/nightly/test_np_large_array.py::test_fully_connected PASSED
tests/nightly/test_np_large_array.py::test_dense PASSED
tests/nightly/test_np_large_array.py::test_softmax PASSED
tests/nightly/test_np_large_array.py::test_ones PASSED
tests/nightly/test_np_large_array.py::test_zeros PASSED
tests/nightly/test_np_large_array.py::test_ones_like PASSED
tests/nightly/test_np_large_array.py::test_zeros_like PASSED
tests/nightly/test_np_large_array.py::test_abs [04:13:04] ../src/base.cc:84: Upgrade advisory: this mxnet has been built against cuDNN lib version 7501, which is older than the oldest version tested by CI (7600)
.  Set MXNET_CUDNN_LIB_CHECKING=0 to quiet this warning.
PASSED
tests/nightly/test_np_large_array.py::test_binary_broadcast PASSED
tests/nightly/test_np_large_array.py::test_all PASSED
tests/nightly/test_np_large_array.py::test_amin PASSED
tests/nightly/test_np_large_array.py::test_amax PASSED
tests/nightly/test_np_large_array.py::test_argmin PASSED
tests/nightly/test_np_large_array.py::test_argmax PASSED
tests/nightly/test_np_large_array.py::test_trigonometric_family PASSED
tests/nightly/test_np_large_array.py::test_any PASSED
tests/nightly/test_np_large_array.py::test_append PASSED
tests/nightly/test_np_large_array.py::test_arange PASSED
tests/nightly/test_np_large_array.py::test_argsort PASSED
tests/nightly/test_np_large_array.py::test_atleast_xd_family PASSED
tests/nightly/test_np_large_array.py::test_average PASSED
tests/nightly/test_np_large_array.py::test_bincount PASSED
tests/nightly/test_np_large_array.py::test_blackman PASSED
tests/nightly/test_np_large_array.py::test_broadcast_to PASSED
tests/nightly/test_np_large_array.py::test_root_family PASSED
tests/nightly/test_np_large_array.py::test_ceil_floor PASSED
tests/nightly/test_np_large_array.py::test_clip PASSED
tests/nightly/test_np_large_array.py::test_column_stack PASSED
tests/nightly/test_np_large_array.py::test_concatenate PASSED
tests/nightly/test_np_large_array.py::test_copysign PASSED
tests/nightly/test_np_large_array.py::test_random_uniform PASSED
tests/nightly/test_np_large_array.py::test_random_normal PASSED
tests/nightly/test_np_large_array.py::test_random_gamma SKIPPED
tests/nightly/test_np_large_array.py::test_random_exponential PASSED
tests/nightly/test_np_large_array.py::test_random_laplace PASSED
tests/nightly/test_np_large_array.py::test_random_choice PASSED
tests/nightly/test_np_large_array.py::test_random_gumbel PASSED
tests/nightly/test_np_large_array.py::test_random_logistic PASSED
tests/nightly/test_np_large_array.py::test_random_multinomial SKIPPED
tests/nightly/test_np_large_array.py::test_random_pareto PASSED
tests/nightly/test_np_large_array.py::test_random_power PASSED
tests/nightly/test_np_large_array.py::test_random_rayleigh PASSED
tests/nightly/test_np_large_array.py::test_random_weibull PASSED
tests/nightly/test_np_large_array.py::test_random_shuffle PASSED
tests/nightly/test_np_large_array.py::test_random_lognormal PASSED
tests/nightly/test_np_large_array.py::test_random_randint Timeout (0:20:00)!
Thread 0x00007f036fb31740 (most recent call first):
  File "/home/ubuntu/workspace/incubator-mxnet/python/mxnet/ndarray/ndarray.py", line 2603 in asnumpy
  File "/home/ubuntu/workspace/incubator-mxnet/python/mxnet/numpy/multiarray.py", line 1264 in item
  File "/home/ubuntu/workspace/incubator-mxnet/python/mxnet/numpy/multiarray.py", line 1215 in __bool__
  File "/home/ubuntu/workspace/incubator-mxnet/tests/nightly/test_np_large_array.py", line 531 in test_random_randint
  File "/home/ubuntu/workspace/incubator-mxnet/python/mxnet/util.py", line 480 in _with_np_array
  File "/home/ubuntu/workspace/incubator-mxnet/python/mxnet/util.py", line 299 in _with_np_shape
  File "/home/ubuntu/anaconda3/envs/pytest/lib/python3.6/site-packages/_pytest/python.py", line 167 in pytest_pyfunc_call
  File "/home/ubuntu/anaconda3/envs/pytest/lib/python3.6/site-packages/pluggy/callers.py", line 187 in _multicall
  File "/home/ubuntu/anaconda3/envs/pytest/lib/python3.6/site-packages/pluggy/manager.py", line 87 in <lambda>
  File "/home/ubuntu/anaconda3/envs/pytest/lib/python3.6/site-packages/pluggy/manager.py", line 93 in _hookexec
  File "/home/ubuntu/anaconda3/envs/pytest/lib/python3.6/site-packages/pluggy/hooks.py", line 286 in __call__
  File "/home/ubuntu/anaconda3/envs/pytest/lib/python3.6/site-packages/_pytest/python.py", line 1445 in runtest
  File "/home/ubuntu/anaconda3/envs/pytest/lib/python3.6/site-packages/_pytest/runner.py", line 134 in pytest_runtest_call
  File "/home/ubuntu/anaconda3/envs/pytest/lib/python3.6/site-packages/pluggy/callers.py", line 187 in _multicall
  File "/home/ubuntu/anaconda3/envs/pytest/lib/python3.6/site-packages/pluggy/manager.py", line 87 in <lambda>
  File "/home/ubuntu/anaconda3/envs/pytest/lib/python3.6/site-packages/pluggy/manager.py", line 93 in _hookexec
  File "/home/ubuntu/anaconda3/envs/pytest/lib/python3.6/site-packages/pluggy/hooks.py", line 286 in __call__
  File "/home/ubuntu/anaconda3/envs/pytest/lib/python3.6/site-packages/_pytest/runner.py", line 210 in <lambda>
  File "/home/ubuntu/anaconda3/envs/pytest/lib/python3.6/site-packages/_pytest/runner.py", line 237 in from_call
  File "/home/ubuntu/anaconda3/envs/pytest/lib/python3.6/site-packages/_pytest/runner.py", line 210 in call_runtest_hook
  File "/home/ubuntu/anaconda3/envs/pytest/lib/python3.6/site-packages/_pytest/runner.py", line 185 in call_and_report
  File "/home/ubuntu/anaconda3/envs/pytest/lib/python3.6/site-packages/_pytest/runner.py", line 99 in runtestprotocol
  File "/home/ubuntu/anaconda3/envs/pytest/lib/python3.6/site-packages/_pytest/runner.py", line 84 in pytest_runtest_protocol
  File "/home/ubuntu/anaconda3/envs/pytest/lib/python3.6/site-packages/pluggy/callers.py", line 187 in _multicall
  File "/home/ubuntu/anaconda3/envs/pytest/lib/python3.6/site-packages/pluggy/manager.py", line 87 in <lambda>
  File "/home/ubuntu/anaconda3/envs/pytest/lib/python3.6/site-packages/pluggy/manager.py", line 93 in _hookexec
  File "/home/ubuntu/anaconda3/envs/pytest/lib/python3.6/site-packages/pluggy/hooks.py", line 286 in __call__
  File "/home/ubuntu/anaconda3/envs/pytest/lib/python3.6/site-packages/_pytest/main.py", line 271 in pytest_runtestloop
  File "/home/ubuntu/anaconda3/envs/pytest/lib/python3.6/site-packages/pluggy/callers.py", line 187 in _multicall
  File "/home/ubuntu/anaconda3/envs/pytest/lib/python3.6/site-packages/pluggy/manager.py", line 87 in <lambda>
  File "/home/ubuntu/anaconda3/envs/pytest/lib/python3.6/site-packages/pluggy/manager.py", line 93 in _hookexec
  File "/home/ubuntu/anaconda3/envs/pytest/lib/python3.6/site-packages/pluggy/hooks.py", line 286 in __call__
  File "/home/ubuntu/anaconda3/envs/pytest/lib/python3.6/site-packages/_pytest/main.py", line 247 in _main
  File "/home/ubuntu/anaconda3/envs/pytest/lib/python3.6/site-packages/_pytest/main.py", line 197 in wrap_session
  File "/home/ubuntu/anaconda3/envs/pytest/lib/python3.6/site-packages/_pytest/main.py", line 240 in pytest_cmdline_main
  File "/home/ubuntu/anaconda3/envs/pytest/lib/python3.6/site-packages/pluggy/callers.py", line 187 in _multicall
  File "/home/ubuntu/anaconda3/envs/pytest/lib/python3.6/site-packages/pluggy/manager.py", line 87 in <lambda>
  File "/home/ubuntu/anaconda3/envs/pytest/lib/python3.6/site-packages/pluggy/manager.py", line 93 in _hookexec
  File "/home/ubuntu/anaconda3/envs/pytest/lib/python3.6/site-packages/pluggy/hooks.py", line 286 in __call__
  File "/home/ubuntu/anaconda3/envs/pytest/lib/python3.6/site-packages/_pytest/config/__init__.py", line 93 in main
  File "/home/ubuntu/anaconda3/envs/pytest/lib/python3.6/site-packages/pytest/__main__.py", line 7 in <module>
  File "/home/ubuntu/anaconda3/envs/pytest/lib/python3.6/runpy.py", line 85 in _run_code
  File "/home/ubuntu/anaconda3/envs/pytest/lib/python3.6/runpy.py", line 193 in _run_module_as_main
PASSED
tests/nightly/test_np_large_array.py::test_slice_assign PASSED
tests/nightly/test_np_large_array.py::test_logical_family PASSED
tests/nightly/test_np_large_array.py::test_deg_rad PASSED
tests/nightly/test_np_large_array.py::test_divide PASSED
tests/nightly/test_np_large_array.py::test_minimum PASSED
tests/nightly/test_np_large_array.py::test_maximum PASSED
tests/nightly/test_np_large_array.py::test_eye PASSED
tests/nightly/test_np_large_array.py::test_fix PASSED
tests/nightly/test_np_large_array.py::test_flip PASSED
tests/nightly/test_np_large_array.py::test_fliplr PASSED
tests/nightly/test_np_large_array.py::test_flipud PASSED
tests/nightly/test_np_large_array.py::test_full PASSED
tests/nightly/test_np_large_array.py::test_full_like PASSED
tests/nightly/test_np_large_array.py::test_comparison_family PASSED
tests/nightly/test_np_large_array.py::test_lcm PASSED
tests/nightly/test_np_large_array.py::test_log_family PASSED
tests/nightly/test_np_large_array.py::test_expand_dims PASSED
tests/nightly/test_np_large_array.py::test_hamming PASSED
tests/nightly/test_np_large_array.py::test_hanning PASSED
tests/nightly/test_np_large_array.py::test_fmax PASSED
tests/nightly/test_np_large_array.py::test_fmin PASSED
tests/nightly/test_np_large_array.py::test_fmod PASSED
tests/nightly/test_np_large_array.py::test_mod PASSED
tests/nightly/test_np_large_array.py::test_value_check_family PASSED
tests/nightly/test_np_large_array.py::test_rint PASSED
tests/nightly/test_np_large_array.py::test_invert PASSED
tests/nightly/test_np_large_array.py::test_exp PASSED
tests/nightly/test_np_large_array.py::test_expm1 PASSED
tests/nightly/test_np_large_array.py::test_frexp SKIPPED
tests/nightly/test_np_large_array.py::test_reciprocal PASSED
tests/nightly/test_np_large_array.py::test_sum PASSED
tests/nightly/test_np_large_array.py::test_negative PASSED
tests/nightly/test_np_large_array.py::test_identity PASSED
tests/nightly/test_np_large_array.py::test_square PASSED
tests/nightly/test_np_large_array.py::test_sign PASSED
tests/nightly/test_np_large_array.py::test_prod PASSED
tests/nightly/test_np_large_array.py::test_add PASSED
tests/nightly/test_np_large_array.py::test_hypot PASSED
tests/nightly/test_np_large_array.py::test_power PASSED
tests/nightly/test_np_large_array.py::test_ldexp PASSED
tests/nightly/test_np_large_array.py::test_multiply PASSED
tests/nightly/test_np_large_array.py::test_subtract PASSED
tests/nightly/test_np_large_array.py::test_diag PASSED
tests/nightly/test_np_large_array.py::test_diag_indices_from PASSED
tests/nightly/test_np_large_array.py::test_diagflat PASSED
tests/nightly/test_np_large_array.py::test_diagonal PASSED
tests/nightly/test_np_large_array.py::test_roll PASSED
tests/nightly/test_np_large_array.py::test_polyval PASSED
tests/nightly/test_np_large_array.py::test_activation PASSED
tests/nightly/test_np_large_array.py::test_arange_like PASSED
tests/nightly/test_np_large_array.py::test_batch_dot SKIPPED
tests/nightly/test_np_large_array.py::test_cast PASSED
tests/nightly/test_np_large_array.py::test_broadcast_like PASSED
tests/nightly/test_np_large_array.py::test_constraint_check PASSED
tests/nightly/test_np_large_array.py::test_batch_flatten PASSED
tests/nightly/test_np_large_array.py::test_batch_norm SKIPPED
tests/nightly/test_np_large_array.py::test_nonzero PASSED
tests/nightly/test_np_large_array.py::test_one_hot PASSED
tests/nightly/test_np_large_array.py::test_pick PASSED
tests/nightly/test_np_large_array.py::test_scalar_poisson PASSED
tests/nightly/test_np_large_array.py::test_tensor_poisson PASSED
tests/nightly/test_np_large_array.py::test_reshape PASSED
tests/nightly/test_np_large_array.py::test_reshape_like PASSED
tests/nightly/test_np_large_array.py::test_sigmoid PASSED
tests/nightly/test_np_large_array.py::test_shape_array PASSED
tests/nightly/test_np_large_array.py::test_stop_gradient PASSED
tests/nightly/test_np_large_array.py::test_sequence_mask PASSED
tests/nightly/test_np_large_array.py::test_topk PASSED
tests/nightly/test_np_large_array.py::test_slice PASSED
tests/nightly/test_np_large_array.py::test_smooth_l1 PASSED
tests/nightly/test_np_large_array.py::test_gamma PASSED
tests/nightly/test_np_large_array.py::test_gammaln PASSED
tests/nightly/test_np_large_array.py::test_digamma PASSED
tests/nightly/test_np_large_array.py::test_rnn_dim_check SKIPPED
tests/nightly/test_np_large_array.py::test_rnn_vanilla SKIPPED
tests/nightly/test_np_large_array.py::test_rnn_gru PASSED
tests/nightly/test_np_large_array.py::test_rnn_lstm PASSED
tests/nightly/test_np_large_array.py::test_ctc_loss PASSED
tests/nightly/test_np_large_array.py::test_erf PASSED
tests/nightly/test_np_large_array.py::test_erfinv PASSED
tests/nightly/test_np_large_array.py::test_index_add PASSED
tests/nightly/test_np_large_array.py::test_index_update PASSED
tests/nightly/test_np_large_array.py::test_layer_norm PASSED
tests/nightly/test_np_large_array.py::test_dlpack PASSED
tests/nightly/test_np_large_array.py::test_pooling PASSED
tests/nightly/test_np_large_array.py::test_roi_pooling PASSED
tests/nightly/test_np_large_array.py::test_save_load SKIPPED
tests/nightly/test_np_large_array.py::test_gather_nd PASSED
tests/nightly/test_np_large_array.py::test_random_bernoulli PASSED
tests/nightly/test_np_large_array.py::test_cumsum PASSED
tests/nightly/test_np_large_array.py::test_round PASSED
tests/nightly/test_np_large_array.py::test_cross PASSED
tests/nightly/test_np_large_array.py::test_array_split PASSED
tests/nightly/test_np_large_array.py::test_std PASSED
tests/nightly/test_np_large_array.py::test_var PASSED
tests/nightly/test_np_large_array.py::test_rollaxis PASSED
tests/nightly/test_np_large_array.py::test_vstack PASSED
tests/nightly/test_np_large_array.py::test_ediff1d PASSED
tests/nightly/test_np_large_array.py::test_split PASSED
tests/nightly/test_np_large_array.py::test_hsplit PASSED
tests/nightly/test_np_large_array.py::test_vsplit PASSED
tests/nightly/test_np_large_array.py::test_dsplit PASSED
tests/nightly/test_np_large_array.py::test_tril_indices PASSED
tests/nightly/test_np_large_array.py::test_tril_indices_extreme PASSED
tests/nightly/test_np_large_array.py::test_diff PASSED
tests/nightly/test_np_large_array.py::test_kron PASSED
tests/nightly/test_np_large_array.py::test_logspace PASSED
tests/nightly/test_np_large_array.py::test_linspace PASSED
tests/nightly/test_np_large_array.py::test_histogram PASSED
tests/nightly/test_np_large_array.py::test_nan_to_num PASSED
tests/nightly/test_np_large_array.py::test_interp PASSED
tests/nightly/test_np_large_array.py::test_edge_padding PASSED
tests/nightly/test_np_large_array.py::test_constant_padding PASSED
tests/nightly/test_np_large_array.py::test_minimum_padding PASSED
tests/nightly/test_np_large_array.py::test_reflection_padding PASSED
tests/nightly/test_np_large_array.py::test_symmetric_padding PASSED
tests/nightly/test_np_large_array.py::test_fill_diagonal PASSED
tests/nightly/test_np_large_array.py::test_insert PASSED

================================================================= warnings summary =================================================================
tests/nightly/test_np_large_array.py:91
  /home/ubuntu/workspace/incubator-mxnet/tests/nightly/test_np_large_array.py:91: DeprecationWarning: invalid escape sequence \
    '''

tests/nightly/test_np_large_array.py:1321
  /home/ubuntu/workspace/incubator-mxnet/tests/nightly/test_np_large_array.py:1321: DeprecationWarning: invalid escape sequence \
    '''

-- Docs: https://docs.pytest.org/en/latest/warnings.html
============================================= 157 passed, 8 skipped, 2 warnings in 13411.31s (3:43:31) =============================================
```
