### PR TITLE
[v1.x] Add more ONNX export support to operators

### DIFF
--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -1281,6 +1281,7 @@ integrationtest_ubuntu_cpu_onnx() {
 	pytest tests/python-pytest/onnx/mxnet_export_test.py
 	pytest tests/python-pytest/onnx/test_models.py
 	pytest tests/python-pytest/onnx/test_node.py
+	pytest tests/python-pytest/onnx/test_operators.py
 	pytest tests/python-pytest/onnx/test_onnxruntime.py
 }
 

--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -154,6 +154,17 @@ def create_basic_op_node(op_name, node, kwargs):
     )
     return [node]
 
+def create_const_scalar_node(input_name, value, kwargs):
+    """Helper function to create a tensor value node and a
+    initializer tensor node with constant value."""
+    from onnx.helper import make_tensor, make_tensor_value_info
+    initializer = kwargs["initializer"]
+    input_type = onnx.mapping.NP_TYPE_TO_TENSOR_TYPE[value.dtype]
+    value_node = make_tensor_value_info(input_name, input_type, ())
+    tensor_node = make_tensor(input_name, input_type, (), (value,))
+    initializer.append(tensor_node)
+    return value_node
+
 @mx_op.register("null")
 def convert_weights_and_inputs(node, **kwargs):
     """Helper function to convert weights and inputs.

--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -2380,4 +2380,3 @@ def convert_zeros_like(node, **kwargs):
     )
     return [node]
 
-

--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -2348,6 +2348,7 @@ def convert_stack(node, **kwargs):
 
 @mx_op.register("slice")
 def convert_slice(node, **kwargs):
+    """Map MXNet's slice operator to onnx Slice operator."""
     name, input_nodes, attrs = get_inputs(node, kwargs)
     starts = convert_string_to_list(attrs.get("begin"))
     ends = convert_string_to_list(attrs.get("end"))

--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -2370,7 +2370,7 @@ def convert_zeros_like(node, **kwargs):
     """Map MXNet's zeros_like operator attributes to onnx's ConstantOfShape operator.
     """
     from onnx.helper import make_node, make_tensor
-    name, input_nodes, _ = get_inputs(node, kwargs)
+    name, _, _ = get_inputs(node, kwargs)
 
     # create tensor with shape of input
     create_const_node(name+"_shape", np.array(kwargs['in_shape'][0], dtype='int64'), kwargs)
@@ -2386,7 +2386,7 @@ def convert_arange_like(node, **kwargs):
     """Map MXNet's arange_like operator attributes to onnx's Range and Reshape operators.
     """
     from onnx.helper import make_node
-    name, input_nodes, attrs = get_inputs(node, kwargs)
+    name, _, attrs = get_inputs(node, kwargs)
 
     opset_version = kwargs['opset_version']
     if opset_version < 11:

--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -2392,6 +2392,7 @@ def convert_arange_like(node, **kwargs):
     if opset_version < 11:
         raise AttributeError("ONNX opset 11 or greater is required to export this operator")
 
+    input_type = kwargs['in_type']
     in_shape = kwargs['in_shape']
     axis = attrs.get('axis')
 
@@ -2402,14 +2403,14 @@ def convert_arange_like(node, **kwargs):
         # determine shape of axis
         output_shape = in_shape[0][int(axis)]
 
-    start = np.double(attrs.get('start', 0.))
-    step = np.double(attrs.get('step', 1.))
-    repeat = np.double(attrs.get('repeat', 1))
+    start = np.array([attrs.get('start', 0.)], dtype=onnx.mapping.TENSOR_TYPE_TO_NP_TYPE[input_type])
+    step = np.array([attrs.get('step', 1.)], dtype=onnx.mapping.TENSOR_TYPE_TO_NP_TYPE[input_type])
+    repeat = np.array([attrs.get('repeat', 1)], dtype=onnx.mapping.TENSOR_TYPE_TO_NP_TYPE[input_type])
     if repeat != 1:
         raise NotImplementedError("arange_like operator with repeat != 1 not yet implemented.")
 
     tot_elements = np.prod(output_shape)
-    limit = np.double(start + (tot_elements * step))
+    limit = np.array([start + (tot_elements * step)], dtype=onnx.mapping.TENSOR_TYPE_TO_NP_TYPE[input_type])
 
     # create constant inputs
     create_const_scalar_node(name+"_start", start, kwargs)

--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -2379,4 +2379,3 @@ def convert_zeros_like(node, **kwargs):
         value=tensor_value
     )
     return [node]
