### PR TITLE
[FEATURE] Add Java build using JavaCPP to map the C API 

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -1,0 +1,61 @@
+name: java
+on:
+  push:
+    paths:
+      - java/**
+  pull_request:
+    paths:
+      - java/**
+  workflow_dispatch:
+env:
+  CI_DEPLOY_NEED_CUDA: 1
+  CI_DEPLOY_NEED_GRADLE: 1
+  CI_DEPLOY_MODULE: ${{ github.workflow }}
+  CI_DEPLOY_PLATFORM: ${{ github.job }}
+  CI_DEPLOY_USERNAME: ${{ secrets.CI_DEPLOY_USERNAME }}
+  CI_DEPLOY_PASSWORD: ${{ secrets.CI_DEPLOY_PASSWORD }}
+jobs:
+  linux-x86_64:
+    runs-on: ubuntu-16.04
+    container: centos:7
+    strategy:
+      matrix:
+        include:
+          - ext: ""
+            options: ""
+          - ext: "-gpu"
+            options: "-x test"
+    steps:
+      - run: yum -y install epel-release
+      - run: yum -y install openblas-devel openblas-static
+      - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
+  macosx-x86_64:
+    runs-on: macos-10.15
+#    strategy:
+#      matrix:
+#        include:
+#          - ext: ""
+#            options: ""
+#          - ext: "-gpu"
+#            options: "-x test"
+    steps:
+      - run: brew install gcc openblas
+      - run: brew unlink gcc && brew link gcc
+      - uses: bytedeco/javacpp-presets/.github/actions/deploy-macosx@actions
+  windows-x86_64:
+    runs-on: windows-2019
+    strategy:
+      matrix:
+        include:
+          - ext: ""
+            options: ""
+          - ext: "-gpu"
+            options: "-x test"
+    steps:
+      - uses: al-cheb/configure-pagefile-action@v1.2
+        with:
+          minimum-size: 8GB
+          maximum-size: 16GB
+          disk-root: "C:"
+      - run: C:\msys64\usr\bin\pacman -S --noconfirm mingw-w64-x86_64-openblas
+      - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions

--- a/cmake/ChooseBlas.cmake
+++ b/cmake/ChooseBlas.cmake
@@ -80,7 +80,7 @@ set(FORTRAN_DIR \\\"\$\{CMAKE_Fortran_IMPLICIT_LINK_DIRECTORIES\}\\\")
         COMMAND ${CMAKE_COMMAND} .
       )
       set(FORTRAN_DIR "")
-      include(build/temp/FortranDir.cmake)
+      include(${CMAKE_CURRENT_BINARY_DIR}/temp/FortranDir.cmake)
       find_library(FORTRAN_LIB NAMES gfortran HINTS ${FORTRAN_DIR})
       message("FORTRAN_DIR is ${FORTRAN_DIR}")
       message("FORTRAN_LIB is ${FORTRAN_LIB}")

--- a/java/README.md
+++ b/java/README.md
@@ -1,0 +1,32 @@
+<!--- Licensed to the Apache Software Foundation (ASF) under one -->
+<!--- or more contributor license agreements.  See the NOTICE file -->
+<!--- distributed with this work for additional information -->
+<!--- regarding copyright ownership.  The ASF licenses this file -->
+<!--- to you under the Apache License, Version 2.0 (the -->
+<!--- "License"); you may not use this file except in compliance -->
+<!--- with the License.  You may obtain a copy of the License at -->
+
+<!---   http://www.apache.org/licenses/LICENSE-2.0 -->
+
+<!--- Unless required by applicable law or agreed to in writing, -->
+<!--- software distributed under the License is distributed on an -->
+<!--- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY -->
+<!--- KIND, either express or implied.  See the License for the -->
+<!--- specific language governing permissions and limitations -->
+<!--- under the License. -->
+
+MXNet Java Package
+====================
+This directory and nested files contain MXNet Java package and language binding.
+
+## Installation
+To install requirements for MXNet Java package, visit MXNet [Install Instruction](https://mxnet.apache.org/get_started)
+
+## Running the unit tests
+For running unit tests, you will need the [Gradle build system](https://gradle.org/). To install:
+ * https://gradle.org/install/
+
+Once ```gradle``` is installed, run the following from MXNet java subdirectory (please make sure the installation path of ```gradle``` is included in your ```$PATH``` environment variable):
+```
+gradle clean build test -Dorg.gradle.jvmargs=-Xmx2048m
+```

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -1,6 +1,8 @@
 plugins {
     id 'java-library'
-    id 'org.bytedeco.gradle-javacpp-build' version '1.5.4'
+    id 'org.bytedeco.gradle-javacpp-build' version '1.5.5-SNAPSHOT'
+    id 'maven-publish'
+    id 'signing'
 }
 
 group = 'org.apache'
@@ -14,7 +16,11 @@ repositories {
 
 dependencies {
     api "org.bytedeco:javacpp:$javacppVersion"
-    api "org.bytedeco:javacpp:$javacppVersion:$javacppPlatform"
+    javacppPlatform "org.bytedeco:javacpp-platform:$javacppVersion"
+    javacppPlatform "org.apache:mxnet:$version:linux-x86_64"
+    javacppPlatform "org.apache:mxnet:$version:macosx-x86_64"
+    javacppPlatform "org.apache:mxnet:$version:windows-x86_64"
+    testRuntimeOnly "org.bytedeco:javacpp:$javacppVersion:$javacppPlatform"
     testImplementation 'junit:junit:4.12'
 }
 
@@ -34,4 +40,98 @@ javacppBuildParser {
 
 javacppBuildCompiler {
     copyLibs = true
+}
+
+jar {
+    manifest {
+        attributes 'Class-Path': configurations.runtimeClasspath.collect { it.getName() }.join(' ')
+    }
+}
+
+javadoc {
+    failOnError = false
+    options.links = ['http://bytedeco.org/javacpp/apidocs']
+}
+
+//doesn't work with Gradle 5.x
+//java {
+//    withJavadocJar()
+//    withSourcesJar()
+//}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
+task sourcesJar(type: Jar, dependsOn: classes) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+}
+
+artifacts {
+    archives javadocJar
+    archives sourcesJar
+}
+
+def pomClosure = {
+    name = 'Apache MXNet Java'
+    delegate.description = 'Apache MXNet Java package and language binding'
+    url = 'https://mxnet.apache.org/'
+    licenses {
+        license {
+            name = 'Apache License, Version 2.0'
+            url = 'http://www.apache.org/licenses/LICENSE-2.0'
+            distribution = 'repo'
+        }
+    }
+    developers {
+        developer {
+            name = 'Contributors'
+            email = 'dev@mxnet.apache.org'
+            organization = 'Apache MXNet'
+            organizationUrl = 'https://mxnet.apache.org/'
+        }
+    }
+    scm {
+        url = 'https://github.com/apache/incubator-mxnet'
+        connection = 'scm:git:git://github.com/apache/incubator-mxnet.git'
+        developerConnection = 'scm:git:ssh://git@github.com/apache/incubator-mxnet.git'
+    }
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+            artifacts = [jar, javacppJar, javadocJar, sourcesJar] + javacppBuild.existingArtifacts(configurations.javacppPlatform)
+            pom pomClosure
+        }
+        mavenJavacppPlatform(MavenPublication) {
+            groupId project.group
+            artifactId project.name + "-platform"
+            artifacts = [javacppPlatformJar, javacppPlatformJavadocJar, javacppPlatformSourcesJar]
+            pom pomClosure
+            pom.withXml javacppBuild.xmlAction(configurations.javacppPlatform)
+        }
+    }
+    repositories {
+        maven {
+            def releasesRepoUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
+            def snapshotsRepoUrl = 'https://oss.sonatype.org/content/repositories/snapshots/'
+            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
+            credentials {
+                username System.getenv('CI_DEPLOY_USERNAME')
+                password System.getenv('CI_DEPLOY_PASSWORD')
+            }
+        }
+    }
+}
+
+signing {
+    useGpgCmd()
+    if (!version.endsWith('SNAPSHOT')) {
+        sign publishing.publications.mavenJava
+        sign publishing.publications.mavenJavacppPlatform
+    }
 }

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -5,14 +5,14 @@ plugins {
     id 'signing'
 }
 
-// group = 'org.apache'
-group = 'org.bytedeco'
+group = 'org.apache'
 version = '2.0-SNAPSHOT'
 
 repositories {
     mavenLocal()
     mavenCentral()
     maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
+    maven { url 'https://repository.apache.org/content/groups/snapshots/' }
 }
 
 configurations {
@@ -151,7 +151,7 @@ publishing {
     repositories {
         maven {
             def releasesRepoUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
-            def snapshotsRepoUrl = 'https://oss.sonatype.org/content/repositories/snapshots/'
+            def snapshotsRepoUrl = 'https://repository.apache.org/content/groups/snapshots/'
             url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
             credentials {
                 username System.getenv('CI_DEPLOY_USERNAME')

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -55,7 +55,18 @@ javacppBuildCompiler {
     copyLibs = true
 }
 
+task copyLicenses(type: Copy) {
+    from(["$projectDir/..", "$projectDir/../tools/dependencies/"]) {
+        include 'DISCLAIMER-WIP'
+        include 'LICENSE'
+        include 'NOTICE'
+        include 'LICENSE.binary.dependencies'
+    }
+    into "$buildDir/resources/main/META-INF"
+}
+
 jar {
+    dependsOn copyLicenses
     manifest {
         attributes 'Class-Path': configurations.runtimeClasspath.collect { it.getName() }.join(' ')
     }

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -1,0 +1,37 @@
+plugins {
+    id 'java-library'
+    id 'org.bytedeco.gradle-javacpp-build' version '1.5.4'
+}
+
+group = 'org.apache'
+version = '2.0-SNAPSHOT'
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+    maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
+}
+
+dependencies {
+    api "org.bytedeco:javacpp:$javacppVersion"
+    api "org.bytedeco:javacpp:$javacppVersion:$javacppPlatform"
+    testImplementation 'junit:junit:4.12'
+}
+
+tasks.withType(org.bytedeco.gradle.javacpp.BuildTask) {
+    includePath = ["$buildDir/$javacppPlatform/include"]
+    linkPath = ["$buildDir/$javacppPlatform/lib"]
+}
+
+javacppBuildCommand {
+    buildCommand = ['bash', 'build.sh']
+}
+
+javacppBuildParser {
+    classOrPackageNames = ['org.apache.mxnet.internal.c_api.presets.*']
+    outputDirectory = file("$buildDir/generated/sources/javacpp/")
+}
+
+javacppBuildCompiler {
+    copyLibs = true
+}

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -5,7 +5,8 @@ plugins {
     id 'signing'
 }
 
-group = 'org.apache'
+// group = 'org.apache'
+group = 'org.bytedeco'
 version = '2.0-SNAPSHOT'
 
 repositories {
@@ -14,19 +15,31 @@ repositories {
     maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
 }
 
+configurations {
+    all {
+        resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
+    }
+    javacppPlatform
+    javacppPlatformGpu
+}
+
 dependencies {
     api "org.bytedeco:javacpp:$javacppVersion"
     javacppPlatform "org.bytedeco:javacpp-platform:$javacppVersion"
-    javacppPlatform "org.apache:mxnet:$version:linux-x86_64"
-    javacppPlatform "org.apache:mxnet:$version:macosx-x86_64"
-    javacppPlatform "org.apache:mxnet:$version:windows-x86_64"
+    javacppPlatform "$group:mxnet:$version:linux-x86_64"
+    javacppPlatform "$group:mxnet:$version:macosx-x86_64"
+    javacppPlatform "$group:mxnet:$version:windows-x86_64"
+    javacppPlatformGpu "$group:mxnet:$version:linux-x86_64-gpu"
+//    javacppPlatformGpu "$group:mxnet:$version:macosx-x86_64-gpu"
+    javacppPlatformGpu "$group:mxnet:$version:windows-x86_64-gpu"
     testRuntimeOnly "org.bytedeco:javacpp:$javacppVersion:$javacppPlatform"
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13.1'
 }
 
 tasks.withType(org.bytedeco.gradle.javacpp.BuildTask) {
-    includePath = ["$buildDir/$javacppPlatform/include"]
-    linkPath = ["$buildDir/$javacppPlatform/lib"]
+    includePath = ["$buildDir/$javacppPlatform$javacppPlatformExtension/include"]
+    linkPath = ["$buildDir/$javacppPlatform$javacppPlatformExtension/lib"]
+    preloadPath = ["$buildDir/$javacppPlatform$javacppPlatformExtension/bin"]
 }
 
 javacppBuildCommand {
@@ -104,7 +117,9 @@ publishing {
     publications {
         mavenJava(MavenPublication) {
             from components.java
-            artifacts = [jar, javacppJar, javadocJar, sourcesJar] + javacppBuild.existingArtifacts(configurations.javacppPlatform)
+            artifacts = [jar, javacppJar, javadocJar, sourcesJar] +
+                        javacppBuild.existingArtifacts(configurations.javacppPlatform) +
+                        javacppBuild.existingArtifacts(configurations.javacppPlatformGpu)
             pom pomClosure
         }
         mavenJavacppPlatform(MavenPublication) {
@@ -113,6 +128,13 @@ publishing {
             artifacts = [javacppPlatformJar, javacppPlatformJavadocJar, javacppPlatformSourcesJar]
             pom pomClosure
             pom.withXml javacppBuild.xmlAction(configurations.javacppPlatform)
+        }
+        mavenJavacppPlatformGpu(MavenPublication) {
+            groupId project.group
+            artifactId project.name + "-platform-gpu"
+            artifacts = [javacppPlatformJar, javacppPlatformJavadocJar, javacppPlatformSourcesJar]
+            pom pomClosure
+            pom.withXml javacppBuild.xmlAction(configurations.javacppPlatformGpu, "-gpu")
         }
     }
     repositories {
@@ -133,5 +155,6 @@ signing {
     if (!version.endsWith('SNAPSHOT')) {
         sign publishing.publications.mavenJava
         sign publishing.publications.mavenJavacppPlatform
+        sign publishing.publications.mavenJavacppPlatformGpu
     }
 }

--- a/java/build.sh
+++ b/java/build.sh
@@ -1,10 +1,28 @@
 #!/bin/bash
 set -e
 
-mkdir -p build/$PLATFORM/cmake
-pushd build/$PLATFORM/cmake
+mkdir -p build/$PLATFORM$PLATFORM_EXTENSION/cmake
+pushd build/$PLATFORM$PLATFORM_EXTENSION/cmake
 
-cmake -DCMAKE_BUILD_TYPE=Distribution -DCMAKE_INSTALL_PREFIX=$(pwd)/.. -DCMAKE_INSTALL_LIBDIR=lib -DUSE_CUDA=OFF -DUSE_OPENCV=OFF $(dirs +1)/..
+if [[ -d "C:/msys64" ]] && [[ -z ${OpenBLAS_home:-} ]]; then
+    export OpenBLAS_HOME=C:/msys64/mingw64/include/OpenBlas/
+    export OpenBLAS=C:/msys64/mingw64/lib/
+fi
+
+CMAKE_FLAGS=
+if [[ -d "${VCINSTALLDIR:-}" ]] && which ninja; then
+    export CC="cl.exe"
+    export CXX="cl.exe"
+    CMAKE_FLAGS="-G Ninja -DCMAKE_CUDA_FLAGS=-Xcompiler=-bigobj"
+fi
+
+GPU_FLAGS="-DUSE_CUDA=OFF"
+if [[ "$PLATFORM_EXTENSION" == *gpu ]]; then
+    GPU_FLAGS="-DUSE_CUDA=ON -DMXNET_CUDA_ARCH=3.5"
+fi
+
+cmake $CMAKE_FLAGS -DCMAKE_BUILD_TYPE=Distribution -DCMAKE_INSTALL_PREFIX=$(pwd)/.. -DCMAKE_INSTALL_LIBDIR=lib $GPU_FLAGS -DUSE_OPENCV=OFF $(dirs +1)/..
+cmake $(dirs +1)/..
 cmake --build . --parallel $(getconf _NPROCESSORS_ONLN)
 cmake --install .
 

--- a/java/build.sh
+++ b/java/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+mkdir -p build/$PLATFORM/cmake
+pushd build/$PLATFORM/cmake
+
+cmake -DCMAKE_BUILD_TYPE=Distribution -DCMAKE_INSTALL_PREFIX=$(pwd)/.. -DCMAKE_INSTALL_LIBDIR=lib -DUSE_CUDA=OFF -DUSE_OPENCV=OFF $(dirs +1)/..
+cmake --build . --parallel $(getconf _NPROCESSORS_ONLN)
+cmake --install .
+
+popd

--- a/java/build.sh
+++ b/java/build.sh
@@ -1,11 +1,19 @@
 #!/bin/bash
 set -e
 
+if [[ -n "$MXNET_LIBRARY_PATH" ]]; then
+    echo Found MXNET_LIBRARY_PATH=$MXNET_LIBRARY_PATH
+    mkdir -p build/$PLATFORM$PLATFORM_EXTENSION/lib
+    cp -RLf ../include build/$PLATFORM$PLATFORM_EXTENSION/include
+    cp $MXNET_LIBRARY_PATH build/$PLATFORM$PLATFORM_EXTENSION/lib
+    exit 0
+fi
+
 mkdir -p build/$PLATFORM$PLATFORM_EXTENSION/cmake
 pushd build/$PLATFORM$PLATFORM_EXTENSION/cmake
 
 if [[ -d "C:/msys64" ]] && [[ -z ${OpenBLAS_home:-} ]]; then
-    export OpenBLAS_HOME=C:/msys64/mingw64/include/OpenBlas/
+    export OpenBLAS_HOME=C:/msys64/mingw64/include/OpenBLAS/
     export OpenBLAS=C:/msys64/mingw64/lib/
 fi
 

--- a/java/settings.gradle
+++ b/java/settings.gradle
@@ -4,9 +4,9 @@ pluginManagement {
         mavenCentral()
         maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
         gradlePluginPortal()
-   }
+    }
 }
 
 rootProject.name = 'mxnet'
 
-gradle.rootProject { ext.javacppVersion = '1.5.4' }
+gradle.rootProject { ext.javacppVersion = '1.5.5-SNAPSHOT' }

--- a/java/settings.gradle
+++ b/java/settings.gradle
@@ -1,0 +1,12 @@
+pluginManagement {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
+        gradlePluginPortal()
+   }
+}
+
+rootProject.name = 'mxnet'
+
+gradle.rootProject { ext.javacppVersion = '1.5.4' }

--- a/java/src/main/java/org/apache/mxnet/internal/c_api/mxnet.java
+++ b/java/src/main/java/org/apache/mxnet/internal/c_api/mxnet.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.mxnet.internal.c_api.presets;
+
+import org.bytedeco.javacpp.annotation.Platform;
+import org.bytedeco.javacpp.annotation.Properties;
+import org.bytedeco.javacpp.tools.Info;
+import org.bytedeco.javacpp.tools.InfoMap;
+import org.bytedeco.javacpp.tools.InfoMapper;
+
+/**
+ *
+ * @author Samuel Audet
+ */
+@Properties(
+    value = {
+        @Platform(
+            value = {"linux", "mac", "windows"},
+            compiler = "cpp11",
+            define = {"DMLC_USE_CXX11 1", "MSHADOW_USE_CBLAS 1", "MSHADOW_IN_CXX11 1", "MSHADOW_USE_CUDA 0", "MSHADOW_USE_F16C 0", "MXNET_USE_TVM_OP 0"},
+            include = {"dlpack/dlpack.h", "mxnet/c_api.h", "mxnet/runtime/c_runtime_api.h", "nnvm/c_api.h"},
+            link = "mxnet",
+            preload = "libmxnet"
+        )
+    },
+    target = "org.apache.mxnet.internal.c_api",
+    global = "org.apache.mxnet.internal.c_api.global.mxnet"
+)
+public class mxnet implements InfoMapper {
+
+    public void map(InfoMap infoMap) {
+        infoMap.put(new Info("MSHADOW_USE_F16C", "MXNET_USE_TVM_OP").define(false))
+               .put(new Info("DLPACK_EXTERN_C", "DLPACK_DLL", "MXNET_EXTERN_C", "MXNET_DLL", "NNVM_DLL", "MXNDArrayCreateEx").cppTypes().annotations())
+               .put(new Info("MXNDArrayCreateSparseEx64", "MXNDArrayGetAuxNDArray64", "MXNDArrayGetAuxType64",
+                             "MXNDArrayGetShape64", "MXSymbolInferShape64", "MXSymbolInferShapePartial64").skip())
+               .put(new Info("NDArrayHandle", "FunctionHandle", "AtomicSymbolCreator", "CachedOpHandle", "SymbolHandle", "AtomicSymbolHandle", "ExecutorHandle",
+                             "DataIterCreator", "DataIterHandle", "DatasetCreator", "DatasetHandle", "BatchifyFunctionCreator", "BatchifyFunctionHandle","KVStoreHandle",
+                             "RecordIOHandle", "RtcHandle", "CudaModuleHandle", "CudaKernelHandle", "ProfileHandle", "DLManagedTensorHandle", "ContextHandle",
+                             "EngineFnPropertyHandle", "EngineVarHandle", "MXNetFunctionHandle", "MXNetObjectHandle", "OpHandle", "SymbolHandle", "GraphHandle",
+                             "OptimizerCreator", "OptimizerHandle", "PredictorHandle").cast().javaNames("Pointer").valueTypes("Pointer").pointerTypes("PointerPointer"));
+    }
+}

