### PR TITLE
[v1.x] For ECR, ensure we sanitize region input from environment variable

### DIFF
--- a/ci/build.py
+++ b/ci/build.py
@@ -97,7 +97,7 @@ def get_dockerfile(platform: str, path=get_dockerfiles_path()) -> str:
 
 
 def build_docker(platform: str, registry: str, num_retries: int, no_cache: bool,
-                 cache_intermediate: bool) -> str:
+                 cache_intermediate: bool=False) -> str:
     """
     Build a container for the given platform
     :param platform: Platform


### PR DESCRIPTION
## Description ##
* Sanitize the region input that we extract from an environment variable to prevent command injection. 
* Set a default value for recently introduced cache_intermediate.
* If using ECR, don't throw an exception if dockerhub environment variables are not set
* Track ECR login using a global variable, so we only have to retrieve login credentials once