### PR TITLE
[v1.x] Tool to help update/restore onnx support

### DIFF
--- a/tools/onnx/update_onnx.py
+++ b/tools/onnx/update_onnx.py
@@ -1,0 +1,69 @@
+import mxnet
+import os
+import logging
+import argparse
+
+def update_onnx(branch='v1.x'):
+    # Detect MXNet
+    print('Detected MXNet version: %s' % mxnet.__version__)
+    mx_path = os.path.abspath(mxnet.__file__)
+    mx_path = mx_path[:mx_path.rfind('/')]
+    onnx_path = mx_path + '/contrib/onnx/'
+    if os.path.isdir(onnx_path):
+        print('Found ONNX path: %s' % onnx_path)
+    else:
+        logging.error('ONNX path not found. %s does not exist' % onnx_path)
+
+    # Backup the current onnx dir
+    backup_path = onnx_path + 'backup'
+    os.system('mkdir %s' % backup_path)
+    os.system('mv -v %s/* %s' % (onnx_path, backup_path))
+
+    # Clone the latest repo and copy the onnx dir
+    clone_path = './mxnet_repo_tmp'
+    os.system('mkdir %s' % clone_path)
+    cwd = os.getcwd()
+    os.chdir(clone_path)
+    os.system('git clone https://github.com/apache/incubator-mxnet mxnet')
+    os.chdir('./mxnet')
+    os.system('git checkout %s' % branch)
+    os.system('cp -r python/mxnet/contrib/onnx/* %s/' % onnx_path)
+    os.chdir(cwd)
+    os.system('rm -rf %s' %clone_path)
+    print('Done')
+
+
+def restore_onnx():
+    # Detect MXNet
+    print('Detected MXNet version: %s' % mxnet.__version__)
+    mx_path = os.path.abspath(mxnet.__file__)
+    mx_path = mx_path[:mx_path.rfind('/')]
+    onnx_path = mx_path + '/contrib/onnx'
+    backup_path = onnx_path + '/backup'
+    if os.path.isdir(backup_path):
+        print('Found ONNX path: %s' % onnx_path)
+        print('Found ONNX backup path: %s' % backup_path)
+    else:
+        logging.error('ONNX backup path not found. %s does not exist' % backup_path)
+
+    # Restore backup
+    os.chdir(onnx_path)
+    os.system('find . -mindepth 1 -maxdepth 1 ! -name backup -exec rm -r "{}" \;')
+    os.system('cp -r ./backup/* .')
+    os.system('rm -rf backup')
+    print('Done')
+
+
+parser = argparse.ArgumentParser(description='Update/Restore ONNX dir with the latest changes '
+                                 'on GitHub')
+parser.add_argument('--branch', default='v1.x',
+                    help='which branch to checkout')
+parser.add_argument('--restore', action='store_true', help='restore the backup files')
+args = parser.parse_args()
+
+if args.restore:
+    print('Restoring')
+    restore_onnx()
+else:
+    print('Updating to changes in branch %s' % args.branch)
+    update_onnx(args.branch)


### PR DESCRIPTION
As we frequently improve our ONNX support, users might want to get timely access to the latest changes. However, MXNet releases might not happen as  frequent as the users would want and they might have other compatibility concerns to update the entire mxnet module. To help with this, this pr adds a simple tool to update(replace) and restore the `mxnet/contrib/onnx` folder to the latest version on github. For example, a user that has mxnet 1.7 installed can use this script to get the latest onnx support without updating mxnet to a later version. This script helps make our onnx support more accessible and users can report bugs back and expect them fixed more easily.

The script will automatically find the currently installed mxnet. The original files will be backuped to `mxnet/contrib/onnx/backup`. `--branch` option controls which mxnet branch to checkout and if `--restore` option is specified then files in `backup` will be restored.

To update to changes in v1.x
```
python update_onnx.py
```
To update to changes in a specific branch
```
python update_onnx.py --branch <branch>
```
To restore the original files
```
python update_onnx.py --restore
```