### PR TITLE
[website] Fix file path in build_docs

### DIFF
--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -1191,8 +1191,12 @@ build_docs() {
 
     # copy the full site for this version to versions folder
     mkdir -p html/versions/master
-    for f in 404.html api assets blog community ecosystem features feed.xml get_started index.html; do
+    for f in 404.html api assets community feed.xml get_started index.html; do
         cp -r html/$f html/versions/master/
+    done
+
+    for f in blog ecosystem features; do
+        cp -r html/pages/$f html/versions/master/
     done
 
     # clean up temp files


### PR DESCRIPTION
## Description ##
The `restricted-website-build-master` pipeline is failing due to files not found issue:https://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/restricted-website-build-master/activity.
By inspecting the build, the missing files `blog`, `ecosystem` and `features` were moved from `html/` to `html/pages`.
This PR fix the file paths in `build_docs`

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
