### PR TITLE
[BUGFIX] Fix backward pass for nested CachedOp

### DIFF
--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -915,7 +915,7 @@ class HybridBlock(Block):
         self._monitor_all = False
         self._backend = None
         self._backend_opts = {}
-        self._partition_if_dynamic = False
+        self._partition_if_dynamic = True
         self._first_forward = True
 
     def __setattr__(self, name, value):
@@ -1174,7 +1174,7 @@ class HybridBlock(Block):
         return _regroup(out, self._out_format)
 
     def optimize_for(self, x, *args, backend=None, clear=False,
-                     partition_if_dynamic=False,
+                     partition_if_dynamic=True,
                      static_alloc=False,
                      static_shape=False,
                      inline_limit=2,
@@ -1281,7 +1281,7 @@ class HybridBlock(Block):
         self._clear_cached_op()
 
     def hybridize(self, active=True,
-                  partition_if_dynamic=False,
+                  partition_if_dynamic=True,
                   static_alloc=False,
                   static_shape=False,
                   inline_limit=2,

--- a/src/imperative/cached_op.cc
+++ b/src/imperative/cached_op.cc
@@ -327,10 +327,9 @@ bool CachedOp::SetBackwardGraph(
   node_range = {num_forward_nodes, idx.num_nodes()};
   entry_range = {num_forward_entries, idx.num_node_entries()};
 
-  bool contain_dynamic_shape = false;
   bool match = true;
   match &= CheckAndInferShape(&g, std::move(shapes), false,
-                              node_range, entry_range, &contain_dynamic_shape);
+                              node_range, entry_range);
   match &= CheckAndInferType(&g, std::move(dtypes), false,
                              node_range, entry_range);
   exec::DevMaskVector dev_mask(idx.num_nodes(), default_ctx.dev_mask());

--- a/src/imperative/cached_op.cc
+++ b/src/imperative/cached_op.cc
@@ -330,7 +330,7 @@ bool CachedOp::SetBackwardGraph(
   bool contain_dynamic_shape = false;
   bool match = true;
   match &= CheckAndInferShape(&g, std::move(shapes), false,
-                              node_range, entry_range, &contain_dynamic_shape;);
+                              node_range, entry_range, &contain_dynamic_shape);
   match &= CheckAndInferType(&g, std::move(dtypes), false,
                              node_range, entry_range);
   exec::DevMaskVector dev_mask(idx.num_nodes(), default_ctx.dev_mask());

--- a/src/imperative/cached_op.cc
+++ b/src/imperative/cached_op.cc
@@ -327,9 +327,10 @@ bool CachedOp::SetBackwardGraph(
   node_range = {num_forward_nodes, idx.num_nodes()};
   entry_range = {num_forward_entries, idx.num_node_entries()};
 
+  bool contain_dynamic_shape = false;
   bool match = true;
   match &= CheckAndInferShape(&g, std::move(shapes), false,
-                              node_range, entry_range);
+                              node_range, entry_range, &contain_dynamic_shape;);
   match &= CheckAndInferType(&g, std::move(dtypes), false,
                              node_range, entry_range);
   exec::DevMaskVector dev_mask(idx.num_nodes(), default_ctx.dev_mask());

--- a/src/imperative/imperative_utils.cc
+++ b/src/imperative/imperative_utils.cc
@@ -84,7 +84,7 @@ void InvokeOperator(const nnvm::IndexedGraph& idx,
   std::vector<uint32_t> &ref_count = *p_ref_count;
 
   const nnvm::IndexedGraph::Node& node = idx[node_idx];
-  if (node.source->op() == bwd_cached_op) {
+  if (node.source->op() == bwd_cached_op && node.source->attrs.name == "_cachedop_backward") {
     const auto& cached_op = dmlc::get<CachedOpPtr>(node.source->attrs.parsed);
     nnvm::Node* fwd_node = node.source->control_deps[0].get();
     auto fwd_node_id = idx.node_id(fwd_node);

--- a/src/operator/subgraph/static_shape_subgraph_property.cc
+++ b/src/operator/subgraph/static_shape_subgraph_property.cc
@@ -54,10 +54,8 @@ class StaticShapeOpSelector: public SubgraphSelector {
   }
 
  private:
-    // static shape ops that fail backward pass inside subgraph CachedOp
-    // GitHub issue: https://github.com/apache/incubator-mxnet/issues/18823
-    std::unordered_set<std::string> unsupported_op_names_ {"Reshape", "_np_reshape", "transpose",
-                                                           "_npi_dstack", "_npi_hstack"};
+    // Rejecte the ops that have FInferShape registered but return true by CheckDynamicShapeExists()
+    std::unordered_set<std::string> unsupported_op_names_ {"_npi_dstack", "_npi_hstack"};
 };
 
 /*


### PR DESCRIPTION
## Description ##
MXNet will error out during the backward propagation if CachedOp is present in the computational graph. This blocks the  custom subgraph partitioning #18823 and the dynamic shape ops optimization #19524. 

Currently CachedOp is used as the symbol executor (external CachedOp) to run the whole graph. It is also used as individual operator inside the graph (internal CachedOp) that combines with other operators. For backward prop, the external CachedOp should be invoked through [`CachedOp::Backward()`](https://github.com/apache/incubator-mxnet/blob/11a7903c09b07f741cf81191be77d48fa8f7f584/src/imperative/cached_op.cc#L1016) while the internal CachedOp should be invoked through [`CachedOpBackward()`](https://github.com/apache/incubator-mxnet/blob/11a7903c09b07f741cf81191be77d48fa8f7f584/src/imperative/cached_op.cc#L1130). However, currently both external and internal CachedOps go through [`CachedOp::Backward()`](https://github.com/apache/incubator-mxnet/blob/11a7903c09b07f741cf81191be77d48fa8f7f584/src/imperative/imperative_utils.cc#L91), which causes the issue. 

The external forward CachedOp was recorded at [`CachedOp::Forward()`](https://github.com/apache/incubator-mxnet/blob/b1b50210f3a9befe421063d3878d43d03c15cf1f/src/imperative/cached_op.cc#L836), with name `_cachedop`. The recorded op is then used to create external backward CachedOp with name `_cachedop_backward`. Hence we utilize op name `_cachedop_backward` to differentiate the way we invoke external/internal backward CachedOps.

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)

