### PR TITLE
Enable large tensor inputs for Deconvolution layer

### DIFF
--- a/src/operator/nn/deconvolution-inl.h
+++ b/src/operator/nn/deconvolution-inl.h
@@ -454,7 +454,7 @@ class DeconvolutionOp {
  private:
   inline index_t InitTemp(const mshadow::Shape<4> &ishape,
                           const mshadow::Shape<4> &oshape) {
-    const int ksize = param_.kernel.Size();
+    const index_t ksize = param_.kernel.Size();
     shape_colunit_ = mshadow::Shape2(ishape[1] * ksize,
                                      oshape[2] * oshape[3]);
     shape_dstunit_ = mshadow::Shape3(param_.num_group,

--- a/tests/nightly/test_np_large_array.py
+++ b/tests/nightly/test_np_large_array.py
@@ -2372,3 +2372,25 @@ def test_convolution():
     assert inp.grad.shape == inp.shape
     assert inp.grad[0][0][0][0] == 0
 
+
+@use_np
+def test_deconvolution():
+    dim = 2
+    batch_size = 1
+    channel = 3
+    height = SMALL_Y
+    width = LARGE_X // 5
+    num_filter = 4
+    kernel = (4,) * dim   # => shape = (3, 3)
+
+    inp=mx.np.ones(shape=(batch_size, channel, 1, width))
+    weight = mx.np.ones(shape=(channel, num_filter, kernel[0], kernel[1]))
+    bias = mx.np.array(num_filter,)
+    inp.attach_grad()
+    with mx.autograd.record():
+        out = mx.npx.deconvolution(data=inp, weight=weight, num_filter=num_filter, \
+                                   kernel=kernel, no_bias=True)
+    assert out.shape == (batch_size, channel + 1, kernel[0], width + 3)
+    assert out[0][0][kernel[0]//2][kernel[1]] == channel * num_filter
+    assert inp.grad.shape == inp.shape
+    assert inp.grad[0][0][0][0] == 0


### PR DESCRIPTION
## Description ##
Skipped for now since this takes more than 20 mins. 

## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

## Testing ##
```
(pytest) ubuntu@ip-172-31-90-243 ~/workspace/incubator-mxnet (test_deconv) $ python -m pytest -s --exitfirst --verbose --timeout=0 tests/nightly/test_np_large_array.py::test_deconvolution
==================================================================================================================================== test session starts ====================================================================================================================================
platform linux -- Python 3.6.10, pytest-5.3.5, py-1.8.2, pluggy-0.13.1 -- /home/ubuntu/anaconda3/envs/pytest/bin/python
cachedir: .pytest_cache
rootdir: /home/ubuntu/workspace/incubator-mxnet, inifile: pytest.ini
plugins: timeout-1.4.2, forked-1.3.0
collected 1 item

tests/nightly/test_np_large_array.py::test_deconvolution Setting module np/mx/python random seeds, use MXNET_MODULE_SEED=852951450 to reproduce.
[03:05:10] ../src/storage/storage.cc:199: Using Pooled (Naive) StorageManager for CPU
PASSED

=============================================================================================================================== 1 passed in 128.25s (0:02:08) ===============================================================================================================================
```