### PR TITLE
Save/Load Gluon Blocks & HybridBlocks

### DIFF
--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -36,7 +36,7 @@ from ..base import mx_real_t, MXNetError, NDArrayHandle, SymbolHandle, py_str, c
 from .. import symbol, ndarray, initializer, autograd, _deferred_compute as dc, name as _name, \
     profiler as _profiler, context as _context
 from ..symbol.numpy import _symbol as np_symbol
-from ..symbol import Symbol
+from ..symbol import Symbol, fromjson
 from ..ndarray import NDArray
 from .parameter import Parameter, DeferredInitializationError
 from .utils import _indent, _brief_print_list, HookHandle, shape_is_known
@@ -683,11 +683,11 @@ class Block:
                     blk._in_format = mdl['in_format']
                     blk._out_format = mdl['out_format']
                     # get saved symbol
-                    out = Symbol.fromjson(mdl['symbol'])
+                    out = fromjson(mdl['symbol'])
                     syms = []
                     # recreate inputs for this symbol
                     for inp in mdl['inputs']:
-                        syms.append(Symbol.fromjson(inp))
+                        syms.append(fromjson(inp))
                     # reset cached_graph and active status
                     blk._cached_graph = (syms, out)
                     blk._active = True

--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -627,7 +627,7 @@ class Block:
             pnames = list(blk.params.keys())
             for p in pnames:
                 param = blk.params[p]
-                pmap[p]=param._uuid
+                pmap[p] = param._uuid
             # recursively save children
             for child in blk._children.values():
                 index[0] += 1
@@ -636,7 +636,7 @@ class Block:
         index = [0]
         _save_cached_graphs(self, index, model)
         # save model
-        fp = open(prefix+'-model.json','w')
+        fp = open(prefix+'-model.json', 'w')
         json.dump(model, fp)
         fp.close()
         # save params

--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -636,9 +636,8 @@ class Block:
         index = [0]
         _save_cached_graphs(self, index, model)
         # save model
-        fp = open(prefix+'-model.json', 'w')
-        json.dump(model, fp)
-        fp.close()
+        with open(prefix+'-model.json', 'w') as fp:
+            json.dump(model, fp)
         # save params
         self.save_parameters('MyModel-model.params')
 
@@ -669,9 +668,9 @@ class Block:
             <prefix>-model.json and <prefix>-model.params
         """
         # load model json from file
-        fp = open(prefix+'-model.json')
-        model = json.load(fp)
-        fp.close()
+        with open(prefix+'-model.json') as fp:
+            model = json.load(fp)
+
         def _load_cached_graphs(blk, index, structure):
             # get block name
             name = type(blk).__name__.lower()

--- a/python/mxnet/symbol/symbol.py
+++ b/python/mxnet/symbol/symbol.py
@@ -46,7 +46,7 @@ from ..util import is_np_shape
 from ..profiler import scope as _profiler_scope
 from ..profiler import _current_scope as _current_profiler_scope
 
-__all__ = ["Symbol", "var", "Variable", "Group",
+__all__ = ["Symbol", "var", "Variable", "Group", "load", "fromjson",
            "pow", "power", "maximum", "minimum", "hypot", "eye", "zeros",
            "ones", "full", "arange", "linspace", "histogram", "split_v2"]
 
@@ -1395,38 +1395,6 @@ class Symbol(SymbolBase):
         else:
             check_call(_LIB.MXSymbolSaveToFile(self.handle, c_str(fname)))
 
-    def load(self, fname):
-        """Loads symbol from a JSON file.
-
-        You can also use pickle to do the job if you only work on python.
-        The advantage of load/save is the file is language agnostic.
-        This means the file saved using save can be loaded by other language binding of mxnet.
-        You also get the benefit being able to directly load/save from cloud storage(S3, HDFS).
-
-        Parameters
-        ----------
-        fname : str
-            The name of the file, examples:
-
-            - `s3://my-bucket/path/my-s3-symbol`
-            - `hdfs://my-bucket/path/my-hdfs-symbol`
-            - `/path-to/my-local-symbol`
-
-        Returns
-        -------
-        sym : Symbol
-            The loaded symbol.
-
-        See Also
-        --------
-        Symbol.save : Used to save symbol into file.
-        """
-        if not isinstance(fname, string_types):
-            raise TypeError('fname need to be string')
-        handle = SymbolHandle()
-        check_call(_LIB.MXSymbolCreateFromFile(c_str(fname), ctypes.byref(handle)))
-        return Symbol(handle)
-
     def tojson(self, remove_amp_cast=True):
         """Saves symbol to a JSON string.
 
