### PR TITLE
[v1.x] ONNX 1.6 compatibility fix + fix for when multiple nodes have the same name

### DIFF
--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -1280,9 +1280,9 @@ integrationtest_ubuntu_cpu_onnx() {
     export DMLC_LOG_STACK_TRACE_DEPTH=10
     #tests/python-pytest/onnx/backend_test.py
     COV_ARG="--cov=./ --cov-report=xml --cov-append"
-    #pytest $COV_ARG --verbose tests/python-pytest/onnx/mxnet_export_test.py
-    #pytest $COV_ARG --verbose tests/python-pytest/onnx/test_models.py
-    #pytest $COV_ARG --verbose tests/python-pytest/onnx/test_node.py
+    pytest $COV_ARG --verbose tests/python-pytest/onnx/mxnet_export_test.py
+    pytest $COV_ARG --verbose tests/python-pytest/onnx/test_models.py
+    pytest $COV_ARG --verbose tests/python-pytest/onnx/test_node.py
     pytest $COV_ARG --verbose tests/python-pytest/onnx/test_operators.py
     pytest $COV_ARG --verbose tests/python-pytest/onnx/test_onnxruntime.py
 }

--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -872,14 +872,14 @@ def convert_softmax(node, **kwargs):
     data = input_nodes[0]
 
     # use op set 11 ONNX Softmax
