### PR TITLE
[v1.x] Change gcc 8 PPA to ppa:jonathonf/gcc

### DIFF
--- a/ci/docker/install/ubuntu_gcc8.sh
+++ b/ci/docker/install/ubuntu_gcc8.sh
@@ -17,7 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-sudo add-apt-repository ppa:jonathonf/gcc-8.0
-sudo add-apt-repository ppa:jonathonf/gcc-7.3
+sudo add-apt-repository ppa:jonathonf/gcc
 sudo apt-get update || true
 sudo apt-get install -y gcc-8 g++-8


### PR DESCRIPTION
## Description ##
Attempt to fix broken CI for v1.x #19636.  
https://jenkins.mxnet-ci.amazon-ml.com/blue/rest/organizations/jenkins/pipelines/mxnet-validation/pipelines/sanity/branches/PR-19601/runs/7/nodes/39/steps/80/log/?start=0

CI broke because the PPA changed from versioned gcc to one bucket for all the gcc versions: https://launchpad.net/~jonathonf/+archive/ubuntu/gcc

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage