### PR TITLE
Cuda 11 build fixes

### DIFF
--- a/ci/build_windows.py
+++ b/ci/build_windows.py
@@ -151,20 +151,6 @@ def windows_build(args):
     mxnet_root = get_mxnet_root()
     logging.info("Found MXNet root: {}".format(mxnet_root))
 
-    if 'GPU' in args.flavour:
-        # Get Thrust version to be shipped in Cuda 11, due to flakyness of
-        # older Thrust versions with MSVC 19 compiler
-        with remember_cwd():
-            tmpdirname = tempfile.mkdtemp()
-            os.chdir(tmpdirname)
-            r = requests.get('https://github.com/thrust/thrust/archive/1.9.8.zip', allow_redirects=True)
-            with open('thrust.zip', 'wb') as f:
-                f.write(r.content)
-            with zipfile.ZipFile('thrust.zip', 'r') as zip_ref:
-                zip_ref.extractall('.')
-            thrust_path = os.path.join(tmpdirname, "thrust-1.9.8")
-
-
     # cuda thrust / CUB + VS 2019 is flaky: try multiple times if fail
     MAXIMUM_TRY = 5
     build_try = 0
@@ -178,8 +164,7 @@ def windows_build(args):
             os.chdir(path)
             env = os.environ.copy()
             if 'GPU' in args.flavour:
-                env["CXXFLAGS"] = '/FS /MD /O2 /Ob2 /I {}'.format(thrust_path)
-                env["CUDAFLAGS"] = '-I {}'.format(thrust_path)
+                env["CXXFLAGS"] = '/FS /MD /O2 /Ob2'
             cmd = "\"{}\" && cmake -GNinja {} {}".format(args.vcvars,
                                                          CMAKE_FLAGS[args.flavour],
                                                          mxnet_root)

