### PR TITLE
[V1.x] Fix local variable 'optimizer' referenced before assignment

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -253,6 +253,7 @@ List of Contributors
 * [Connor Goggins](https://github.com/connorgoggins)
 * [Joe Evans](https://github.com/josephevans)
 * [Zhaoqi Zhu](https://github.com/zha0q1)
+* [Harshit Sharma](https://github.com/harshitshrma)
 
 Label Bot
 ---------

--- a/python/mxnet/model.py
+++ b/python/mxnet/model.py
@@ -903,9 +903,9 @@ class FeedForward(BASE_ESTIMATOR):
                                    rescale_grad=(1.0/batch_size),
                                    **(self.kwargs))
         elif isinstance(self.optimizer, opt.Optimizer):
+            optimizer = self.optimizer
             if not optimizer.idx2name:
                 optimizer.idx2name = param_idx2name.copy()
-            optimizer = self.optimizer
 
         # do training
         _train_multi_device(self.symbol, self.ctx, arg_names, param_names, aux_names,


### PR DESCRIPTION
## Description ##
This PR solves referenced before assignment error for the variable 'optimizer' which occurs when fit method is called (#18791).