### PR TITLE
[BUGFIX] fix #18938, #18939, #18940

### DIFF
--- a/src/operator/sequence_last-inl.h
+++ b/src/operator/sequence_last-inl.h
@@ -153,6 +153,10 @@ class SequenceLastOp : public Operator {
     auto d1 = in_data[seq_last::kData].size(1);
     auto dsize = in_data[seq_last::kData].Size();
 
+    if (dsize == 0) {
+      return;  // noop if any input dimension is zero-sized, out_data is of a right shape
+    }
+
     auto batch = (axis != 0) ? d0 : d1;
     auto max_seq_len = in_data[seq_last::kData].size(axis);
     auto rest_size = dsize / (d0 * d1);

--- a/src/operator/sequence_mask-inl.h
+++ b/src/operator/sequence_mask-inl.h
@@ -97,6 +97,11 @@ class SequenceMaskOp : public Operator {
     auto d0 = in_data[seq_mask::kData].size(0);
     auto d1 = in_data[seq_mask::kData].size(1);
     auto dsize = in_data[seq_mask::kData].Size();
+
+    if (dsize == 0) {
+      return;  // noop if any input dimension is zero-sized, out_data is of a right shape
+    }
+
     auto rest_size = dsize / (d0 * d1);
 
     Shape<3> s3 = Shape3(d0, d1, rest_size);

--- a/src/operator/sequence_reverse-inl.h
+++ b/src/operator/sequence_reverse-inl.h
@@ -136,6 +136,11 @@ class SequenceReverseOp : public Operator {
     auto max_seq_len = in_data[seq_reverse::kData].size(0);
     auto n = in_data[seq_reverse::kData].size(1);
     auto total_size = in_data[seq_reverse::kData].Size();
+
+    if (total_size == 0) {
+      return;  // noop if any input dimension is zero-sized, out_data is of a right shape
+    }
+
     auto rest_dim = static_cast<int>(total_size / n / max_seq_len);
 
     Shape<3> s3 = Shape3(max_seq_len, n, rest_dim);

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -9428,3 +9428,11 @@ def test_sldwin_selfatten_operators():
             test_sldwin_atten_op_impl(2, 128, 2, 8, 16, symmetric, d)
             test_sldwin_atten_op_impl(1, 8, 2, 4, 2, symmetric, d)
 
+def test_zero_sized_dim():
+    """Test for issue: https://github.com/apache/incubator-mxnet/issues/18938"""
+    mx.util.set_np_shape(True)  # Must be done to prevent zero-sized dimension conversion to 'unknown'
+    data = mx.nd.array(np.random.rand(1, 0, 0))
+    res = mx.nd.op.SequenceLast(data)
+    assert data.shape[1:] == res.shape
+    assert len(res) == 0
+

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -9429,10 +9429,27 @@ def test_sldwin_selfatten_operators():
             test_sldwin_atten_op_impl(1, 8, 2, 4, 2, symmetric, d)
 
 def test_zero_sized_dim():
-    """Test for issue: https://github.com/apache/incubator-mxnet/issues/18938"""
-    mx.util.set_np_shape(True)  # Must be done to prevent zero-sized dimension conversion to 'unknown'
-    data = mx.nd.array(np.random.rand(1, 0, 0))
-    res = mx.nd.op.SequenceLast(data)
-    assert data.shape[1:] == res.shape
-    assert len(res) == 0
 
+    mx.util.set_np_shape(True)  # Must be done to prevent zero-sized dimension conversion to 'unknown'
+
+    def seq_last():
+        """Test for issue: https://github.com/apache/incubator-mxnet/issues/18938"""
+        data = mx.nd.array(np.random.rand(1, 0, 0))
+        res = mx.nd.op.SequenceLast(data)
+        assert data.shape[1:] == res.shape
+
+    def seq_mask():
+        """Test for issue: https://github.com/apache/incubator-mxnet/issues/18939"""
+        data = mx.nd.array(np.random.rand(0, 1, 1))
+        res = mx.nd.op.SequenceMask(data)
+        assert data.shape == res.shape
+
+    def seq_reverse():
+        """Test for issue: https://github.com/apache/incubator-mxnet/issues/18940"""
+        data = mx.nd.array(np.random.rand(0, 1, 1))
+        res = mx.nd.op.SequenceReverse(data)
+        assert data.shape == res.shape
+
+    seq_last()
+    seq_reverse()
+    seq_mask()


### PR DESCRIPTION
## Description ##
Fixes  https://github.com/apache/incubator-mxnet/issues/18938,  #https://github.com/apache/incubator-mxnet/issues/18939 and  #https://github.com/apache/incubator-mxnet/issues/18940

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
Return early if zero-sized dimension is used. Added test to `test_operator.py`

## Comments ##
One caveat - for the solution to work NumPy shape semantics must be used as shown in the test, otherwise the shape's zero-sized dimension of the output gets converted to 'unknown' dimension in the call to `[src.common.utils.h]::ConvertToNumpyShape` which in turn will throw an error about unknown shape. I think it's alright to use NumPy shape semantics because the input is using NumPy semantics but if not then this will require a much bigger fix.
