### PR TITLE
[BACKPORT]Fix windows dll loading for compute capabilties >7.5 (#19410)

### DIFF
--- a/tools/windowsbuild/warp_dll.cpp
+++ b/tools/windowsbuild/warp_dll.cpp
@@ -78,7 +78,7 @@ int find_version()
 {
 	std::vector<int> known_sm = find_mxnet_dll();
 	int count = 0;
-	int version = 75;
+	int version = 9999;
 	if (cudaSuccess != cudaGetDeviceCount(&count))
 	{
 		return 30;
@@ -105,6 +105,11 @@ int find_version()
 			return known_sm[i];
 		}
 	}
+
+    if (version == 9999)
+    {
+        return 30;
+    }
 
 	return version;
 }


### PR DESCRIPTION
Previously any higher compute capabilties would load mxnet_75.dll
Any new compute capabilities should now load the correct dll if present

Co-authored-by: vlado <vlado@indicalab.com>

Backport #19410 as a part of effort #19911