### PR TITLE
Fix compilation with USE_LAPACK=0 USE_BLAS=mkl

### DIFF
--- a/3rdparty/mshadow/mshadow/base.h
+++ b/3rdparty/mshadow/mshadow/base.h
@@ -337,7 +337,7 @@ const float kPi = 3.1415926f;
   typedef index_t openmp_index_t;
 #endif
 
-#if MSHADOW_USE_MKL
+#if MSHADOW_USE_MKL && MXNET_USE_LAPACK
   // lapack_index_t could be replaced by index_t and removed when all blas library support large tensor
   typedef index_t lapack_index_t;
 #else


### PR DESCRIPTION
## Description ##
Fix  building with USE_LAPACK=0 USE_BLAS=mkl options broken by https://github.com/apache/incubator-mxnet/pull/19067