--- a/src/operator/contrib/multi_lamb.cu
+++ b/src/operator/contrib/multi_lamb.cu
@@ -51,9 +51,9 @@ __global__ void KernelStep1(const MultiLAMBKernelParam<DType, MPDType> kernel_pa
   MPDType biascorrection1, biascorrection2;
   if (bias_correction) {
     biascorrection1 = 1.0 -
-                      static_cast<MPDType>(pow(beta1, (float)kernel_params.step_count[tensor_id]));
+                      static_cast<MPDType>(pow(beta1, static_cast<float>(kernel_params.step_count[tensor_id])));
     biascorrection2 = 1.0 -
-                      static_cast<MPDType>(pow(beta2, (float)kernel_params.step_count[tensor_id]));
+                      static_cast<MPDType>(pow(beta2, static_cast<float>(kernel_params.step_count[tensor_id])));
   } else {
     biascorrection1 = static_cast<MPDType>(1.0);
     biascorrection2 = static_cast<MPDType>(1.0);

--- a/src/operator/contrib/multi_lamb.cu
+++ b/src/operator/contrib/multi_lamb.cu
@@ -51,9 +51,13 @@ __global__ void KernelStep1(const MultiLAMBKernelParam<DType, MPDType> kernel_pa
   MPDType biascorrection1, biascorrection2;
   if (bias_correction) {
     biascorrection1 = 1.0 -
-                      static_cast<MPDType>(pow(beta1, static_cast<float>(kernel_params.step_count[tensor_id])));
+                      static_cast<MPDType>(pow(beta1,
+                                           static_cast<float>(kernel_params.step_count[tensor_id])
+                                          ));
     biascorrection2 = 1.0 -
-                      static_cast<MPDType>(pow(beta2, static_cast<float>(kernel_params.step_count[tensor_id])));
+                      static_cast<MPDType>(pow(beta2,
+                                           static_cast<float>(kernel_params.step_count[tensor_id])
+                                          ));
   } else {
     biascorrection1 = static_cast<MPDType>(1.0);
     biascorrection2 = static_cast<MPDType>(1.0);

--- a/src/operator/contrib/multi_lamb.cu
+++ b/src/operator/contrib/multi_lamb.cu
@@ -51,9 +51,9 @@ __global__ void KernelStep1(const MultiLAMBKernelParam<DType, MPDType> kernel_pa
   MPDType biascorrection1, biascorrection2;
   if (bias_correction) {
     biascorrection1 = 1.0 -
-                      static_cast<MPDType>(std::pow(beta1, kernel_params.step_count[tensor_id]));
+                      static_cast<MPDType>(pow(beta1, (float)kernel_params.step_count[tensor_id]));
     biascorrection2 = 1.0 -
-                      static_cast<MPDType>(std::pow(beta2, kernel_params.step_count[tensor_id]));
+                      static_cast<MPDType>(pow(beta2, (float)kernel_params.step_count[tensor_id]));
   } else {
     biascorrection1 = static_cast<MPDType>(1.0);
     biascorrection2 = static_cast<MPDType>(1.0);

--- a/src/operator/contrib/multi_lamb.cu
+++ b/src/operator/contrib/multi_lamb.cu
@@ -50,14 +50,10 @@ __global__ void KernelStep1(const MultiLAMBKernelParam<DType, MPDType> kernel_pa
 
   MPDType biascorrection1, biascorrection2;
   if (bias_correction) {
-    biascorrection1 = 1.0 -
-                      static_cast<MPDType>(pow(beta1,
-                                           static_cast<float>(kernel_params.step_count[tensor_id])
-                                          ));
-    biascorrection2 = 1.0 -
-                      static_cast<MPDType>(pow(beta2,
-                                           static_cast<float>(kernel_params.step_count[tensor_id])
-                                          ));
+    biascorrection1 = 1.0 - static_cast<MPDType>(
+                      pow(beta1, static_cast<float>(kernel_params.step_count[tensor_id])));
+    biascorrection2 = 1.0 - static_cast<MPDType>(
+                      pow(beta2, static_cast<float>(kernel_params.step_count[tensor_id])));
   } else {
     biascorrection1 = static_cast<MPDType>(1.0);
     biascorrection2 = static_cast<MPDType>(1.0);

--- a/src/operator/contrib/multi_lans.cu
+++ b/src/operator/contrib/multi_lans.cu
@@ -54,9 +54,9 @@ __global__ void KernelStep1(const MultiLANSKernelParam<DType, MPDType> kernel_pa
   MPDType biascorrection1, biascorrection2;
 
   biascorrection1 = 1.0 -
-                    static_cast<MPDType>(pow(beta1, (float)kernel_params.step_count[tensor_id]));
+                    static_cast<MPDType>(pow(beta1, static_cast<float>(kernel_params.step_count[tensor_id])));
   biascorrection2 = 1.0 -
-                    static_cast<MPDType>(pow(beta2, (float)kernel_params.step_count[tensor_id]));
+                    static_cast<MPDType>(pow(beta2, static_cast<float>(kernel_params.step_count[tensor_id])));
 
   MPDType r_weight[ILP_LAMB];
   MPDType r_grad[ILP_LAMB];

--- a/src/operator/contrib/multi_lans.cu
+++ b/src/operator/contrib/multi_lans.cu
@@ -53,12 +53,10 @@ __global__ void KernelStep1(const MultiLANSKernelParam<DType, MPDType> kernel_pa
 
   MPDType biascorrection1, biascorrection2;
 
-  biascorrection1 = 1.0 -
-                    static_cast<MPDType>(pow(beta1,
-                                         static_cast<float>(kernel_params.step_count[tensor_id])));
-  biascorrection2 = 1.0 -
-                    static_cast<MPDType>(pow(beta2,
-                                         static_cast<float>(kernel_params.step_count[tensor_id])));
+  biascorrection1 = 1.0 - static_cast<MPDType>(
+                    pow(beta1, static_cast<float>(kernel_params.step_count[tensor_id])));
+  biascorrection2 = 1.0 - static_cast<MPDType>(
+                    pow(beta2, static_cast<float>(kernel_params.step_count[tensor_id])));
 
   MPDType r_weight[ILP_LAMB];
   MPDType r_grad[ILP_LAMB];

--- a/src/operator/contrib/multi_lans.cu
+++ b/src/operator/contrib/multi_lans.cu
@@ -54,9 +54,9 @@ __global__ void KernelStep1(const MultiLANSKernelParam<DType, MPDType> kernel_pa
   MPDType biascorrection1, biascorrection2;
 
   biascorrection1 = 1.0 -
-                    static_cast<MPDType>(std::pow(beta1, kernel_params.step_count[tensor_id]));
+                    static_cast<MPDType>(pow(beta1, (float)kernel_params.step_count[tensor_id]));
   biascorrection2 = 1.0 -
-                    static_cast<MPDType>(std::pow(beta2, kernel_params.step_count[tensor_id]));
+                    static_cast<MPDType>(pow(beta2, (float)kernel_params.step_count[tensor_id]));
 
   MPDType r_weight[ILP_LAMB];
   MPDType r_grad[ILP_LAMB];

--- a/src/operator/contrib/multi_lans.cu
+++ b/src/operator/contrib/multi_lans.cu
@@ -54,9 +54,11 @@ __global__ void KernelStep1(const MultiLANSKernelParam<DType, MPDType> kernel_pa
   MPDType biascorrection1, biascorrection2;
 
   biascorrection1 = 1.0 -
-                    static_cast<MPDType>(pow(beta1, static_cast<float>(kernel_params.step_count[tensor_id])));
+                    static_cast<MPDType>(pow(beta1,
+                                         static_cast<float>(kernel_params.step_count[tensor_id])));
   biascorrection2 = 1.0 -
-                    static_cast<MPDType>(pow(beta2, static_cast<float>(kernel_params.step_count[tensor_id])));
+                    static_cast<MPDType>(pow(beta2,
+                                         static_cast<float>(kernel_params.step_count[tensor_id])));
 
   MPDType r_weight[ILP_LAMB];
   MPDType r_grad[ILP_LAMB];


### PR DESCRIPTION
## Description ##
Fixes to build properly on Windows with Cuda 11.0:

* Update multi_lamb.cu and multi_lans.cu to use cuda's pow() function instead of std::pow() and statically cast exponent to float so it matches cuda pow signature.

Fixes compilation errors:
```
multi_lamb.cu(53): error: calling a __host__ function("pow<float, int, (int)0> ") from a __global__ function("mxnet::op::KernelStep1<(bool)1, float, float> ") is not allowed
multi_lamb.cu(53): error: identifier "pow<float, int, (int)0> " is undefined in device code
```
## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
