### PR TITLE
[Backport][PIP] add build target in cmake for osx compat (#19110)

### DIFF
--- a/tools/pip/setup.py
+++ b/tools/pip/setup.py
@@ -26,8 +26,13 @@ import platform
 from setuptools import setup, find_packages
 
 if platform.system() == 'Linux':
-    sys.argv.append('--universal')
+    sys.argv.append('--python-tag')
+    sys.argv.append('py3')
     sys.argv.append('--plat-name=manylinux2014_x86_64')
+elif platform.system() == 'Darwin':
+    sys.argv.append('--python-tag')
+    sys.argv.append('py3')
+    sys.argv.append('--plat-name=macosx_10_13_x86_64')
 
 # We can not import `mxnet.info.py` in setup.py directly since mxnet/__init__.py
 # Will be invoked which introduces dependences


### PR DESCRIPTION
Backport #19110 as a part of effort #19911

* add build target in cmake for osx compat

* update wheel tags