-

--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -2393,6 +2393,7 @@ def convert_arange_like(node, **kwargs):
         raise AttributeError("ONNX opset 11 or greater is required to export this operator")
 
     input_type = kwargs['in_type']
+    dtype = onnx.mapping.TENSOR_TYPE_TO_NP_TYPE[input_type]
     in_shape = kwargs['in_shape']
     axis = attrs.get('axis')
 
@@ -2403,14 +2404,14 @@ def convert_arange_like(node, **kwargs):
         # determine shape of axis
         output_shape = in_shape[0][int(axis)]
 
-    start = np.array([attrs.get('start', 0.)], dtype=onnx.mapping.TENSOR_TYPE_TO_NP_TYPE[input_type])
-    step = np.array([attrs.get('step', 1.)], dtype=onnx.mapping.TENSOR_TYPE_TO_NP_TYPE[input_type])
-    repeat = np.array([attrs.get('repeat', 1)], dtype=onnx.mapping.TENSOR_TYPE_TO_NP_TYPE[input_type])
+    start = np.array([attrs.get('start', 0.)], dtype=dtype)
+    step = np.array([attrs.get('step', 1.)], dtype=dtype)
+    repeat = np.array([attrs.get('repeat', 1)], dtype=dtype)
     if repeat != 1:
         raise NotImplementedError("arange_like operator with repeat != 1 not yet implemented.")
 
     tot_elements = np.prod(output_shape)
-    limit = np.array([start + (tot_elements * step)], dtype=onnx.mapping.TENSOR_TYPE_TO_NP_TYPE[input_type])
+    limit = np.array([start + (tot_elements * step)], dtype=dtype)
 
     # create constant inputs
     create_const_scalar_node(name+"_start", start, kwargs)

--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -2369,7 +2369,7 @@ def convert_slice(node, **kwargs):
 def convert_zeros_like(node, **kwargs):
     """Map MXNet's zeros_like operator attributes to onnx's ConstantOfShape operator.
     """
-    name, input_nodes, attrs = get_inputs(node, kwargs)
+    name, input_nodes, _ = get_inputs(node, kwargs)
     tensor_value = onnx.helper.make_tensor(name+"_val", onnx.TensorProto.INT32, [1], [0])
     node = onnx.helper.make_node(
         "ConstantOfShape",
@@ -2379,48 +2379,5 @@ def convert_zeros_like(node, **kwargs):
         value=tensor_value
     )
     return [node]
-
-
-@mx_op.register("_contrib_arange_like")
-def convert_arange_like(node, **kwargs):
-    """Map MXNet's arange_like operator attributes to onnx's Range operator.
-    """
-    name, input_nodes, attrs = get_inputs(node, kwargs)
-
-    opset_version = kwargs['opset_version']
-    if opset_version < 11:
-        raise AttributeError("ONNX opset 11 or greater is required to export this operator")
-
-    in_shape = kwargs['in_shape']
-    axis = attrs.get('axis')
-    if axis is None:
-        # output will be same shape as input
-        raise NotImplementedError("arange_like operator without axis attribute not yet implemented.")
-    else:
-        # determine shape of axis
-        axis_dim = in_shape[int(axis)]
-
-    start = attrs.get('start', np.float32(0.))
-    step = attrs.get('step', np.float32(1.0))
-    repeat = int(attrs.get('repeat', 1))
-    if repeat != 1:
-        raise NotImplementedError("arange_like operator with repeat != 1 not yet implemented.")
-
-    nodes = [
-        create_const_scalar_node(name+"_start", start, kwargs),
-        create_const_scalar_node(name+"_limit", np.float32(np.inf), kwargs),
-        create_const_scalar_node(name+"_step", step, kwargs)
-    ]
-
-    node = onnx.helper.make_node(
-        "Range",
-        [name+"_start", name+"_limit", name+"_step"],
-        [name],
-        name=name
-    )
-    return [node]
-
-
-
 
 

--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -2283,7 +2283,7 @@ def convert_layer_norm(node, **kwargs):
     name, input_nodes, attrs = get_inputs(node, kwargs)
 
     in_shape = kwargs['in_shape']
