### PR TITLE
[FEATURE] OneDNN adaptive pooling support was added to mxnet.

### DIFF
--- a/src/operator/contrib/adaptive_avg_pooling-inl.h
+++ b/src/operator/contrib/adaptive_avg_pooling-inl.h
@@ -166,6 +166,7 @@ template <>
 struct hash<mxnet::op::AdaptiveAvgPoolParam> {
   size_t operator()(const mxnet::op::AdaptiveAvgPoolParam &val) {
     size_t ret = 0;
+    ret = dmlc::HashCombine(ret, val.output_size);
     return ret;
   }
 };

--- a/src/operator/contrib/adaptive_avg_pooling-inl.h
+++ b/src/operator/contrib/adaptive_avg_pooling-inl.h
@@ -43,6 +43,9 @@
 #include "../operator_common.h"
 #include "../mxnet_op.h"
 #include "../mshadow_op.h"
+#if MXNET_USE_MKLDNN == 1
+#include "../nn/mkldnn/mkldnn_adaptive_pooling-inl.h"
+#endif
 
 namespace mxnet {
 namespace op {
@@ -52,6 +55,9 @@ struct AdaptiveAvgPoolParam : public dmlc::Parameter<AdaptiveAvgPoolParam> {
   DMLC_DECLARE_PARAMETER(AdaptiveAvgPoolParam) {
     DMLC_DECLARE_FIELD(output_size).set_default(mxnet::Tuple<int>())
     .describe("int (output size) or a tuple of int for output (height, width).");
+  }
+  bool operator==(const AdaptiveAvgPoolParam &other) const {
+    return this->output_size == other.output_size;
   }
 };
 
@@ -116,7 +122,6 @@ inline void AdaptiveAvgPoolOpBackward(const nnvm::NodeAttrs& attrs,
   });
 }
 
-
 static bool AdaptiveAvgPoolOpInferShape(const nnvm::NodeAttrs& attrs,
                                        mxnet::ShapeVector *in_shape,
                                        mxnet::ShapeVector *out_shape) {
@@ -156,5 +161,13 @@ MSHADOW_XINLINE int get_stride(Tensor<xpu, Dim, DType> tensor, int idx) {
 
 }  // namespace op
 }  // namespace mxnet
-
+namespace std {
+template <>
+struct hash<mxnet::op::AdaptiveAvgPoolParam> {
+  size_t operator()(const mxnet::op::AdaptiveAvgPoolParam &val) {
+    size_t ret = 0;
+    return ret;
+  }
+};
+}  // namespace std
 #endif  // MXNET_OPERATOR_CONTRIB_ADAPTIVE_AVG_POOLING_INL_H_

--- a/src/operator/contrib/adaptive_avg_pooling.cc
+++ b/src/operator/contrib/adaptive_avg_pooling.cc
@@ -216,12 +216,12 @@ bool SupportMKLDNNAveragePooling(const NDArray &in_data,
   const int OH = out_data.shape()[2];
   const int OW = out_data.shape()[3];
 
-  const int strides_1 = floor((IH << 1) / OH) - floor(IH / OH);
-  const int strides_2 = floor((IW << 1) / OW) - floor(IW / OW);
-  const int kernel_1 = ceil((IH << 1) / OH) - floor(IH / OH);
-  const int kernel_2 = ceil((IW << 1) / OW) - floor(IW / OW);
-  const int pad_l_top = (strides_1 * (OH - 1) + kernel_1 - IH) / 2;
-  const int pad_l_left = (strides_2 * (OW - 1) + kernel_2 - IW) / 2;
+  const int strides_H = floor((IH << 1) / OH) - floor(IH / OH);
+  const int strides_W = floor((IW << 1) / OW) - floor(IW / OW);
+  const int kernel_H = ceil((IH << 1) / OH) - floor(IH / OH);
+  const int kernel_W = ceil((IW << 1) / OW) - floor(IW / OW);
+  const int pad_l_top = (strides_H * (OH - 1) + kernel_H - IH) / 2;
+  const int pad_l_left = (strides_W * (OW - 1) + kernel_W - IW) / 2;
 
   return pad_l_top == 0 && pad_l_left == 0;
 }
@@ -253,12 +253,11 @@ void AdaptiveAvgPoolComputeExCPU(const nnvm::NodeAttrs &attrs,
 }
 #endif
 
