### PR TITLE
Use multi-tensor zeroing for resetting grads

### DIFF
--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -742,18 +742,16 @@ class Block:
                 if g.stype == 'row_sparse':
                     ndarray.zeros_like(g, out=g)
                 else:
-                    arrays[g.ctx].append(g)
+                    if is_np_array():
+                        arrays[g.ctx].append(g.as_nd_ndarray())
+                    else:
+                        arrays[g.ctx].append(g)
 
         if len(arrays) == 0:
             return
 
-        if is_np_array():
-            for arr in arrays.values():
-                for ele in arr:
-                    ele[()] = 0
-        else:
-            for arr in arrays.values():
-                ndarray.reset_arrays(*arr, num_arrays=len(arr))
+        for arr in arrays.values():
+            ndarray.reset_arrays(*arr, num_arrays=len(arr))
 
     def reset_ctx(self, ctx):
         """Re-assign all Parameters to other contexts.


### PR DESCRIPTION
## Description ##
Use multi-tensor kernel strategy for resetting gradients. 
Undo [https://github.com/apache/incubator-mxnet/pull/16716](https://github.com/apache/incubator-mxnet/pull/16716)

## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage ([https://github.com/sxjscience/mxnet/blob/master/tests/python/unittest/test_numpy_gluon.py#L185](https://github.com/sxjscience/mxnet/blob/master/tests/python/unittest/test_numpy_gluon.py#L185))
- [x] Code is well-documented

### Changes ###
- [x] in zero_grad method, use ndarray.reset_arrays for resetting multiple arrays within same kernel

## Comments ##
Performance observed training BERT-large on single V100 GPU:

........................................................................**Throughput samples / s**
**BatchSize - BatchAccumulation............Pre-Change............This-PR (multi-tensor )............  Improvement(%)** 
 ................4   -   2 ..............................................  29.82 ..........................36.24.............................................. 21.5
 ................4   -   4...............................................   36.89............................41.45..............................................12.3
 ................8   -   4...............................................   45.25............................48.41.............................................. 6.9