### PR TITLE
Mark test_dropout as flaky

### DIFF
--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -6463,8 +6463,7 @@ def test_stack():
         check_numeric_gradient(out, inputs)
 
 
-## TODO: test fails intermittently when cudnn on. temporarily disabled cudnn until gets fixed.
-## tracked at https://github.com/apache/incubator-mxnet/issues/14288
+@pytest.mark.flaky
 def test_dropout():
     def zero_count(array, ratio):
         zeros = 0
@@ -6591,18 +6590,18 @@ def test_dropout():
     check_dropout_ratio(1.0, shape)
     check_dropout_ratio(0.75, shape)
     check_dropout_ratio(0.25, shape)
-    # check_dropout_ratio(0.5, shape, cudnn_off=False)
-    # check_dropout_ratio(0.0, shape, cudnn_off=False)
-    # check_dropout_ratio(1.0, shape, cudnn_off=False)
-    # check_dropout_ratio(0.75, shape, cudnn_off=False)
-    # check_dropout_ratio(0.25, shape, cudnn_off=False)
+    check_dropout_ratio(0.5, shape, cudnn_off=False)
+    check_dropout_ratio(0.0, shape, cudnn_off=False)
+    check_dropout_ratio(1.0, shape, cudnn_off=False)
+    check_dropout_ratio(0.75, shape, cudnn_off=False)
+    check_dropout_ratio(0.25, shape, cudnn_off=False)
 
     check_passthrough(0.5, shape)
     check_passthrough(0.0, shape)
     check_passthrough(1.0, shape)
-    # check_passthrough(0.5, shape, cudnn_off=False)
-    # check_passthrough(0.0, shape, cudnn_off=False)
-    # check_passthrough(1.0, shape, cudnn_off=False)
+    check_passthrough(0.5, shape, cudnn_off=False)
+    check_passthrough(0.0, shape, cudnn_off=False)
+    check_passthrough(1.0, shape, cudnn_off=False)
 
     nshape = (10, 10, 10, 10)
     with mx.autograd.train_mode():
@@ -6619,19 +6618,19 @@ def test_dropout():
         check_dropout_axes(0.25, nshape, axes = (0, 1, 2))
         check_dropout_axes(0.25, nshape, axes = (0, 2, 3))
         check_dropout_axes(0.25, nshape, axes = (1, 2, 3))
-        # check_dropout_axes(0.25, nshape, axes = (0,), cudnn_off=False)
-        # check_dropout_axes(0.25, nshape, axes = (1,), cudnn_off=False)
-        # check_dropout_axes(0.25, nshape, axes = (2,), cudnn_off=False)
-        # check_dropout_axes(0.25, nshape, axes = (3,), cudnn_off=False)
-        # check_dropout_axes(0.25, nshape, axes = (0, 1), cudnn_off=False)
-        # check_dropout_axes(0.25, nshape, axes = (0, 2), cudnn_off=False)
-        # check_dropout_axes(0.25, nshape, axes = (0, 3), cudnn_off=False)
-        # check_dropout_axes(0.25, nshape, axes = (1, 2), cudnn_off=False)
-        # check_dropout_axes(0.25, nshape, axes = (1, 3), cudnn_off=False)
-        # check_dropout_axes(0.25, nshape, axes = (2, 3), cudnn_off=False)
-        # check_dropout_axes(0.25, nshape, axes = (0, 1, 2), cudnn_off=False)
-        # check_dropout_axes(0.25, nshape, axes = (0, 2, 3), cudnn_off=False)
-        # check_dropout_axes(0.25, nshape, axes = (1, 2, 3), cudnn_off=False)
+        check_dropout_axes(0.25, nshape, axes = (0,), cudnn_off=False)
+        check_dropout_axes(0.25, nshape, axes = (1,), cudnn_off=False)
+        check_dropout_axes(0.25, nshape, axes = (2,), cudnn_off=False)
+        check_dropout_axes(0.25, nshape, axes = (3,), cudnn_off=False)
+        check_dropout_axes(0.25, nshape, axes = (0, 1), cudnn_off=False)
+        check_dropout_axes(0.25, nshape, axes = (0, 2), cudnn_off=False)
+        check_dropout_axes(0.25, nshape, axes = (0, 3), cudnn_off=False)
+        check_dropout_axes(0.25, nshape, axes = (1, 2), cudnn_off=False)
+        check_dropout_axes(0.25, nshape, axes = (1, 3), cudnn_off=False)
+        check_dropout_axes(0.25, nshape, axes = (2, 3), cudnn_off=False)
+        check_dropout_axes(0.25, nshape, axes = (0, 1, 2), cudnn_off=False)
+        check_dropout_axes(0.25, nshape, axes = (0, 2, 3), cudnn_off=False)
+        check_dropout_axes(0.25, nshape, axes = (1, 2, 3), cudnn_off=False)
 
 
 @pytest.mark.skip(reason="test fails intermittently. temporarily disabled till it gets fixed. tracked at https://github.com/apache/incubator-mxnet/issues/11290")


### PR DESCRIPTION
Two issues.

Issue 1: https://github.com/apache/incubator-mxnet/issues/14288

Issue 2:

[2020-11-17T06:58:34.678Z]         def check_passthrough(ratio, shape, cudnn_off=True):
[2020-11-17T06:58:34.678Z]             # test inference_mode forward and then backward
[2020-11-17T06:58:34.678Z]             a = mx.random.uniform(shape=shape)
[2020-11-17T06:58:34.678Z]             a.attach_grad()
[2020-11-17T06:58:34.678Z]             with mx.autograd.record(train_mode=False):
[2020-11-17T06:58:34.678Z]                 b = mx.nd.Dropout(a, ratio, cudnn_off=cudnn_off) # dropout acts as identity
[2020-11-17T06:58:34.678Z]             b.backward()
[2020-11-17T06:58:34.678Z]             assert_almost_equal(a.grad.asnumpy(), mx.nd.ones_like(b).asnumpy())
[2020-11-17T06:58:34.678Z]     
[2020-11-17T06:58:34.678Z]         shape = (100, 100)
[2020-11-17T06:58:34.678Z]         check_dropout_ratio(0.5, shape)
[2020-11-17T06:58:34.678Z]         check_dropout_ratio(0.0, shape)
[2020-11-17T06:58:34.678Z] >       check_dropout_ratio(1.0, shape)
[...]
[2020-11-17T06:58:34.678Z]         # Hopefully should be within ratio/2 %
[2020-11-17T06:58:34.678Z]         error = abs(output_sum - input_sum) / input_sum
[2020-11-17T06:58:34.678Z]         if ratio == 1.0:
[2020-11-17T06:58:34.678Z] >           assert output_zeroes == len(input)
[2020-11-17T06:58:34.678Z] E           assert 9999 == 10000
[2020-11-17T06:58:34.678Z] E             +9999
[2020-11-17T06:58:34.678Z] E             -10000