### PR TITLE
[v1.x] Address CI failures with docker timeouts (v2)

### DIFF
--- a/ci/safe_docker_run.py
+++ b/ci/safe_docker_run.py
@@ -121,7 +121,7 @@ class SafeDockerClient:
             # Race condition:
             # add a random sleep to (a) give docker time to flush disk buffer after pulling image
             # and (b) minimize race conditions between jenkins runs on same host
-            time.sleep(random.randint(5,20))
+            time.sleep(random.randint(2,10))
             # If the call to docker_client.containers.run is interrupted, it is possible that
             # the container won't be cleaned up. We avoid this by temporarily masking the signals.
             signal.pthread_sigmask(signal.SIG_BLOCK, {signal.SIGINT, signal.SIGTERM})

--- a/ci/safe_docker_run.py
+++ b/ci/safe_docker_run.py
@@ -26,8 +26,10 @@ import argparse
 import atexit
 import logging
 import os
+import random
 import signal
 import sys
+import time
 from functools import reduce
 from itertools import chain
 from typing import Dict, Any
@@ -117,6 +119,9 @@ class SafeDockerClient:
         ret = 0
         try:
             # Race condition:
+            # add a random sleep to (a) give docker time to flush disk buffer after pulling image
+            # and (b) minimize race conditions between jenkins runs on same host
+            time.sleep(random.randint(5,20))
             # If the call to docker_client.containers.run is interrupted, it is possible that
             # the container won't be cleaned up. We avoid this by temporarily masking the signals.
             signal.pthread_sigmask(signal.SIG_BLOCK, {signal.SIGINT, signal.SIGTERM})


### PR DESCRIPTION
## Description ##
Add random sleep (between 2-10 sec) to give docker time to flush pulled images to disk and minimize chance of race condition between jenkins slave slots (on same machine) which causes docker run timeout. 