### PR TITLE
Separate backend from hybridize and refactor optimize_for kwargs

### DIFF
--- a/example/extensions/lib_pass/README.md
+++ b/example/extensions/lib_pass/README.md
@@ -69,7 +69,8 @@ sym, _, _ = mx.model.load_checkpoint('mymodel', 0)
 sym2 = sym.optimize_for("myPass")
 # Gluon flow 1
 sym_block = nn.SymbolBlock(sym, inputs)
-sym_block.hybridize(backend='myPass')
+sym_block.hybridize(static_alloc=True, static_shape=True)
+sym_block.optimize_for(x, backend='myPass')
 # Gluon flow 2
 sym_block = nn.SymbolBlock(sym, inputs)
 sym_block.optimize_for(x, backend='myPass')
@@ -85,13 +86,7 @@ sym.optimize_for(backend, args=None, aux=None, ctx=None, **kwargs)
 
 The `optimize_for` API takes at least 1 argument, `backend` which is a string that identifies which backend to use to optimize the model. The `args` and `aux` arguments are optional and take a list of NDArray or dict of str to NDArray. They are used to infer shapes and types and before executing the graph pass. The `ctx` argument is optional and takes a device context to infer storage types. It also takes any other user-specified options that will be passed to the backend APIs.
 
-For the Gluon API, `hybridize` can be called on HybridBlocks to execute a graph pass on the internal CachedOp Symbol.
-
-```python
-block.hybridize(backend=None, backend_opts=None, **kwargs)
-```
-
-The `hybridize` function prepares the HybridBlock to be converted into a backend symbol. The `backend` argument is a string that identifies which pass that will be executed on the model. The `backend_opts` takes other user-specified options that will be passed to the backend APIs. The actual pass runs once just before the first the forward pass.
+The `hybridize` function prepares the HybridBlock to be converted into a backend symbol.
 
 If you just want to run a graph pass on the HybridBlock but not run a complete forward pass, you can use the `optimize_for` API that combines the work done in the `hybridize` API with part of the work done in the forward pass.
 
@@ -106,7 +101,7 @@ block.optimize_for(x, backend='myPass')
 block.export('optimized')
 ```
 
-But you can also use `optimize_for` in place of `hybridize` and run inference immediately after too.
+But you can also use `optimize_for` and run inference immediately after too.
 
 ```python
 block.optimize_for(x, backend='myPass')

--- a/example/extensions/lib_pass/README.md
+++ b/example/extensions/lib_pass/README.md
@@ -84,11 +84,7 @@ APIs in MXNet are available in both Symbol and Gluon APIs. For the Symbol API, `
 sym.optimize_for(backend, args=None, aux=None, ctx=None, **kwargs)
 ```
 
-The `optimize_for` API takes at least 1 argument, `backend` which is a string that identifies which backend to use to optimize the model. The `args` and `aux` arguments are optional and take a list of NDArray or dict of str to NDArray. They are used to infer shapes and types and before executing the graph pass. The `ctx` argument is optional and takes a device context to infer storage types. It also takes any other user-specified options that will be passed to the backend APIs.
-
-The `hybridize` function prepares the HybridBlock to be converted into a backend symbol.
-
-If you just want to run a graph pass on the HybridBlock but not run a complete forward pass, you can use the `optimize_for` API that combines the work done in the `hybridize` API with part of the work done in the forward pass.
+The `optimize_for` API takes at least 1 argument, `backend` which is a string that identifies which backend to use to optimize the model. The `args` and `aux` arguments are optional and take a list of NDArray or dict of str to NDArray. They are used to infer shapes and types and before executing the graph pass. The `ctx` argument is optional and takes a device context to infer storage types. It also takes any other user-specified options that will be passed to the backend APIs (in the `kwargs`).
 
 ```python
 block.optimize_for(x, backend=None, backend_opts=None, **kwargs)

--- a/example/extensions/lib_pass/test_pass.py
+++ b/example/extensions/lib_pass/test_pass.py
@@ -58,16 +58,6 @@ def test_model(pass_name):
     out = sym_block(mx.nd.ones((3,2)),mx.nd.ones((3,2)))
     print(out)
 
-    # Gluon Hybridize
-    print('-------------------------------')
-    print('Testing pass "%s" Gluon Hybridize with shapes/types' % pass_name)
-    inputs = [a,b]
-    sym_block = nn.SymbolBlock(sym, inputs)
-    sym_block.initialize()
-    sym_block.hybridize(backend=pass_name)
-    out4 = sym_block(mx.nd.ones((3,2)),mx.nd.ones((3,2)))
-    print(out4)
-    
     # Gluon optimize_for
     print('-------------------------------')
     print('Testing pass "%s" Gluon Hybridize with shapes/types without inference' % pass_name)

--- a/example/extensions/lib_subgraph/README.md
+++ b/example/extensions/lib_subgraph/README.md
@@ -110,7 +110,7 @@ For the Gluon API, `hybridize` can be called on HybridBlocks to partition the in
 block.hybridize(backend=None, clear=True)
 ```
 
