### PR TITLE
[v1.x] Refactor onnx tests for object classification, add object detection tests

### DIFF
--- a/ci/docker/install/ubuntu_onnx.sh
+++ b/ci/docker/install/ubuntu_onnx.sh
@@ -31,4 +31,4 @@ apt-get update || true
 apt-get install -y libprotobuf-dev protobuf-compiler
 
 echo "Installing pytest, pytest-cov, protobuf, Pillow, ONNX, tabulate and onnxruntime..."
-pip3 install pytest pytest-cov protobuf==3.5.2 onnx==1.7.0 Pillow==5.0.0 tabulate==0.7.5 onnxruntime==1.4.0 gluonnlp
+pip3 install pytest pytest-cov protobuf==3.5.2 onnx==1.7.0 Pillow==5.0.0 tabulate==0.7.5 onnxruntime==1.6.0 gluonnlp

--- a/ci/docker/install/ubuntu_onnx.sh
+++ b/ci/docker/install/ubuntu_onnx.sh
@@ -31,4 +31,4 @@ apt-get update || true
 apt-get install -y libprotobuf-dev protobuf-compiler
 
 echo "Installing pytest, pytest-cov, protobuf, Pillow, ONNX, tabulate and onnxruntime..."
-pip3 install pytest pytest-cov protobuf==3.5.2 onnx==1.7.0 Pillow==5.0.0 tabulate==0.7.5 onnxruntime==1.6.0 gluonnlp
+pip3 install pytest pytest-cov protobuf==3.5.2 onnx==1.7.0 Pillow==5.0.0 tabulate==0.7.5 onnxruntime==1.6.0 gluonnlp gluoncv

--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -1719,6 +1719,10 @@ def convert_slice_channel(node, **kwargs):
     """
     name, input_nodes, attrs = get_inputs(node, kwargs)
 
+    opset_version = kwargs['opset_version']
+    if opset_version < 11:
+        raise AttributeError('ONNX opset 11 or greater is required to export this operator')
+
     num_outputs = int(attrs.get("num_outputs"))
     axis = int(attrs.get("axis", 1))
     squeeze_axis = int(attrs.get("squeeze_axis", 0))
@@ -1733,15 +1737,12 @@ def convert_slice_channel(node, **kwargs):
         )
         return [node]
     elif squeeze_axis == 0 and num_outputs > 1:
-        in_shape = kwargs.get('in_shape')[0]
-        split = in_shape[axis] // num_outputs
         node = onnx.helper.make_node(
             "Split",
             input_nodes,
             [name+str(i) for i in range(num_outputs)],
             axis=axis,
-            split=[split for _ in range(num_outputs)],
-            name=name,
+            name=name
         )
         return [node]
     else:

--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -1548,6 +1548,13 @@ def convert_broadcast_mul(node, **kwargs):
     """
     return create_basic_op_node('Mul', node, kwargs)
 
+@mx_op.register("broadcast_minimum")
+def convert_broadcast_min(node, **kwargs):
+    """Map MXNet's broadcast_minimum operator attributes to onnx's Min operator
+    and return the created node.
+    """
+    return create_basic_op_node('Min', node, kwargs)
+
 @mx_op.register("elemwise_div")
 def convert_elemwise_div(node, **kwargs):
     """Map MXNet's elemwise_div operator attributes to onnx's Div operator
@@ -3112,6 +3119,36 @@ def convert_greater_scalar(node, **kwargs):
         make_node("ConstantOfShape", [name+"_shape"], [name+"_rhs"], value=tensor_value),
         make_node("Greater", [input_nodes[0], name+"_rhs"], [name+"_gt"]),
         make_node("Cast", [name+"_gt"], [name], to=input_type, name=name)
+    ]
+    return nodes
+
+
+@mx_op.register("_lesser_scalar")
+def convert_lesser_scalar(node, **kwargs):
+    """Map MXNet's lesser_scalar operator attributes to onnx's Less
+    operator and return the created node.
+    """
+    from onnx.helper import make_node, make_tensor
+    name, input_nodes, attrs = get_inputs(node, kwargs)
+
+    scalar = float(attrs.get('scalar'))
+    input_type = kwargs['in_type']
+    dtype = onnx.mapping.TENSOR_TYPE_TO_NP_TYPE[input_type]
+
+    if str(dtype).startswith('int'):
+        scalar = int(scalar)
+    else:
+        if dtype == 'float16':
+            # when using float16, we must convert it to np.uint16 view first
+            # pylint: disable=too-many-function-args
+            scalar = np.float16(scalar).view(np.uint16)
+
+    tensor_value = make_tensor(name+"_scalar", input_type, [1], [scalar])
+    nodes = [
+        make_node("Shape", [input_nodes[0]], [name+"_shape"]),
+        make_node("ConstantOfShape", [name+"_shape"], [name+"_rhs"], value=tensor_value),
+        make_node("Less", [input_nodes[0], name+"_rhs"], [name+"_lt"]),
+        make_node("Cast", [name+"_lt"], [name], to=input_type, name=name)
     ]
     return nodes
 

--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -1975,7 +1975,7 @@ def convert_broadcast_equal(node, **kwargs):
     and return the created node.
     """
     from onnx.helper import make_node
