### PR TITLE
[v1.x] provide a faster PrefetchedDataLoader

### DIFF
--- a/python/mxnet/gluon/data/dataloader.py
+++ b/python/mxnet/gluon/data/dataloader.py
@@ -764,13 +764,13 @@ class PrefetchedDataLoader(DataLoader):
     """
     def __init__(self, dataset, batch_size=None, shuffle=False, sampler=None,
                  last_batch=None, batch_sampler=None, batchify_fn=None,
-                 num_workers=1, pin_memory=False, pin_device_id=0,
+                 num_workers=0, pin_memory=False, pin_device_id=0,
                  prefetch=None, thread_pool=False, timeout=120):
         super(PrefetchedDataLoader, self).\
             __init__(dataset, batch_size, shuffle, sampler,
                      last_batch, batch_sampler, batchify_fn,
-                     num_workers if num_workers >= 1 else 1,
-                     pin_memory, pin_device_id, prefetch, thread_pool, timeout)
+                     num_workers, pin_memory, pin_device_id,
+                     prefetch, thread_pool, timeout)
         self.refresh()
 
     def __iter__(self):

--- a/python/mxnet/gluon/data/dataloader.py
+++ b/python/mxnet/gluon/data/dataloader.py
@@ -662,7 +662,7 @@ class PrefetchedDataLoader(DataLoader):
     When generate multiple iterator from PrefetchedDataLoader, only the first iter
     is the prefetched iter, and PrefetchedDataLoader will not prefetch any data
     if its prefetched iter is not being used.
-    
+
     Example:
     >>> from mxnet.gluon.data import PrefetchedDataLoader, ArrayDataset
     >>> train_data = ArrayDataset([i for i in range(10)],[9-i for i in range(10)])
@@ -689,7 +689,7 @@ class PrefetchedDataLoader(DataLoader):
     >>> # no prefetch is happened since train_loader has already prefetch data.
     >>> _ = next(it4)
     >>> # since the prefetch is performed, it4 become the prefetched iter.
-    >>> 
+    >>>
     >>> test_data = ArrayDataset([i for i in range(10)],[9-i for i in range(10)])
     >>> test_iter = PrefetchedDataLoader(test_data,
     ...                                  batch_size=1,num_workers=1)

--- a/python/mxnet/gluon/data/dataloader.py
+++ b/python/mxnet/gluon/data/dataloader.py
@@ -621,7 +621,7 @@ class DataLoader(object):
     def __init__(self, dataset, batch_size=None, shuffle=False, sampler=None,
                  last_batch=None, batch_sampler=None, batchify_fn=None,
                  num_workers=0, pin_memory=False, pin_device_id=0,
-                 prefetch=None, thread_pool=False, timeout=120, auto_reload = True):
+                 prefetch=None, thread_pool=False, timeout=120, auto_reload=True):
         self._dataset = dataset
         self._pin_memory = pin_memory
         self._pin_device_id = pin_device_id

--- a/python/mxnet/gluon/data/dataloader.py
+++ b/python/mxnet/gluon/data/dataloader.py
@@ -620,7 +620,7 @@ class DataLoader(object):
     def __init__(self, dataset, batch_size=None, shuffle=False, sampler=None,
                  last_batch=None, batch_sampler=None, batchify_fn=None,
                  num_workers=0, pin_memory=False, pin_device_id=0,
-                 prefetch=None, thread_pool=False, timeout=120, auto_reload=True):
+                 prefetch=None, thread_pool=False, timeout=120, auto_reload=False):
         self._dataset = dataset
         self._pin_memory = pin_memory
         self._pin_device_id = pin_device_id

--- a/python/mxnet/gluon/data/dataloader.py
+++ b/python/mxnet/gluon/data/dataloader.py
@@ -609,8 +609,7 @@ class DataLoader(object):
     >>> # since the prefetch is performed, it4 become the prefetched iter.
     >>>
     >>> test_data = ArrayDataset([i for i in range(10)],[9-i for i in range(10)])
-    >>> test_iter = PrefetchedDataLoader(test_data,
-    ...                                  batch_size=1,num_workers=1)
+    >>> test_iter = DataLoader(test_data, batch_size=1,num_workers=1)
     >>> for epoch in range(200):
     ...   # there is almost no difference between it and the default DataLoader
     ...   for data, label in train_iter:

--- a/python/mxnet/gluon/data/dataloader.py
+++ b/python/mxnet/gluon/data/dataloader.py
@@ -676,7 +676,7 @@ class DataLoader(object):
         if self.auto_reload:
             self.refresh()
         else:
-            self._iter = None
+            self.clean() # ensure self._iter exists.
 
     def __iter__(self):
         if self._iter is None:

--- a/python/mxnet/gluon/data/dataloader.py
+++ b/python/mxnet/gluon/data/dataloader.py
@@ -596,7 +596,7 @@ class DataLoader(object):
     >>> it3 = iter(train_iter)
     >>> it4 = iter(train_iter)
     >>> _ = next(it2) # the first iter we are using is the prefetched iter.
-    >>> _ = next(it) # since the prefetched iter is cconsumed, we have to fetch data for `it`.
+    >>> _ = next(it) # since the prefetched iter is consumed, we have to fetch data for `it`.
     (pre)fetching data here
     >>> _ = [None for _ in it3]
     (pre)fetching data here

--- a/tests/python/unittest/test_gluon_data.py
+++ b/tests/python/unittest/test_gluon_data.py
@@ -24,7 +24,7 @@ import random
 from mxnet import gluon
 import platform
 from common import setup_module, with_seed, teardown
-from mxnet.gluon.data import DataLoader
+from mxnet.gluon.data import DataLoader, PrefetchedDataLoader
 import mxnet.ndarray as nd
 from mxnet import context
 from mxnet.gluon.data.dataset import Dataset
@@ -159,6 +159,14 @@ def test_multi_worker():
     data = Dataset()
     for thread_pool in [True, False]:
         loader = gluon.data.DataLoader(data, batch_size=1, num_workers=5, thread_pool=thread_pool)
+        for i, batch in enumerate(loader):
+            assert (batch.asnumpy() == i).all()
+
+@with_seed()
+def test_prefetched_multi_worker():
+    data = Dataset()
+    for thread_pool in [True, False]:
+        loader = gluon.data.PrefetchedDataLoader(data, batch_size=1, num_workers=5, thread_pool=thread_pool)
         for i, batch in enumerate(loader):
             assert (batch.asnumpy() == i).all()
 

--- a/tests/python/unittest/test_gluon_data.py
+++ b/tests/python/unittest/test_gluon_data.py
@@ -24,7 +24,7 @@ import random
 from mxnet import gluon
 import platform
 from common import setup_module, with_seed, teardown
-from mxnet.gluon.data import DataLoader, PrefetchedDataLoader
+from mxnet.gluon.data import DataLoader
 import mxnet.ndarray as nd
 from mxnet import context
 from mxnet.gluon.data.dataset import Dataset
@@ -158,18 +158,11 @@ class Dataset(gluon.data.Dataset):
 def test_multi_worker():
     data = Dataset()
     for thread_pool in [True, False]:
-        loader = gluon.data.DataLoader(data, batch_size=1, num_workers=5, thread_pool=thread_pool)
-        for i, batch in enumerate(loader):
-            assert (batch.asnumpy() == i).all()
-
-@with_seed()
-def test_prefetched_multi_worker():
-    data = Dataset()
-    for thread_pool in [True, False]:
-        loader = gluon.data.PrefetchedDataLoader(data, batch_size=1, num_workers=5, thread_pool=thread_pool)
-        for i, batch in enumerate(loader):
-            assert (batch.asnumpy() == i).all()
-
+        for auto_reload in [True, False]:
+            loader = gluon.data.DataLoader(data, batch_size=1, num_workers=5,
+                                           thread_pool=thread_pool,auto_reload=auto_reload)
+            for i, batch in enumerate(loader):
+                assert (batch.asnumpy() == i).all()
 
 @with_seed()
 def test_multi_worker_shape():

--- a/tests/python/unittest/test_gluon_data.py
+++ b/tests/python/unittest/test_gluon_data.py
@@ -29,7 +29,6 @@ import mxnet.ndarray as nd
 from mxnet import context
 from mxnet.gluon.data.dataset import Dataset
 from mxnet.gluon.data.dataset import ArrayDataset
-import pytest
 
 @with_seed()
 def test_array_dataset():
@@ -155,15 +154,15 @@ class Dataset(gluon.data.Dataset):
     def __getitem__(self, key):
         return mx.nd.full((10,), key)
 
-@pytest.mark.parametrize("auto_reload", [True, False])
-@pytest.mark.parametrize("thread_pool", [True, False])
 @with_seed()
-def test_multi_worker(auto_reload, thread_pool):
+def test_multi_worker():
     data = Dataset()
-    loader = gluon.data.DataLoader(data, batch_size=1, num_workers=5,
-                                   thread_pool=thread_pool,auto_reload=auto_reload)
-    for i, batch in enumerate(loader):
-        assert (batch.asnumpy() == i).all()
+    for thread_pool in [True, False]:
+        for auto_reload in [True, False]:
+            loader = gluon.data.DataLoader(data, batch_size=1, num_workers=5,
+                                           thread_pool=thread_pool,auto_reload=auto_reload)
+            for i, batch in enumerate(loader):
+                assert (batch.asnumpy() == i).all()
 
 @with_seed()
 def test_multi_worker_shape():

--- a/tests/python/unittest/test_gluon_data.py
+++ b/tests/python/unittest/test_gluon_data.py
@@ -29,6 +29,7 @@ import mxnet.ndarray as nd
 from mxnet import context
 from mxnet.gluon.data.dataset import Dataset
 from mxnet.gluon.data.dataset import ArrayDataset
+import pytest
 
 @with_seed()
 def test_array_dataset():
@@ -154,15 +155,15 @@ class Dataset(gluon.data.Dataset):
     def __getitem__(self, key):
         return mx.nd.full((10,), key)
 
+@pytest.mark.parametrize("auto_reload", [True, False])
+@pytest.mark.parametrize("thread_pool", [True, False])
 @with_seed()
-def test_multi_worker():
+def test_multi_worker(auto_reload, thread_pool):
     data = Dataset()
-    for thread_pool in [True, False]:
-        for auto_reload in [True, False]:
-            loader = gluon.data.DataLoader(data, batch_size=1, num_workers=5,
-                                           thread_pool=thread_pool,auto_reload=auto_reload)
-            for i, batch in enumerate(loader):
-                assert (batch.asnumpy() == i).all()
+    loader = gluon.data.DataLoader(data, batch_size=1, num_workers=5,
+                                   thread_pool=thread_pool,auto_reload=auto_reload)
+    for i, batch in enumerate(loader):
+        assert (batch.asnumpy() == i).all()
 
 @with_seed()
 def test_multi_worker_shape():


### PR DESCRIPTION
## Description ##
there already exists some faster dataloader in mxnet 2.0, but in v1.x, the exist dataloader is slower and could be improved by changing its prefetch behavior as what 2.0 have done.
test:
```python
$ cat iternew.py && python iternew.py
import mxnet as mx
from mxnet.gluon.data import DataLoader,ArrayDataset
from time import sleep,perf_counter_ns
train_data=ArrayDataset(mx.nd.array([[i] for i in range(50000)]),mx.nd.array([[99-i] for i in range(50000)]))
test_data=ArrayDataset(mx.nd.array([[i] for i in range(10000)]),mx.nd.array([[99-i] for i in range(10000)]))
def transform_train(sample):
  sleep(0.0016)
  return sample

def transform_test(sample):
  sleep(0.0008)
  return sample

train_iter=DataLoader(train_data.transform_first(transform_train),batch_size=500,num_workers=10)
test_iter =DataLoader(test_data .transform_first(transform_test ),batch_size=500,num_workers=10)
if True:
  tic=perf_counter_ns()
  for epoch in range(10):
    print("epoch"+str(epoch)+" start at "+str(round((perf_counter_ns()-tic)*1e-9,2))+"s")
    for i in train_iter:
      sleep(0.1)
    print("       finished train phase at "+str(round((perf_counter_ns()-tic)*1e-9,2))+"s")
    for i in test_iter:
      sleep(0.05)
    print("        finished test phase at "+str(round((perf_counter_ns()-tic)*1e-9,2))+"s")
  print("cost="+str((perf_counter_ns()-tic)*1e-9)+"s")
epoch0 start at 0.0s
       finished train phase at 11.28s
        finished test phase at 12.35s
epoch1 start at 12.35s
       finished train phase at 22.73s
        finished test phase at 23.79s
epoch2 start at 23.79s
       finished train phase at 34.15s
        finished test phase at 35.21s
epoch3 start at 35.22s
       finished train phase at 45.59s
        finished test phase at 46.66s
epoch4 start at 46.66s
       finished train phase at 57.01s
        finished test phase at 58.07s
epoch5 start at 58.07s
       finished train phase at 68.43s
        finished test phase at 69.5s
epoch6 start at 69.5s
       finished train phase at 79.87s
        finished test phase at 80.93s
epoch7 start at 80.93s
       finished train phase at 91.3s
        finished test phase at 92.37s
epoch8 start at 92.37s
       finished train phase at 102.74s
        finished test phase at 103.8s
epoch9 start at 103.8s
       finished train phase at 114.17s
        finished test phase at 115.23s
cost=115.23376344s
```
(cost ~`129.67192333600002s` if we are using `Dataloader` rather than `PrefetchedDataLoader`)
(test is done using v1.7.0, the newest v1.x is on my GPU server and running, I do not want to bother my GPU server.)
## Checklist ##
### Essentials ###
- [X] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [X] Code is well-documented

### Changes ###
- [X] add a `auto_reload` flag for `DataLoader`, which loads data faster in the first several batch compare to the default `Dataloader`.
- (Don't know whether the test case is appropriate.)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
Now, the default behavior of DataLoader is prefetch immediately after it is created, rather than wait for its `__iter__()` is called.
This behavior is compatible to MXNet 2.0's dataloader with `nopython` mode, since it really speeds up the program (~5% faster with my handwriting autoaugment transform function when training CIFAR-100 with RTX 3090, batch_size=250, wide resnet 16-4 and deep mutual learning technique.) and provide almost no difference(all the parameter create the prefetched dataloader is private and should not be modified by any other code), I switch the default behavior to prefetch.