--- a/java/src/main/java/org/apache/mxnet/internal/c_api/mxnet.java
+++ b/java/src/main/java/org/apache/mxnet/internal/c_api/mxnet.java
@@ -35,11 +35,16 @@ import org.bytedeco.javacpp.tools.InfoMapper;
             define = {"DMLC_USE_CXX11 1", "MSHADOW_USE_CBLAS 1", "MSHADOW_IN_CXX11 1", "MSHADOW_USE_CUDA 0", "MSHADOW_USE_F16C 0", "MXNET_USE_TVM_OP 0"},
             include = {"dlpack/dlpack.h", "mxnet/c_api.h", "mxnet/runtime/c_runtime_api.h", "nnvm/c_api.h"},
             link = "mxnet",
-            linkpath = "/usr/local/lib/"
+            linkpath = {"/usr/lib64/", "/usr/lib/", "/usr/local/lib/"},
+            preload = {"gfortran@.5", "gfortran@.4", "gfortran@.3"},
+            preloadpath = {"/usr/local/lib/gcc/10/", "/usr/local/lib/gcc/9/", "/usr/local/lib/gcc/8/",
+                           "/usr/local/lib/gcc/7/", "/usr/local/lib/gcc/6/", "/usr/local/lib/gcc/5/"}
         ),
         @Platform(
             value = "windows",
-            link = "libmxnet"
+            link = "libmxnet",
+            preload = {"libwinpthread-1", "libgcc_s_seh-1", "libgfortran-5", "libgfortran-4", "libgfortran-3", "libopenblas"},
+            preloadpath = "C:/msys64/mingw64/bin/"
         )
     },
     target = "org.apache.mxnet.internal.c_api",

