### PR TITLE
chore: fix case of GitHub

### DIFF
--- a/.github/workflows/os_x_staticbuild.yml
+++ b/.github/workflows/os_x_staticbuild.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install Dependencies
         run: |
           brew install nasm automake ninja libtool cmake pkgconfig protobuf hdf5 zlib ccache
-          ccache -M 500M  # Limit the ccache size; Github's overall cache limit is 5GB
+          ccache -M 500M  # Limit the ccache size; GitHub's overall cache limit is 5GB
           python -m pip install -r ci/docker/install/requirements
         shell: bash
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -71,5 +71,5 @@ prepare_mkl.sh    @szha
 # Tools
 /tools/           @szha @pllarroy
 
-# Github configuration
+# GitHub configuration
 /.github/         @szha @leezu

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Stay Connected
 
 | Channel | Purpose |
 |---|---|
-| [Follow MXNet Development on Github](https://github.com/apache/incubator-mxnet/issues) | See what's going on in the MXNet project. |
+| [Follow MXNet Development on GitHub](https://github.com/apache/incubator-mxnet/issues) | See what's going on in the MXNet project. |
 | [MXNet Confluence Wiki for Developers](https://cwiki.apache.org/confluence/display/MXNET/Apache+MXNet+Home) <i class="fas fa-external-link-alt"> | MXNet developer wiki for information related to project development, maintained by contributors and developers. To request write access, send an email to [send request to the dev list](mailto:dev@mxnet.apache.org?subject=Requesting%20CWiki%20write%20access) <i class="far fa-envelope"></i>. |
 | [dev@mxnet.apache.org mailing list](https://lists.apache.org/list.html?dev@mxnet.apache.org) | The "dev list". Discussions about the development of MXNet. To subscribe, send an email to [dev-subscribe@mxnet.apache.org](mailto:dev-subscribe@mxnet.apache.org) <i class="far fa-envelope"></i>. |
 | [discuss.mxnet.io](https://discuss.mxnet.io) <i class="fas fa-external-link-alt"></i> | Asking & answering MXNet usage questions. |

--- a/docs/python_docs/python/tutorials/packages/legacy/ndarray/gotchas_numpy_in_mxnet.md
+++ b/docs/python_docs/python/tutorials/packages/legacy/ndarray/gotchas_numpy_in_mxnet.md
@@ -104,7 +104,7 @@ pad_array(nd.array([1, 2, 3]), max_length=10)
 `<NDArray 10 @cpu(0)>` <!--notebook-skip-line-->
 
 
-### Search for an operator on [Github](https://github.com/apache/incubator-mxnet/labels/Operator)
+### Search for an operator on [GitHub](https://github.com/apache/incubator-mxnet/labels/Operator)
 
 Apache MXNet community is responsive to requests, and everyone is welcomed to contribute new operators. Have in mind, that there is always a lag between new operators being merged into the codebase and release of a next stable version. For example, [nd.diag()](https://github.com/apache/incubator-mxnet/pull/11643) operator was recently introduced to Apache MXNet, but on the moment of writing this tutorial, it is not in any stable release. You can always get all latest implementations by installing the [master version](https://mxnet.apache.org/get_started?version=master&platform=linux&language=python&environ=pip&processor=cpu#) of Apache MXNet.
 

--- a/docs/python_docs/themes/mx-theme/mxtheme/footer.html
+++ b/docs/python_docs/themes/mx-theme/mxtheme/footer.html
@@ -7,7 +7,7 @@
                     <li><a
                             href="https://lists.apache.org/list.html?dev@mxnet.apache.org">Mailing list</a> <a class="u-email" href="mailto:dev-subscribe@mxnet.apache.org">(subscribe)</a></li>
                     <li><a href="https://discuss.mxnet.io">MXNet Discuss forum</a></li>
-                    <li><a href="https://github.com/apache/incubator-mxnet/issues">Github Issues</a></li>
+                    <li><a href="https://github.com/apache/incubator-mxnet/issues">GitHub Issues</a></li>
                     <li><a href="https://github.com/apache/incubator-mxnet/projects">Projects</a></li>
                     <li><a href="https://cwiki.apache.org/confluence/display/MXNET/Apache+MXNet+Home">Developer Wiki</a></li>
                     <li><a href="/community">Contribute To MXNet</a></li>

--- a/docs/python_docs/themes/mx-theme/mxtheme/header_sourcelink.html
+++ b/docs/python_docs/themes/mx-theme/mxtheme/header_sourcelink.html
@@ -4,7 +4,7 @@
 <i class="material-icons">edit</i>
 </a>
 <div class="mdl-tooltip" data-mdl-for="button-show-github">
-{{ _('Edit on Github') }}
+{{ _('Edit on GitHub') }}
 </div>
 {%- elif show_source and has_source and sourcename %}
 <a id="button-show-source"

--- a/docs/static_site/src/.htaccess
+++ b/docs/static_site/src/.htaccess
@@ -72,7 +72,7 @@ RewriteCond %{REQUEST_FILENAME} -d
 RewriteCond %{REQUEST_FILENAME}/index.html -f
 RewriteRule ^(.*) $1/index.html [NC,L]
 
-# Redirect FAQ TODO: temporary fix for Github issue #18547
+# Redirect FAQ TODO: temporary fix for GitHub issue #18547
 RewriteRule ^versions/master/faq/(.*)$ /api/faq/$1 [R,NC,L]
 
 # 404

--- a/docs/static_site/src/_includes/footer.html
+++ b/docs/static_site/src/_includes/footer.html
@@ -6,7 +6,7 @@
                 <ul class="contact-list">
                     <li><a href="{{'community#stay-connected'|relative_url}}">Mailing lists</a></li>
                     <li><a href="https://discuss.mxnet.io">MXNet Discuss forum</a></li>
-                    <li><a href="{{'community#github-issues'|relative_url}}">Github Issues</a></li>
+                    <li><a href="{{'community#github-issues'|relative_url}}">GitHub Issues</a></li>
                     <li><a href="https://github.com/apache/incubator-mxnet/projects">Projects</a></li>
                     <li><a href="https://cwiki.apache.org/confluence/display/MXNET/Apache+MXNet+Home">Developer Wiki</a></li>
                     <li><a href="{{'community'|relative_url}}">Contribute To MXNet</a></li>

--- a/docs/static_site/src/_includes/get_started/devices/raspberry_pi.md
+++ b/docs/static_site/src/_includes/get_started/devices/raspberry_pi.md
@@ -129,7 +129,7 @@ cd ..
 
 We would like to simplify this setup by integrating the Conan C++ dependency
 manager. Please send an email to the MXNet development mailinglist or open an
-issue on Github if you would like to help.
+issue on GitHub if you would like to help.
 
 ### Building the Python wheel
 
@@ -157,7 +157,7 @@ rm -rf ${TMPDIR}
 
 We intend to fix the `setup.py` to avoid the repackaging step. If you would like
 to help, please send an email to the MXNet development mailinglist or open an
-issue on Github.
+issue on GitHub.
 
 
 ### Final remarks

--- a/docs/static_site/src/pages/community/index.md
+++ b/docs/static_site/src/pages/community/index.md
@@ -33,7 +33,7 @@ In MXNet, we have the following communication channels.
 
 | Channel | Purpose |
 |---|---|
-| [Follow MXNet Development on Github](#github-issues) | See what's going on in the MXNet project. |
+| [Follow MXNet Development on GitHub](#github-issues) | See what's going on in the MXNet project. |
 | [Check out the MXNet Confluence Wiki](https://cwiki.apache.org/confluence/display/MXNET/Apache+MXNet+Home) <i class="fas fa-external-link-alt"> | MXNet developer wiki for information related to project development, maintained by contributors and developers. To request write access, send an email to [send request to the dev list](mailto:dev@mxnet.apache.org?subject=Requesting%20CWiki%20write%20access) <i class="far fa-envelope"></i>. |
 | [dev@mxnet.apache.org mailing list](https://lists.apache.org/list.html?dev@mxnet.apache.org) | The "dev list". Discussions about the development of MXNet. To subscribe, send an email to [dev-subscribe@mxnet.apache.org](mailto:dev-subscribe@mxnet.apache.org) <i class="far fa-envelope"></i>. |
 | [discuss.mxnet.io](https://discuss.mxnet.io) <i class="fas fa-external-link-alt"></i> | Asking & answering MXNet usage questions. |
@@ -100,14 +100,14 @@ Any new features of improvements that are non-trivial should follow the [RFC](ht
 1. [Create an RFC issue on GitHub](https://github.com/apache/incubator-mxnet/issues/new/choose): RFC issues will notify MXNet developer community through all channels, including dev@ list and Slack.
 1. [Create the PR on GitHub](https://github.com/apache/incubator-mxnet/pulls) and mention the RFC issue in description.
 
-#### Github Issues
+#### GitHub Issues
 
-Apache MXNet uses Github issues to track feature requests and bug reports. [Open a Github issue](https://github.com/apache/incubator-mxnet/issues/new/choose) <i class="fas fa-external-link-alt"></i>.
+Apache MXNet uses GitHub issues to track feature requests and bug reports. [Open a GitHub issue](https://github.com/apache/incubator-mxnet/issues/new/choose) <i class="fas fa-external-link-alt"></i>.
 
-We also use Github projects for tracking larger projects, and Github milestones for tracking releases.
+We also use GitHub projects for tracking larger projects, and GitHub milestones for tracking releases.
 
-* [Github Projects](https://github.com/apache/incubator-mxnet/projects) <i class="fab fa-github"></i>
-* [Github Milestones](https://github.com/apache/incubator-mxnet/milestones) <i class="fab fa-github"></i>
+* [GitHub Projects](https://github.com/apache/incubator-mxnet/projects) <i class="fab fa-github"></i>
+* [GitHub Milestones](https://github.com/apache/incubator-mxnet/milestones) <i class="fab fa-github"></i>
 * [Roadmaps](https://github.com/apache/incubator-mxnet/labels/Roadmap) <i class="fab fa-github"></i>
 
 

--- a/example/README.md
+++ b/example/README.md
@@ -128,8 +128,8 @@ If your tutorial depends on specific packages, simply add them to this provision
 * [Face Detection with End-to-End Integration of a ConvNet and a 3D Model (ECCV16)](https://github.com/tfwu/FaceDetection-ConvNet-3D) by [tfwu](https://github.com/tfwu), source code for paper Yunzhu Li, Benyuan Sun, Tianfu Wu and Yizhou Wang, "Face Detection with End-to-End Integration of a ConvNet and a 3D Model", ECCV 2016 <https://arxiv.org/abs/1606.00850>
 * [End-to-End Chinese plate recognition base on MXNet](https://github.com/szad670401/end-to-end-for-chinese-plate-recognition) by [szad670401](https://github.com/szad670401)
 * [Reproduce ResNet-v2 (Identity Mappings in Deep Residual Networks) using MXNet](https://github.com/tornadomeet/ResNet) by [tornadomeet](https://github.com/tornadomeet)
-* [Learning similarity among images in MXNet](http://www.jianshu.com/p/70a66c8f73d3) by xlvector in Chinese. Github [link](https://github.com/xlvector/learning-dl/tree/master/mxnet/triple-loss)
-* [Matrix decomposition (SVD) with MXNet](http://www.jianshu.com/p/ebf7bf53ed3e) by xlvector in Chinese. Github [link](https://github.com/xlvector/mxnet/blob/svd/example/svd/svd.py)
+* [Learning similarity among images in MXNet](http://www.jianshu.com/p/70a66c8f73d3) by xlvector in Chinese. GitHub [link](https://github.com/xlvector/learning-dl/tree/master/mxnet/triple-loss)
+* [Matrix decomposition (SVD) with MXNet](http://www.jianshu.com/p/ebf7bf53ed3e) by xlvector in Chinese. GitHub [link](https://github.com/xlvector/mxnet/blob/svd/example/svd/svd.py)
 * [MultiGPU enabled image generative models (GAN and DCGAN)](https://github.com/tqchen/mxnet-gan) by [Tianqi Chen](https://github.com/tqchen)
 * [Deep reinforcement learning for playing flappybird by mxnet](https://github.com/li-haoran/DRL-FlappyBird) by LIHaoran
 * [Neural Style in Markov Random Field (MRF) and Perceptual Losses Realtime transfer](https://github.com/zhaw/neural_style) by [zhaw](https://github.com/zhaw)

--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -1274,7 +1274,7 @@ class HybridBlock(Block):
 
         assert self._cached_op, "Gluon failed to build the cache. " \
                                 "This should never happen. " \
-                                "Please submit an issue on Github" \
+                                "Please submit an issue on GitHub" \
                                 " https://github.com/apache/incubator-mxnet."
         if self._callback:
             self._cached_op._register_op_hook(self._callback, self._monitor_all)
@@ -1388,7 +1388,7 @@ class HybridBlock(Block):
         self._build_cache(x, *args)
         assert self._cached_op, "Gluon failed to build the cache. " \
                                 "This should never happen. " \
-                                "Please submit an issue on Github" \
+                                "Please submit an issue on GitHub" \
                                 " https://github.com/apache/incubator-mxnet."
         # do not actually call the cached_op
 

--- a/src/operator/tensor/matrix_op-inl.h
+++ b/src/operator/tensor/matrix_op-inl.h
@@ -369,7 +369,7 @@ bool TransposeCommonImpl(RunContext ctx,
       } else {
         LOG(FATAL) << "Not Implemented. We should never reach here because the 2D case "
                       "in GPU has been covered by transpose_pseudo2D."
-                      " Report an issue in Github.";
+                      " Report an issue in GitHub.";
       }
       break;
      }

--- a/tools/license_header.py
+++ b/tools/license_header.py
@@ -110,7 +110,7 @@ _WHITE_LIST = [
                # This file
                'tools/license_header.py',
 
-               # Github template
+               # GitHub template
                '.github/ISSUE_TEMPLATE/bug_report.md',
                '.github/ISSUE_TEMPLATE/feature_request.md',
                '.github/ISSUE_TEMPLATE/flaky_test.md',


### PR DESCRIPTION
## Description ##

Changes `Github` to `GitHub`

## Checklist ##
### Essentials ###
- [X] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