-    name, input_nodes, attrs = get_inputs(node, kwargs)
+    name, input_nodes, _ = get_inputs(node, kwargs)
     input_type = kwargs['in_type']
 
     nodes = [
@@ -2693,7 +2693,7 @@ def convert_zeros_like(node, **kwargs):
     from onnx.helper import make_node, make_tensor
     name, input_nodes, attrs = get_inputs(node, kwargs)
     dtype = attrs.get('dtype')
-    if dtype != None:
+    if dtype is not None:
         data_type = onnx.mapping.NP_TYPE_TO_TENSOR_TYPE[np.dtype(dtype)]
     else:
         data_type = kwargs['in_type']
@@ -2714,7 +2714,7 @@ def convert_ones_like(node, **kwargs):
     from onnx.helper import make_node, make_tensor
     name, input_nodes, attrs = get_inputs(node, kwargs)
     dtype = attrs.get('dtype')
-    if dtype != None:
+    if dtype is not None:
         data_type = onnx.mapping.NP_TYPE_TO_TENSOR_TYPE[np.dtype(dtype)]
     else:
         data_type = kwargs['in_type']

--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -1738,7 +1738,7 @@ def convert_slice_channel(node, **kwargs):
         node = onnx.helper.make_node(
             "Split",
             input_nodes,
-            [name+'_output'+str(i) for i in range(num_outputs)],
+            [name+str(i) for i in range(num_outputs)],
             axis=axis,
             split=[split for _ in range(num_outputs)],
             name=name,

--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -2839,6 +2839,11 @@ def convert_arange(node, **kwargs):
     step = attrs.get('step', 1.)
     dtype = attrs.get('dtype', 'float32')
     repeat = int(attrs.get('repeat', 1))
+
+    if stop == 'None':
+        stop = start
+        start = 0
+
     if repeat != 1:
         raise NotImplementedError("arange operator with repeat != 1 not yet implemented.")
 

--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -1973,7 +1973,15 @@ def convert_broadcast_equal(node, **kwargs):
     """Map MXNet's broadcast_equal operator attributes to onnx's Equal operator
     and return the created node.
     """
-    return create_basic_op_node('Equal', node, kwargs)
+    from onnx.helper import make_node
+    name, input_nodes, attrs = get_inputs(node, kwargs)
+    input_type = kwargs['in_type']
+
+    nodes = [
+        make_node("Equal", input_nodes, [name+"_equal"]),
+        make_node("Cast", [name+"_equal"], [name], name=name, to=int(input_type))
+    ]
+    return nodes
 
 
 @mx_op.register("broadcast_logical_and")

--- a/tests/python-pytest/onnx/test_operators.py
+++ b/tests/python-pytest/onnx/test_operators.py
@@ -311,6 +311,14 @@ def test_onnx_export_broadcast_add(tmp_path, dtype):
 
 
 @pytest.mark.parametrize('dtype', ['float32', 'float64', 'int32', 'int64'])
+def test_onnx_export_broadcast_equal(tmp_path, dtype):
+    M = def_model('broadcast_equal')
+    x = mx.nd.zeros((4,5,6), dtype=dtype)
+    y = mx.nd.ones((4,5,6), dtype=dtype)
+    op_export_test('broadcast_equal', M, [x, y], tmp_path)
+
+
+@pytest.mark.parametrize('dtype', ['float32', 'float64', 'int32', 'int64'])
 @pytest.mark.parametrize('axis', [0, 1, 2, -1])
 def test_onnx_export_stack(tmp_path, dtype, axis):
     M = def_model('stack', axis=axis)

--- a/tests/python-pytest/onnx/test_operators.py
+++ b/tests/python-pytest/onnx/test_operators.py
@@ -620,6 +620,18 @@ def test_onnx_export_slice_like(tmp_path, dtype, axes):
         op_export_test('slice_like_3', M, [x, y3], tmp_path)
 
 
+@pytest.mark.parametrize('dtype', ['float16', 'float32', 'int32', 'int64'])
+@pytest.mark.parametrize('axis', [None, 0, 2])
+@pytest.mark.parametrize('num_outputs', [2, 5])
+def test_onnx_export_slice_channel(tmp_path, dtype, axis, num_outputs):
+    x = mx.nd.zeros((10,20,30,40), dtype=dtype)
+    if axis is None:
+        M = def_model('SliceChannel', num_outputs=num_outputs)
+    else:
+        M = def_model('SliceChannel', axis=axis, num_outputs=num_outputs)
+    op_export_test('SliceChannel', M, [x], tmp_path)
+
+
 @pytest.mark.parametrize('dtype', ['int32', 'int64', 'float16', 'float32', 'float64'])
 @pytest.mark.parametrize('lhs_axes', [[1, 3], [3, 1], [-2, -4], [-4, -2]])
 @pytest.mark.parametrize('rhs_axes', [[1, 3], [3, 1], [-2, -4], [-4, -2]])

--- a/tests/python-pytest/onnx/test_operators.py
+++ b/tests/python-pytest/onnx/test_operators.py
@@ -118,14 +118,13 @@ def test_onnx_export_arange_like(tmp_path, dtype, axis, start, step, test_data):
     op_export_test('arange_like', M, [x], tmp_path)
 
 
-@pytest.mark.parametrize("stop", [2, 50, 5000])
-@pytest.mark.parametrize("step", [0.25, 0.5, 1, 5])
-@pytest.mark.parametrize("start", [0., 1.])
+@pytest.mark.parametrize("params", [[0, 2, 1], [0, 50, 0.25], [-100, 100, 0.5], [5, None, 1], [-5, None, -1]])
 @pytest.mark.parametrize("dtype", ["float32", "float64", "int32", "int64"])
-def test_onnx_export_arange(tmp_path, dtype, start, stop, step):
+def test_onnx_export_arange(tmp_path, dtype, params):
+    start, stop, step = params[0], params[1], params[2]
     if "int" in dtype:
         start = int(start)
-        stop = int(stop)
+        stop = int(stop) if stop != None else None
         step = int(step)
         if step == 0:
             step = 1

--- a/tests/python-pytest/onnx/test_operators.py
+++ b/tests/python-pytest/onnx/test_operators.py
@@ -621,7 +621,7 @@ def test_onnx_export_slice_like(tmp_path, dtype, axes):
 
 
 @pytest.mark.parametrize('dtype', ['float16', 'float32', 'int32', 'int64'])
-@pytest.mark.parametrize('axis', [None, 0, 2])
+@pytest.mark.parametrize('axis', [None, 0, 2, -1])
 @pytest.mark.parametrize('num_outputs', [2, 5])
 def test_onnx_export_slice_channel(tmp_path, dtype, axis, num_outputs):
     x = mx.nd.zeros((10,20,30,40), dtype=dtype)

--- a/tests/python-pytest/onnx/test_operators.py
+++ b/tests/python-pytest/onnx/test_operators.py
@@ -318,6 +318,17 @@ def test_onnx_export_broadcast_equal(tmp_path, dtype):
     op_export_test('broadcast_equal', M, [x, y], tmp_path)
 
 
+@pytest.mark.parametrize('dtype', ['float16', 'float32', 'float64', 'int32', 'int64'])
+def test_onnx_export_broadcast_minimum(tmp_path, dtype):
+    M = def_model('broadcast_minimum')
+    if 'int' in dtype:
+        x = mx.nd.random.randint(0, 1000, (4, 5, 6), dtype=dtype)
+        y = mx.nd.random.randint(0, 1000, (4, 5, 6), dtype=dtype)
+    else:
+        x = mx.nd.random.uniform(0, 1000, (4, 5, 6), dtype=dtype)
+        y = mx.nd.random.uniform(0, 1000, (4, 5, 6), dtype=dtype)
+    op_export_test('broadcast_minimum', M, [x, y], tmp_path)
+
 @pytest.mark.parametrize('dtype', ['float32', 'float64', 'int32', 'int64'])
 @pytest.mark.parametrize('axis', [0, 1, 2, -1])
 def test_onnx_export_stack(tmp_path, dtype, axis):
@@ -465,6 +476,18 @@ def test_onnx_export_greater_scalar(tmp_path, dtype, scalar):
         x = mx.random.uniform(0, 9999, (5,10), dtype=dtype)
     M = def_model('_internal._greater_scalar', scalar=scalar)
     op_export_test('_internal._greater_scalar', M, [x], tmp_path)
+
+
+@pytest.mark.parametrize("dtype", ["float16", "float32", "float64", "int32", "int64"])
+@pytest.mark.parametrize("scalar", [0., 0.1, 0.5, 1., 5, 555.])
+def test_onnx_export_lesser_scalar(tmp_path, dtype, scalar):
+    if 'int' in dtype:
+        scalar = int(scalar)
+        x = mx.nd.arange(0, 12, dtype=dtype).reshape((3, 4))
+    else:
+        x = mx.random.uniform(0, 9999, (5,10), dtype=dtype)
+    M = def_model('_internal._lesser_scalar', scalar=scalar)
+    op_export_test('_internal._lesser_scalar', M, [x], tmp_path)
 
 
 @pytest.mark.parametrize("dtype", ["float16", "float32", "float64", "int32", "int64"])


### PR DESCRIPTION
## Description ##
Refactor onnx tests for object classification, add object detection tests.
Also fix a few ONNX export operators:

- SliceChannel and add unit test
- broadcast_equal add add unit test
- zeros_likes
- ones_like
- arange (update unit test)
- broadcast_mod (set name attribute)