### PR TITLE
[1.8.x] fix for MX_ERROR_MSG namespace

### DIFF
--- a/include/mxnet/lib_api.h
+++ b/include/mxnet/lib_api.h
@@ -242,7 +242,7 @@ class MXerrorMsgs {
 };
 
 // Add a new error message, example: MX_ERROR_MSG << "my error msg";
-#define MX_ERROR_MSG MXerrorMsgs::get()->add(__FILE__, __LINE__)
+#define MX_ERROR_MSG mxnet::ext::MXerrorMsgs::get()->add(__FILE__, __LINE__)
 
 /*!
  * \brief Tensor data type, consistent with mshadow data type


### PR DESCRIPTION
## Description ##
When used out side of the `mxnet::ext` namespace the MX_ERROR_MSG macro causes errors like:
```
/home/ubuntu/NeoMXNet/3rdparty/mxnet/include/mxnet/lib_api.h:245:22: error: ‘MXerrorMsgs’ has not been declared
 #define MX_ERROR_MSG MXerrorMsgs::get()->add(__FILE__, __LINE__)
                      ^
```
The fix is to change:
https://github.com/apache/incubator-mxnet/blob/636b6e2a7482a7c242a7f5bbc5e694243e5ceae3/include/mxnet/lib_api.h#L245
to:
```
#define MX_ERROR_MSG mxnet::ext::MXerrorMsgs::get()->add(__FILE__, __LINE__)
```
So that any usage outside of the namespace will get the scope.