-    axes = [-i for i in range(len(in_shape), 0, -1)]
+    axes = [-i for i in range(len(in_shape[0]), 0, -1)]
     eps = attrs.get('eps')
     nodes = [
         make_node("ReduceMean", [input_nodes[0]], [name+"_rm0_out"], axes=axes),

--- a/tests/python-pytest/onnx/test_operators.py
+++ b/tests/python-pytest/onnx/test_operators.py
@@ -20,6 +20,7 @@ from mxnet.gluon import HybridBlock, nn
 import numpy as np
 import onnxruntime as rt
 from mxnet.test_utils import assert_almost_equal
+import pytest
 
 def op_export_test(op_name, Model, inputs, tmp_path):
     def export_to_onnx(model, op_name, inputs):
@@ -36,6 +37,8 @@ def op_export_test(op_name, Model, inputs, tmp_path):
         sess = rt.InferenceSession(onnx_file)
         input_name = sess.get_inputs()[0].name
         pred = sess.run(None, {input_name: inputs.asnumpy()})[0]
+        #input_dict = dict((sess.get_inputs()[i].name, inputs[i].asnumpy()) for i in range(len(inputs)))
+        #pred = sess.run(None, input_dict)[0]
         return pred
 
     # create a new model 
@@ -80,6 +83,16 @@ def test_onnx_export_zeros_like(tmp_path):
     x = mx.nd.array([[-2,-1,0],[0,50,99],[4,5,6],[7,8,9]], dtype='float32')
     op_export_test('zeros_like', Model, x, tmp_path)
 
+@pytest.mark.parametrize("dtype", ["float32", "double"])
+def test_onnx_export_arange_like(dtype, tmp_path):
+    class Model(HybridBlock):
+        def __init__(self, **kwargs):
+            super(Model, self).__init__(**kwargs)
+        def hybrid_forward(self, F, x):
+            out = F.contrib.arange_like(x)
+            return out
+    x = mx.nd.array([[-2,-1,0],[0,50,99],[4,5,6],[7,8,9]], dtype=dtype)
+    op_export_test('arange_like', Model, x, tmp_path)
 
 
 if __name__ == '__main__':
@@ -88,4 +101,5 @@ if __name__ == '__main__':
         test_onnx_export_abs(tmp_path)
         test_onnx_export_slice(tmp_path)
         test_onnx_export_zeros_like(tmp_path)
+        test_onnx_export_arange_like(tmp_path)
 

--- a/tests/python-pytest/onnx/test_operators.py
+++ b/tests/python-pytest/onnx/test_operators.py
@@ -1,0 +1,91 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import mxnet as mx
+from mxnet.gluon import HybridBlock, nn
+import numpy as np
+import onnxruntime as rt
+from mxnet.test_utils import assert_almost_equal
+
+def op_export_test(op_name, Model, inputs, tmp_path):
+    def export_to_onnx(model, op_name, inputs):
+        model_path = f'{tmp_path}/{op_name}'
+        model.export(model_path, epoch=0)
+        sym_file = f'{model_path}-symbol.json'
+        params_file = f'{model_path}-0000.params'
+        dtype = inputs[0].dtype
+        onnx_file = f'{tmp_path}/{op_name}.onnx'
+        mx.contrib.onnx.export_model(sym_file, params_file, [inputs.shape],
+                                     dtype, onnx_file)
+        return onnx_file
+    def onnx_rt(onnx_file, inputs):
+        sess = rt.InferenceSession(onnx_file)
+        input_name = sess.get_inputs()[0].name
+        pred = sess.run(None, {input_name: inputs.asnumpy()})[0]
+        return pred
+
+    # create a new model 
+    model = Model()
+    model.initialize(ctx=mx.cpu(0))
+    model.hybridize()
+    pred_nat = model(inputs)
+    print(pred_nat)
+    onnx_file = export_to_onnx(model, op_name, inputs)
+    pred_onx = onnx_rt(onnx_file, inputs)
+    print(pred_onx)
+    assert_almost_equal(pred_nat, pred_onx)
+
+
+def test_onnx_export_abs(tmp_path):
+    class Model(HybridBlock):
+        def __init__(self, **kwargs):
+            super(Model, self).__init__(**kwargs)
+        def hybrid_forward(self, F, x):
+            out = F.abs(x)
+            return out
+    x = mx.nd.array([[-2, -1], [0, 99]], dtype='float32')
+    op_export_test('abs', Model, x, tmp_path)
+
+def test_onnx_export_slice(tmp_path):
+    class Model(HybridBlock):
+        def __init__(self, **kwargs):
+            super(Model, self).__init__(**kwargs)
+        def hybrid_forward(self, F, x):
+            out = F.slice(x, begin=(0,1), end=(2,4))
+            return out
+    x = mx.nd.array([[1,2,3,4],[5,6,7,8],[9,10,11,12]], dtype='float32')
+    op_export_test('slice', Model, x, tmp_path)
+
+def test_onnx_export_zeros_like(tmp_path):
+    class Model(HybridBlock):
+        def __init__(self, **kwargs):
+            super(Model, self).__init__(**kwargs)
+        def hybrid_forward(self, F, x):
+            out = F.zeros_like(x)
+            return out
+    x = mx.nd.array([[-2,-1,0],[0,50,99],[4,5,6],[7,8,9]], dtype='float32')
+    op_export_test('zeros_like', Model, x, tmp_path)
+
+
+
+if __name__ == '__main__':
+    import tempfile
+    with tempfile.TemporaryDirectory() as tmp_path:
+        test_onnx_export_abs(tmp_path)
+        test_onnx_export_slice(tmp_path)
+        test_onnx_export_zeros_like(tmp_path)
+

--- a/tests/python-pytest/onnx/test_operators.py
+++ b/tests/python-pytest/onnx/test_operators.py
@@ -21,6 +21,7 @@ import numpy as np
 import onnxruntime as rt
 from mxnet.test_utils import assert_almost_equal
 import pytest
+import tempfile
 
 def op_export_test(op_name, Model, inputs, tmp_path):
     def export_to_onnx(model, op_name, inputs):
@@ -49,80 +50,85 @@ def op_export_test(op_name, Model, inputs, tmp_path):
     assert_almost_equal(pred_nat, pred_onx)
 
 
-def test_onnx_export_abs(tmp_path):
-    class Model(HybridBlock):
-        def __init__(self, **kwargs):
-            super(Model, self).__init__(**kwargs)
-        def hybrid_forward(self, F, x):
-            out = F.abs(x)
-            return out
-    x = mx.nd.array([[-2, -1], [0, 99]], dtype='float32')
-    op_export_test('abs', Model, [x], tmp_path)
+def test_onnx_export_abs():
+    with tempfile.TemporaryDirectory() as tmp_path:
+        class Model(HybridBlock):
+            def __init__(self, **kwargs):
+                super(Model, self).__init__(**kwargs)
+            def hybrid_forward(self, F, x):
+                out = F.abs(x)
+                return out
+        x = mx.nd.array([[-2, -1], [0, 99]], dtype='float32')
+        op_export_test('abs', Model, [x], tmp_path)
 
-def test_onnx_export_slice(tmp_path):
-    class Model(HybridBlock):
-        def __init__(self, **kwargs):
-            super(Model, self).__init__(**kwargs)
-        def hybrid_forward(self, F, x):
-            out = F.slice(x, begin=(0,1), end=(2,4))
-            return out
-    x = mx.nd.array([[1,2,3,4],[5,6,7,8],[9,10,11,12]], dtype='float32')
-    op_export_test('slice', Model, [x], tmp_path)
+def test_onnx_export_slice():
+    with tempfile.TemporaryDirectory() as tmp_path:
+        class Model(HybridBlock):
+            def __init__(self, **kwargs):
+                super(Model, self).__init__(**kwargs)
+            def hybrid_forward(self, F, x):
+                out = F.slice(x, begin=(0,1), end=(2,4))
+                return out
+        x = mx.nd.array([[1,2,3,4],[5,6,7,8],[9,10,11,12]], dtype='float32')
+        op_export_test('slice', Model, [x], tmp_path)
 
-def test_onnx_export_stack(tmp_path):
-    dtype = 'float32'
-    class Model(HybridBlock):
-        def __init__(self, **kwargs):
-            super(Model, self).__init__(**kwargs)
-        def hybrid_forward(self, F, x, y):
-            out = F.stack(x, y)
-            return out
-    x = mx.nd.array([1, 2], dtype=dtype)
-    y = mx.nd.array([3, 4], dtype=dtype)
-    op_export_test('stack', Model, [x, y], tmp_path)
+def test_onnx_export_stack():
+    with tempfile.TemporaryDirectory() as tmp_path:
+        dtype = 'float32'
+        class Model(HybridBlock):
+            def __init__(self, **kwargs):
+                super(Model, self).__init__(**kwargs)
+            def hybrid_forward(self, F, x, y):
+                out = F.stack(x, y)
+                return out
+        x = mx.nd.array([1, 2], dtype=dtype)
+        y = mx.nd.array([3, 4], dtype=dtype)
+        op_export_test('stack', Model, [x, y], tmp_path)
 
-def test_onnx_export_zeros_like(tmp_path):
-    class Model(HybridBlock):
-        def __init__(self, **kwargs):
-            super(Model, self).__init__(**kwargs)
-        def hybrid_forward(self, F, x):
-            out = F.zeros_like(x)
-            return out
-    x = mx.nd.array([[-2,-1,0],[0,50,99],[4,5,6],[7,8,9]], dtype='float32')
-    op_export_test('zeros_like', Model, [x], tmp_path)
+def test_onnx_export_zeros_like():
+    with tempfile.TemporaryDirectory() as tmp_path:
+        class Model(HybridBlock):
+            def __init__(self, **kwargs):
+                super(Model, self).__init__(**kwargs)
+            def hybrid_forward(self, F, x):
+                out = F.zeros_like(x)
+                return out
+        x = mx.nd.array([[-2,-1,0],[0,50,99],[4,5,6],[7,8,9]], dtype='float32')
+        op_export_test('zeros_like', Model, [x], tmp_path)
 
 @pytest.mark.parametrize("dtype", ["float32", "double"])
-def test_onnx_export_arange_like(dtype, tmp_path):
-    class Model(HybridBlock):
-        def __init__(self, **kwargs):
-            super(Model, self).__init__(**kwargs)
-        def hybrid_forward(self, F, x):
-            out = F.contrib.arange_like(x)
-            return out
-    x = mx.nd.array([[-2,-1,0],[0,50,99],[4,5,6],[7,8,9]], dtype=dtype)
-    op_export_test('arange_like', Model, [x], tmp_path)
+def test_onnx_export_arange_like(dtype):
+    with tempfile.TemporaryDirectory() as tmp_path:
+        class Model(HybridBlock):
+            def __init__(self, **kwargs):
+                super(Model, self).__init__(**kwargs)
+            def hybrid_forward(self, F, x):
+                out = F.contrib.arange_like(x)
+                return out
+        x = mx.nd.array([[-2,-1,0],[0,50,99],[4,5,6],[7,8,9]], dtype=dtype)
+        op_export_test('arange_like', Model, [x], tmp_path)
 
-def test_onnx_export_layernorm(tmp_path):
-    dtype = 'float32'
-    class Model(HybridBlock):
-        def __init__(self, **kwargs):
-            super(Model, self).__init__(**kwargs)
-        def hybrid_forward(self, F, x, gamma, beta):
-            out = F.LayerNorm(x, gamma, beta, axis=1)
-            return out
-    x = mx.nd.array([[1,3],[2,4]], dtype=dtype)
-    gamma = mx.random.uniform(0, 1, x[0].shape).astype(dtype)
-    beta = mx.random.uniform(0, 1, x[0].shape).astype(dtype)
-    op_export_test('LayerNorm', Model, [x, gamma, beta], tmp_path)
+def test_onnx_export_layernorm():
+    with tempfile.TemporaryDirectory() as tmp_path:
+        dtype = 'float32'
+        class Model(HybridBlock):
+            def __init__(self, **kwargs):
+                super(Model, self).__init__(**kwargs)
+            def hybrid_forward(self, F, x, gamma, beta):
+                out = F.LayerNorm(x, gamma, beta, axis=1)
+                return out
+        x = mx.nd.array([[1,3],[2,4]], dtype=dtype)
+        gamma = mx.random.uniform(0, 1, x[0].shape).astype(dtype)
+        beta = mx.random.uniform(0, 1, x[0].shape).astype(dtype)
+        op_export_test('LayerNorm', Model, [x, gamma, beta], tmp_path)
 
 
 if __name__ == '__main__':
-    import tempfile
-    with tempfile.TemporaryDirectory() as tmp_path:
-        test_onnx_export_abs(tmp_path)
-        test_onnx_export_slice(tmp_path)
-        test_onnx_export_stack(tmp_path)
-        test_onnx_export_zeros_like(tmp_path)
-        test_onnx_export_arange_like(tmp_path)
-        test_onnx_export_layernorm(tmp_path)
+    test_onnx_export_abs()
+    test_onnx_export_slice()
+    test_onnx_export_stack()
+    test_onnx_export_zeros_like()
+    test_onnx_export_arange_like('float32')
+    test_onnx_export_arange_like('double')
+    test_onnx_export_layernorm()
 


### PR DESCRIPTION
## Description ##
Implements ONNX export for the following operators:
* gelu (leakyrelu with act_type = 'gelu')
* LayerNorm
* Embedding
* Stack
* arange_like
* zeros_like

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
