### PR TITLE
LT Nightly tests: removing forked and adding overall timeout for 2 hrs

### DIFF
--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -1023,7 +1023,7 @@ nightly_test_large_tensor() {
     set -ex
     export PYTHONPATH=./python/
     export DMLC_LOG_STACK_TRACE_DEPTH=100
-    pytest --forked tests/nightly/test_np_large_array.py
+    pytest -s --exitfirst --verbose --timeout=7200 tests/nightly/test_np_large_array.py
 }
 
 #Tests Model backwards compatibility on MXNet


### PR DESCRIPTION
## Description ##
`--forked` option causes significant slowdown in pytest runs hence it is better to remove that option and simply increase timeout for large tensor tests 

## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

## Testing ##
Done by creating the nightly CI docker build:
`ci/build.py -e BRANCH=master --docker-registry mxnetci --platform ubuntu_cpu --docker-build-retries 3 --shm-size 500m /work/runtime_functions.sh build_ubuntu_cpu_large_tensor`
and then ran inside the container:
`ci/build.py -e BRANCH=master --docker-registry mxnetci --platform ubuntu_cpu --docker-build-retries 3 --shm-size 500m /work/runtime_functions.sh build_ubuntu_cpu_large_tensor`

Final output of above command:
```
========== 201 passed, 11 skipped, 275 warnings in 4228.09s (1:10:28) ==========
2021-02-02 03:11:30,367 - root - INFO - Waiting for status of container 3364a354be6a for 600 s.
2021-02-02 03:11:30,552 - root - INFO - Container exit status: {'Error': None, 'StatusCode': 0}
2021-02-02 03:11:30,553 - root - INFO - Container exited with success 👍
2021-02-02 03:11:30,553 - root - INFO - Executed command for reproduction:
```