-The `hybridize` function prepares the HybridBlock to be converted into a backend symbol. The `clear` argument defaults to `True` and clears any previous optimizations done on the block. If you want to chain optimizations together, set `clear` to `False`. The actual partitioning takes place during the forward pass.
+The `hybridize` function prepares the HybridBlock to be converted into a backend symbol. The `clear` argument defaults to `True` and clears any previous optimizations done on the block. The actual partitioning takes place during the forward pass.
 
 If you just want to partition the HybridBlock but not run a complete forward pass, you can use the `optimize_for` API that combines the work done in the `hybridize` API with part of the work done in the forward pass.
 

--- a/example/extensions/lib_subgraph/README.md
+++ b/example/extensions/lib_subgraph/README.md
@@ -107,7 +107,7 @@ block.export('partitioned')
 ```
 
 For the Gluon API, hybridization is needed, so calling `optimize_for` on a non-hybridized block will hybridize it.
-If the users need to pass some hybridization parameters, they can either call `hybridize` explicitedly, or directly pass the arguments to `optimize_for`.
+If the users need to pass some hybridization parameters, they can either call `hybridize` explicitly, or directly pass the arguments to `optimize_for`.
 
 This:
 ```python
@@ -119,7 +119,7 @@ is equivalent to:
 block.optimize_for(x, backend='myPart', static_shape=True, static_alloc=False)
 ```
 
-It's important to note that `hybridize` clars the CachedOp and any previous optimization.
+It's important to note that `hybridize` clears the CachedOp and any previous optimization.
 
 ```python
 block.optimize_for(x, backend='myPart')

--- a/example/extensions/lib_subgraph/README.md
+++ b/example/extensions/lib_subgraph/README.md
@@ -83,16 +83,10 @@ sym, _, _ = mx.model.load_checkpoint('mymodel', 0)
 # Symbol/Module flow
 sym2 = sym.optimize_for("myPart")
 
-# Gluon flow 1
-sym_block = nn.SymbolBlock(sym, inputs)
-sym_block.hybridize(backend='myPart')
-
-# Gluon flow 2
+# Gluon flow
 sym_block = nn.SymbolBlock(sym, inputs)
 sym_block.optimize_for(x, backend='myPart')
 ```
-
-In the Gluon hybridize flow, the model is actually hybridized during the first inference, rather than immediately when calling `hybridize`. This hybridize-based flow is useful if a user expects to run inference immediately after hybridizing. But for users than just want to partition but not run a whole forward pass, the `optimize_for` API combines the hybrdize/forward APIs but does not run a forward pass. After calling `optimize_for` users can `export` their model immediately without running a forward pass. 
 
 ### Using a Custom Partitioner Library
 
@@ -104,21 +98,7 @@ sym.optimize_for(backend, args=None, aux=None, ctx=None, **kwargs)
 
 The `optimize_for` API takes at least 1 argument, `backend` which is a string that identifies which backend to partition the model for. The `args` and `aux` arguments are optional and take a list of NDArray or dict of str to NDArray. They are used to infer shapes and types and before partitioning, and passed to the backend to use during compilation. The `ctx` argument is optional and takes a device context to infer storage types. It also takes any other user-specified options that will be passed to the backend partitioning APIs. The backend options can be passed as kwargs.
 
-For the Gluon API, `hybridize` can be called on HybridBlocks to partition the internal CachedOp Symbol.
-
-```python
-block.hybridize(backend=None, clear=True)
-```
-
-The `hybridize` function prepares the HybridBlock to be converted into a backend symbol. The `clear` argument defaults to `True` and clears any previous optimizations done on the block. The actual partitioning takes place during the forward pass.
-
-If you just want to partition the HybridBlock but not run a complete forward pass, you can use the `optimize_for` API that combines the work done in the `hybridize` API with part of the work done in the forward pass.
-
-```python
-block.optimize_for(x, backend=None, clear=True, **kwargs)
-```
-
-When the `optimize_for` API is called on a HybridBlock it partitions immediately. This lets users export the partitioned model without running a complete forward pass. Chaining multiple optimizations is as simple as calling `optimize_for` multiple times, no need to execute a forward pass (as opposed to `hybridize`).
+When the `optimize_for` API is called on a HybridBlock it partitions immediately. This lets users export the partitioned model without running a complete forward pass. Chaining multiple optimizations is as simple as calling `optimize_for` multiple times.
 
 ```python
 block.optimize_for(x, backend='myPart')
