### PR TITLE
[wip] onnx support more ops

### DIFF
--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -2444,7 +2444,8 @@ def convert_sequencemask(node, **kwargs):
     create_const_scalar_node(name+'_0_s', np.int64(0), kwargs)
     create_const_scalar_node(name+'_1_s', np.int64(1), kwargs)
     create_const_scalar_node(name+'_2_s', np.int64(2), kwargs)
-    create_const_scalar_node(name+'_mask_val', np.float32(mask_val), kwargs),
+    make_tensor([mask_val], name+'_mask_val', kwargs["initializer"], dtype='float32')
+    #create_const_scalar_node(name+'_mask_val', np.float32(mask_val), kwargs),
 
     nodes = [
         make_node('Shape', [input_nodes[0]], [name+'_in_shape']),
@@ -2466,7 +2467,7 @@ def convert_sequencemask(node, **kwargs):
             make_node('Cast', [input_nodes[1]], [name+'_cast'], to=int(TensorProto.INT64)),
             make_node('Less', [name+'_reshape_0', name+'_cast'], [name+'_less_1']),
             make_node('Reshape', [name+'_less_1', name+'_shape_1'], [name+"_reshape_1"], name = '3333'),
-            make_node('Where', [name+'_reshape_1', input_nodes[0], name+'_mask_val'], [name]),
+            make_node('Where', [name+'_reshape_1', input_nodes[0], name+'_mask_val'], [name], name=name),
         ]
     else:
         nodes += [
@@ -2476,7 +2477,8 @@ def convert_sequencemask(node, **kwargs):
             make_node('Cast', [name+"_reshape_0"], [name+'_cast'], to=int(TensorProto.INT64)),
             make_node('Less', [name+'_range_1', name+'_cast'], [name+'_less_1']),
             make_node('Reshape', [name+'_less_1', name+'_shape_1'], [name+"_reshape_1"]),
-            make_node('Where', [name+'_reshape_1', input_nodes[0], name+'_mask_val'], [name]),
+            #make_node('Cast', [input_nodes[0]], [name+'_cast111'], to=int(TensorProto.FLOAT)),
+            make_node('Where', [name+'_reshape_1', input_nodes[0], name+'_mask_val'], [name], name=name),
         ]
     return nodes
 

--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -2596,4 +2596,3 @@ def convert_arange_like(node, **kwargs):
         make_node("Reshape", [name+"_range0_out", name+"_shape"], [name])
     ]
     return nodes
-

--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -2349,6 +2349,8 @@ def convert_matmul_selfatt_qk(node, **kwargs):
             make_node('MatMul', [name+'_mul0_out', name+'_transpose2_out'], [name], name=name)
         ]
 
+    return nodes
+
 
 @mx_op.register("broadcast_axis")
 def convert_broadcast_axis(node, **kwargs):

--- a/tests/python-pytest/onnx/test_operators.py
+++ b/tests/python-pytest/onnx/test_operators.py
@@ -90,7 +90,7 @@ def test_onnx_export_zeros_like(tmp_path):
     op_export_test('zeros_like', M, [x], tmp_path)
 
 
-@pytest.mark.parametrize("dtype", ["float32", "double"])
+@pytest.mark.parametrize("dtype", ["float32", "float64"])
 def test_onnx_export_arange_like(tmp_path, dtype):
     M = def_model('contrib.arange_like')
     x = mx.nd.array([[-2,-1,0],[0,50,99],[4,5,6],[7,8,9]], dtype=dtype)
@@ -104,3 +104,40 @@ def test_onnx_export_layernorm(tmp_path):
     beta = mx.random.uniform(0, 1, x[0].shape, dtype='float32')
     op_export_test('LayerNorm', M, [x, gamma, beta], tmp_path)
 
+
+@pytest.mark.parametrize('dtype', ['float32', 'float64', 'int32'])
+def test_onnx_export_broadcast_axis(tmp_path, dtype):
+    M1 = def_model('broadcast_axis', axis=(0, 2), size=(3, 4))
+    M2 = def_model('broadcast_axis', axis=(0, 2), size=(1, 5))
+    x1 = mx.nd.array([[[1], [2]]], dtype=dtype)
+    op_export_test('broadcast_axis_1', M1, [x1], tmp_path)
+    op_export_test('broadcast_axis_2', M2, [x1], tmp_path)
+    M3 = def_model('broadcast_axis', axis=(1, 4), size=(3, 5))
+    x2 = mx.nd.ones((1, 1, 3, 1, 1, 1), dtype=dtype)
+    op_export_test('broadcast_axis_3', M3, [x2], tmp_path)
+
+
+@pytest.mark.parametrize('dtype', ['float32'])
+def test_onnx_export_SequenceMask(tmp_path, dtype):
+    M1 = def_model('SequenceMask', use_sequence_length=True, axis=1, value=-5)
+    M2 = def_model('SequenceMask', use_sequence_length=True, axis=0, value=-99)
+    x = mx.nd.array([[[[  1.,   2.,   3.,  3.5]],
+                      [[  4.,   5.,   6.,  6.5]]],
+                     [[[  7.,   8.,   9.,  9.5]],
+                      [[ 10.,  11.,  12., 12.5]]],
+                     [[[ 13.,  14.,  15., 15.5]],
+                      [[ 16.,  17.,  18., 18.5]]]], dtype=dtype)
+    seq_len1 = mx.nd.array([1, 2, 1], dtype=dtype)
+    seq_len2 = mx.nd.array([1, 2], dtype=dtype)
+    op_export_test('SequenceMask_1', M1, [x, seq_len1], tmp_path)
+    op_export_test('SequenceMask_2', M2, [x, seq_len2], tmp_path)
+
+
+@pytest.mark.parametrize('dtype', ['float32', 'float64', 'int32'])
+def test_onnx_export_contrib_interleaved_matmul_selfatt_qk(tmp_path, dtype):
+    M1 = def_model('contrib.interleaved_matmul_selfatt_qk', heads=3)
+    x1 = mx.nd.random.uniform(0, 1, (3, 3, 3*3*3))
+    op_export_test('contrib_interleaved_matmul_selfatt_qk_1', M1, [x1], tmp_path)
+    M2 = def_model('contrib.interleaved_matmul_selfatt_qk', heads=5)
+    x2 = mx.nd.random.uniform(0, 1, (7, 5, 4*5*6))
+    op_export_test('contrib_interleaved_matmul_selfatt_qk_2', M2, [x2], tmp_path)


### PR DESCRIPTION
- SequenceMask 
- _contrib_interleaved_matmul_selfatt_qk
- broadcast_axis
- reshape (add support for `reverse`)

Test cases to be added after onnx test suite is more complete