### PR TITLE
[BUGFIX]correcting cuda 11.2 image name in CI and CD

### DIFF
--- a/cd/utils/mxnet_base_image.sh
+++ b/cd/utils/mxnet_base_image.sh
@@ -34,7 +34,7 @@ case ${mxnet_variant} in
     echo "nvidia/cuda:11.0-cudnn8-runtime-ubuntu16.04"
     ;;
     cu112*)
-    echo "nvidia/cuda:11.2-cudnn8-runtime-ubuntu16.04"
+    echo "nvidia/cuda:11.2.1-cudnn8-runtime-ubuntu16.04"
     ;;
     cpu)
     echo "ubuntu:16.04"

--- a/ci/docker/Dockerfile.build.ubuntu_gpu_cu112
+++ b/ci/docker/Dockerfile.build.ubuntu_gpu_cu112
@@ -18,7 +18,7 @@
 #
 # Dockerfile to run MXNet on Ubuntu 16.04 for GPU
 
-FROM nvidia/cuda:11.2-cudnn8-devel-ubuntu16.04
+FROM nvidia/cuda:11.2.1-cudnn8-devel-ubuntu16.04
 
 WORKDIR /work/deps
 


### PR DESCRIPTION
## Description ##
corrects the name of CUDA 11.2 nvidia containers introduced in PR #19930
Correct names taken from here: https://hub.docker.com/r/nvidia/cuda

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented