### PR TITLE
[BUGFIX] Fixed problem with Distribution repr due to cached_property

### DIFF
--- a/python/mxnet/gluon/probability/distributions/distribution.py
+++ b/python/mxnet/gluon/probability/distributions/distribution.py
@@ -179,10 +179,14 @@ class Distribution(object):
         mode = self.F
         args_string = ''
         if 'symbol' not in mode.__name__:
-            for k, _ in self.arg_constraints.items():
+            for k in self.arg_constraints:
                 try:
                     v = self.__dict__[k]
                 except KeyError:
+                    # TODO: Some of the keys in `arg_constraints` are cached_properties, which
+                    # are set as instance property only after they are called (hence won't
+                    # be in self.__dict__). In case they have not been called yet, we set shape
+                    # to `None` - as a quick fix, since it is not known.
                     shape_v = None
                 else:
                     if isinstance(v, Number):

--- a/python/mxnet/gluon/probability/distributions/distribution.py
+++ b/python/mxnet/gluon/probability/distributions/distribution.py
@@ -180,11 +180,15 @@ class Distribution(object):
         args_string = ''
         if 'symbol' not in mode.__name__:
             for k, _ in self.arg_constraints.items():
-                v = self.__dict__[k]
-                if isinstance(v, Number):
-                    shape_v = ()
+                try:
+                    v = self.__dict__[k]
+                except KeyError:
+                    shape_v = None
                 else:
-                    shape_v = v.shape
+                    if isinstance(v, Number):
+                        shape_v = ()
+                    else:
+                        shape_v = v.shape
                 args_string += '{}: size {}'.format(k, shape_v) + ', '
         args_string += ', '.join(['F: {}'.format(mode.__name__),
                                   'event_dim: {}'.format(self.event_dim)])


### PR DESCRIPTION
## Description ##
The `repr` of Distribution base class fails when any of its subclasses has one of its `arg_constraints` defined as `cached_property` which has not yet been initialized. This affects only Mxnet 2.

Solves #19720 

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- Uninitialized `cached_properties` will appear with size `None`. For example a `Categorical` distribution initialized with logit values, will show `prob` size as `None` untill `prob` is called.

```python
Categorical(prob: size None, logit: size (3,), F: mxnet.ndarray, event_dim: 0)
```

## Comments ##
- Another possible solution which doesn't need lots of code change is calling the uncached property within the `__repr__` method, which will force initialize it. 