@@ -126,11 +106,25 @@ block.optimize_for(x, backend='myOtherPart')
 block.export('partitioned')
 ```
 
-But you can also use `optimize_for` in place of `hybridize` and run inference immediately after too.
+For the Gluon API, hybridization is needed, so calling `optimize_for` on a non-hybridized block will hybridize it.
+If the users need to pass some hybridization parameters, they can either call `hybridize` explicitedly, or directly pass the arguments to `optimize_for`.
+
+This:
+```python
+block.hybridize(static_shape=True, static_alloc=False)
+block.optimize_for(x, backend='myPart')
+```
+is equivalent to:
+```python
+block.optimize_for(x, backend='myPart', static_shape=True, static_alloc=False)
+```
+
+It's important to note that `hybridize` clars the CachedOp and any previous optimization.
 
 ```python
 block.optimize_for(x, backend='myPart')
-block(x)
+block.hybridize()
+# block is not optimized for myPart anymore!!
 ```
 
 ### Writing A Custom Partitioner

--- a/example/extensions/lib_subgraph/README.md
+++ b/example/extensions/lib_subgraph/README.md
@@ -102,27 +102,27 @@ Partitioning APIs in MXNet are available in both Symbol and Gluon APIs. For the 
 sym.optimize_for(backend, args=None, aux=None, ctx=None, **kwargs)
 ```
 
-The `optimize_for` API takes at least 1 argument, `backend` which is a string that identifies which backend to partition the model for. The `args` and `aux` arguments are optional and take a list of NDArray or dict of str to NDArray. They are used to infer shapes and types and before partitioning, and passed to the backend to use during compilation. The `ctx` argument is optional and takes a device context to infer storage types. It also takes any other user-specified options that will be passed to the backend partitioning APIs.
+The `optimize_for` API takes at least 1 argument, `backend` which is a string that identifies which backend to partition the model for. The `args` and `aux` arguments are optional and take a list of NDArray or dict of str to NDArray. They are used to infer shapes and types and before partitioning, and passed to the backend to use during compilation. The `ctx` argument is optional and takes a device context to infer storage types. It also takes any other user-specified options that will be passed to the backend partitioning APIs. The backend options can be passed as kwargs.
 
 For the Gluon API, `hybridize` can be called on HybridBlocks to partition the internal CachedOp Symbol.
 
 ```python
-block.hybridize(backend=None, backend_opts=None, clear=True, **kwargs)
+block.hybridize(backend=None, clear=True)
 ```
 
