### PR TITLE
[v1.x] ONNX support adaptiveAveragePooling2D and update Softmax to support temperature

### DIFF
--- a/docs/python_docs/environment.yml
+++ b/docs/python_docs/environment.yml
@@ -27,6 +27,7 @@ dependencies:
 - matplotlib
 - notebook
 - pip:
+  - nbformat==5.0.8
   - nbconvert==5.6.1
   - nbsphinx==0.4.3
   - recommonmark==0.6.0

--- a/docs/python_docs/environment.yml
+++ b/docs/python_docs/environment.yml
@@ -27,7 +27,6 @@ dependencies:
 - matplotlib
 - notebook
 - pip:
-  - nbformat==5.0.8
   - nbconvert==5.6.1
   - nbsphinx==0.4.3
   - recommonmark==0.6.0

--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -186,7 +186,7 @@ def create_tensor(shape_list, shape_name, initializer, dtype='int64'):
     data_type = onnx.mapping.NP_TYPE_TO_TENSOR_TYPE[shape_np.dtype]
     dims = np.shape(shape_np)
     tensor_node = onnx.helper.make_tensor_value_info(shape_name, data_type, dims)
-    if dtype==np.float16:
+    if dtype == np.float16:
         shape_list = shape_np.view(dtype=np.uint16).flatten().tolist()
     initializer.append(
         onnx.helper.make_tensor(

--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -3036,7 +3036,8 @@ def convert_contrib_AdaptiveAvgPooling2D(node, **kwargs):
 
     if len(output_size) <= 2:
         if output_size[0] != 1 or (len(output_size) == 2 and output_size[1] != 1):
-            raise NotImplementedError("_contrib_AdaptiveAvgPooling2D operator with output_size != 1 not yet implemented.")
+            raise NotImplementedError("_contrib_AdaptiveAvgPooling2D operator with output_size != 1 \
+                                not yet implemented.")
     nodes = [
         make_node("GlobalAveragePool", [input_nodes[0]], [name])
     ]

--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -186,6 +186,8 @@ def create_tensor(shape_list, shape_name, initializer, dtype='int64'):
     data_type = onnx.mapping.NP_TYPE_TO_TENSOR_TYPE[shape_np.dtype]
     dims = np.shape(shape_np)
     tensor_node = onnx.helper.make_tensor_value_info(shape_name, data_type, dims)
+    if dtype==np.float16:
+        shape_list = shape_np.view(dtype=np.uint16).flatten().tolist()
     initializer.append(
         onnx.helper.make_tensor(
             name=shape_name,

--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -3039,6 +3039,6 @@ def convert_contrib_AdaptiveAvgPooling2D(node, **kwargs):
             raise NotImplementedError("_contrib_AdaptiveAvgPooling2D operator with output_size != 1 \
                                 not yet implemented.")
     nodes = [
-        make_node("GlobalAveragePool", [input_nodes[0]], [name])
+        make_node("GlobalAveragePool", [input_nodes[0]], [name], name=name)
     ]
     return nodes

--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -3023,3 +3023,21 @@ def convert_contrib_box_decode(node, **kwargs):
     ]
 
     return nodes
+
+@mx_op.register("_contrib_AdaptiveAvgPooling2D")
+def convert_contrib_AdaptiveAvgPooling2D(node, **kwargs):
+    """Map MXNet's _contrib_BilinearResize2D operator attributes to onnx's operator.
+    """
+    from onnx.helper import make_node
+    name, input_nodes, attrs = get_inputs(node, kwargs)
+
+    output_size = attrs.get('output_size', '1')
+    output_size = convert_string_to_list(output_size)
+
+    if len(output_size) <= 2:
+        if output_size[0] != 1 or (len(output_size) == 2 and output_size[1] != 1):
+            raise NotImplementedError("_contrib_AdaptiveAvgPooling2D operator with output_size != 1 not yet implemented.")
+    nodes = [
+        make_node("GlobalAveragePool", [input_nodes[0]], [name])
+    ]
+    return nodes

--- a/tests/python-pytest/onnx/test_operators.py
+++ b/tests/python-pytest/onnx/test_operators.py
@@ -338,17 +338,18 @@ def test_onnx_export_cast(tmp_path, src_dtype, dst_dtype, shape):
 
 
 @pytest.mark.parametrize('dtype', ['float16', 'float32'])
-def test_onnx_export_softmax(tmp_path, dtype):
+@pytest.mark.parametrize('temperature', [.1, 1., 10.])
+def test_onnx_export_softmax(tmp_path, dtype, temperature):
     x = mx.nd.random.uniform(0, 1, (2, 3, 4), dtype=dtype)
-    M1 = def_model('softmax')
+    M1 = def_model('softmax', temperature=temperature)
     op_export_test('softmax_1', M1, [x], tmp_path)
-    M2 = def_model('softmax', use_length=True, axis=0)
+    M2 = def_model('softmax', use_length=True, axis=0, temperature=temperature)
     l2 = mx.nd.array([[2,0,2,1],[1,1,2,1], [0,0,0,1]], dtype=int)
     op_export_test('softmax_2', M2, [x, l2], tmp_path)
-    M3 = def_model('softmax', use_length=True, axis=-1)
+    M3 = def_model('softmax', use_length=True, axis=-1, temperature=temperature)
     l3 = mx.nd.array([[2,0,4],[0,0,0]], dtype=int)
     op_export_test('softmax_3', M3, [x, l3], tmp_path)
-    M4 = def_model('softmax', use_length=True, axis=1)
+    M4 = def_model('softmax', use_length=True, axis=1, temperature=temperature)
     l4 = mx.nd.array([[2,0,3,1],[0,1,0,0]], dtype=int)
     op_export_test('softmax_4', M4, [x, l4], tmp_path)
 

--- a/tests/python-pytest/onnx/test_operators.py
+++ b/tests/python-pytest/onnx/test_operators.py
@@ -421,3 +421,15 @@ def test_onnx_export_contrib_box_decode(tmp_path, dtype, fmt, clip):
     op_export_test('contrib_box_decode', M1, [data, anchors], tmp_path)
     M2 = def_model('contrib.box_decode', format=fmt, clip=clip, std0=0.3, std1=1.4, std2=0.5, std3=1.6)
     op_export_test('contrib_box_decode', M1, [data, anchors], tmp_path)
+
+@pytest.mark.parametrize('dtype', ['float16', 'float32'])
+def test_onnx_export_contrib_AdaptiveAvgPooling2D(tmp_path, dtype):
+    x = mx.nd.random.uniform(0, 1, (1, 2, 3, 4), dtype=dtype)
+    M1 = def_model('contrib.AdaptiveAvgPooling2D')
+    op_export_test('contrib_AdaptiveAvgPooling2D', M1, [x], tmp_path)
+    M2 = def_model('contrib.AdaptiveAvgPooling2D', output_size=1)
+    op_export_test('contrib_AdaptiveAvgPooling2D', M2, [x], tmp_path)
+    M3 = def_model('contrib.AdaptiveAvgPooling2D', output_size=[1])
+    op_export_test('contrib_AdaptiveAvgPooling2D', M3, [x], tmp_path)
+    M4 = def_model('contrib.AdaptiveAvgPooling2D', output_size=[1,1])
+    op_export_test('contrib_AdaptiveAvgPooling2D', M4, [x], tmp_path)

--- a/tests/python-pytest/onnx/test_operators.py
+++ b/tests/python-pytest/onnx/test_operators.py
@@ -341,7 +341,7 @@ def test_onnx_export_cast(tmp_path, src_dtype, dst_dtype, shape):
 @pytest.mark.parametrize('temperature', [.1, 1., 10.])
 def test_onnx_export_softmax(tmp_path, dtype, temperature):
     x = mx.nd.random.uniform(0, 1, (2, 3, 4), dtype=dtype)
-    M1 = def_model('softmax', temperature=temperature)
+    M1 = def_model('softmax')
     op_export_test('softmax_1', M1, [x], tmp_path)
     M2 = def_model('softmax', use_length=True, axis=0, temperature=temperature)
     l2 = mx.nd.array([[2,0,2,1],[1,1,2,1], [0,0,0,1]], dtype=int)


### PR DESCRIPTION
## Description ##
Support onnx conversion of `_contrib_AdaptiveAvgPooling2D`. Update onnx conversion of `softmax` to support `temperature` attribute.

Due to some incompatible issue of mx-onnx conversion, currently we only support the conversion when `output_size==1`. Pytorch has the similar implementation: https://github.com/pytorch/pytorch/pull/9711.

By inspecting all models in gluon model zoo, 16 of them has `_contrib_AdaptiveAvgPooling2D`. Out of the 16 models, 7 models use `output_size>1`, which are not supported in this pr. 
Unsupported models:
`psp_resnet50_ade`
`psp_resnet101_ade`
`psp_resnet101_voc`
`psp_resnet101_citys`
`psp_resnet101_coco`
`icnet_resnet50_mhpv1`
`icnet_resnet50_citys`


## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
