### PR TITLE
[website] Fix static website build

### DIFF
--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -1191,12 +1191,8 @@ build_docs() {
 
     # copy the full site for this version to versions folder
     mkdir -p html/versions/master
-    for f in 404.html api assets community feed.xml get_started index.html; do
+    for f in 404.html api assets blog community ecosystem features feed.xml get_started index.html; do
         cp -r html/$f html/versions/master/
-    done
-
-    for f in blog ecosystem features; do
-        cp -r html/pages/$f html/versions/master/
     done
 
     # clean up temp files

--- a/docs/static_site/src/pages/blog.html
+++ b/docs/static_site/src/pages/blog.html
@@ -1,3 +1,12 @@
+---
+layout: page
+title: Blog
+subtitle: Latest news on MXNet and its ecosystem
+permalink: /blog/
+action: See All Blog Posts
+action_url: https://medium.com/apache-mxnet
+---
+
 <!---
   Licensed to the Apache Software Foundation (ASF) under one
   or more contributor license agreements.  See the NOTICE file
@@ -16,14 +25,6 @@
   specific language governing permissions and limitations
   under the License.
 -->
----
-layout: page
-title: Blog
-subtitle: Latest news on MXNet and its ecosystem
-permalink: /blog/
-action: See All Blog Posts
-action_url: https://medium.com/apache-mxnet
----
 
 <div class="row">
     <div class="col-8">

--- a/docs/static_site/src/pages/ecosystem.html
+++ b/docs/static_site/src/pages/ecosystem.html
@@ -1,21 +1,3 @@
-<!---
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
--->
 ---
 layout: page
 title: Ecosystem
@@ -84,6 +66,26 @@ ecosystem_other:
   link: https://github.com/awslabs/multi-model-server
 
 ---
+
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
 <div class="ecosystem-page">
     <div class="row">
         <h2>D2L.ai</h2>

--- a/docs/static_site/src/pages/features.html
+++ b/docs/static_site/src/pages/features.html
@@ -1,3 +1,12 @@
+---
+layout: page
+title: Features
+subtitle: Whether you are looking for a flexible library to quickly develop cutting-edge deep learning research or a robust framework to push production workload, MXNet caters to all needs.
+permalink: /features/
+action: Get Started
+action_url: /get_started
+---
+
 <!---
   Licensed to the Apache Software Foundation (ASF) under one
   or more contributor license agreements.  See the NOTICE file
@@ -16,14 +25,6 @@
   specific language governing permissions and limitations
   under the License.
 -->
----
-layout: page
-title: Features
-subtitle: Whether you are looking for a flexible library to quickly develop cutting-edge deep learning research or a robust framework to push production workload, MXNet caters to all needs.
-permalink: /features/
-action: Get Started
-action_url: /get_started
----
 
 <!-- HYBRID FRONTEND -->
 <div class="row">


### PR DESCRIPTION
## Description ##
The `restricted-website-build-master` pipeline is failing due to files not found issue: https://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/restricted-website-build-master/activity. The pipeline fails after https://github.com/apache/incubator-mxnet/pull/19743 got merged. Building the static website locally, I find that the license header at the top of `blog.html`, `ecosystem.html` and `features.html` stop the pages from building. After moving the header to a lower section, I am able to build all three pages locally.

This PR tries to fix the website build pipeline by relocating the license header, and also revert the previous PR https://github.com/apache/incubator-mxnet/pull/19901 that failed to fix the issue 

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