@@ -1442,29 +1410,6 @@ class Symbol(SymbolBase):
         else:
             check_call(_LIB.MXSymbolSaveToJSON(self.handle, ctypes.byref(json_str)))
         return py_str(json_str.value)
-
-    def fromjson(self, json_str):
-        """Loads symbol from json string.
-
-        Parameters
-        ----------
-        json_str : str
-            A JSON string.
-
-        Returns
-        -------
-        sym : Symbol
-            The loaded symbol.
-
-        See Also
-        --------
-        Symbol.tojson : Used to save symbol into json string.
-        """
-        if not isinstance(json_str, string_types):
-            raise TypeError('fname required to be string')
-        handle = SymbolHandle()
-        check_call(_LIB.MXSymbolCreateFromJSON(c_str(json_str), ctypes.byref(handle)))
-        return Symbol(handle)
 
     @staticmethod
     def _get_ndarray_inputs(arg_key, args, arg_names, allow_missing):
@@ -2841,6 +2786,63 @@ def Group(symbols, create_fn=Symbol):
         mx_uint(len(symbols)),
         c_handle_array(symbols), ctypes.byref(handle)))
     return create_fn(handle)
+
+
+def load(fname):
+    """Loads symbol from a JSON file.
+
+    You can also use pickle to do the job if you only work on python.
+    The advantage of load/save is the file is language agnostic.
+    This means the file saved using save can be loaded by other language binding of mxnet.
+    You also get the benefit being able to directly load/save from cloud storage(S3, HDFS).
+
+    Parameters
+    ----------
+    fname : str
+        The name of the file, examples:
+
+        - `s3://my-bucket/path/my-s3-symbol`
+        - `hdfs://my-bucket/path/my-hdfs-symbol`
+        - `/path-to/my-local-symbol`
+
+    Returns
+    -------
+    sym : Symbol
+        The loaded symbol.
+
+    See Also
+    --------
+    Symbol.save : Used to save symbol into file.
+    """
+    if not isinstance(fname, string_types):
+        raise TypeError('fname need to be string')
+    handle = SymbolHandle()
+    check_call(_LIB.MXSymbolCreateFromFile(c_str(fname), ctypes.byref(handle)))
+    return Symbol(handle)
+
+
+def fromjson(json_str):
+    """Loads symbol from json string.
+
+    Parameters
+    ----------
+    json_str : str
+        A JSON string.
+
+    Returns
+    -------
+    sym : Symbol
+        The loaded symbol.
+
+    See Also
+    --------
+    Symbol.tojson : Used to save symbol into json string.
+    """
+    if not isinstance(json_str, string_types):
+        raise TypeError('fname required to be string')
+    handle = SymbolHandle()
+    check_call(_LIB.MXSymbolCreateFromJSON(c_str(json_str), ctypes.byref(handle)))
+    return Symbol(handle)
 
 
 # pylint: disable=no-member

--- a/python/mxnet/symbol/symbol.py
+++ b/python/mxnet/symbol/symbol.py
@@ -46,7 +46,7 @@ from ..util import is_np_shape
 from ..profiler import scope as _profiler_scope
 from ..profiler import _current_scope as _current_profiler_scope
 
