### PR TITLE
[v1.x] Migrate to use ECR as docker cache instead of dockerhub

### DIFF
--- a/ci/Jenkinsfile_docker_cache
+++ b/ci/Jenkinsfile_docker_cache
@@ -37,7 +37,7 @@ core_logic: {
       ws('workspace/docker_cache') {
         timeout(time: total_timeout, unit: 'MINUTES') {
           utils.init_git()
-          sh "ci/docker_cache.py --docker-registry ${env.DOCKER_CACHE_REGISTRY}"
+          sh "ci/docker_cache.py --docker-registry ${env.DOCKER_ECR_REGISTRY}"
         }
       }
     }

--- a/ci/Jenkinsfile_utils.groovy
+++ b/ci/Jenkinsfile_utils.groovy
@@ -160,7 +160,7 @@ def collect_test_results_windows(original_file_name, new_file_name) {
 
 
 def docker_run(platform, function_name, use_nvidia, shared_mem = '500m', env_vars = "") {
-  def command = "ci/build.py %ENV_VARS% --docker-registry ${env.DOCKER_CACHE_REGISTRY} %USE_NVIDIA% --platform %PLATFORM% --docker-build-retries 3 --shm-size %SHARED_MEM% /work/runtime_functions.sh %FUNCTION_NAME%"
+  def command = "ci/build.py %ENV_VARS% --docker-registry ${env.DOCKER_ECR_REGISTRY} %USE_NVIDIA% --platform %PLATFORM% --docker-build-retries 3 --shm-size %SHARED_MEM% /work/runtime_functions.sh %FUNCTION_NAME%"
   command = command.replaceAll('%ENV_VARS%', env_vars.length() > 0 ? "-e ${env_vars}" : '')
   command = command.replaceAll('%USE_NVIDIA%', use_nvidia ? '--nvidiadocker' : '')
   command = command.replaceAll('%PLATFORM%', platform)

--- a/ci/build.py
+++ b/ci/build.py
@@ -147,9 +147,6 @@ def build_docker(platform: str, registry: str, num_retries: int, no_cache: bool,
     image_id = _get_local_image_id(docker_tag=tag)
     if not image_id:
         raise FileNotFoundError('Unable to find docker image id matching with {}'.format(tag))
-    # now that we've built the container, push it to our docker cache if DOCKER_ECR_CACHE is defined
-    if 'DOCKER_ECR_REGISTRY' in os.environ:
-        push_docker_cache(registry, tag, image_id)
     return image_id
 
 
@@ -290,9 +287,6 @@ def load_docker_cache(tag, docker_registry) -> None:
     if docker_registry:
         # noinspection PyBroadException
         try:
-            if "dkr.ecr" in docker_registry:
-                # we need to get credentials to login to ECR
-                os.system("$(aws ecr get-login --region ${DOCKER_ECR_REGION} --no-include-email)")
             import docker_cache
             logging.info('Docker cache download is enabled from registry %s', docker_registry)
             docker_cache.load_docker_cache(registry=docker_registry, docker_tag=tag)
@@ -306,9 +300,6 @@ def push_docker_cache(registry, tag, image_id) -> None:
     if registry:
         # noinspection PyBroadException
         try:
-            if "dkr.ecr" in registry:
-                # we need to get credentials to login to ECR
-                os.system("$(aws ecr get-login --region ${DOCKER_ECR_REGION} --no-include-email)")
             import docker_cache
             logging.info('Docker cache upload is enabled to registry %s', registry)
             docker_cache._upload_image(registry, tag, image_id)

--- a/ci/build.py
+++ b/ci/build.py
@@ -265,6 +265,9 @@ def load_docker_cache(tag, docker_registry) -> None:
     if docker_registry:
         # noinspection PyBroadException
         try:
+            if "dkr.ecr" in registry:
+                # we need to get credentials to login to ECR
+                os.system("$(aws ecr get-login --no-include-email)")
             import docker_cache
             logging.info('Docker cache download is enabled from registry %s', docker_registry)
             docker_cache.load_docker_cache(registry=docker_registry, docker_tag=tag)
@@ -275,7 +278,7 @@ def load_docker_cache(tag, docker_registry) -> None:
 
 def push_docker_cache(registry, tag, image_id) -> None:
     """Uploads tagged container to given docker registry"""
-    if docker_registry:
+    if registry:
         # noinspection PyBroadException
         try:
             if "dkr.ecr" in registry:

--- a/ci/build.py
+++ b/ci/build.py
@@ -265,7 +265,7 @@ def load_docker_cache(tag, docker_registry) -> None:
     if docker_registry:
         # noinspection PyBroadException
         try:
-            if "dkr.ecr" in registry:
+            if "dkr.ecr" in docker_registry:
                 # we need to get credentials to login to ECR
                 os.system("$(aws ecr get-login --no-include-email)")
             import docker_cache

--- a/ci/build.py
+++ b/ci/build.py
@@ -295,19 +295,6 @@ def load_docker_cache(tag, docker_registry) -> None:
     else:
         logging.info('Distributed docker cache disabled')
 
-def push_docker_cache(registry, tag, image_id) -> None:
-    """Uploads tagged container to given docker registry"""
-    if registry:
-        # noinspection PyBroadException
-        try:
-            import docker_cache
-            logging.info('Docker cache upload is enabled to registry %s', registry)
-            docker_cache._upload_image(registry, tag, image_id)
-        except Exception:
-            logging.exception('Unable to push image to Docker cache...')
-    else:
-        logging.info('Distributed docker cache disabled')
-
 
 def log_environment():
     instance_info = ec2_instance_info()

--- a/ci/build.py
+++ b/ci/build.py
@@ -123,8 +123,9 @@ def build_docker(platform: str, registry: str, num_retries: int, no_cache: bool,
     image_id = _get_local_image_id(docker_tag=tag)
     if not image_id:
         raise FileNotFoundError('Unable to find docker image id matching with {}'.format(tag))
-    # now that we've built the container, push it to our docker cache
-    push_docker_cache(registry, tag, image_id)
+    # now that we've built the container, push it to our docker cache if DOCKER_ECR_CACHE is defined
+    if 'DOCKER_ECR_REGISTRY' in os.environ:
+        push_docker_cache(registry, tag, image_id)
     return image_id
 
 

--- a/ci/build.py
+++ b/ci/build.py
@@ -273,7 +273,7 @@ def load_docker_cache(tag, docker_registry) -> None:
     else:
         logging.info('Distributed docker cache disabled')
 
-def push_docker_cache(registry, docker_tag, image_id) -> None:
+def push_docker_cache(registry, tag, image_id) -> None:
     """Uploads tagged container to given docker registry"""
     if docker_registry:
         # noinspection PyBroadException

--- a/ci/build.py
+++ b/ci/build.py
@@ -267,7 +267,7 @@ def load_docker_cache(tag, docker_registry) -> None:
         try:
             if "dkr.ecr" in docker_registry:
                 # we need to get credentials to login to ECR
-                os.system("$(aws ecr get-login --no-include-email)")
+                os.system("$(aws ecr get-login --region ${DOCKER_ECR_REGION} --no-include-email)")
             import docker_cache
             logging.info('Docker cache download is enabled from registry %s', docker_registry)
             docker_cache.load_docker_cache(registry=docker_registry, docker_tag=tag)
@@ -283,7 +283,7 @@ def push_docker_cache(registry, tag, image_id) -> None:
         try:
             if "dkr.ecr" in registry:
                 # we need to get credentials to login to ECR
-                os.system("$(aws ecr get-login --no-include-email)")
+                os.system("$(aws ecr get-login --region ${DOCKER_ECR_REGION} --no-include-email)")
             import docker_cache
             logging.info('Docker cache upload is enabled to registry %s', registry)
             docker_cache._upload_image(registry, tag, image_id)

--- a/ci/docker_cache.py
+++ b/ci/docker_cache.py
@@ -96,6 +96,14 @@ def _build_save_container(platform, registry, load_cache) -> Optional[str]:
         # Error handling is done by returning the errorous platform name. This is necessary due to
         # Parallel being unable to handle exceptions
 
+def _ecr_login(registry):
+    """
+    Use the AWS CLI to get credentials to login to ECR.
+    """
+    # extract region from registry
+    region = registry.split(".")[3]
+    logging.info("Logging into ECR region %s using aws-cli..", region)
+    os.system("$(aws ecr get-login --region "+region+" --no-include-email)")
 
 def _upload_image(registry, docker_tag, image_id) -> None:
     """
@@ -105,6 +113,10 @@ def _upload_image(registry, docker_tag, image_id) -> None:
     :param image_id: Image id
     :return: None
     """
+
+    if "dkr.ecr" in registry:
+        _ecr_login(registry)
+
     # We don't have to retag the image since it is already in the right format
     logging.info('Uploading %s (%s) to %s', docker_tag, image_id, registry)
     push_cmd = ['docker', 'push', docker_tag]
@@ -124,6 +136,9 @@ def load_docker_cache(registry, docker_tag) -> None:
     if not registry:
         return
     assert docker_tag
+
+    if "dkr.ecr" in registry:
+        _ecr_login(registry)
 
     logging.info('Loading Docker cache for %s from %s', docker_tag, registry)
     pull_cmd = ['docker', 'pull', docker_tag]

--- a/ci/docker_cache.py
+++ b/ci/docker_cache.py
@@ -84,7 +84,7 @@ def _build_save_container(platform, registry, load_cache) -> Optional[str]:
     logging.debug('Building %s as %s', platform, docker_tag)
     try:
         # Increase the number of retries for building the cache.
-        image_id = build_util.build_docker(docker_binary='docker', platform=platform, registry=registry, num_retries=10, no_cache=False)
+        image_id = build_util.build_docker(platform=platform, registry=registry, num_retries=10, no_cache=False)
         logging.info('Built %s as %s', docker_tag, image_id)
 
         # Push cache to registry


### PR DESCRIPTION
## Description ##
This PR changes the docker tag used in build containers to use a new single ECR registry (defined in a Jenkins environment variable) to retrieve and store build containers. This creates a unique docker tag based on the hash of the Dockerfile and all copied files, to prevent name collisions of build container names between branches.

This should allow CI to be more stable and faster because we won't have to rebuild the containers on every CI run (master branch already reuses docker images built nightly, but other branches can not utilize them because the dockerfiles are different.) 

A jenkins pipeline monitors the v1.x branch and will regenerate the docker images from a restricted node and push them to the ECR registry on PR merge.

Considering there are 60+ stages in the v1.x pipeline and each stage takes about 15 minutes to build the docker images, this would save us about 15 hours of setup time (2 executors per slave node,) so about 7.5 hours of actual instance hours.
