### PR TITLE
Use blas=mkl in nightly large tensor tests

### DIFF
--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -703,6 +703,21 @@ build_ubuntu_cpu_large_tensor() {
     ninja
 }
 
+build_ubuntu_cpu_large_tensor_nightly() {
+    set -ex
+    cd /work/build
+    CC=gcc-7 CXX=g++-7 cmake \
+        -DUSE_SIGNAL_HANDLER=ON                 \
+        -DUSE_CUDA=OFF                          \
+        -DUSE_CUDNN=OFF                         \
+        -DUSE_MKLDNN=ON                         \
+        -DUSE_BLAS=MKL                          \
+        -G Ninja                                \
+        /work/mxnet
+
+    ninja
+}
+
 build_ubuntu_gpu_large_tensor() {
     set -ex
     cd /work/build

--- a/tests/nightly/JenkinsfileForBinaries
+++ b/tests/nightly/JenkinsfileForBinaries
@@ -43,7 +43,7 @@ core_logic: {
       node(NODE_LINUX_GPU) {
         ws('workspace/build-cpu-int64') {
           utils.init_git()
-          utils.docker_run('ubuntu_cpu', 'build_ubuntu_cpu_large_tensor', false)
+          utils.docker_run('ubuntu_cpu', 'build_ubuntu_cpu_large_tensor_nightly', false)
           utils.pack_lib('cpu_int64', mx_lib)
         }
       }


### PR DESCRIPTION
use mkl for nightly large tensors tests for better performance
build tested locally