### PR TITLE
Mark test_np_average as flaky

### DIFF
--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -891,6 +891,7 @@ def test_np_max_min_error(func, shape, exception):
 @pytest.mark.parametrize('is_weighted', [True, False])
 @pytest.mark.parametrize('returned', [True, False])
 @pytest.mark.parametrize('req_a', ['null', 'add', 'write'])
+@pytest.mark.flaky
 def test_np_average(a_shape, w_shape, axes, is_weighted, req_a,
                     hybridize, returned, dtype):
     class TestAverage(HybridBlock):


### PR DESCRIPTION
[2020-11-14T04:52:26.695Z]         if returned:
[2020-11-14T04:52:26.695Z]             np_out, np_sum_of_weights = np_out
[2020-11-14T04:52:26.695Z]             mx_out, mx_sum_of_weights = mx_out
[2020-11-14T04:52:26.695Z]             assert_almost_equal(mx_sum_of_weights.asnumpy(), np_sum_of_weights, rtol=rtol, atol=atol)
[2020-11-14T04:52:26.695Z]         assert mx_out.shape == np_out.shape
[2020-11-14T04:52:26.695Z] >       assert_almost_equal(mx_out.asnumpy(), np_out, rtol=rtol, atol=atol)
[...]
[2020-11-14T04:52:26.695Z] >       raise AssertionError(msg)
[2020-11-14T04:52:26.695Z] E       AssertionError:
[2020-11-14T04:52:26.695Z] E       Items are not equal:
[2020-11-14T04:52:26.695Z] E       Error 1.772945 exceeds tolerance rtol=1.000000e-03, atol=1.000000e-04.
[2020-11-14T04:52:26.695Z] E
[2020-11-14T04:52:26.695Z] E        ACTUAL: array(39093.145, dtype=float32)
[2020-11-14T04:52:26.695Z] E        DESIRED: 39023.957