-
-inline static bool AdaptivePoolingStorageType(const nnvm::NodeAttrs &attrs,
-                                              const int dev_mask,
-                                              DispatchMode *dispatch_mode,
-                                              std::vector<int> *in_attrs,
-                                              std::vector<int> *out_attrs) {
+inline bool AdaptivePoolingStorageType(const nnvm::NodeAttrs &attrs,
+                                       const int dev_mask,
+                                       DispatchMode *dispatch_mode,
+                                       std::vector<int> *in_attrs,
+                                       std::vector<int> *out_attrs) {
   CHECK_EQ(in_attrs->size(), 1);
   bool dispatched = false;
   for (int &v : *in_attrs)

--- a/src/operator/contrib/adaptive_avg_pooling.cc
+++ b/src/operator/contrib/adaptive_avg_pooling.cc
@@ -22,9 +22,10 @@
  * \brief adaptive average pooling operator
  * \author Hang Zhang
 */
-#include "adaptive_avg_pooling-inl.h"
-// #include "elemwise_op_common.h"
+#include <nnvm/op_attr_types.h>
 #include "../elemwise_op_common.h"
+#include "../operator_common.h"
+#include "adaptive_avg_pooling-inl.h"
 
 #define START_IND(a, b, c) static_cast<int>(std::floor(static_cast<float>(a * c) / b))
 #define END_IND(a, b, c) static_cast<int>(std::ceil(static_cast<float>((a + 1) * c) / b))
@@ -197,6 +198,91 @@ num_threads(engine::OpenMP::Get()->GetRecommendedOMPThreadCount())
   }
 }
 
+#if MXNET_USE_MKLDNN == 1
+bool CanMKLDNNSupportAveragePooling(const NDArray &in_data,
+                                    const NDArray &out_data) {
+  for (int64_t idx = 2; idx < in_data.shape().ndim(); ++idx) {
+    const int s1 = in_data.shape()[idx];
+    const int s2 = out_data.shape()[idx];
+    if (s2 == 0) {
+      return false;
+    }
+    if (s1 % s2 != 0) {
+      return false;
+    }
+  }
+  const int IH = in_data.shape()[2];
+  const int IW = in_data.shape()[3];
+  const int OH = out_data.shape()[2];
+  const int OW = out_data.shape()[3];
+
+  const int strides_1 = floor((IH << 1) / OH) - floor(IH / OH);
+  const int strides_2 = floor((IW << 1) / OW) - floor(IW / OW);
+  const int kernel_1 = ceil((IH << 1) / OH) - floor(IH / OH);
+  const int kernel_2 = ceil((IW << 1) / OW) - floor(IW / OW);
+  const int pad_l_top = (strides_1 * (OH - 1) + kernel_1 - IH) / 2;
+  const int pad_l_left = (strides_2 * (OW - 1) + kernel_2 - IW) / 2;
+
+  return pad_l_top == 0 && pad_l_left == 0;
+}
+
+
+void AdaptiveAvgPoolComputeExCPU(const nnvm::NodeAttrs &attrs,
+                                 const OpContext &ctx,
+                                 const std::vector<NDArray> &inputs,
+                                 const std::vector<OpReqType> &req,
+                                 const std::vector<NDArray> &outputs) {
+  CHECK_EQ(inputs.size(), 1U);
+  CHECK_EQ(outputs.size(), 1U);
+  /*
+  DNNL doesn't support adaptive pooling. 
+  Fallback is needed when padding is not equal 0;
+  */
+  if (SupportMKLDNN(inputs[0]) &&
+      CanMKLDNNSupportAveragePooling(inputs[0], outputs[0])) {
+    const AdaptiveAvgPoolParam &param =
+        nnvm::get<AdaptiveAvgPoolParam>(attrs.parsed);
+    const NDArray *workspace = nullptr;
+    MKLDNN_OPCHECK_INIT(false, 1, inputs, outputs);
+    MKLDNNAdaptivePoolingCompute(ctx, param, inputs[0], req[0], outputs[0],
+                                 workspace);
+    return;
+  }
+  FallBackCompute(AdaptiveAvgPoolOpForward<cpu>, attrs, ctx, inputs, req,
+                  outputs);
+}
+#endif
+
+
+inline static bool AdaptivePoolingStorageType(const nnvm::NodeAttrs &attrs,
+                                              const int dev_mask,
+                                              DispatchMode *dispatch_mode,
+                                              std::vector<int> *in_attrs,
+                                              std::vector<int> *out_attrs) {
+  CHECK_EQ(in_attrs->size(), 1);
+  bool dispatched = false;
+#if MXNET_USE_MKLDNN == 1
+  if (!dispatched) {
+    dispatched = MKLDNNStorageType(attrs, dev_mask, true, dispatch_mode,
+                                   in_attrs, out_attrs);
+  }
+  if (!MKLDNNEnvSet()) {
+    *dispatch_mode = DispatchMode::kFComputeFallback;
+  }
+#else
+  for (int &v : *in_attrs)
+    if (v == -1) v = kDefaultStorage;
+  if (!dispatched && common::ContainsOnlyStorage(*in_attrs, kDefaultStorage)) {
+    dispatched = storage_type_assign(out_attrs, kDefaultStorage, dispatch_mode,
+                                     DispatchMode::kFCompute);
+  }
+  if (!dispatched) {
+    dispatched = dispatch_fallback(out_attrs, dispatch_mode);
+  }
+#endif
+  return dispatched;
+}
+
 
 DMLC_REGISTER_PARAMETER(AdaptiveAvgPoolParam);
 