-The `hybridize` function prepares the HybridBlock to be converted into a backend symbol. The `backend` argument is a string that identifies which backend that will partition the model. The `backend_opts` are other user-specified options (as a Python dictionary of strings mapped to strings) that will be passed to the backend partitioning APIs. The `clear` argument defaults to `True` and clears any previous optimizations done on the block. If you want to chain optimizations together, set `clear` to `False`. The actual partitioning takes place during the forward pass. If you want to use `hybridize` to chain multiple optimizations, be sure to execute a forward pass after each call to `hybridize`. 
+The `hybridize` function prepares the HybridBlock to be converted into a backend symbol. The `clear` argument defaults to `True` and clears any previous optimizations done on the block. If you want to chain optimizations together, set `clear` to `False`. The actual partitioning takes place during the forward pass.
 
 If you just want to partition the HybridBlock but not run a complete forward pass, you can use the `optimize_for` API that combines the work done in the `hybridize` API with part of the work done in the forward pass.
 
 ```python
-block.optimize_for(x, backend=None, backend_opts=None, clear=True, **kwargs)
+block.optimize_for(x, backend=None, clear=True, **kwargs)
 ```
 
 When the `optimize_for` API is called on a HybridBlock it partitions immediately. This lets users export the partitioned model without running a complete forward pass. Chaining multiple optimizations is as simple as calling `optimize_for` multiple times, no need to execute a forward pass (as opposed to `hybridize`).
 
 ```python
 block.optimize_for(x, backend='myPart')
-block.optimize_for(x, backend='myOtherPart', clear=False)
+block.optimize_for(x, backend='myOtherPart')
 block.export('partitioned')
 ```
 

--- a/example/extensions/lib_subgraph/test_subgraph.py
+++ b/example/extensions/lib_subgraph/test_subgraph.py
@@ -62,16 +62,6 @@ def test(backend):
     out = sym_block(mx.nd.ones((3,2)),mx.nd.ones((3,2)))
     print(out)
 
-    # Gluon Hybridize partitioning with shapes/types
-    print('-------------------------------')
-    print('Testing %s Gluon Hybridize partitioning with shapes/types' % backend)
-    inputs = [a,b]
-    sym_block = nn.SymbolBlock(sym, inputs)
-    sym_block.initialize()
-    sym_block.hybridize(backend=backend)
-    out2 = sym_block(mx.nd.ones((3,2)),mx.nd.ones((3,2)))
-    print(out2)
-
     # Gluon Hybridize partitioning with shapes/types without inference
     print('-------------------------------')
     print('Testing %s Gluon Hybridize partitioning with shapes/types without inference' % backend)
@@ -84,7 +74,7 @@ def test(backend):
     # Test with additional input to subgraph op
     print('-------------------------------')
     print('Testing %s Gluon Hybridize partitioning with extra input' % backend)
-    sym_block2.optimize_for(mx.nd.ones((3,2)), mx.nd.ones((3,2)), backend="addInputPass", clear=False)
+    sym_block2.optimize_for(mx.nd.ones((3,2)), mx.nd.ones((3,2)), backend="addInputPass")
     out3 = sym_block2(mx.nd.ones((3,2)),mx.nd.ones((3,2)))
     print(out3)
     
@@ -102,13 +92,13 @@ def test(backend):
     out5 = sym2_block(mx.nd.ones((3,2)))
     print(out5)
 
-    # Gluon Hybridize partitioning with shapes/types
+    # Gluon optimize_for partitioning with shapes/types
     print('-------------------------------')
-    print('Testing %s Gluon Hybridize partitioning with shapes/types' % backend)
+    print('Testing %s Gluon optimize_for partitioning with shapes/types' % backend)
     inputs = [a]
     sym2_block = nn.SymbolBlock(sym2, inputs)
     sym2_block.initialize()
-    sym2_block.hybridize(backend=backend)
+    sym2_block.optimize_for(mx.nd.ones((3,2)), backend=backend)
     out8 = sym2_block(mx.nd.ones((3,2)))
     print(out8)
 

--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -1227,7 +1227,7 @@ class HybridBlock(Block):
         forward_bulk_size : optional int, default None
             Segment size of bulk execution during forward pass.
         backward_bulk_size : optional int, default None
-            Segment size of bulk execution during forward pass.
+            Segment size of bulk execution during backward pass.
         **kwargs: The backend options, optional
             Passed on to `PrePartition` and `PostPartition` functions of `SubgraphProperty`
         """
@@ -1309,7 +1309,7 @@ class HybridBlock(Block):
         forward_bulk_size : optional int, default None
             Segment size of bulk execution during forward pass.
         backward_bulk_size : optional int, default None
-            Segment size of bulk execution during forward pass.
+            Segment size of bulk execution during backward pass.
         """
 
         self._active = active

