### PR TITLE
[v1.x] pass version param

### DIFF
--- a/cd/Jenkinsfile_release_job
+++ b/cd/Jenkinsfile_release_job
@@ -45,6 +45,7 @@ pipeline {
     string(defaultValue: "mxnet_lib", description: "Pipeline to build", name: "RELEASE_JOB_TYPE")
     string(defaultValue: "cpu,native,cu100,cu101,cu102,cu110,cu112", description: "Comma separated list of variants", name: "MXNET_VARIANTS")
     booleanParam(defaultValue: false, description: 'Whether this is a release build or not', name: "RELEASE_BUILD")
+    string(defaultValue: "nightly_v1.x", description: "String used for naming docker images", name: "VERSION")
   }
 
   stages {
@@ -74,6 +75,7 @@ pipeline {
             |Release Build: ${params.RELEASE_BUILD}
             |Commit Id: ${env.GIT_COMMIT}
             |Branch: ${env.GIT_BRANCH}
+            |Version: ${VERSION}
             |Variants: ${params.MXNET_VARIANTS}""".stripMargin()
           }
         }

--- a/cd/Jenkinsfile_utils.groovy
+++ b/cd/Jenkinsfile_utils.groovy
@@ -34,6 +34,7 @@ def trigger_release_job(cd_release_job, job_name, job_type, mxnet_variants) {
       string(name: "RELEASE_JOB_TYPE", value: "${job_type}"),
       string(name: "MXNET_VARIANTS", value: "${mxnet_variants}"),
       booleanParam(name: "RELEASE_BUILD", value: "${env.RELEASE_BUILD}"),
+      string(name: "VERSION", value: "${env.VERSION}"),
       string(name: "COMMIT_ID", value: "${env.GIT_COMMIT}")
     ],
     // If propagate is true, any result other than successful will

--- a/cd/python/docker/python_images.sh
+++ b/cd/python/docker/python_images.sh
@@ -70,18 +70,6 @@ push() {
 
     # Push image
     docker push "${image_name}"
-
-    # Iterate over remaining tags, if any
-    for ((i=1;i<${#docker_tags[@]};i++)); do
-        local docker_tag="${docker_tags[${i}]}"
-        local latest_image_name="${RELEASE_PUBLIC_ECR_REPOSITORY}/${repository}:${docker_tag}_py3"
-
-        docker tag "${image_name}" "${latest_image_name}"
-        docker push "${latest_image_name}"
-        echo "Successfully pushed ${latest_image_name}. Pull it with:"
-        echo "docker pull ${latest_image_name}"
-        echo "For a complete list of tags see https://hub.docker.com/u/${RELEASE_DOCKERHUB_REPOSITORY}/${repository}"
-    done
 }
 
 case ${command} in

--- a/cd/utils/docker_tag.sh
+++ b/cd/utils/docker_tag.sh
@@ -23,8 +23,12 @@ mxnet_variant=${1:?"Please specify the mxnet variant as the first parameter"}
 is_release=${RELEASE_BUILD:-false}
 version=${VERSION:-nightly_v1.x}
 
-# The docker tags will be in the form <version>_<hardware>(_mkl)
-# Eg. nightly_cpu, 1.4.0_cpu_mkl, nightly_gpu_cu80_mkl, etc.
+if [[ ${version} == "null" ]]; then
+    version="nightly_v1.x"
+fi
+
+# The docker tags will be in the form <version>_<hardware>
+# Eg. nightly_v1.x_cpu, 1.8.0_cpu, nightly_v1.x_gpu_cu110, etc.
 
 if [[ ${mxnet_variant} == "cpu" ]]; then
     tag_suffix="cpu"
@@ -39,15 +43,3 @@ else
 fi
 
 echo "${version}_${tag_suffix}"
-
-# Print out latest tags as well
-if [[ ${is_release} == "true" ]]; then
-    if [[ ${mxnet_variant} == "cpu" ]]; then
-        echo "latest"
-        echo "latest_cpu"
-    elif [[ ${mxnet_variant} == "native" ]]; then
-        echo "latest_cpu_native"
-    elif [[ ${mxnet_variant} == "cu90" ]]; then
-        echo "latest_gpu"
-    fi
-fi


### PR DESCRIPTION
This PR enables version name to be passed down from release pipeline for naming docker images.

Also removes multiple tagging for same image.