### PR TITLE
Change __str__ representation of bfloat16 NDArray from uints to floats.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -287,6 +287,7 @@ List of Contributors
 * [Wei Chu](https://github.com/waytrue17)
 * [Joe Evans](https://github.com/josephevans)
 * [Nikolay Ulmasov](https://github.com/r3stl355)
+* [Paweł Głomski](https://github.com/PawelGlomski-Intel)
 
 Label Bot
 ---------

--- a/python/mxnet/ndarray/ndarray.py
+++ b/python/mxnet/ndarray/ndarray.py
@@ -458,6 +458,13 @@ fixed-size items.
 
     __nonzero__ = __bool__
 
+    def __str__(self):
+        """Returns a readable string representation of the array."""
+        if self.dtype == np.dtype([('bfloat16', np.uint16)]):
+            return super(NDArray, self.astype(float)).__str__()
+        else:
+            return super(NDArray, self).__str__()
+
     def __len__(self):
         """Number of element along the first axis."""
         return self.shape[0]

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -2057,3 +2057,9 @@ def test_load_saved_gpu_array_when_no_gpus_are_present():
     # but there are no GPUs
     array.__setstate__(ndarray_state)
 
+def test_readable_bfloat16_print():
+    arr_bfloat16 = mx.nd.linspace(0, 1, 16).reshape((2, 2, 2, 2)).astype(np.dtype([('bfloat16', np.uint16)]))
+    arr_uint16 = arr_bfloat16.asnumpy()
+    arr_float = arr_bfloat16.astype(float)
+    assert (arr_bfloat16.__str__() == arr_float.__str__())
+    assert (arr_bfloat16.__repr__().find(arr_uint16.__str__()) != -1)


### PR DESCRIPTION
`print(mx.nd.arange(1, 5, dtype=[('bfloat16', np.uint16)]))`

Before: `[(16256,) (16384,) (16448,) (16512,)]`
After: `[1. 2. 3. 4.]`

Resolves #18788