@@ -219,6 +305,11 @@ The pooling kernel and stride sizes are automatically chosen for desired output 
 .set_attr<FCompute>("FCompute<cpu>", AdaptiveAvgPoolOpForward<cpu>)
 .set_attr<nnvm::FGradient>("FGradient",
   ElemwiseGradUseNone{"_backward_contrib_AdaptiveAvgPooling2D"})
+.set_attr<FInferStorageType>("FInferStorageType", AdaptivePoolingStorageType)
+#if MXNET_USE_MKLDNN == 1
+.set_attr<bool>("TIsMKLDNN", true)
+.set_attr<FComputeEx>("FComputeEx<cpu>",  AdaptiveAvgPoolComputeExCPU)
+#endif
 .add_argument("data", "NDArray-or-Symbol", "Input data")
 .add_arguments(AdaptiveAvgPoolParam::__FIELDS__());
 

--- a/src/operator/nn/mkldnn/mkldnn_adaptive_pooling-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_adaptive_pooling-inl.h
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file mkldnn_adaptive_pooling-inl.h
+ * \brief
+ * \author Mateusz Ozga
+*/
+#ifndef MXNET_OPERATOR_NN_MKLDNN_MKLDNN_ADAPTIVE_POOLING_INL_H_
+#define MXNET_OPERATOR_NN_MKLDNN_MKLDNN_ADAPTIVE_POOLING_INL_H_
+
+#if MXNET_USE_MKLDNN == 1
+
+#include <mkldnn.hpp>
+#include <utility>
+#include "../../operator_common.h"
+#include "./mkldnn_base-inl.h"
+
+namespace mxnet {
+namespace op {
+
+class MKLDNNAdaptivePoolingFwd {
+ public:
+  MKLDNNAdaptivePoolingFwd(const mxnet::NDArray &input,
+                           const mxnet::NDArray &output,
+                           const mkldnn::memory::dims &kernel,
+                           const mkldnn::memory::dims &strides,
+                           const mkldnn::memory::dims &pad_l,
+                           const mkldnn::memory::dims &pad_r,
+                           const mkldnn::algorithm alg_kind,
+                           const bool with_workspace, const bool is_train)
+      : with_workspace_(with_workspace), fwd_(nullptr) {
+    Init(input, output, kernel, strides, pad_l, pad_r, is_train, alg_kind);
+  }
+  ~MKLDNNAdaptivePoolingFwd() = default;
+
+ public:
+  void Execute(const NDArray &input, const OpReqType req, const NDArray &output,
+               const NDArray *workspace);
+
+ private:
+  bool with_workspace_;
+  std::shared_ptr<mkldnn::pooling_forward::primitive_desc> fwd_pd_;
+  std::shared_ptr<mkldnn::pooling_forward> fwd_;
+
+ private:
+  void Init(const mxnet::NDArray &input, const mxnet::NDArray &output,
+            const mkldnn::memory::dims &kernel,
+            const mkldnn::memory::dims &strides,
+            const mkldnn::memory::dims &pad_l,
+            const mkldnn::memory::dims &pad_r, const bool is_train,
+            const mkldnn::algorithm alg_kind);
+};
+
+
+template <typename T = mkldnn::memory::dims>
+void updateAdaptivePaddingKernel(T *kernel, T *strides, T *pad_l, T *pad_r,
+                                 const NDArray &in_data,
+                                 const NDArray &out_data) {
+  const int IH = in_data.shape()[2];
+  const int IW = in_data.shape()[3];
+  const int OH = out_data.shape()[2];
+  const int OW = out_data.shape()[3];
+
+  strides->at(0) = floor((IH << 1) / OH) - floor(IH / OH);
+  strides->at(1) = floor((IW << 1) / OW) - floor(IW / OW);
+  kernel->at(0) = ceil((IH << 1) / OH) - floor(IH / OH);
+  kernel->at(1) = ceil((IW << 1) / OW) - floor(IW / OW);
+  pad_l->at(0) = (strides->at(0) * (OH - 1) + kernel->at(0) - IH) >> 1;
+  pad_l->at(1) = (strides->at(1) * (OW - 1) + kernel->at(1) - IW) >> 1;
+}
+
+template <typename T>
+MKLDNNAdaptivePoolingFwd &GetPoolingFwd(const T &param, const bool is_train,
+                                        const NDArray &input,
+                                        const NDArray &output) {
+  if (input.shape().ndim() != 4) {
+    LOG(FATAL) << "MKLDNN Adaptive Avg Pool 2d: Expect only 2D input";
+  }
+  typedef ParamOpSign<T> MKLDNNPoolingSignature;
+#if DMLC_CXX11_THREAD_LOCAL
+  static thread_local std::unordered_map<MKLDNNPoolingSignature,
+                                         MKLDNNAdaptivePoolingFwd, OpHash>
+      pooling_fwds;
+#else
+  static MX_THREAD_LOCAL std::unordered_map<MKLDNNPoolingSignature,
+                                            MKLDNNAdaptivePoolingFwd, OpHash>
+      pooling_fwds;
+#endif
+  bool with_workspace = is_train && true;
+  MKLDNNPoolingSignature key(param);
+  key.AddSign(is_train);
+  key.AddSign(with_workspace);
+  key.AddSign(input);
+  key.AddSign(output);
+
+  auto it = pooling_fwds.find(key);
+  if (it == pooling_fwds.end()) {
+    const int kernel_ndims = input.shape().ndim();
+
+    mkldnn::memory::dims kernel(kernel_ndims);
+    mkldnn::memory::dims strides(kernel_ndims);
+    mkldnn::memory::dims pad_l(kernel_ndims);
+    mkldnn::memory::dims pad_r(kernel_ndims);
+
+    updateAdaptivePaddingKernel(&kernel, &strides, &pad_l, &pad_r, input, output);
+    mkldnn::memory::validate_dims(kernel);
+    mkldnn::memory::validate_dims(strides);
+    mkldnn::memory::validate_dims(pad_l);
+    mkldnn::memory::validate_dims(pad_r);
+
+    mkldnn::algorithm kind = mkldnn::algorithm::pooling_avg;
+    MKLDNNAdaptivePoolingFwd fwd(input, output, kernel, kernel, pad_l, pad_r,
+                                 kind, false, false);
+    it = AddToCache(&pooling_fwds, key, fwd);
+  }
+  return it->second;
+}
+
+template <typename T>
+void MKLDNNAdaptivePoolingCompute(const OpContext &ctx, const T &param,
+                                  const NDArray &in_data, const OpReqType req,
+                                  const NDArray &out_data,
+                                  const NDArray *workspace) {
+  auto &fwd = GetPoolingFwd(param, ctx.is_train, in_data, out_data);
+  fwd.Execute(in_data, req, out_data, workspace);
+}
+}  // namespace op
+}  // namespace mxnet
+#endif  // MXNET_USE_MKLDNN == 1
+#endif  // MXNET_OPERATOR_NN_MKLDNN_MKLDNN_ADAPTIVE_POOLING_INL_H_