-__all__ = ["Symbol", "var", "Variable", "Group", "load", "load_json",
+__all__ = ["Symbol", "var", "Variable", "Group",
            "pow", "power", "maximum", "minimum", "hypot", "eye", "zeros",
            "ones", "full", "arange", "linspace", "histogram", "split_v2"]
 
@@ -1395,12 +1395,45 @@ class Symbol(SymbolBase):
         else:
             check_call(_LIB.MXSymbolSaveToFile(self.handle, c_str(fname)))
 
+    def load(fname):
+        """Loads symbol from a JSON file.
+
+        You can also use pickle to do the job if you only work on python.
+        The advantage of load/save is the file is language agnostic.
+        This means the file saved using save can be loaded by other language binding of mxnet.
+        You also get the benefit being able to directly load/save from cloud storage(S3, HDFS).
+
+        Parameters
+        ----------
+        fname : str
+            The name of the file, examples:
+
+            - `s3://my-bucket/path/my-s3-symbol`
+            - `hdfs://my-bucket/path/my-hdfs-symbol`
+            - `/path-to/my-local-symbol`
+
+        Returns
+        -------
+        sym : Symbol
+            The loaded symbol.
+
+        See Also
+        --------
+        Symbol.save : Used to save symbol into file.
+        """
+        if not isinstance(fname, string_types):
+            raise TypeError('fname need to be string')
+        handle = SymbolHandle()
+        check_call(_LIB.MXSymbolCreateFromFile(c_str(fname), ctypes.byref(handle)))
+        return Symbol(handle)
+
+            
     def tojson(self, remove_amp_cast=True):
         """Saves symbol to a JSON string.
 
         See Also
         --------
-        symbol.load_json : Used to load symbol from JSON string.
+        symbol.fromjson : Used to load symbol from JSON string.
         """
         json_str = ctypes.c_char_p()
         if remove_amp_cast:
@@ -1411,6 +1444,30 @@ class Symbol(SymbolBase):
             check_call(_LIB.MXSymbolSaveToJSON(self.handle, ctypes.byref(json_str)))
         return py_str(json_str.value)
 
+    def fromjson(json_str):
+        """Loads symbol from json string.
+
+        Parameters
+        ----------
+        json_str : str
+            A JSON string.
+
+        Returns
+        -------
+        sym : Symbol
+            The loaded symbol.
+
+        See Also
+        --------
+        Symbol.tojson : Used to save symbol into json string.
+        """
+        if not isinstance(json_str, string_types):
+            raise TypeError('fname required to be string')
+        handle = SymbolHandle()
+        check_call(_LIB.MXSymbolCreateFromJSON(c_str(json_str), ctypes.byref(handle)))
+        return Symbol(handle)
+
+    
     @staticmethod
     def _get_ndarray_inputs(arg_key, args, arg_names, allow_missing):
         """Helper function to get NDArray lists handles from various inputs.
@@ -2786,63 +2843,6 @@ def Group(symbols, create_fn=Symbol):
         mx_uint(len(symbols)),
         c_handle_array(symbols), ctypes.byref(handle)))
     return create_fn(handle)
-
-
-def load(fname):
-    """Loads symbol from a JSON file.
-
-    You can also use pickle to do the job if you only work on python.
-    The advantage of load/save is the file is language agnostic.
-    This means the file saved using save can be loaded by other language binding of mxnet.
-    You also get the benefit being able to directly load/save from cloud storage(S3, HDFS).
-
-    Parameters
-    ----------
-    fname : str
-        The name of the file, examples:
-
-        - `s3://my-bucket/path/my-s3-symbol`
-        - `hdfs://my-bucket/path/my-hdfs-symbol`
-        - `/path-to/my-local-symbol`
-
-    Returns
-    -------
-    sym : Symbol
-        The loaded symbol.
-
-    See Also
-    --------
-    Symbol.save : Used to save symbol into file.
-    """
-    if not isinstance(fname, string_types):
-        raise TypeError('fname need to be string')
-    handle = SymbolHandle()
-    check_call(_LIB.MXSymbolCreateFromFile(c_str(fname), ctypes.byref(handle)))
-    return Symbol(handle)
-
-
-def load_json(json_str):
-    """Loads symbol from json string.
-
-    Parameters
-    ----------
-    json_str : str
-        A JSON string.
-
-    Returns
-    -------
-    sym : Symbol
-        The loaded symbol.
-
-    See Also
-    --------
-    Symbol.tojson : Used to save symbol into json string.
-    """
-    if not isinstance(json_str, string_types):
-        raise TypeError('fname required to be string')
-    handle = SymbolHandle()
-    check_call(_LIB.MXSymbolCreateFromJSON(c_str(json_str), ctypes.byref(handle)))
-    return Symbol(handle)
 
 
 # pylint: disable=no-member

--- a/python/mxnet/symbol/symbol.py
+++ b/python/mxnet/symbol/symbol.py
@@ -1395,7 +1395,7 @@ class Symbol(SymbolBase):
         else:
             check_call(_LIB.MXSymbolSaveToFile(self.handle, c_str(fname)))
 
-    def load(fname):
+    def load(self, fname):
         """Loads symbol from a JSON file.
 
         You can also use pickle to do the job if you only work on python.
@@ -1427,7 +1427,6 @@ class Symbol(SymbolBase):
         check_call(_LIB.MXSymbolCreateFromFile(c_str(fname), ctypes.byref(handle)))
         return Symbol(handle)
 
-            
     def tojson(self, remove_amp_cast=True):
         """Saves symbol to a JSON string.
 
@@ -1444,7 +1443,7 @@ class Symbol(SymbolBase):
             check_call(_LIB.MXSymbolSaveToJSON(self.handle, ctypes.byref(json_str)))
         return py_str(json_str.value)
 
-    def fromjson(json_str):
+    def fromjson(self, json_str):
         """Loads symbol from json string.
 
         Parameters
@@ -1467,7 +1466,6 @@ class Symbol(SymbolBase):
         check_call(_LIB.MXSymbolCreateFromJSON(c_str(json_str), ctypes.byref(handle)))
         return Symbol(handle)
 
-    
     @staticmethod
     def _get_ndarray_inputs(arg_key, args, arg_names, allow_missing):
         """Helper function to get NDArray lists handles from various inputs.

--- a/tests/python/unittest/test_contrib_control_flow.py
+++ b/tests/python/unittest/test_contrib_control_flow.py
@@ -1135,7 +1135,7 @@ def test_foreach():
         out.extend(states)
         out = mx.sym.Group(out)
         js_1 = out.tojson()
-        out = mx.sym.load_json(js_1)
+        out = mx.sym.fromjson(js_1)
         js_2 = out.tojson()
         assert js_1 == js_2
         arr_grads = []
@@ -1457,7 +1457,7 @@ def test_foreach_nested():
     out = mx.sym.broadcast_add(out, states[0])
 
     js_1 = out.tojson()
-    out = mx.sym.load_json(js_1)
+    out = mx.sym.fromjson(js_1)
     js_2 = out.tojson()
     assert js_1 == js_2
 

--- a/tests/python/unittest/test_contrib_operator.py
+++ b/tests/python/unittest/test_contrib_operator.py
@@ -415,7 +415,7 @@ def test_dynamic_reshape():
         shape = mx.sym.Variable('shape')
         net = mx.sym.contrib.dynamic_reshape(data, shape)
         js = net.tojson()
-        net = mx.sym.load_json(js)
+        net = mx.sym.fromjson(js)
         dat_npy = np.random.rand(*src_shape)
         grad_npy = np.random.rand(*dst_shape)
         args = {

--- a/tests/python/unittest/test_gluon_save.py
+++ b/tests/python/unittest/test_gluon_save.py
@@ -58,5 +58,3 @@ def test_save():
     # run inference again
     out2 = net2(x)
     mx.test_utils.assert_almost_equal(out1.asnumpy(), out2.asnumpy())
-
-test_save()

--- a/tests/python/unittest/test_gluon_save.py
+++ b/tests/python/unittest/test_gluon_save.py
@@ -1,0 +1,60 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import mxnet as mx
+
+def test_save():
+    class MyBlock(mx.gluon.Block):
+        def __init__(self, **kwargs):
+            super(MyBlock, self).__init__(**kwargs)
+            self.layers = []
+        def add(self, block):
+            self.layers.append(block)
+            self.register_child(block)
+        def forward(self, x, *args):
+            out = (x,) + args
+            for block in self._children.values():
+                out = block()(*out)
+            return out
+
+    def createNet():
+        inside = MyBlock()
+        dense = mx.gluon.nn.Dense(10)
+        inside.add(dense)
+        net = MyBlock()
+        net.add(inside)
+        net.add(mx.gluon.nn.Dense(10))
+        return net
+
+    # create and initialize model
+    net1 = createNet()
+    net1.initialize()
+    # hybridize (the hybridizeable blocks, ie. the Dense layers)
+    net1.hybridize()
+    x = mx.nd.random.randn(1,10)
+    out1 = net1(x)
+
+    # save hybridized model
+    net1.save('MyModel')
+
+    # create a new model, uninitialized
+    net2 = createNet()
+    # reload hybridized model
+    net2.load('MyModel')
+    # run inference again
+    out2 = net2(x)
+    mx.test_utils.assert_almost_equal(out1.asnumpy(), out2.asnumpy())

--- a/tests/python/unittest/test_gluon_save.py
+++ b/tests/python/unittest/test_gluon_save.py
@@ -45,7 +45,7 @@ def test_save():
     net1.initialize()
     # hybridize (the hybridizeable blocks, ie. the Dense layers)
     net1.hybridize()
-    x = mx.nd.zeros(1,10)
+    x = mx.nd.zeros((1,10))
     out1 = net1(x)
 
     # save hybridized model

--- a/tests/python/unittest/test_gluon_save.py
+++ b/tests/python/unittest/test_gluon_save.py
@@ -45,7 +45,7 @@ def test_save():
     net1.initialize()
     # hybridize (the hybridizeable blocks, ie. the Dense layers)
     net1.hybridize()
-    x = mx.nd.random.randn(1,10)
+    x = mx.nd.zeros(1,10)
     out1 = net1(x)
 
     # save hybridized model

--- a/tests/python/unittest/test_gluon_save.py
+++ b/tests/python/unittest/test_gluon_save.py
@@ -58,3 +58,5 @@ def test_save():
     # run inference again
     out2 = net2(x)
     mx.test_utils.assert_almost_equal(out1.asnumpy(), out2.asnumpy())
+
+test_save()

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -2269,7 +2269,7 @@ def test_reshape_new(src_shape, shape_args, reverse, dst_shape):
     net = mx.sym.Variable("data")
     net = mx.sym.Reshape(net, shape=shape_args, reverse=reverse)
     js = net.tojson()
-    net = mx.sym.load_json(js)
+    net = mx.sym.fromjson(js)
     _, output_shape, __ = net.infer_shape(data=src_shape)
     assert output_shape[0] == dst_shape, \
         'Src Shape = %s, Shape Arguments = %s, Reverse = %s, Dst Shape = %s, ' \
@@ -2308,7 +2308,7 @@ def test_reshape_old():
     net = mx.sym.Variable("data")
     net = mx.sym.Reshape(net, target_shape=(2, 0))
     js = net.tojson()
-    net = mx.sym.load_json(js)
+    net = mx.sym.fromjson(js)
     _, output_shape, __ = net.infer_shape(data=(2, 3, 5, 5))
     assert(output_shape[0] == (2, 75))
     # Test for Flatten
@@ -2329,7 +2329,7 @@ def test_reshape_like():
         rhs = mx.sym.Variable("rhs")
         net = mx.sym.reshape_like(lhs, rhs, lhs_begin=lbeg, lhs_end=lend, rhs_begin=rbeg, rhs_end=rend)
         js = net.tojson()
-        net = mx.sym.load_json(js)
+        net = mx.sym.fromjson(js)
         _, output_shape, __ = net.infer_shape(lhs=lhs_shape, rhs=rhs_shape)
 
         assert output_shape[0] == dst_shape, \
@@ -2370,7 +2370,7 @@ def test_reshape_like():
     rhs = mx.sym.Variable("rhs")
     net = mx.sym.reshape_like(lhs, rhs)
     js = net.tojson()
-    net = mx.sym.load_json(js)
+    net = mx.sym.fromjson(js)
     _, output_shape, __ = net.infer_shape(lhs=(40, 30), rhs=(30,20,2))
     assert(output_shape[0] == (30,20,2))
 


### PR DESCRIPTION
## Description ##
master branch version of PoC for saving & loading Gluon Blocks & HybridBlocks from #19535. Version for v1.x is #19565. This PR is fundamentally different due to the changes on the master branch for block names/UUIDs compared to v1.x

This PR adds 2 new APIs to Gluon Blocks:

### save
Saves the model parameters and a json structure of the model that stores the various names/UUIDs in order to later restore and match the saved parameters. This does not actually store the model. Users still need to recreate their model architecture using their Gluon code in Python. 

It also stores the hybridized Symbol objects for HybridBlocks and associated settings so that it can be later reloaded.

### load
Loads the model parameters and a json structure of the model. It restores the names/UUIDs of blocks in order to match the saved parameters.

Also restores hybridized Symbol objects in HybridBlocks so they do not need to be hybridized again. After calling the `load` API users can immediately run inference without needing to hybridize.

## Other changes
- renames `load_json` function in Symbol namespace to `fromjson` to match the corresponding `tojson` API
