### PR TITLE
Fix CI README unittest_ubuntu_python3_armv7 -> unittest_ubuntu_python3_arm

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -64,7 +64,7 @@ non-virtualized platforms:
 
 ```
 ./build.py -p armv7
-./build.py -p test.armv7 /work/runtime_functions.sh unittest_ubuntu_python3_armv7
+./build.py -p test.armv7 /work/runtime_functions.sh unittest_ubuntu_python3_arm
 ```
 
 For the test step to succeed, you must run Linux kernel 4.8 or later and have qemu installed.


### PR DESCRIPTION
The documentation in `ci/README.md` refers to `unittest_ubuntu_python3_armv7` but that condition does not exist.  It should say `unittest_ubuntu_python3_arm`.  Or at least that is the condition that exists and the one CI runs.  