### PR TITLE
[v1.x] Update CI build scripts to install python 3.6 from deadsnakes repo

### DIFF
--- a/ci/docker/Dockerfile.build.ubuntu_cpu
+++ b/ci/docker/Dockerfile.build.ubuntu_cpu
@@ -31,6 +31,7 @@ RUN /work/deb_ubuntu_ccache.sh
 COPY install/ubuntu_python.sh /work/
 COPY install/requirements /work/
 RUN /work/ubuntu_python.sh
+RUN alias python3=python3.6
 
 COPY install/ubuntu_scala.sh /work/
 COPY install/sbt.gpg /work/

--- a/ci/docker/Dockerfile.build.ubuntu_cpu
+++ b/ci/docker/Dockerfile.build.ubuntu_cpu
@@ -31,7 +31,6 @@ RUN /work/deb_ubuntu_ccache.sh
 COPY install/ubuntu_python.sh /work/
 COPY install/requirements /work/
 RUN /work/ubuntu_python.sh
-RUN alias python3=python3.6
 
 COPY install/ubuntu_scala.sh /work/
 COPY install/sbt.gpg /work/

--- a/ci/docker/install/ubuntu_python.sh
+++ b/ci/docker/install/ubuntu_python.sh
@@ -27,9 +27,8 @@ apt-get install -y software-properties-common
 add-apt-repository -y ppa:deadsnakes/ppa
 apt-get update || true
 apt-get install -y python-dev python3.6-dev virtualenv wget
-ln -sf /usr/bin/python3.6 /usr/bin/python3
 
 # the version of the pip shipped with ubuntu may be too lower, install a recent version here
 wget -nv https://bootstrap.pypa.io/get-pip.py
-python3 get-pip.py
+python3.6 get-pip.py
 pip3 install -r /work/requirements

--- a/ci/docker/install/ubuntu_python.sh
+++ b/ci/docker/install/ubuntu_python.sh
@@ -27,6 +27,7 @@ apt-get install -y software-properties-common
 add-apt-repository -y ppa:deadsnakes/ppa
 apt-get update || true
 apt-get install -y python-dev python3.6-dev virtualenv wget
+ln -sf /usr/bin/python3.6 /usr/bin/python3
 
 # the version of the pip shipped with ubuntu may be too lower, install a recent version here
 wget -nv https://bootstrap.pypa.io/get-pip.py

--- a/ci/docker/install/ubuntu_python.sh
+++ b/ci/docker/install/ubuntu_python.sh
@@ -26,9 +26,11 @@ apt-get update || true
 apt-get install -y software-properties-common
 add-apt-repository -y ppa:deadsnakes/ppa
 apt-get update || true
-apt-get install -y python-dev python3.6-dev virtualenv wget
+apt-get install -y python3.6-dev virtualenv wget
+# setup symlink in /usr/local/bin to override python3 version
+ln -sf /usr/bin/python3.6 /usr/local/bin/python3
 
 # the version of the pip shipped with ubuntu may be too lower, install a recent version here
 wget -nv https://bootstrap.pypa.io/get-pip.py
-python3.6 get-pip.py
+python3 get-pip.py
 pip3 install -r /work/requirements

--- a/ci/docker/install/ubuntu_python.sh
+++ b/ci/docker/install/ubuntu_python.sh
@@ -23,7 +23,10 @@
 set -ex
 # install libraries for mxnet's python package on ubuntu
 apt-get update || true
-apt-get install -y python-dev python3-dev virtualenv wget
+apt-get install -y software-properties-common
+add-apt-repository -y ppa:deadsnakes/ppa
+apt-get update || true
+apt-get install -y python-dev python3.6-dev virtualenv wget
 
 # the version of the pip shipped with ubuntu may be too lower, install a recent version here
 wget -nv https://bootstrap.pypa.io/get-pip.py

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -518,7 +518,7 @@ build_ubuntu_cpu_cmake_debug() {
     cmake \
         -DUSE_CUDA=OFF \
         -DUSE_TVM_OP=ON \
-        -DPython3_EXECUTABLE=/usr/bin/python3 \
+        -DPython3_EXECUTABLE=python3 \
         -DUSE_MKL_IF_AVAILABLE=OFF \
         -DUSE_OPENMP=OFF \
         -DUSE_OPENCV=ON \
@@ -539,7 +539,7 @@ build_ubuntu_cpu_cmake_no_tvm_op() {
     cmake \
         -DUSE_CUDA=OFF \
         -DUSE_TVM_OP=OFF \
-        -DPython3_EXECUTABLE=/usr/bin/python3 \
+        -DPython3_EXECUTABLE=python3 \
         -DUSE_MKL_IF_AVAILABLE=OFF \
         -DUSE_OPENMP=OFF \
         -DUSE_OPENCV=ON \
@@ -875,7 +875,7 @@ build_ubuntu_gpu_cmake_mkldnn() {
         -DUSE_CUDA=1                            \
         -DUSE_CUDNN=1                           \
         -DUSE_TVM_OP=0                          \
-        -DPython3_EXECUTABLE=/usr/bin/python3   \
+        -DPython3_EXECUTABLE=python3            \
         -DUSE_MKLML_MKL=1                       \
         -DCMAKE_BUILD_TYPE=Release              \
         -DMXNET_CUDA_ARCH="$CI_CMAKE_CUDA_ARCH" \
@@ -893,8 +893,8 @@ build_ubuntu_gpu_cmake() {
         -DUSE_SIGNAL_HANDLER=ON                 \
         -DUSE_CUDA=ON                           \
         -DUSE_CUDNN=ON                          \
-        -DUSE_TVM_OP=OFF                         \
-        -DPython3_EXECUTABLE=/usr/bin/python3   \
+        -DUSE_TVM_OP=OFF                        \
+        -DPython3_EXECUTABLE=python3            \
         -DUSE_MKL_IF_AVAILABLE=OFF              \
         -DUSE_MKLML_MKL=OFF                     \
         -DUSE_MKLDNN=OFF                        \
@@ -916,8 +916,8 @@ build_ubuntu_gpu_cmake_no_rtc() {
         -DUSE_SIGNAL_HANDLER=ON                 \
         -DUSE_CUDA=ON                           \
         -DUSE_CUDNN=ON                          \
-        -DUSE_TVM_OP=OFF                         \
-        -DPython3_EXECUTABLE=/usr/bin/python3   \
+        -DUSE_TVM_OP=OFF                        \
+        -DPython3_EXECUTABLE=python3            \
         -DUSE_MKL_IF_AVAILABLE=OFF              \
         -DUSE_MKLML_MKL=OFF                     \
         -DUSE_MKLDNN=ON                         \
@@ -957,8 +957,8 @@ build_ubuntu_gpu_large_tensor() {
         -DUSE_SIGNAL_HANDLER=ON                 \
         -DUSE_CUDA=ON                           \
         -DUSE_CUDNN=ON                          \
-        -DUSE_TVM_OP=OFF                         \
-        -DPython3_EXECUTABLE=/usr/bin/python3   \
+        -DUSE_TVM_OP=OFF                        \
+        -DPython3_EXECUTABLE=python3            \
         -DUSE_MKL_IF_AVAILABLE=OFF              \
         -DUSE_MKLML_MKL=OFF                     \
         -DUSE_MKLDNN=OFF                        \


### PR DESCRIPTION
## Description ##
Install python3.6 from deadsnakes repo, since 3.5 is EOL'd and get-pip.py no longer works with 3.5.
