### PR TITLE
[v1.x] Disable unix-gpu-cu110 pipeline for v1.x builds

### DIFF
--- a/ci/jenkins/Jenkinsfile_full
+++ b/ci/jenkins/Jenkinsfile_full
@@ -31,7 +31,6 @@ def buildJobs = [
     'miscellaneous',
     'unix-cpu',
     'unix-gpu',
-    'unix-gpu-cu110',
     'website',
     'windows-cpu',
     'windows-gpu'


### PR DESCRIPTION
We're now using cuda 11.0 in windows builds, so no reason to have separate pipeline.