--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -1233,10 +1233,10 @@ class HybridBlock(Block):
         """
         self._backend = backend
         if len(kwargs) > 0:
-             self._backend_opts = kwargs
+            self._backend_opts = kwargs
 
         if clear or not self._active:
-            self.hybridize(True, clear, partition_if_dynamic, static_alloc, static_shape,
+            self.hybridize(True, partition_if_dynamic, static_alloc, static_shape,
                            inline_limit, forward_bulk_size, backward_bulk_size)
 
         # do part of forward API call
@@ -1259,6 +1259,9 @@ class HybridBlock(Block):
         # do not actually call the cached_op
 
         self._first_forward = True
+        # clear the backend
+        self._backend = None
+        self._backend_opts = None
 
     def _clear_cached_op(self):
         self._cached_graph = ()
@@ -1279,7 +1282,7 @@ class HybridBlock(Block):
             self._active = False
         self._clear_cached_op()
 
-    def hybridize(self, active=True, clear=True,
+    def hybridize(self, active=True,
                   partition_if_dynamic=False,
                   static_alloc=False,
                   static_shape=False,
@@ -1293,12 +1296,6 @@ class HybridBlock(Block):
         ----------
         active : bool, default True
             Whether to turn hybrid on or off.
-        backend : str
-            The name of backend, as registered in `SubgraphBackendRegistry`, default None
-        backend_opts : dict of user-specified options to pass to the backend for partitioning, optional
-            Passed on to `PrePartition` and `PostPartition` functions of `SubgraphProperty`
-        clear : bool, default True
-            clears any previous optimizations
         partition_if_dynamic : bool, default False
             whether to partition the graph when dynamic shape op exists
         static_alloc : bool, default False
@@ -1323,8 +1320,7 @@ class HybridBlock(Block):
             self._flags.append(("forward_bulk_size", forward_bulk_size))
         if backward_bulk_size is not None:
             self._flags.append(("backward_bulk_size", backward_bulk_size))
-        if clear:
-            self._clear_cached_op()
+        self._clear_cached_op()
         if active and self._forward_hooks or self._forward_pre_hooks:
             warnings.warn('"{block}" is being hybridized while still having forward hook/pre-hook. '
                           'If "{block}" is a child of HybridBlock, the hooks will not take effect.'

--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -1175,7 +1175,14 @@ class HybridBlock(Block):
             out = [out]
         return _regroup(out, self._out_format)
 
-    def optimize_for(self, x, *args, backend=None, backend_opts=None, clear=True, partition_if_dynamic=False, **kwargs):
+    def optimize_for(self, x, *args, backend=None, clear=False,
+                     partition_if_dynamic=False,
+                     static_alloc=False,
+                     static_shape=False,
+                     inline_limit=2,
+                     forward_bulk_size=None,
+                     backward_bulk_size=None,
+                     **kwargs):
         """Partitions the current HybridBlock and optimizes it for a given backend
         without executing a forward pass. Modifies the HybridBlock in-place.
 
@@ -1205,8 +1212,9 @@ class HybridBlock(Block):
             The name of backend, as registered in `SubgraphBackendRegistry`, default None
         backend_opts : dict of user-specified options to pass to the backend for partitioning, optional
             Passed on to `PrePartition` and `PostPartition` functions of `SubgraphProperty`
-        clear : clears any previous optimizations
-        partition_if_dynamic : bool
+        clear : bool, default False
+            clears any previous optimizations
+        partition_if_dynamic : bool, default False
             whether to partition the graph when dynamic shape op exists
         static_alloc : bool, default False
             Statically allocate memory to improve speed. Memory usage may increase.
@@ -1214,10 +1222,22 @@ class HybridBlock(Block):
             Optimize for invariant input shapes between iterations. Must also
             set static_alloc to True. Change of input shapes is still allowed
             but slower.
