### PR TITLE
[FEATURE][BACK(?)PORT]fix the update behavior, porting v1.x code to v2.0

### DIFF
--- a/python/mxnet/gluon/data/dataloader.py
+++ b/python/mxnet/gluon/data/dataloader.py
@@ -668,7 +668,7 @@ class DataLoader(object):
                         initargs=[self._dataset, is_np_shape(), is_np_array()])
                     # resume keyboard interupt signal in main process
                     signal.signal(signal.SIGINT, original_sigint_handler)
-                self._refresh()
+                self.refresh()
 
     def __iter__(self):
         if self._mx_iter is not None:
@@ -705,7 +705,6 @@ class DataLoader(object):
     def refresh(self):
         """Refresh its iter, fetch data again. Only valid without nopython mode"""
         self._iter = self._prefetch_iter()
-            
 
     def __len__(self):
         return len(self._batch_sampler)


### PR DESCRIPTION
## Description ##
currently, `nopython` mode provide an iter that prefetch data before an `__iter__()` is called, but no prefetch is done without nopython mode.
this PR will fix such issue, enable auto-reload even without nopython mode.

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

