### PR TITLE
Fix serialization bug for writing large arrays to npz

### DIFF
--- a/src/serialization/cnpy.cc
+++ b/src/serialization/cnpy.cc
@@ -315,7 +315,8 @@ size_t npy_header_blob_read_callback(void *pOpaque, mz_uint64 file_ofs, void *pB
         std::memcpy(pBuf_blob, blob->dptr_, n - npy_header_n);
     } else {
         // Read n bytes from blob
-        const void* pSrc = static_cast<const void*>(static_cast<char*>(blob->dptr_) + file_ofs);
+        const void* pSrc = static_cast<const void*>(
+            static_cast<char*>(blob->dptr_) + file_ofs - npy_header->size());
         std::memcpy(pBuf, pSrc, n);
     }
     return n;

--- a/tests/python/unittest/test_numpy_ndarray.py
+++ b/tests/python/unittest/test_numpy_ndarray.py
@@ -1000,6 +1000,16 @@ def test_np_ndarray_indexing():
 
 
 @use_np
+@pytest.mark.parametrize('load_fn', [_np.load, npx.load])
+def test_np_save_load_large_ndarrays(load_fn, tmp_path):
+    weight = mx.np.arange(32768 * 512).reshape((32768, 512))
+    mx.npx.savez(str(tmp_path / 'params.npz'), weight=weight)
+    arr_loaded = load_fn(str(tmp_path / 'params.npz'))['weight']
+    assert _np.array_equal(arr_loaded.asnumpy() if load_fn is npx.load
+                           else arr_loaded, weight)
+
+
+@use_np
 @pytest.mark.serial
 @pytest.mark.parametrize('load_fn', [_np.load, npx.load])
 def test_np_save_load_ndarrays(load_fn):


### PR DESCRIPTION
## Description ##
Fixes https://github.com/apache/incubator-mxnet/issues/19595

There was an index offset bug in the branch responsible for large arrays. The bug was introduced when rewriting the `zip_source_buffer_fragment_create` functionality of libzip for miniz. This functionality is important to write multiple buffers (npy header buffer and data buffer) to the same zip entry without extra memory allocation. miniz is more "lowlevel" and doesn't contain such convenience API (but supports inplace appending to a zipfile which is important for writing multiple arrays to same npz file).

Turns out the CI didn't test saving large arrays and this bug went unnoticed.
