### PR TITLE
CI: switch to cudnn8 devel docker as it is now available

### DIFF
--- a/ci/docker/Dockerfile.build.ubuntu
+++ b/ci/docker/Dockerfile.build.ubuntu
@@ -144,7 +144,7 @@ COPY runtime_functions.sh /work/
 ####################################################################################################
 FROM base as gpu
 
-# Install TensorRT and CuDNN
+# Install TensorRT
 # Use bash as it has better support for string comparisons in if clauses
 SHELL ["/bin/bash", "-c"]
 # We need to redeclare ARG due to
@@ -169,7 +169,5 @@ RUN export SHORT_CUDA_VERSION=${CUDA_VERSION%.*} && \
                            libnvinfer-plugin${TRT_MAJOR_VERSION}=${TRT_VERSION} \
                            libnvinfer-plugin-dev=${TRT_VERSION}; \
     fi && \
-    apt-get install -y libcudnn8-dev && \
     rm -rf /var/lib/apt/lists/*
 
-ENV CUDNN_VERSION=8.0.5

--- a/ci/docker/docker-compose.yml
+++ b/ci/docker/docker-compose.yml
@@ -95,7 +95,7 @@ services:
       dockerfile: Dockerfile.build.ubuntu
       target: gpu
       args:
-        BASE_IMAGE: nvidia/cuda:11.1-devel-ubuntu18.04
+        BASE_IMAGE: nvidia/cuda:11.1-cudnn8-devel-ubuntu18.04
       cache_from:
         - ${DOCKER_CACHE_REGISTRY}/build.ubuntu_tensorrt_cu111:latest
   ubuntu_gpu_cu111:
@@ -105,7 +105,7 @@ services:
       dockerfile: Dockerfile.build.ubuntu
       target: gpu
       args:
-        BASE_IMAGE: nvidia/cuda:11.1-devel-ubuntu20.04
+        BASE_IMAGE: nvidia/cuda:11.1-cudnn8-devel-ubuntu20.04
       cache_from:
         - ${DOCKER_CACHE_REGISTRY}/build.ubuntu_gpu_cu111:latest
   ###################################################################################################


### PR DESCRIPTION
See https://gitlab.com/nvidia/container-images/cuda/-/issues/83#note_469420005
