### PR TITLE
Support destructors for custom stateful ops

### DIFF
--- a/ci/docker/install/requirements
+++ b/ci/docker/install/requirements
@@ -31,5 +31,4 @@ pylint==2.3.1  # pylint and astroid need to be aligned
 astroid==2.3.3  # pylint and astroid need to be aligned
 requests<2.19.0,>=2.18.4
 scipy==1.2.1
-six==1.11.0
 setuptools<50

--- a/example/extensions/lib_custom_op/gemm_lib.cc
+++ b/example/extensions/lib_custom_op/gemm_lib.cc
@@ -184,6 +184,10 @@ class MyStatefulGemm : public CustomStatefulOp {
                           const std::unordered_map<std::string, std::string>& attrs)
     : count(count), attrs_(attrs) {}
 
+  ~MyStatefulGemm() {
+    std::cout << "Info: destructing MyStatefulGemm" << std::endl;
+  }
+  
   MXReturnValue Forward(std::vector<MXTensor>* inputs,
                         std::vector<MXTensor>* outputs,
                         const OpResource& op_res) {

--- a/example/extensions/lib_custom_op/gemm_lib.cc
+++ b/example/extensions/lib_custom_op/gemm_lib.cc
@@ -214,7 +214,7 @@ MXReturnValue createOpState(const std::unordered_map<std::string, std::string>& 
   // testing passing of keyword arguments
   int count = attrs.count("test_kw") > 0 ? std::stoi(attrs.at("test_kw")) : 0;
   // creating stateful operator instance
-  *op_inst = new MyStatefulGemm(count, attrs);
+  *op_inst = CustomStatefulOp::create<MyStatefulGemm>(count, attrs);
   std::cout << "Info: stateful operator created" << std::endl;
   return MX_SUCCESS;
 }

--- a/example/extensions/lib_custom_op/transposerowsp_lib.cc
+++ b/example/extensions/lib_custom_op/transposerowsp_lib.cc
@@ -185,6 +185,7 @@ MXReturnValue createOpState(const std::unordered_map<std::string, std::string>& 
   int count = attrs.count("test_kw") > 0 ? std::stoi(attrs.at("test_kw")) : 0;
   // creating stateful operator instance
   *op_inst = new MyStatefulTransposeRowSP(count, attrs);
+  (*op_inst)->ignore_warn = true;
   std::cout << "Info: stateful operator created" << std::endl;
   return MX_SUCCESS;
 }

--- a/include/mxnet/lib_api.h
+++ b/include/mxnet/lib_api.h
@@ -686,6 +686,7 @@ class CustomOpSelector {
  */
 class CustomStatefulOp {
  public:
+  virtual ~CustomStatefulOp();
   virtual MXReturnValue Forward(std::vector<MXTensor>* inputs,
                                 std::vector<MXTensor>* outputs,
                                 const OpResource& op_res) = 0;
@@ -700,6 +701,7 @@ class CustomStatefulOp {
 /*! \brief StatefulOp wrapper class to pass to backend OpState */
 class CustomStatefulOpWrapper {
  public:
+  ~CustomStatefulOpWrapper();
   explicit CustomStatefulOpWrapper(CustomStatefulOp* inst) : instance(inst) {}
   CustomStatefulOp* get_instance() { return instance; }
  private:

--- a/include/mxnet/lib_api.h
+++ b/include/mxnet/lib_api.h
@@ -697,7 +697,7 @@ class CustomStatefulOp {
   }
 
   bool wasCreated() { return created; }
-  
+
   virtual MXReturnValue Forward(std::vector<MXTensor>* inputs,
                                 std::vector<MXTensor>* outputs,
                                 const OpResource& op_res) = 0;
@@ -1019,7 +1019,7 @@ typedef int (*opCallCreateOpState_t)(createOpState_t create_op, const char* cons
 
 #define MXLIB_OPCALLDESTROYOPSTATE_STR "_opCallDestroyOpState"
 typedef int (*opCallDestroyOpState_t)(void* state_op);
- 
+
 #define MXLIB_OPCALLFSTATEFULCOMP_STR "_opCallFStatefulCompute"
 typedef int (*opCallFStatefulComp_t)(int is_forward, void* state_op,
                                      const int64_t** inshapes, int* indims,
@@ -1140,7 +1140,7 @@ class CustomStatefulOpWrapper {
   CustomStatefulOp* instance;
   opCallDestroyOpState_t destroy_;
 };
- 
+
 #if defined(_WIN32) || defined(_WIN64) || defined(__WINDOWS__)
 #define MX_INT_RET  __declspec(dllexport) int __cdecl
 #define MX_VOID_RET __declspec(dllexport) void __cdecl

--- a/include/mxnet/lib_api.h
+++ b/include/mxnet/lib_api.h
@@ -686,7 +686,18 @@ class CustomOpSelector {
  */
 class CustomStatefulOp {
  public:
+  CustomStatefulOp();
   virtual ~CustomStatefulOp();
+
+  template<class A, typename ...Ts>
+  static CustomStatefulOp* create(Ts...args) {
+    CustomStatefulOp* op = new A(args...);
+    op->created = true;
+    return op;
+  }
+
+  bool wasCreated() { return created; }
+  
   virtual MXReturnValue Forward(std::vector<MXTensor>* inputs,
                                 std::vector<MXTensor>* outputs,
                                 const OpResource& op_res) = 0;
@@ -696,6 +707,11 @@ class CustomStatefulOp {
     MX_ERROR_MSG << "Error! Operator does not support backward" << std::endl;
     return MX_FAIL;
   }
+
+  bool ignore_warn;
+
+ private:
+  bool created;
 };
 
 /*! \brief StatefulOp wrapper class to pass to backend OpState */

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -1171,6 +1171,8 @@ void registerOperators(void *lib, int verbose, mxnet::ext::msgSize_t msgSize,
       << "Error custom library failed to create stateful operator '" << name_str << "'" << msgs;
 
       CustomStatefulOp* state_op = reinterpret_cast<CustomStatefulOp*>(state_op_inst);
+      if (!state_op->wasCreated() && !state_op->ignore_warn)
+        LOG(INFO) << "WARNING! Custom stateful op " << state_op_inst << " was created without calling CustomStatefulOp::create(). Please ensure this object was allocated with 'new' since it will be destructed with 'delete'. To suppress this message without calling CustomStatefulOp::create() set ignore_warn to 'true' in CreateOpState function.";
       return OpStatePtr::Create<CustomStatefulOpWrapper>(state_op);
     };
 

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -544,6 +544,9 @@ void registerOperators(void *lib, int verbose, mxnet::ext::msgSize_t msgSize,
   opCallCreateOpState_t callCreateOpState =
     get_func<opCallCreateOpState_t>(lib, const_cast<char*>(MXLIB_OPCALLCREATEOPSTATE_STR));
 
+  opCallDestroyOpState_t callDestroyOpState =
+    get_func<opCallDestroyOpState_t>(lib, const_cast<char*>(MXLIB_OPCALLDESTROYOPSTATE_STR));
+
   opCallFStatefulComp_t callFStatefulComp =
     get_func<opCallFStatefulComp_t>(lib, const_cast<char*>(MXLIB_OPCALLFSTATEFULCOMP_STR));
 
@@ -1172,8 +1175,12 @@ void registerOperators(void *lib, int verbose, mxnet::ext::msgSize_t msgSize,
 
       CustomStatefulOp* state_op = reinterpret_cast<CustomStatefulOp*>(state_op_inst);
       if (!state_op->wasCreated() && !state_op->ignore_warn)
-        LOG(INFO) << "WARNING! Custom stateful op " << state_op_inst << " was created without calling CustomStatefulOp::create(). Please ensure this object was allocated with 'new' since it will be destructed with 'delete'. To suppress this message without calling CustomStatefulOp::create() set ignore_warn to 'true' in CreateOpState function.";
-      return OpStatePtr::Create<CustomStatefulOpWrapper>(state_op);
+        LOG(INFO) << "WARNING! Custom stateful op " << state_op_inst << " was created without "
+                  << "calling CustomStatefulOp::create(). Please ensure this object was "
+                  << "allocated with 'new' since it will be destructed with 'delete'. "
+                  << "To suppress this message without calling CustomStatefulOp::create() "
+                  << "set ignore_warn to 'true' on custom stateful op instance.";
+      return OpStatePtr::Create<CustomStatefulOpWrapper>(state_op, callDestroyOpState);
     };
 
     /* -------------- BELOW IS THE REGISTRATION FOR CUSTOM OPERATORS --------------- */

--- a/src/lib_api.cc
+++ b/src/lib_api.cc
@@ -862,7 +862,7 @@ mxnet::ext::CustomStatefulOp::CustomStatefulOp() : ignore_warn(false), created(f
 mxnet::ext::CustomStatefulOp::~CustomStatefulOp() {};
 
 mxnet::ext::CustomStatefulOpWrapper::~CustomStatefulOpWrapper() {
-  if(instance) delete instance;
+  destroy_(instance);
 }
 
 mxnet::ext::CustomPass::CustomPass() : name("ERROR") {}
@@ -1253,6 +1253,13 @@ MX_INT_RET _opCallCreateOpState(mxnet::ext::createOpState_t create_op, const cha
   mxnet::ext::CustomStatefulOp** op_ptr =
     reinterpret_cast<mxnet::ext::CustomStatefulOp**>(state_op);
   return create_op(attrs, ctx, in_shapes, in_types, op_ptr);
+}
+
+/*! \brief calls StatefulOp destructor for operator from library */
+MX_VOID_RET _opCallDestroyOpState(void* state_op) {
+  mxnet::ext::CustomStatefulOp* op_ptr =
+    reinterpret_cast<mxnet::ext::CustomStatefulOp*>(state_op);
+  delete op_ptr;
 }
 
 /*! \brief returns status of calling Stateful Forward/Backward for operator from library */

--- a/src/lib_api.cc
+++ b/src/lib_api.cc
@@ -858,6 +858,7 @@ void mxnet::ext::CustomOp::raiseDuplicateContextError() {
     + op_name_str + "'");
 }
 
+mxnet::ext::CustomStatefulOp::CustomStatefulOp() : ignore_warn(false), created(false) {};
 mxnet::ext::CustomStatefulOp::~CustomStatefulOp() {};
 
 mxnet::ext::CustomStatefulOpWrapper::~CustomStatefulOpWrapper() {

--- a/src/lib_api.cc
+++ b/src/lib_api.cc
@@ -858,6 +858,12 @@ void mxnet::ext::CustomOp::raiseDuplicateContextError() {
     + op_name_str + "'");
 }
 
+mxnet::ext::CustomStatefulOp::~CustomStatefulOp() {};
+
+mxnet::ext::CustomStatefulOpWrapper::~CustomStatefulOpWrapper() {
+  if(instance) delete instance;
+}
+
 mxnet::ext::CustomPass::CustomPass() : name("ERROR") {}
 mxnet::ext::CustomPass::CustomPass(const char* pass_name)
   : name(pass_name) {}

--- a/src/lib_api.cc
+++ b/src/lib_api.cc
@@ -858,8 +858,8 @@ void mxnet::ext::CustomOp::raiseDuplicateContextError() {
     + op_name_str + "'");
 }
 
-mxnet::ext::CustomStatefulOp::CustomStatefulOp() : ignore_warn(false), created(false) {};
-mxnet::ext::CustomStatefulOp::~CustomStatefulOp() {};
+mxnet::ext::CustomStatefulOp::CustomStatefulOp() : ignore_warn(false), created(false) {}
+mxnet::ext::CustomStatefulOp::~CustomStatefulOp() {}
 
 mxnet::ext::CustomStatefulOpWrapper::~CustomStatefulOpWrapper() {
   destroy_(instance);


### PR DESCRIPTION
## Description ##
Support destructors for custom stateful ops
- Adds virtual destructor for CustomStatefulOp base class
- Added new library C API `_opCallDestroyOpState` to call delete on CustomStatefulOp in custom library
- Calls delete on customStatefulOp instance in CustomStatefulOpWrapper destructor
- Adds static `create` API to CustomStatefulOp to create instances of CustomStatefulOp derived classes using `new`. This API takes variadic args and passes them to the constructor of the templated class. For example: `CustomStatefulOp::create<MyStatefulGemm>(count, attrs);`
- Adds an example destructor to the MyStatefulGemm class and calls the new `create` API
- Added check to ensure instances of CustomStatefulOp were created with the `create` API to ensure they are allocated with new (since `delete` will be called on destruction) or emit a suppressible warning message.
- Added an example suppressing the message in the `MyStatefulTransposeRowSP` class
- The `MyStatefulTransposeCSR` class is an example where the message is emitted.

Now, when MXNet calls the destructor for the CustomStatefulOpWrapper class it will subsequently `delete` the instance of the CustomStatefulOp allocated with `new` and call the inherited class's destructor