+        inline_limit : optional int, default 2
+            Maximum number of operators that can be inlined.
+        forward_bulk_size : optional int, default None
+            Segment size of bulk execution during forward pass.
+        backward_bulk_size : optional int, default None
+            Segment size of bulk execution during forward pass.
+        **kwargs: The backend options, optional
+            Passed on to `PrePartition` and `PostPartition` functions of `SubgraphProperty`
         """
+        self._backend = backend
+        if len(kwargs) > 0:
+             self._backend_opts = kwargs
 
-        # do hybrize API call
-        self.hybridize(True, backend, backend_opts, clear, partition_if_dynamic, **kwargs)
+        if clear or not self._active:
+            self.hybridize(True, clear, partition_if_dynamic, static_alloc, static_shape,
+                           inline_limit, forward_bulk_size, backward_bulk_size)
 
         # do part of forward API call
         has_symbol, has_ndarray, ctx_set, _ = _gather_type_ctx_info([x] + list(args))
@@ -1259,7 +1279,13 @@ class HybridBlock(Block):
             self._active = False
         self._clear_cached_op()
 
-    def hybridize(self, active=True, backend=None, backend_opts=None, clear=True, partition_if_dynamic=False, **kwargs):
+    def hybridize(self, active=True, clear=True,
+                  partition_if_dynamic=False,
+                  static_alloc=False,
+                  static_shape=False,
+                  inline_limit=2,
+                  forward_bulk_size=None,
+                  backward_bulk_size=None):
         """Activates or deactivates :py:class:`HybridBlock` s recursively. Has no effect on
         non-hybrid children.
 
@@ -1271,8 +1297,9 @@ class HybridBlock(Block):
             The name of backend, as registered in `SubgraphBackendRegistry`, default None
         backend_opts : dict of user-specified options to pass to the backend for partitioning, optional
             Passed on to `PrePartition` and `PostPartition` functions of `SubgraphProperty`
-        clear : clears any previous optimizations
-        partition_if_dynamic : bool
+        clear : bool, default True
+            clears any previous optimizations
+        partition_if_dynamic : bool, default False
             whether to partition the graph when dynamic shape op exists
         static_alloc : bool, default False
             Statically allocate memory to improve speed. Memory usage may increase.
@@ -1280,24 +1307,34 @@ class HybridBlock(Block):
             Optimize for invariant input shapes between iterations. Must also
             set static_alloc to True. Change of input shapes is still allowed
             but slower.
