### PR TITLE
[DOC] Update dgl_graph.cc

### DIFF
--- a/src/operator/contrib/dgl_graph.cc
+++ b/src/operator/contrib/dgl_graph.cc
@@ -763,7 +763,7 @@ NNVM_REGISTER_OP(_contrib_dgl_csr_neighbor_uniform_sample)
 uniform probability. The operator is designed for DGL.
 
 The operator outputs three sets of NDArrays to represent the sampled results
-(the number of NDArrays in each set is the same as the number of seed NDArrays):
+(the number of NDArrays in each set is the same as the number of seed NDArrays minus two (csr matrix and probability)):
 1) a set of 1D NDArrays containing the sampled vertices, 2) a set of CSRNDArrays representing
 the sampled edges, 3) a set of 1D NDArrays indicating the layer where a vertex is sampled.
 The first set of 1D NDArrays have a length of max_num_vertices+1. The last element in an NDArray
@@ -868,7 +868,7 @@ NNVM_REGISTER_OP(_contrib_dgl_csr_neighbor_non_uniform_sample)
 non-uniform probability. The operator is designed for DGL.
 
 The operator outputs four sets of NDArrays to represent the sampled results
-(the number of NDArrays in each set is the same as the number of seed NDArrays):
+(the number of NDArrays in each set is the same as the number of seed NDArrays minus two (csr matrix and probability)):
 1) a set of 1D NDArrays containing the sampled vertices, 2) a set of CSRNDArrays representing
 the sampled edges, 3) a set of 1D NDArrays with the probability that vertices are sampled,
 4) a set of 1D NDArrays indicating the layer where a vertex is sampled.


### PR DESCRIPTION
Update _contrib_csr_neighbor_non_uniform_sample and contrib_csr_neighbor_uniform_sample documentation to indicate that the expected number of arrays for seed_arrays is the num_args minus two (csr matrix and probability).

## Description ##
Update the documentation per issue #18989

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
