### PR TITLE
Extensions naming macros fix

### DIFF
--- a/include/mxnet/lib_api.h
+++ b/include/mxnet/lib_api.h
@@ -919,13 +919,13 @@ class Registry {
 #define MX_TOSTRING(x) MX_STRINGIFY(x)
 
 /*! \brief declare a variable with custom name */
-#define MX_REGISTER_NAME_(Name) MXNet ## _CustomOp ## _
+#define MX_REGISTER_NAME_(Name) MXNet ## _CustomOp ## _ ## Name
 #define MX_REGISTER_DEF_(Name) mxnet::ext::CustomOp MX_REGISTER_NAME_(Name)
 
-#define MX_REGISTER_PROP_NAME_(Name) MXNet ## _CustomSubProp ## _
+#define MX_REGISTER_PROP_NAME_(Name) MXNet ## _CustomSubProp ## _ ## Name
 #define MX_REGISTER_PROP_DEF_(Name) mxnet::ext::CustomPartitioner MX_REGISTER_PROP_NAME_(Name)
 
-#define MX_REGISTER_PASS_NAME_(Name) MXNet ## _CustomPass ## _
+#define MX_REGISTER_PASS_NAME_(Name) MXNet ## _CustomPass ## _ ## Name
 #define MX_REGISTER_PASS_DEF_(Name) mxnet::ext::CustomPass MX_REGISTER_PASS_NAME_(Name)
 
 /*! \brief assign a var to a value */


### PR DESCRIPTION
## Description ##
The macros used to define components in Extensions were not using the name given. This resulted in duplicate defined symbols when ops, partitioners, or graph passes are defined in separate files (ie. compilation units) since the counter is reset:
```
CMakeFiles/pass1.cc.o:(.bss+0x0): multiple definition of `MXNet_CustomPass_0'
CMakeFiles/pass2.cc.o:(.bss+0x0): first defined here
collect2: error: ld returned 1 exit status
```
This PR fixes this by concatenating the given name of the component to the variable name. 

Now, variables will be named:
```
MXNet_CustomPass_0_pass1
MXNet_CustomPass_0_pass2
```