--- a/src/operator/nn/mkldnn/mkldnn_adaptive_pooling-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_adaptive_pooling-inl.h
@@ -20,7 +20,7 @@
 /*!
  * Copyright (c) 2021 by Contributors
  * \file mkldnn_adaptive_pooling-inl.h
-*/
+ */
 #ifndef MXNET_OPERATOR_NN_MKLDNN_MKLDNN_ADAPTIVE_POOLING_INL_H_
 #define MXNET_OPERATOR_NN_MKLDNN_MKLDNN_ADAPTIVE_POOLING_INL_H_
 
@@ -28,6 +28,7 @@
 
 #include <mkldnn.hpp>
 #include <utility>
+
 #include "../../operator_common.h"
 #include "./mkldnn_base-inl.h"
 
@@ -36,22 +37,25 @@ namespace op {
 
 class MKLDNNAdaptivePoolingFwd {
  public:
-  MKLDNNAdaptivePoolingFwd(const mxnet::NDArray &input,
-                           const mxnet::NDArray &output,
-                           const mkldnn::memory::dims &kernel,
-                           const mkldnn::memory::dims &strides,
-                           const mkldnn::memory::dims &pad_l,
-                           const mkldnn::memory::dims &pad_r,
+  MKLDNNAdaptivePoolingFwd(const mxnet::NDArray& input,
+                           const mxnet::NDArray& output,
+                           const mkldnn::memory::dims& kernel,
+                           const mkldnn::memory::dims& strides,
+                           const mkldnn::memory::dims& pad_l,
+                           const mkldnn::memory::dims& pad_r,
                            const mkldnn::algorithm alg_kind,
-                           const bool with_workspace, const bool is_train)
+                           const bool with_workspace,
+                           const bool is_train)
       : with_workspace_(with_workspace), fwd_(nullptr) {
     Init(input, output, kernel, strides, pad_l, pad_r, is_train, alg_kind);
   }
   ~MKLDNNAdaptivePoolingFwd() = default;
 
  public:
-  void Execute(const NDArray &input, const OpReqType req, const NDArray &output,
-               const NDArray *workspace);
+  void Execute(const NDArray& input,
+               const OpReqType req,
+               const NDArray& output,
+               const NDArray* workspace);
 
  private:
   bool with_workspace_;
@@ -59,18 +63,23 @@ class MKLDNNAdaptivePoolingFwd {
   std::shared_ptr<mkldnn::pooling_forward> fwd_;
 
  private:
-  void Init(const mxnet::NDArray &input, const mxnet::NDArray &output,
-            const mkldnn::memory::dims &kernel,
-            const mkldnn::memory::dims &strides,
-            const mkldnn::memory::dims &pad_l,
-            const mkldnn::memory::dims &pad_r, const bool is_train,
+  void Init(const mxnet::NDArray& input,
+            const mxnet::NDArray& output,
+            const mkldnn::memory::dims& kernel,
+            const mkldnn::memory::dims& strides,
+            const mkldnn::memory::dims& pad_l,
+            const mkldnn::memory::dims& pad_r,
+            const bool is_train,
             const mkldnn::algorithm alg_kind);
 };
 
 template <typename T = mkldnn::memory::dims>
-void updateAdaptivePaddingKernel(T *kernel, T *strides, T *pad_l, T *pad_r,
-                                 const NDArray &in_data,
-                                 const NDArray &out_data) {
+void updateAdaptivePaddingKernel(T* kernel,
+                                 T* strides,
+                                 T* pad_l,
+                                 T* pad_r,
+                                 const NDArray& in_data,
+                                 const NDArray& out_data) {
   const int IH = in_data.shape()[2];
   const int IW = in_data.shape()[3];
   const int OH = out_data.shape()[2];
@@ -78,28 +87,28 @@ void updateAdaptivePaddingKernel(T *kernel, T *strides, T *pad_l, T *pad_r,
 
   strides->at(0) = floor((IH << 1) / OH) - floor(IH / OH);
   strides->at(1) = floor((IW << 1) / OW) - floor(IW / OW);
-  kernel->at(0) = ceil((IH << 1) / OH) - floor(IH / OH);
-  kernel->at(1) = ceil((IW << 1) / OW) - floor(IW / OW);
-  pad_l->at(0) = (strides->at(0) * (OH - 1) + kernel->at(0) - IH) >> 1;
-  pad_l->at(1) = (strides->at(1) * (OW - 1) + kernel->at(1) - IW) >> 1;
+  kernel->at(0)  = ceil((IH << 1) / OH) - floor(IH / OH);
+  kernel->at(1)  = ceil((IW << 1) / OW) - floor(IW / OW);
+  pad_l->at(0)   = (strides->at(0) * (OH - 1) + kernel->at(0) - IH) >> 1;
+  pad_l->at(1)   = (strides->at(1) * (OW - 1) + kernel->at(1) - IW) >> 1;
 }
 
 template <typename T>
-MKLDNNAdaptivePoolingFwd &GetPoolingFwd(const T &param, const bool is_train,
-                                        const NDArray &input,
-                                        const NDArray &output) {
+MKLDNNAdaptivePoolingFwd& GetPoolingFwd(const T& param,
+                                        const bool is_train,
+                                        const NDArray& input,
+                                        const NDArray& output) {
   if (input.shape().ndim() != 4) {
     LOG(FATAL) << "MKLDNN Adaptive Avg Pool 2d: Expect only 2D input";
   }
   typedef ParamOpSign<T> MKLDNNPoolingSignature;
 #if DMLC_CXX11_THREAD_LOCAL
-  static thread_local std::unordered_map<MKLDNNPoolingSignature,
-                                         MKLDNNAdaptivePoolingFwd, OpHash>
+  static thread_local std::unordered_map<MKLDNNPoolingSignature, MKLDNNAdaptivePoolingFwd, OpHash>
       pooling_fwds;
 #else
-  static MX_THREAD_LOCAL std::unordered_map<MKLDNNPoolingSignature,
-                                            MKLDNNAdaptivePoolingFwd, OpHash>
-      pooling_fwds;
+  static MX_THREAD_LOCAL
+      std::unordered_map<MKLDNNPoolingSignature, MKLDNNAdaptivePoolingFwd, OpHash>
+          pooling_fwds;
 #endif
   bool with_workspace = is_train;
   MKLDNNPoolingSignature key(param);
@@ -117,27 +126,27 @@ MKLDNNAdaptivePoolingFwd &GetPoolingFwd(const T &param, const bool is_train,
     mkldnn::memory::dims pad_l(kernel_ndims);
     mkldnn::memory::dims pad_r(kernel_ndims);
 
-    updateAdaptivePaddingKernel(&kernel, &strides, &pad_l, &pad_r, input,
-                                output);
+    updateAdaptivePaddingKernel(&kernel, &strides, &pad_l, &pad_r, input, output);
     mkldnn::memory::validate_dims(kernel);
     mkldnn::memory::validate_dims(strides);
     mkldnn::memory::validate_dims(pad_l);
     mkldnn::memory::validate_dims(pad_r);
 
     mkldnn::algorithm kind = mkldnn::algorithm::pooling_avg;
-    MKLDNNAdaptivePoolingFwd fwd(input, output, kernel, kernel, pad_l, pad_r,
-                                 kind, false, false);
+    MKLDNNAdaptivePoolingFwd fwd(input, output, kernel, kernel, pad_l, pad_r, kind, false, false);
     it = AddToCache(&pooling_fwds, key, fwd);
   }
   return it->second;
 }
 
 template <typename T>
-void MKLDNNAdaptivePoolingCompute(const OpContext &ctx, const T &param,
-                                  const NDArray &in_data, const OpReqType req,
-                                  const NDArray &out_data,
-                                  const NDArray *workspace) {
-  auto &fwd = GetPoolingFwd(param, ctx.is_train, in_data, out_data);
+void MKLDNNAdaptivePoolingCompute(const OpContext& ctx,
+                                  const T& param,
+                                  const NDArray& in_data,
+                                  const OpReqType req,
+                                  const NDArray& out_data,
+                                  const NDArray* workspace) {
+  auto& fwd = GetPoolingFwd(param, ctx.is_train, in_data, out_data);
   fwd.Execute(in_data, req, out_data, workspace);
 }
 }  // namespace op

--- a/src/operator/nn/mkldnn/mkldnn_adaptive_pooling-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_adaptive_pooling-inl.h
@@ -18,9 +18,8 @@
  */
 
 /*!
+ * Copyright (c) 2021 by Contributors
  * \file mkldnn_adaptive_pooling-inl.h
- * \brief
- * \author Mateusz Ozga
 */
 #ifndef MXNET_OPERATOR_NN_MKLDNN_MKLDNN_ADAPTIVE_POOLING_INL_H_
 #define MXNET_OPERATOR_NN_MKLDNN_MKLDNN_ADAPTIVE_POOLING_INL_H_
@@ -68,7 +67,6 @@ class MKLDNNAdaptivePoolingFwd {
             const mkldnn::algorithm alg_kind);
 };
 
-
 template <typename T = mkldnn::memory::dims>
 void updateAdaptivePaddingKernel(T *kernel, T *strides, T *pad_l, T *pad_r,
                                  const NDArray &in_data,
@@ -103,7 +101,7 @@ MKLDNNAdaptivePoolingFwd &GetPoolingFwd(const T &param, const bool is_train,
                                             MKLDNNAdaptivePoolingFwd, OpHash>
       pooling_fwds;
 #endif
-  bool with_workspace = is_train && true;
+  bool with_workspace = is_train;
   MKLDNNPoolingSignature key(param);
   key.AddSign(is_train);
   key.AddSign(with_workspace);
@@ -119,7 +117,8 @@ MKLDNNAdaptivePoolingFwd &GetPoolingFwd(const T &param, const bool is_train,
     mkldnn::memory::dims pad_l(kernel_ndims);
     mkldnn::memory::dims pad_r(kernel_ndims);
 
-    updateAdaptivePaddingKernel(&kernel, &strides, &pad_l, &pad_r, input, output);
+    updateAdaptivePaddingKernel(&kernel, &strides, &pad_l, &pad_r, input,
+                                output);
     mkldnn::memory::validate_dims(kernel);
     mkldnn::memory::validate_dims(strides);
     mkldnn::memory::validate_dims(pad_l);

--- a/src/operator/nn/mkldnn/mkldnn_adaptive_pooling.cc
+++ b/src/operator/nn/mkldnn/mkldnn_adaptive_pooling.cc
@@ -18,9 +18,8 @@
  */
 
 /*!
+ * Copyright (c) 2021 by Contributors
  * \file mkldnn_adaptive_pooling.cc
- * \brief
- * \author Mateusz Ozga
 */
 
 #if MXNET_USE_MKLDNN == 1
@@ -80,7 +79,7 @@ void MKLDNNAdaptivePoolingFwd::Execute(const NDArray &input,
       LOG(FATAL) << "MKLDNN Average Pooling: incorrect worskapce input";
     }
     auto ws = std::make_shared<mkldnn::memory>(
-        (*(this->fwd_pd_)).workspace_desc(), engine,
+        this->fwd_pd_->workspace_desc(), engine,
         workspace->GetMKLDNNData()->get_data_handle());
     args[MKLDNN_ARG_WORKSPACE] = *ws;
   }

--- a/src/operator/nn/mkldnn/mkldnn_adaptive_pooling.cc
+++ b/src/operator/nn/mkldnn/mkldnn_adaptive_pooling.cc
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file mkldnn_adaptive_pooling.cc
+ * \brief
+ * \author Mateusz Ozga
+*/
+
+#if MXNET_USE_MKLDNN == 1
+
+#include "./mkldnn_adaptive_pooling-inl.h"
+
+namespace mxnet {
+namespace op {
+void MKLDNNAdaptivePoolingFwd::Init(
+    const mxnet::NDArray &input, const mxnet::NDArray &output,
+    const mkldnn::memory::dims &kernel, const mkldnn::memory::dims &strides,
+    const mkldnn::memory::dims &pad_l, const mkldnn::memory::dims &pad_r,
+    const bool is_train, const mkldnn::algorithm alg_kind) {
+  const auto src_md = input.GetMKLDNNData()->get_desc();
+  const auto dst_md = GetMemDesc(output);
+  const mkldnn::engine engine = CpuEngine::Get()->get_engine();
+
+  if (alg_kind != mkldnn::algorithm::pooling_avg &&
+      alg_kind != mkldnn::algorithm::pooling_avg_include_padding &&
+      alg_kind != mkldnn::algorithm::pooling_avg_exclude_padding) {
+    LOG(FATAL) << "MKLDNN Adaptive Pooling: algorithm is not supported";
+  }
+
+  mkldnn::prop_kind prop = mkldnn::prop_kind::forward_scoring;
+  if (is_train && alg_kind != mkldnn::algorithm::pooling_avg) {
+    prop = mkldnn::prop_kind::forward_training;
+  }
+  if (is_train && prop == mkldnn::prop_kind::forward_scoring) {
+    LOG(INFO) << "MKLDNN Pooling: training with prop_kind is forward_scoring";
+  }
+
+  const auto fwd_desc = mkldnn::pooling_forward::desc(
+      prop, alg_kind, src_md, dst_md, strides, kernel, pad_l, pad_r);
+  this->fwd_pd_.reset(
+      new mkldnn::pooling_forward::primitive_desc(fwd_desc, engine));
+  this->fwd_.reset(new mkldnn::pooling_forward(*(this->fwd_pd_)));
+}
+
+void MKLDNNAdaptivePoolingFwd::Execute(const NDArray &input,
+                                       const OpReqType req,
+                                       const NDArray &output,
+                                       const NDArray *workspace) {
+  NDArray in_buffer = input;
+  if (input.IsView() && input.IsMKLDNNData()) {
+    in_buffer = input.Reorder2Default();
+  }
+
+  auto input_mem = in_buffer.GetMKLDNNData();
+  auto output_mem_t = CreateMKLDNNMem(output, this->fwd_pd_->dst_desc(), req);
+
+  mkldnn_args_map_t args = {{MKLDNN_ARG_SRC, *input_mem},
+                            {MKLDNN_ARG_DST, *(output_mem_t.second)}};
+
+  if (this->with_workspace_) {
+    auto engine = CpuEngine::Get()->get_engine();
+    if (workspace == nullptr) {
+      LOG(FATAL) << "MKLDNN Average Pooling: incorrect worskapce input";
+    }
+    auto ws = std::make_shared<mkldnn::memory>(
+        (*(this->fwd_pd_)).workspace_desc(), engine,
+        workspace->GetMKLDNNData()->get_data_handle());
+    args[MKLDNN_ARG_WORKSPACE] = *ws;
+  }
+  if (this->fwd_) {
+    MKLDNNStream::Get()->RegisterPrimArgs(*(this->fwd_), args);
+    CommitOutput(output, output_mem_t);
+    MKLDNNStream::Get()->Submit();
+  } else {
+    LOG(FATAL) << "MKLDNN Pooling: forward primitive is nullptr";
+  }
+}
+
+}  // namespace op
+}  // namespace mxnet
+#endif  // MXNET_USE_MKLDNN == 1


### PR DESCRIPTION
## Description ##
OneDNN adaptive pooling operator was added to MxNet. There is a fallback to a naive impl. of this kernel - just in case the paddings are 0. Additionally, there is a mechanism to check the correctness of this one'. 

## Benchmark ##
```python
#!/usr/bin/env python3
import mxnet as mx
import time
import numpy as np

def isSupported(x, y):
    for i in range(2, len(x)):
        s1 = x[i]
        s2 = y[i]
        if s2 == 0:
            return False
        if s1 % s2 != 0:
            return False
            
    IH = x[2]
    IW = x[3]
    OH = y[2]
    OW = y[3]

    strides_H = np.floor((IH << 1) / OH) - np.floor(IH / OH)
    strides_W = np.floor((IW << 1) / OW) - np.floor(IW / OW)
    kernel_H = np.ceil((IH << 1) / OH) - np.floor(IH / OH)
    kernel_W = np.ceil((IW << 1) / OW) - np.floor(IW / OW)
    pad_l_top = (strides_H * (OH - 1) + kernel_H - IH) / 2
    pad_l_left = (strides_W * (OW - 1) + kernel_W - IW) / 2

    return pad_l_top == 0 and pad_l_left == 0

def time_procedure(shape, output_height, count):
  data = mx.nd.random_uniform(shape=shape, low=-1.0, high = 1.0)
  mx.nd.waitall()
  begin = time.time()
  for i in range(0, count):
    out = mx.nd.contrib.AdaptiveAvgPooling2D(data, output_size=output_height)
    mx.nd.waitall()
  return (time.time() - begin) / count


count = 200
for x in [1, 2, 4, 8, 16, 32]:
      for y in [1, 2, 4, 8, 16, 32, 128, 256, 512, 1024, 2048]:
          shape = (x, x, y, y)
          for i in [1, 2, 4, 8, 16, 32]:
              timing = time_procedure(shape, i, count)
              print("{}x{:5d}:{:5d} | {:.7f}".format(shape, i, isSupported([x,x,y,y], [x,x, i,i]), timing))
```
## Result ##
Tensor size| Output | Before| After | [%]
--- | --- | --- |---|---|
(1, 1, 1, 1)|      1|    	  0.0000497 | 0.0000629|        -21%
(1, 1, 16, 16)|    1|    	  0.0000733| 0.0000796|			-8%
(1, 1, 16, 16)|    2|    	  0.0000736| 0.0000802|			-8%
(1, 1, 16, 16)|    4|    	  0.0000719| 0.0000792|			-9%
(1, 1, 16, 16)|    8|    	  0.0000706| 0.0000797|			-11%
(1, 1, 16, 16)|   16|    	  0.0000708| 0.0001080|			-34%
(1, 1, 1024, 1024)|    1|     0.0014483 | 0.0014640|		-1%
(1, 1, 1024, 1024)|    2|     0.0014560 | 0.0004589|		217%
(1, 1, 1024, 1024)|    4|     0.0014526 | 0.0001407|		932%
(1, 1, 1024, 1024)|    8|     0.0014463 | 0.0001315|		1000%
(1, 1, 1024, 1024)|   16|     0.0014479 | 0.0001167|		1141%
(1, 1, 1024, 1024)|   32|     0.0014398 | 0.0001279|		1026%
(1, 1, 2048, 2048)|    1|     0.0057222 | 0.0051859|		10%
(1, 1, 2048, 2048)|    2|     0.0058086 | 0.0015009|		287%
(1, 1, 2048, 2048)|    4|     0.0058387 | 0.0004973|		1074%
(1, 1, 2048, 2048)|    8|     0.0058525 | 0.0004041|		1348%
(1, 1, 2048, 2048)|   16|     0.0058573 | 0.0003883|		1408%
(1, 1, 2048, 2048)|   32|     0.0058751 | 0.0003341|		1658%
(32, 32, 16, 16)|    1|   	  0.0000653| 0.0000602|			8%
(32, 32, 16, 16)|    2|   0.0000631| 0.0000675|				-7%
(32, 32, 16, 16)|    4|   0.0000664| 0.0001043|				-36%
(32, 32, 16, 16)|    8|   0.0000870| 0.0001660|				-48%
(32, 32, 16, 16)|   16|   0.0002160| 0.0001838|				18%
(32, 32, 16, 16)|   32|   0.0004524| 0.0005508|				-18%
(32, 32, 32, 32)|    1|   0.0001380| 0.0001253|				10%
(32, 32, 32, 32)|    2|   0.0001359| 0.0000991|				37%
(32, 32, 32, 32)|    4|   0.0001158| 0.0001014|				14%
(32, 32, 32, 32)|    8|   0.0001302| 0.0001172|				11%
(32, 32, 32, 32)|   16|   0.0001963| 0.0001168|				68%
(32, 32, 32, 32)|   32|   0.0005488| 0.0002003|				174%
(32, 32, 128, 128)|    1| 0.0016189| 0.0014996|				8%
(32, 32, 128, 128)|    2| 0.0017290| 0.0015577|				11%
(32, 32, 128, 128)|    4| 0.0017293| 0.0015723|				10%
(32, 32, 128, 128)|    8| 0.0017221| 0.0015734|				9%
(32, 32, 128, 128)|   16| 0.0015885| 0.0016033|				-1%
(32, 32, 128, 128)|   32| 0.0018777| 0.0017448|				8%
(32, 32, 256, 256)|    1| 0.0062000| 0.0054002|				15%
(32, 32, 256, 256)|    2| 0.0063598| 0.0055455|				15%
(32, 32, 256, 256)|    4| 0.0071068| 0.0063158|				13%
(32, 32, 256, 256)|    8| 0.0067929| 0.0062830|				18%
(32, 32, 256, 256)|   16| 0.0063883| 0.0061792|				3%
(32, 32, 256, 256)|   32| 0.0059441| 0.0064057|				7%
(32, 32, 512, 512)|    1| 0.0239963| 0.0209755|				14%
(32, 32, 512, 512)|    2| 0.0262547| 0.0228893|				15%
(32, 32, 512, 512)|    4| 0.0287423| 0.0247784|				16%
(32, 32, 512, 512)|    8| 0.0303701| 0.0274140|				11%
(32, 32, 512, 512)|   16| 0.0251173| 0.0229451|				19%
(32, 32, 512, 512)|   32| 0.0245377| 0.0235681|				4%
(32, 32, 1024, 1024)|  1| 0.0951804| 0.0824345|				15%
(32, 32, 1024, 1024)|  2| 0.1156001| 0.1018558|				13%
(32, 32, 1024, 1024)|  4| 0.1179827| 0.1032433|				14%
(32, 32, 1024, 1024)|  8| 0.1467115| 0.1301773|				13%
(32, 32, 1024, 1024)|  16|0.1426910| 0.1349685|				6%
(32, 32, 1024, 1024)|  32|0.1043669| 0.0940493|				11%

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backwards-incompatible change, why must this change be made.
- Interesting edge cases to note here
