### PR TITLE
[v.1x] Bump Up CI ONNX Tests Thread Count

### DIFF
--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -1258,7 +1258,7 @@ integrationtest_ubuntu_cpu_onnx() {
     pytest $COV_ARG --verbose tests/python-pytest/onnx/test_models.py
     pytest $COV_ARG --verbose tests/python-pytest/onnx/test_node.py
     pytest $COV_ARG --verbose tests/python-pytest/onnx/test_operators.py
-    pytest -n 20 $COV_ARG --verbose tests/python-pytest/onnx/test_onnxruntime.py
+    pytest -n 24 $COV_ARG --verbose tests/python-pytest/onnx/test_onnxruntime.py
 }
 
 integrationtest_ubuntu_gpu_python() {

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -1258,7 +1258,7 @@ integrationtest_ubuntu_cpu_onnx() {
     pytest $COV_ARG --verbose tests/python-pytest/onnx/test_models.py
     pytest $COV_ARG --verbose tests/python-pytest/onnx/test_node.py
     pytest $COV_ARG --verbose tests/python-pytest/onnx/test_operators.py
-    pytest -n 12 $COV_ARG --verbose tests/python-pytest/onnx/test_onnxruntime.py
+    pytest -n 20 $COV_ARG --verbose tests/python-pytest/onnx/test_onnxruntime.py
 }
 
 integrationtest_ubuntu_gpu_python() {


### PR DESCRIPTION
onnxruntime model tests are bottlenecked at network I/O so we can try to bump up thread count