### PR TITLE
[website] Automate website artifacts uploading

### DIFF
--- a/ci/docker/Dockerfile.build.ubuntu
+++ b/ci/docker/Dockerfile.build.ubuntu
@@ -47,6 +47,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get install -y \
         ## Utilities
         curl \
+        zip \ 
         unzip \
         pandoc \
         ## Development tools

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -1232,7 +1232,7 @@ push_docs() {
     aws s3 cp versions.zip s3://mxnet-website-static-artifacts --acl public-read
     # Backup versions folder with the latest version name
     backup_file="versions_backup_upto_$folder_name.zip"
-    aws s3 cp versions.zip s3://mxnet-website-static-artifacts/$backup_file --acl public-read
+    aws s3 cp s3://mxnet-website-static-artifacts/versions.zip s3://mxnet-website-static-artifacts/$backup_file --acl public-read
     popd
 }
 

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -1227,12 +1227,12 @@ push_docs() {
     fi
     mv master $folder_name
     popd
-    # back up versions folder
-    wget https://mxnet-website-static-artifacts.s3.us-east-2.amazonaws.com/versions.zip -O versions-backup.zip
-    aws s3 cp versions-backup.zip s3://mxnet-website-static-artifacts --acl public-read
-
-    zip -r9 versions.zip versions/.
-    aws s3 cp versions.zip s3://mxnet-website-static-artifacts --acl public-read
+    zip -r9 versions-test.zip versions/.
+    # Upload versions folder
+    aws s3 cp versions-test.zip s3://mxnet-website-static-artifacts --acl public-read
+    # Backup versions folder with the latest version name
+    backup_file = "versions_backup_upto_$folder_name.zip"
+    aws s3 cp versions-test.zip s3://mxnet-website-static-artifacts/$backup_file --acl public-read
     popd
 }
 

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -1231,7 +1231,7 @@ push_docs() {
     # Upload versions folder
     aws s3 cp versions-test.zip s3://mxnet-website-static-artifacts --acl public-read
     # Backup versions folder with the latest version name
-    backup_file = "versions_backup_upto_$folder_name.zip"
+    backup_file="versions_backup_upto_$folder_name.zip"
     aws s3 cp versions-test.zip s3://mxnet-website-static-artifacts/$backup_file --acl public-read
     popd
 }

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -1231,8 +1231,8 @@ push_docs() {
     wget https://mxnet-website-static-artifacts.s3.us-east-2.amazonaws.com/versions.zip -O versions-backup.zip
     aws s3 cp versions-backup.zip s3://mxnet-website-static-artifacts --acl public-read
 
-    zip -r9 versions-test.zip versions/.
-    aws s3 cp versions-test.zip s3://mxnet-website-static-artifacts --acl public-read
+    zip -r9 versions.zip versions/.
+    aws s3 cp versions.zip s3://mxnet-website-static-artifacts --acl public-read
     popd
 }
 

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -1228,7 +1228,7 @@ push_docs() {
     mv master $folder_name
     popd
     # back up versions folder
-    wget https://mxnet-website-static-artifacts.s3.us-east-2.amazonaws.com/versions.zip versions-backup
+    wget https://mxnet-website-static-artifacts.s3.us-east-2.amazonaws.com/versions.zip -O versions-backup.zip
     aws s3 cp versions-backup.zip s3://mxnet-website-static-artifacts --acl public-read
 
     zip -r9 versions-test.zip versions/.

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -1227,6 +1227,10 @@ push_docs() {
     fi
     mv master $folder_name
     popd
+    # back up versions folder
+    wget https://mxnet-website-static-artifacts.s3.us-east-2.amazonaws.com/versions.zip versions-backup
+    aws s3 cp versions-backup.zip s3://mxnet-website-static-artifacts --acl public-read
+
     zip -r9 versions-test.zip versions/.
     aws s3 cp versions-test.zip s3://mxnet-website-static-artifacts --acl public-read
     popd

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -1227,12 +1227,12 @@ push_docs() {
     fi
     mv master $folder_name
     popd
-    zip -r9 versions-test.zip versions/.
+    zip -r9 versions.zip versions/.
     # Upload versions folder
-    aws s3 cp versions-test.zip s3://mxnet-website-static-artifacts --acl public-read
+    aws s3 cp versions.zip s3://mxnet-website-static-artifacts --acl public-read
     # Backup versions folder with the latest version name
     backup_file="versions_backup_upto_$folder_name.zip"
-    aws s3 cp versions-test.zip s3://mxnet-website-static-artifacts/$backup_file --acl public-read
+    aws s3 cp versions.zip s3://mxnet-website-static-artifacts/$backup_file --acl public-read
     popd
 }
 

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -1212,6 +1212,26 @@ build_docs_beta() {
     popd
 }
 
+push_docs() {
+    folder_name=$1
+    set -ex
+    pip3 install --user awscli
+    export PATH=~/.local/bin:$PATH
+    pushd docs/_build
+    tar -xzf full_website.tgz --strip-components 1
+    # check if folder_name already exists in versions
+    pushd versions
+    if [ -d "$folder_name" ]; then
+        echo "Folder $folder_name already exists in versions. Please double check the FOLDER_NAME variable in Jenkens pipeline"
+        exit 1
+    fi
+    mv master $folder_name
+    popd
+    zip -r9 versions-test.zip versions/.
+    aws s3 cp versions-test.zip s3://mxnet-website-static-artifacts --acl public-read
+    popd
+}
+
 create_repo() {
    repo_folder=$1
    mxnet_url=$2

--- a/ci/jenkins/Jenkins_steps.groovy
+++ b/ci/jenkins/Jenkins_steps.groovy
@@ -1204,7 +1204,7 @@ def docs_upload_s3() {
 
               utils.docker_run('ubuntu_cpu', "push_docs ${env.FOLDER_NAME}", false)
 
-              archiveArtifacts 'docs/_build/versions.zip'
+              archiveArtifacts 'docs/_build/versions-test.zip'
             } else {
               sh 'echo Can not find website version for release. Please specify env var FOLDER_NAME in Jenkins pipeline'
               sh 'exit 1'

--- a/ci/jenkins/Jenkins_steps.groovy
+++ b/ci/jenkins/Jenkins_steps.groovy
@@ -1204,7 +1204,7 @@ def docs_upload_s3() {
 
               utils.docker_run('ubuntu_cpu', "push_docs ${env.FOLDER_NAME}", false)
 
-              archiveArtifacts 'docs/_build/versions-test.zip'
+              archiveArtifacts 'docs/_build/versions.zip'
             } else {
               sh 'echo Can not find website version for release. Please specify env var FOLDER_NAME in Jenkins pipeline'
               sh 'exit 1'

--- a/ci/jenkins/Jenkins_steps.groovy
+++ b/ci/jenkins/Jenkins_steps.groovy
@@ -1093,6 +1093,30 @@ def docs_prepare() {
     }]
 }
 
+// This is for updateing the new version of website artifact
+// Assumes you have run all of the docs generation functions
+// Called from Jenkins_website_version_artifacts
+def docs_full_website() {
+    return ['Build artifacts full_website.tgz': {
+      node(NODE_LINUX_CPU) {
+        ws('workspace/docs') {
+          timeout(time: max_time, unit: 'MINUTES') {
+            utils.init_git()
+
+            unstash 'jekyll-artifacts'
+            unstash 'python-artifacts'
+
+            utils.docker_run('ubuntu_cpu_jekyll', 'build_docs', false)
+
+            utils.pack_lib('full_website', 'docs/_build/full_website.tgz', false)
+
+            // archive so the publish pipeline can access the artifact
+            archiveArtifacts 'docs/_build/full_website.tgz'
+          }
+        }
+      }
+    }]
+}
 
 def docs_prepare_beta() {
     return ['Prepare for publication to the staging website': {
@@ -1168,6 +1192,28 @@ def docs_publish_beta() {
     }]
 }
 
+// This is for uploading website artifacts to S3 bucket
+// Assumes you have run docs_full_website function
+def docs_upload_s3() {
+    return ['Upload artifacts to s3 bucket': {
+      node(NODE_LINUX_CPU) {
+        ws('workspace/docs') {
+          timeout(time: max_time, unit: 'MINUTES') {
+            if(env.FOLDER_NAME) {
+              utils.unpack_and_init('full_website', 'docs/_build/full_website.tgz')
+
+              utils.docker_run('ubuntu_cpu', "push_docs ${env.FOLDER_NAME}", false)
+
+              archiveArtifacts 'docs/_build/versions-test.zip'
+            } else {
+              sh 'echo Can not find website version for release. Please specify env var FOLDER_NAME in Jenkins pipeline'
+              sh 'exit 1'
+            }
+          }
+        }
+      }
+    }]
+}
 
 def sanity_lint() {
     return ['Lint': {

--- a/ci/jenkins/Jenkinsfile_website_version_artifacts
+++ b/ci/jenkins/Jenkinsfile_website_version_artifacts
@@ -1,0 +1,61 @@
+// -*- mode: groovy -*-
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+// Jenkins pipeline
+// See documents at https://jenkins.io/doc/book/pipeline/jenkinsfile/
+
+// timeout in minutes
+max_time = 240
+
+node('restricted-utility') {
+  // Loading the utilities requires a node context unfortunately
+  checkout scm
+  utils = load('ci/Jenkinsfile_utils.groovy')
+  custom_steps = load('ci/jenkins/Jenkins_steps.groovy')
+}
+
+utils.assign_node_labels(utility: 'restricted-utility', linux_cpu: 'restricted-mxnetlinux-cpu', linux_gpu: 'restricted-mxnetlinux-gpu', linux_gpu_p3: 'restricted-mxnetlinux-gpu-p3', windows_cpu: 'restricted-mxnetwindows-cpu', windows_gpu: 'restricted-mxnetwindows-gpu')
+
+utils.main_wrapper(
+core_logic: {
+  utils.parallel_stage('Build', [
+    custom_steps.compile_unix_cpu_openblas('libmxnet')
+  ])
+
+  utils.parallel_stage('Build Docs', [
+    custom_steps.docs_jekyll(),
+    custom_steps.docs_python('libmxnet'),
+  ])
+
+  utils.parallel_stage('Build Full Website', [
+    custom_steps.docs_full_website()
+  ])
+
+  utils.parallel_stage('Upload Docs', [
+    custom_steps.docs_upload_s3()
+  ])
+}
+,
+failure_handler: {
+  // Only send email if master or release branches failed
+  if (currentBuild.result == "FAILURE" && (env.BRANCH_NAME == "master" || env.BRANCH_NAME.startsWith("v"))) {
+    emailext body: 'Build for MXNet branch ${BRANCH_NAME} has broken. Please view the build at ${BUILD_URL}', replyTo: '${EMAIL}', subject: '[BUILD FAILED] Branch ${BRANCH_NAME} build ${BUILD_NUMBER}', to: '${EMAIL}'
+  }
+}
+)


### PR DESCRIPTION
## Description ##
Port #19244 as a part of the MXNet release process for 2.0+ versions.  Also added a back-up mechanism to the versions folder. The back-up artifact will have name `versions_backup_upto_$(release_version).zip'

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
