### PR TITLE
use CC=gcc-7 CXX=g++-7 for all unix CI builds

### DIFF
--- a/ci/docker/Dockerfile.build.ubuntu
+++ b/ci/docker/Dockerfile.build.ubuntu
@@ -45,7 +45,6 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         unzip \
         pandoc \
         ## Development tools
-        cmake \
         build-essential \
         ninja-build \
         git \

--- a/ci/docker/Dockerfile.build.ubuntu
+++ b/ci/docker/Dockerfile.build.ubuntu
@@ -56,6 +56,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         clang-10 \
         clang-tidy-10 \
         g++ \
+        g++-7 \
         g++-8 \
         intel-mkl-2020.0-088 \
         libomp-dev \

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -314,7 +314,7 @@ build_ubuntu_cpu() {
 build_ubuntu_cpu_openblas() {
     set -ex
     cd /work/build
-    CXXFLAGS="-Wno-error=strict-overflow" cmake \
+    CXXFLAGS="-Wno-error=strict-overflow" CC=gcc-7 CXX=g++-7 cmake \
         -DCMAKE_BUILD_TYPE="RelWithDebInfo" \
         -DENABLE_TESTCOVERAGE=ON \
         -DUSE_TVM_OP=ON \
@@ -331,7 +331,7 @@ build_ubuntu_cpu_openblas() {
 build_ubuntu_cpu_mkl() {
     set -ex
     cd /work/build
-    cmake \
+    CC=gcc-7 CXX=g++-7 cmake \
         -DCMAKE_BUILD_TYPE="RelWithDebInfo" \
         -DENABLE_TESTCOVERAGE=OFF \
         -DUSE_MKLDNN=OFF \
@@ -347,7 +347,7 @@ build_ubuntu_cpu_mkl() {
 build_ubuntu_cpu_cmake_debug() {
     set -ex
     cd /work/build
-    cmake \
+    CC=gcc-7 CXX=g++-7 cmake \
         -DCMAKE_BUILD_TYPE=Debug \
         -DENABLE_TESTCOVERAGE=ON \
         -DUSE_CUDA=OFF \
@@ -364,7 +364,7 @@ build_ubuntu_cpu_cmake_debug() {
 build_ubuntu_cpu_cmake_no_tvm_op() {
     set -ex
     cd /work/build
-    cmake \
+    CC=gcc-7 CXX=g++-7 cmake \
         -DUSE_CUDA=OFF \
         -DUSE_TVM_OP=OFF \
         -DUSE_MKL_IF_AVAILABLE=OFF \
@@ -509,7 +509,7 @@ build_ubuntu_cpu_clang100_mkldnn() {
 build_ubuntu_cpu_mkldnn() {
     set -ex
     cd /work/build
-    cmake \
+    CC=gcc-7 CXX=g++-7 cmake \
         -DCMAKE_BUILD_TYPE="RelWithDebInfo" \
         -DENABLE_TESTCOVERAGE=ON \
         -DUSE_MKL_IF_AVAILABLE=OFF \
@@ -524,7 +524,7 @@ build_ubuntu_cpu_mkldnn() {
 build_ubuntu_cpu_mkldnn_mkl() {
     set -ex
     cd /work/build
-    cmake \
+    CC=gcc-7 CXX=g++-7 cmake \
         -DCMAKE_BUILD_TYPE="RelWithDebInfo" \
         -DENABLE_TESTCOVERAGE=OFF \
         -DUSE_MKLDNN=ON \
@@ -541,6 +541,8 @@ build_ubuntu_gpu_tensorrt() {
 
     set -ex
 
+    export CC=gcc-7
+    export CXX=g++-7
     export ONNX_NAMESPACE=onnx
 
     # Build ONNX
@@ -593,7 +595,7 @@ build_ubuntu_gpu_tensorrt() {
 build_ubuntu_gpu_mkldnn() {
     set -ex
     cd /work/build
-    cmake \
+    CC=gcc-7 CXX=g++-7 cmake \
         -DCMAKE_BUILD_TYPE="RelWithDebInfo" \
         -DUSE_MKL_IF_AVAILABLE=OFF \
         -DUSE_CUDA=ON \
@@ -607,7 +609,7 @@ build_ubuntu_gpu_mkldnn() {
 build_ubuntu_gpu_mkldnn_nocudnn() {
     set -ex
     cd /work/build
-    cmake \
+    CC=gcc-7 CXX=g++-7 cmake \
         -DCMAKE_BUILD_TYPE="RelWithDebInfo" \
         -DUSE_MKL_IF_AVAILABLE=OFF \
         -DUSE_CUDA=ON \
@@ -622,7 +624,7 @@ build_ubuntu_gpu_mkldnn_nocudnn() {
 build_ubuntu_gpu() {
     set -ex
     cd /work/build
-    cmake \
+    CC=gcc-7 CXX=g++-7 cmake \
         -DCMAKE_BUILD_TYPE="RelWithDebInfo" \
         -DUSE_MKL_IF_AVAILABLE=OFF \
         -DUSE_CUDA=ON \
@@ -640,7 +642,7 @@ build_ubuntu_gpu() {
 build_ubuntu_gpu_debug() {
     set -ex
     cd /work/build
-    cmake \
+    CC=gcc-7 CXX=g++-7 cmake \
         -DCMAKE_BUILD_TYPE=Debug \
         -DUSE_MKL_IF_AVAILABLE=OFF \
         -DUSE_CUDA=ON \
@@ -657,7 +659,7 @@ build_ubuntu_gpu_debug() {
 build_ubuntu_cpu_large_tensor() {
     set -ex
     cd /work/build
-    cmake \
+    CC=gcc-7 CXX=g++-7 cmake \
         -DUSE_SIGNAL_HANDLER=ON                 \
         -DUSE_CUDA=OFF                          \
         -DUSE_CUDNN=OFF                         \
@@ -671,7 +673,7 @@ build_ubuntu_cpu_large_tensor() {
 build_ubuntu_gpu_large_tensor() {
     set -ex
     cd /work/build
-    cmake \
+    CC=gcc-7 CXX=g++-7 cmake \
         -DUSE_SIGNAL_HANDLER=ON                 \
         -DUSE_CUDA=ON                           \
         -DUSE_CUDNN=ON                          \


### PR DESCRIPTION
## Description ##
This PR reverts gcc version update (from `gcc-7` to `gcc-8`) for unix CI builds made in https://github.com/apache/incubator-mxnet/commit/afc76b0f82839dfe00f7cab04be6de3df94564fe. gcc8+ is known to cause memory issues #19623 #18501 . We did a RFC #19688 for the same, and as per community feedback reverting the gcc version back to `gcc-7` until we fix the root cause.

We need to install `gcc-7` explicitly now as ubuntu version has been upgraded by the same commit from 18 to 20. While ubuntu18 came with `gcc-7` as default, ubuntu20 comes with `gcc-9`.

Also, removing `apt-get install cmake` as `pip3 install cmake` already exists. Once tensorrt supports ubuntu 20.04, we can drop the [18.04 image](https://github.com/apache/incubator-mxnet/blob/16e2b15f6e334ca88f29b9c14e55547df2c136fc/ci/docker/docker-compose.yml#L91-L100) and remove the pip3 installation in favor of apt (as apt install on 20.04 provides a recent enough cmake).