+        inline_limit : optional int, default 2
+            Maximum number of operators that can be inlined.
+        forward_bulk_size : optional int, default None
+            Segment size of bulk execution during forward pass.
+        backward_bulk_size : optional int, default None
+            Segment size of bulk execution during forward pass.
         """
-
-        self._backend = backend
-        if backend_opts is not None:
-            assert isinstance(backend_opts, dict), \
-            "HybridBlock hybridize requires backend_opts to be a dictionary."
-            self._backend_opts = backend_opts
 
         self._active = active
         self._partition_if_dynamic = partition_if_dynamic
-        self._flags = list(kwargs.items())
+        self._flags = [("static_alloc", static_alloc), ("static_shape", static_shape),
+                       ("inline_limit", inline_limit)]
+        if forward_bulk_size is not None:
+            self._flags.append(("forward_bulk_size", forward_bulk_size))
+        if backward_bulk_size is not None:
+            self._flags.append(("backward_bulk_size", backward_bulk_size))
         if clear:
             self._clear_cached_op()
         if active and self._forward_hooks or self._forward_pre_hooks:
             warnings.warn('"{block}" is being hybridized while still having forward hook/pre-hook. '
                           'If "{block}" is a child of HybridBlock, the hooks will not take effect.'
                           .format(block=self))
-        super(HybridBlock, self).hybridize(active, **kwargs)
+        super(HybridBlock, self).hybridize(active,
+                                           static_alloc=static_alloc,
+                                           static_shape=static_shape,
+                                           inline_limit=inline_limit,
+                                           forward_bulk_size=forward_bulk_size,
+                                           backward_bulk_size=backward_bulk_size)
 
     def cast(self, dtype):
         if self._active:

--- a/tests/python/unittest/test_extensions.py
+++ b/tests/python/unittest/test_extensions.py
@@ -161,7 +161,7 @@ def test_subgraph():
     # Gluon Hybridize partitioning with shapes/types
     sym_block = nn.SymbolBlock(sym, [a,b])
     sym_block.initialize()
-    sym_block.hybridize(backend='myProp')
+    sym_block.optimize_for(mx.nd.ones((3,2)),mx.nd.ones((3,2)),backend='myProp')
     out4 = sym_block(mx.nd.ones((3,2)),mx.nd.ones((3,2)))
     # check that result matches one executed by MXNet
     assert_almost_equal(out[0].asnumpy(), out4[0].asnumpy(), rtol=1e-3, atol=1e-3)

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -1871,10 +1871,6 @@ def test_share_inputs_outputs():
             res = t(d1)
             assert_almost_equal(res.asnumpy(), d1.asnumpy())
 
-    param = deepcopy(params[2])
-    param['param_indices'] = (1)
-    param['data_indices'] = (0)
-    params.append(param)
     # Test the case that inputs and outputs of a backward graph share NDArrays.
     for param in params:
         t = TestIOBackward()

--- a/tests/python/unittest/test_subgraph_op.py
+++ b/tests/python/unittest/test_subgraph_op.py
@@ -438,7 +438,7 @@ def test_subgraph_backend_gluon(sym, subgraph_backend, op_names, tmpdir):
                                        ctx=mx.current_context())
     check_call(_LIB.MXSetSubgraphPropertyOpNamesV2(c_str(subgraph_backend), mx_uint(len(op_names)),
                                                 c_str_array(op_names)))
-    sym_block.hybridize(backend=subgraph_backend)
+    sym_block.optimize_for(*x, backend=subgraph_backend)
     outputs2 = sym_block(*x)
     check_call(_LIB.MXRemoveSubgraphPropertyOpNamesV2(c_str(subgraph_backend)))
 
@@ -472,7 +472,7 @@ def test_subgraph_backend_gluon_ext1(tmpdir):
     op_names = ['FullyConnected']
     check_call(_LIB.MXSetSubgraphPropertyOpNamesV2(c_str(subgraph_backend), mx_uint(len(op_names)),
                                                 c_str_array(op_names)))
-    net.hybridize(backend = subgraph_backend)
+    net.optimize_for(x, backend = subgraph_backend)
     outputs2 = net(x)
     check_call(_LIB.MXRemoveSubgraphPropertyOpNamesV2(c_str(subgraph_backend)))
 
@@ -510,7 +510,7 @@ def test_subgraph_backend_gluon_ext2(tmpdir):
     op_names = ['FullyConnected']
     check_call(_LIB.MXSetSubgraphPropertyOpNamesV2(c_str(subgraph_backend), mx_uint(len(op_names)),
                                                 c_str_array(op_names)))
-    net.hybridize(backend = subgraph_backend)
+    net.optimize_for(x, backend = subgraph_backend)
     outputs2 = net(x)
     check_call(_LIB.MXRemoveSubgraphPropertyOpNamesV2(c_str(subgraph_backend)))
 


### PR DESCRIPTION
## Description ##
This PR separates the partitioning backend from hybridize.
`hybridize` now clears any previous optimization, sets the CachedOp args and activate the hybridization.
`optimize_for` is responsible of setting the backend, backend options and running the partitioning with backend.

If the user wish to use any partitioning backend, they have use optimize_for.

It also changes the default value of `optimize_for`'s `clear` arg, making the chaining of the backend the default behavior.

The PR also make the CachedOp kwargs explicit and documented :  `static_alloc, static_shape, inline_limit, forward_bulk_size, backward_bulk_size`.

## Examples ##

### How optimize_for changed
#### Before
```
blk.optimize_for(x, backend="someBackend", backend_opts={'dedup_subgraph':True})
```
#### After
```
blk.optimize_for(x, backend="someBackend", dedup_subgraph=True)
```
### How hybridize changed
#### Before
```
blk.hybridize(backend="someBackend", static_alloc=True)
blk(x)
```
#### After 
Hybridize can't be used to set the backend anymore, we now have to use `optimize_for`, which will call hybridize internally.
```
blk.optimize_for(x, backend="someBackend", static_alloc=True)
```

### How chaining backends changed
#### Before
```
blk.optimize_for(x, backend="firstBackend", static_alloc=True)
blk.optimize_for(x, backend="secondBackend", clear=False, dedup_subgraph=True)
```
#### After
`clear` default value is `False`, we simply chain them
```
blk.optimize_for(x, backend="firstBackend", static_alloc=True)
blk.optimize_for(x, backend="secondBackend", dedup_subgraph=True)
```

cc @samskalicky who helped to design the API offline and reviewed the  `1.x` related PR #19386 
     @mseth10 who helped by reviewing the `1.x` PR