--- a/java/src/main/java/org/apache/mxnet/internal/c_api/mxnet.java
+++ b/java/src/main/java/org/apache/mxnet/internal/c_api/mxnet.java
@@ -30,7 +30,7 @@ import org.bytedeco.javacpp.tools.InfoMapper;
 @Properties(
     value = {
         @Platform(
-            value = {"linux", "mac", "windows"},
+            value = {"linux-x86_64", "macosx-x86_64", "windows-x86_64"},
             compiler = "cpp11",
             define = {"DMLC_USE_CXX11 1", "MSHADOW_USE_CBLAS 1", "MSHADOW_IN_CXX11 1", "MSHADOW_USE_CUDA 0", "MSHADOW_USE_F16C 0", "MXNET_USE_TVM_OP 0"},
             include = {"dlpack/dlpack.h", "mxnet/c_api.h", "mxnet/runtime/c_runtime_api.h", "nnvm/c_api.h"},

--- a/java/src/main/java/org/apache/mxnet/internal/c_api/mxnet.java
+++ b/java/src/main/java/org/apache/mxnet/internal/c_api/mxnet.java
@@ -30,12 +30,16 @@ import org.bytedeco.javacpp.tools.InfoMapper;
 @Properties(
     value = {
         @Platform(
-            value = {"linux-x86_64", "macosx-x86_64", "windows-x86_64"},
+            value = {"linux", "macosx", "windows"},
             compiler = "cpp11",
             define = {"DMLC_USE_CXX11 1", "MSHADOW_USE_CBLAS 1", "MSHADOW_IN_CXX11 1", "MSHADOW_USE_CUDA 0", "MSHADOW_USE_F16C 0", "MXNET_USE_TVM_OP 0"},
             include = {"dlpack/dlpack.h", "mxnet/c_api.h", "mxnet/runtime/c_runtime_api.h", "nnvm/c_api.h"},
             link = "mxnet",
-            preload = "libmxnet"
+            linkpath = "/usr/local/lib/"
+        ),
+        @Platform(
+            value = "windows",
+            link = "libmxnet"
         )
     },
     target = "org.apache.mxnet.internal.c_api",

--- a/java/src/test/java/org/apache/mxnet/internal/c_api/UnitTest.java
+++ b/java/src/test/java/org/apache/mxnet/internal/c_api/UnitTest.java
@@ -1,0 +1,12 @@
+package org.apache.mxnet.internal.c_api;
+
+import org.junit.Test;
+import static org.apache.mxnet.internal.c_api.global.mxnet.*;
+
+public class UnitTest {
+    @Test public void test() {
+        int[] version = new int[1];
+        MXGetVersion(version);
+        System.out.println(version[0]);
+    }
+}


### PR DESCRIPTION
## Description ##
Based on the discussion in issue #17783, I am proposing here as base for a new Java API to use JavaCPP, which takes care of building MXNet from source, generating appropriate low-level wrapper classes and JNI code for the C API, as well as bundle the resulting binaries in artifacts. This build was adapted, ported, and upgraded to Gradle from the JavaCPP Presets for MXNet 1.x available here:
 * https://github.com/bytedeco/javacpp-presets/tree/master/mxnet

This PR also contains a new "java" workflow for GitHub Actions that builds and deploys binaries for Linux (CentOS 7), Mac, and Windows, with and without CUDA (although the build currently fails with CUDA 11.2 on Windows), which produces files as per those previously deployed here:
 * https://oss.sonatype.org/content/repositories/snapshots/org/bytedeco/mxnet/2.0-SNAPSHOT/

(To have this deploy artifacts as part of `org.apache`, we need to enter credentials under the CI_DEPLOY_USERNAME and CI_DEPLOY_PASSWORD secrets for GitHub Actions.)

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [x] Configurations to build and map the C API to Java with Gradle and JavaCPP
- [x] An initial simple test that runs as part of the CI on GitHub Actions under the "java" workflow
- [x] API documentation that gets deployed automatically from Javadoc

## Comments ##
- The generated wrapper classes are not currently being pushed as source to the repository. Should they be? We can see what that looks like here: https://github.com/bytedeco/javacpp-presets/tree/master/mxnet/src/gen/java/org/bytedeco/mxnet
- I believe the code is generally straightforward to follow, so I have not added a lot of comments, but please let me know which parts may need to be better documented, if any.
- There probably should be some small example somewhere that developers of the high-level API could use as starting point. But where should we put that? What should it contain? I'm thinking something like this: https://github.com/bytedeco/javacpp-presets/tree/master/mxnet#sample-usage