### PR TITLE
[v.1x] Attempt to fix v1.x cd by installing new cuda compt package

### DIFF
--- a/ci/docker/Dockerfile.build.ubuntu_gpu_cu102
+++ b/ci/docker/Dockerfile.build.ubuntu_gpu_cu102
@@ -71,7 +71,7 @@ RUN /work/ubuntu_cudnn.sh
 
 # update the cuda compatibity package because cd host uses nvidia driver 460
 RUN apt-get update && apt-get install -y cuda-compat-11-2
-Run ln -sfn /usr/local/cuda-11.2 /usr/local/cuda
+RUN ln -sfn /usr/local/cuda-11.2 /usr/local/cuda
 
 # Always last
 ARG USER_ID=0

--- a/ci/docker/Dockerfile.build.ubuntu_gpu_cu102
+++ b/ci/docker/Dockerfile.build.ubuntu_gpu_cu102
@@ -69,6 +69,8 @@ ENV CUDNN_VERSION=8.0.4.30
 COPY install/ubuntu_cudnn.sh /work/
 RUN /work/ubuntu_cudnn.sh
 
+RUN sudo apt-get install -y cuda-compat-11-2
+
 # Always last
 ARG USER_ID=0
 ARG GROUP_ID=0

--- a/ci/docker/Dockerfile.build.ubuntu_gpu_cu102
+++ b/ci/docker/Dockerfile.build.ubuntu_gpu_cu102
@@ -69,7 +69,9 @@ ENV CUDNN_VERSION=8.0.4.30
 COPY install/ubuntu_cudnn.sh /work/
 RUN /work/ubuntu_cudnn.sh
 
-RUN sudo apt-get install -y cuda-compat-11-2
+# update the cuda compatibity package because cd host uses nvidia driver 460
+RUN apt-get update && apt-get install -y cuda-compat-11-2
+Run ln -sfn /usr/local/cuda-11.2 /usr/local/cuda
 
 # Always last
 ARG USER_ID=0

--- a/ci/docker/Dockerfile.build.ubuntu_gpu_cu110
+++ b/ci/docker/Dockerfile.build.ubuntu_gpu_cu110
@@ -34,7 +34,7 @@ RUN /work/ubuntu_python.sh
 
 # update the cuda compatibity package because cd host uses nvidia driver 460
 RUN apt-get update && apt-get install -y cuda-compat-11-2
-Run ln -sfn /usr/local/cuda-11.2 /usr/local/cuda
+RUN ln -sfn /usr/local/cuda-11.2 /usr/local/cuda
 
 # Always last
 ARG USER_ID=0

--- a/ci/docker/Dockerfile.build.ubuntu_gpu_cu110
+++ b/ci/docker/Dockerfile.build.ubuntu_gpu_cu110
@@ -32,6 +32,10 @@ COPY install/ubuntu_python.sh /work/
 COPY install/requirements /work/
 RUN /work/ubuntu_python.sh
 
+# update the cuda compatibity package because cd host uses nvidia driver 460
+RUN apt-get update && apt-get install -y cuda-compat-11-2
+Run ln -sfn /usr/local/cuda-11.2 /usr/local/cuda
+
 # Always last
 ARG USER_ID=0
 ARG GROUP_ID=0

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -985,6 +985,10 @@ cd_unittest_ubuntu() {
     # fi
 
     if [[ ${mxnet_variant} = cu* ]]; then
+        # update the cuda compatibity package because cd host uses nvidia driver 460
+        sudo apt-get install -y cuda-compat-11-2
+        ln -sfn /usr/local/cuda-11.2 /usr/local/cuda
+
         $nose_cmd $NOSE_TIMER_ARGUMENTS --verbose tests/python/gpu
 
         # Adding these here as CI doesn't test all CUDA environments
@@ -1082,6 +1086,11 @@ unittest_ubuntu_tensorrt_gpu() {
 # need to separte it from unittest_ubuntu_python3_gpu()
 unittest_ubuntu_python3_quantization_gpu() {
     set -ex
+
+    # update the cuda compatibity package because cd host uses nvidia driver 460
+    sudo apt-get install -y cuda-compat-11-2
+    ln -sfn /usr/local/cuda-11.2 /usr/local/cuda
+
     export PYTHONPATH=./python/
     export MXNET_MKLDNN_DEBUG=0 # Ignored if not present
     export MXNET_STORAGE_FALLBACK_LOG_VERBOSE=0

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -985,10 +985,6 @@ cd_unittest_ubuntu() {
     # fi
 
     if [[ ${mxnet_variant} = cu* ]]; then
-        # update the cuda compatibity package because cd host uses nvidia driver 460
-        sudo apt-get install -y cuda-compat-11-2
-        ln -sfn /usr/local/cuda-11.2 /usr/local/cuda
-
         $nose_cmd $NOSE_TIMER_ARGUMENTS --verbose tests/python/gpu
 
         # Adding these here as CI doesn't test all CUDA environments
@@ -1086,11 +1082,6 @@ unittest_ubuntu_tensorrt_gpu() {
 # need to separte it from unittest_ubuntu_python3_gpu()
 unittest_ubuntu_python3_quantization_gpu() {
     set -ex
-
-    # update the cuda compatibity package because cd host uses nvidia driver 460
-    sudo apt-get install -y cuda-compat-11-2
-    ln -sfn /usr/local/cuda-11.2 /usr/local/cuda
-
     export PYTHONPATH=./python/
     export MXNET_MKLDNN_DEBUG=0 # Ignored if not present
     export MXNET_STORAGE_FALLBACK_LOG_VERBOSE=0


### PR DESCRIPTION
We updated restricted-mxnetlinux-gpu nodes' ami to use the new NVIDIA 460 driver. So, we will also need to install the new cuda compt package so that during the test stage we can find gpus. (Old compt package won't work with the new nvidia driver)

https://github.com/apache/incubator-mxnet/issues/19948