-    if axis == -1 and temperature == 'None':
+    if axis == -1 and temperature == 1.:
         nodes = []
         if use_length == "True":
             nodes += [
                 create_const_scalar_node(name+"_0_s", np.int64(0), kwargs),
                 create_const_scalar_node(name+"_1_s", np.int64(1), kwargs),
-                create_tensor([np.finfo(dtype).min], name+"_mask_val", kwargs["initializer"],
-                              dtype=dtype),
+                # magic number, this is fp16 min
+                create_tensor([-65500.0], name+"_mask_val", kwargs["initializer"], dtype=dtype),
                 create_tensor([], name+"_void", kwargs["initializer"]),
                 create_tensor([1], name+"_1", kwargs["initializer"]),
                 make_node("Shape", [data], [name+"_shape"]),

--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -2333,6 +2333,8 @@ def convert_layer_norm(node, **kwargs):
     axes = int(attrs.get('axis', -1))
     eps = attrs.get('eps', 9.99999975e-06)
 
+    input_type = int(kwargs['in_type'])
+    dtype = onnx.mapping.TENSOR_TYPE_TO_NP_TYPE[input_type]
 
     nodes = [
         create_tensor([axes], name+"_axes", kwargs["initializer"]),
@@ -2340,7 +2342,7 @@ def convert_layer_norm(node, **kwargs):
         create_tensor([], name+"_void", kwargs["initializer"]),
         create_const_scalar_node(name+'_0_s', np.int64(0), kwargs),
         create_const_scalar_node(name+'_1_s', np.int64(1), kwargs),
-        create_const_scalar_node(name+"_2_s", np.int64(2), kwargs),
+        create_const_scalar_node(name+"_2_s", np.array(2, dtype=dtype), kwargs),
         create_const_scalar_node(name+"_eps", np.float32(eps), kwargs),
         make_node("ReduceMean", [input_nodes[0]], [name+"_rm0_out"], axes=[axes]),
         make_node("Sub", [input_nodes[0], name+"_rm0_out"], [name+"_sub0_out"]),
@@ -3025,7 +3027,7 @@ def convert_maximum_scalar(node, **kwargs):
 
     input_type = int(kwargs['in_type'])
     dtype = onnx.mapping.TENSOR_TYPE_TO_NP_TYPE[input_type]
-
+    
     scalar = None
     if 'float' in str(dtype):
         scalar = float(attrs.get('scalar', '0'))

--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -3348,3 +3348,45 @@ def convert_slice_like(node, **kwargs):
             ]
 
     return nodes
+
+
+@mx_op.register("broadcast_like")
+def convert_broadcast_like(node, **kwargs):
+    """Map MXNet's broadcast_like operator attributes to onnx's operator.
+    """
+    from onnx.helper import make_node
+    name, input_nodes, attrs = get_inputs(node, kwargs)
+
+    lhs = input_nodes[0]
+    rhs = input_nodes[1]
+    lhs_axes = convert_string_to_list(str(attrs.get('lhs_axes', 'None')))
+    rhs_axes = convert_string_to_list(str(attrs.get('rhs_axes', 'None')))
+
+    if lhs_axes[0] is None or rhs_axes[0] is None:
+        nodes = [
+            make_node('Shape', [rhs], [name+'_rhs_shape']),
+            make_node('Expand', [lhs, name+'_rhs_shape'], [name], name=name)
+        ]
+        return nodes
+
+    lhs_axes = [[i] for i in lhs_axes]
+    rhs_axes = [[i] for i in rhs_axes]
+
+    nodes = [
+        create_tensor([0], name+'_0', kwargs['initializer']),
+        create_tensor(lhs_axes, name+'_lhs_axes', kwargs['initializer']),
+        create_tensor(rhs_axes, name+'_rhs_axes', kwargs['initializer']),
+        make_node('Shape', [lhs], [name+'_lhs_shape']),
+        make_node('Shape', [rhs], [name+'_rhs_shape']),
+        make_node('Shape', [name+'_lhs_shape'], [name+'_lhs_dim']),
+        make_node('Less', [name+'_lhs_axes', name+'_0'], [name+'_less']),
+        make_node('Cast', [name+'_less'], [name+'_mask'], to=int(onnx.TensorProto.INT64)),
+        make_node('Mul', [name+'_mask', name+'_lhs_dim'], [name+'_mul']),
+        make_node('Add', [name+'_lhs_axes', name+'_mul'], [name+'_lhs_axes_positive']),
+        make_node('GatherND', [name+'_rhs_shape', name+'_rhs_axes'], [name+'_gather']),
+        make_node('ScatterND', [name+'_lhs_shape', name+'_lhs_axes_positive', name+'_gather'],
+                  [name+'_scatter']),
+        make_node('Expand', [lhs, name+'_scatter'], [name], name=name)
+    ]
+
+    return nodes

--- a/python/mxnet/contrib/onnx/mx2onnx/export_onnx.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/export_onnx.py
@@ -224,9 +224,15 @@ class MXNetGraph(object):
         # Determine output shape
         graph_outputs = MXNetGraph.get_outputs(sym, params, in_shape, output_label, in_type)
 
+        appeared_names = set()
         graph_input_idx = 0
         for idx, node in enumerate(mx_graph):
             op = node["op"]
+            # check if the current node has the same name as nodes before
+            if node["name"] in appeared_names:
+                node["name"] = 'idx_' + str(idx) + '_' + node["name"]
+            else:
+                appeared_names.add(node["name"])
             name = node["name"]
             if verbose:
                 logging.info("Converting idx: %d, op: %s, name: %s", idx, op, name)
@@ -253,10 +259,6 @@ class MXNetGraph(object):
                 graph_input_idx += 1
 
             else:
-                # If this node is not weight, then we add a prefix to the name to avoid name
-                # clashing issue in case some op nodes have the same name
-                if name not in params:
-                    node["name"] = 'op_node_' + str(idx) + '_' + node["name"]
                 # Handling graph layers
                 converted = MXNetGraph.convert_layer(
                     node,

--- a/python/mxnet/contrib/onnx/mx2onnx/export_onnx.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/export_onnx.py
@@ -253,6 +253,10 @@ class MXNetGraph(object):
                 graph_input_idx += 1
 
             else:
+                # If this node is not weight, then we add a prefix to the name to avoid name
+                # clashing issue in case some op nodes have the same name
+                if name not in params:
+                    node["name"] = 'op_node_' + str(idx) + '_' + node["name"]
                 # Handling graph layers
                 converted = MXNetGraph.convert_layer(
                     node,

--- a/tests/python-pytest/onnx/test_operators.py
+++ b/tests/python-pytest/onnx/test_operators.py
@@ -464,7 +464,9 @@ def test_onnx_link_op_with_multiple_outputs(tmp_path):
     op_export_test('link_op_with_multiple_outputs_case3', Model3, [A], tmp_path)
 
 
-@pytest.mark.parametrize('dtype', ['float16', 'float32', 'float64', 'int32', 'int64'])
+# opset 8 MAX only supports float types
+# opset 12 and up suppots float and int
+@pytest.mark.parametrize('dtype', ['float16', 'float32', 'float64'])
 @pytest.mark.parametrize('shape', [(3, 4, 5), (1, 4, 1, 7)])
 def test_onnx_maximum_scalar(tmp_path, dtype, shape):
     x = mx.random.uniform(0, 10, shape).astype(dtype)

--- a/tests/python-pytest/onnx/test_operators.py
+++ b/tests/python-pytest/onnx/test_operators.py
@@ -539,3 +539,21 @@ def test_onnx_export_gather_nd(tmp_path, dtype):
     M2 = def_model('gather_nd')
     op_export_test('gather_nd2', M2, [x2, y2], tmp_path)
 
+
+@pytest.mark.parametrize('dtype', ['float16', 'float32', 'float64', 'int32', 'int64'])
+@pytest.mark.parametrize('axes', [None, (0, 1, 2), (-2, -3), (-2, 0)])
+def test_onnx_export_slice_like(tmp_path, dtype, axes):
+    x = mx.nd.random.uniform(0, 1, (4, 5, 6, 7)).astype(dtype)
+    if axes is None:
+        M = def_model('slice_like')
+        y = mx.nd.zeros((2, 3, 4, 5), dtype=dtype)
+        op_export_test('slice_like', M, [x, y], tmp_path)
+    else:
+        M = def_model('slice_like', axes=axes)
+        y1 = mx.nd.zeros((2, 3, 4), dtype=dtype)
+        y2 = mx.nd.zeros((2, 3, 4, 5), dtype=dtype)
+        y3 = mx.nd.zeros((2, 3, 4, 5, 6), dtype=dtype)
+        op_export_test('slice_like_1', M, [x, y1], tmp_path)
+        op_export_test('slice_like_2', M, [x, y2], tmp_path)
+        op_export_test('slice_like_3', M, [x, y3], tmp_path)
+

--- a/tests/python-pytest/onnx/test_operators.py
+++ b/tests/python-pytest/onnx/test_operators.py
@@ -342,19 +342,21 @@ def test_onnx_export_cast(tmp_path, src_dtype, dst_dtype, shape):
 
 
 @pytest.mark.parametrize('dtype', ['float16', 'float32'])
-@pytest.mark.parametrize('temperature', [.1, 1., 10.])
+@pytest.mark.parametrize('temperature', [None, .1, 1., 10.])
 def test_onnx_export_softmax(tmp_path, dtype, temperature):
-    x = mx.nd.random.uniform(0, 1, (2, 3, 4), dtype=dtype)
+    x = mx.nd.random.uniform(0, 1, (4, 5, 6), dtype=dtype)
     M1 = def_model('softmax')
     op_export_test('softmax_1', M1, [x], tmp_path)
     M2 = def_model('softmax', use_length=True, axis=0, temperature=temperature)
-    l2 = mx.nd.array([[2,0,2,1],[1,1,2,1], [0,0,0,1]], dtype=int)
+    l2 = mx.random.uniform(0, 4, (5, 6)).astype('int32')
     op_export_test('softmax_2', M2, [x, l2], tmp_path)
     M3 = def_model('softmax', use_length=True, axis=-1, temperature=temperature)
-    l3 = mx.nd.array([[2,0,4],[0,0,0]], dtype=int)
+    # note that the axis==-1 case uses negative value masking + ONNX softmax
+    # when valid_len==0 the masked values will NOT be 0
+    l3 = mx.random.uniform(1, 6, (4, 5)).astype('int32')
     op_export_test('softmax_3', M3, [x, l3], tmp_path)
     M4 = def_model('softmax', use_length=True, axis=1, temperature=temperature)
-    l4 = mx.nd.array([[2,0,3,1],[0,1,0,0]], dtype=int)
+    l4 = mx.random.uniform(0, 5, (4, 6)).astype('int32')
     op_export_test('softmax_4', M4, [x, l4], tmp_path)
 
 

--- a/tests/python-pytest/onnx/test_operators.py
+++ b/tests/python-pytest/onnx/test_operators.py
@@ -557,3 +557,14 @@ def test_onnx_export_slice_like(tmp_path, dtype, axes):
         op_export_test('slice_like_2', M, [x, y2], tmp_path)
         op_export_test('slice_like_3', M, [x, y3], tmp_path)
 
+
+@pytest.mark.parametrize('dtype', ['int32', 'int64', 'float16', 'float32', 'float64'])
+@pytest.mark.parametrize('lhs_axes', [[1, 3], [3, 1], [-2, -4], [-4, -2]])
+@pytest.mark.parametrize('rhs_axes', [[1, 3], [3, 1], [-2, -4], [-4, -2]])
+def test_onnx_export_broadcast_like(tmp_path, dtype, lhs_axes, rhs_axes):
+    x = mx.random.normal(0, 10, (2, 1, 1, 1, 6)).astype(dtype)
+    y = mx.random.normal(0, 10, (2, 3, 4, 5, 6)).astype(dtype)
+    M1 = def_model('broadcast_like')
+    op_export_test('broadcast_like1', M1, [x, y], tmp_path)
+    M2 = def_model('broadcast_like', lhs_axes=lhs_axes, rhs_axes=rhs_axes)
+    op_export_test('broadcast_like2', M2, [x, y], tmp_path)


### PR DESCRIPTION
This pr fixes:
1. softmax when axis == -1
2. compatibility with onnx 1.6
3. adds a prefix (index) to the exported nodes so that we can handle when multiple nodes have the same name