### PR TITLE
Remove ignore timeout option from Large tensor nightly tests

### DIFF
--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -1027,7 +1027,7 @@ nightly_test_large_tensor() {
     set -ex
     export PYTHONPATH=./python/
     export DMLC_LOG_STACK_TRACE_DEPTH=100
-    pytest --timeout=0 --forked tests/nightly/test_np_large_array.py
+    pytest --forked tests/nightly/test_np_large_array.py
 }
 
 #Tests Model backwards compatibility on MXNet


### PR DESCRIPTION
## Description ##
Removes ignore timeout option from nightly tests. Else they continue running forever.

## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
