### PR TITLE
Fix CD pipeline - python formatting issue

### DIFF
--- a/python/mxnet/contrib/quantization.py
+++ b/python/mxnet/contrib/quantization.py
@@ -288,7 +288,8 @@ class _LayerHistogramCollector(CalibrationCollector):
                 th_dict[name] = (-th, th)
             del hist_dict[name]  # release the memory
             if logger:
-                logger.debug(f"layer={name}, min_val={min_val}, max_val={max_val}, th={th}, divergence={divergence}")
+                logger.debug("layer={name}, min_val={min_val}, max_val={max_val}, th={th}, divergence={divergence}"
+                             .format(name=name, min_val=min_val, max_val=max_val, th=th, divergence=divergence))
         return th_dict
 
 class _LayerOutputMinMaxCollector(CalibrationCollector):


### PR DESCRIPTION
## Description ##
Quantization commit broke  [CD pipeline to release python docker images](https://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/restricted-mxnet-cd%2Fmxnet-cd-release-job/detail/mxnet-cd-release-job/2186/pipeline)

We've used f-strings in quantization.py file and it fails because CD pipeline uses python 3.5 and this feature is available since version 3.6 of python.

@mseth10 