### PR TITLE
[v1.x] ONNX Type inference support

### DIFF
--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -2893,7 +2893,7 @@ def convert_zeros_like(node, **kwargs):
     """Map MXNet's zeros_like operator attributes to onnx's ConstantOfShape operator.
     """
     from onnx.helper import make_node, make_tensor
-    name, input_nodes, attrs = get_inputs(node, kwargs)
+    name, input_nodes, _ = get_inputs(node, kwargs)
     input_dtypes = get_input_dtypes(node, kwargs)
     dtype = np.dtype(input_dtypes[0])
     dtype_t = onnx.mapping.NP_TYPE_TO_TENSOR_TYPE[dtype]
@@ -2912,7 +2912,7 @@ def convert_ones_like(node, **kwargs):
     """Map MXNet's ones_like operator attributes to onnx's ConstantOfShape operator.
     """
     from onnx.helper import make_node, make_tensor
-    name, input_nodes, attrs = get_inputs(node, kwargs)
+    name, input_nodes, _ = get_inputs(node, kwargs)
     input_dtypes = get_input_dtypes(node, kwargs)
     dtype = np.dtype(input_dtypes[0])
     dtype_t = onnx.mapping.NP_TYPE_TO_TENSOR_TYPE[dtype]

--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -1761,10 +1761,10 @@ def convert_cast(node, **kwargs):
     """
     name, input_nodes, attrs = get_inputs(node, kwargs)
 
-    dtype = attrs.get('dtype')
-    to_dtype = onnx.mapping.NP_TYPE_TO_TENSOR_TYPE[np.dtype(dtype)]
+    dtype = np.dtype(attrs.get('dtype'))
+    dtype_t = onnx.mapping.NP_TYPE_TO_TENSOR_TYPE[dtype]
     nodes = [
-        onnx.helper.make_node("Cast", input_nodes, [name], to=to_dtype, name=name)
+        onnx.helper.make_node("Cast", input_nodes, [name], to=dtype_t, name=name)
     ]
     return nodes, (dtype,)
 
@@ -2894,13 +2894,9 @@ def convert_zeros_like(node, **kwargs):
     """
     from onnx.helper import make_node, make_tensor
     name, input_nodes, attrs = get_inputs(node, kwargs)
-    dtype = attrs.get('dtype')
-    if dtype is not None:
-        data_type = onnx.mapping.NP_TYPE_TO_TENSOR_TYPE[np.dtype(dtype)]
-    else:
-        input_dtypes = get_input_dtypes(node, kwargs)
-        dtype = np.dtype(input_dtypes[0])
-        dtype_t = onnx.mapping.NP_TYPE_TO_TENSOR_TYPE[dtype]
+    input_dtypes = get_input_dtypes(node, kwargs)
+    dtype = np.dtype(input_dtypes[0])
+    dtype_t = onnx.mapping.NP_TYPE_TO_TENSOR_TYPE[dtype]
 
     # create tensor with shape of input
     tensor_value = make_tensor(name+"_zero", dtype_t, [1], [0])
@@ -2917,13 +2913,9 @@ def convert_ones_like(node, **kwargs):
     """
     from onnx.helper import make_node, make_tensor
     name, input_nodes, attrs = get_inputs(node, kwargs)
-    dtype = attrs.get('dtype')
-    if dtype is not None:
-        data_type = onnx.mapping.NP_TYPE_TO_TENSOR_TYPE[np.dtype(dtype)]
-    else:
-        input_dtypes = get_input_dtypes(node, kwargs)
-        dtype = np.dtype(input_dtypes[0])
-        dtype_t = onnx.mapping.NP_TYPE_TO_TENSOR_TYPE[dtype]
+    input_dtypes = get_input_dtypes(node, kwargs)
+    dtype = np.dtype(input_dtypes[0])
+    dtype_t = onnx.mapping.NP_TYPE_TO_TENSOR_TYPE[dtype]
 
     # create tensor with shape of input
     tensor_value = make_tensor(name+"_one", dtype_t, [1], [1])

--- a/python/mxnet/contrib/onnx/mx2onnx/export_onnx.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/export_onnx.py
@@ -208,7 +208,7 @@ class MXNetGraph(object):
             ONNX graph
         """
         try:
-            from onnx import (checker, helper, NodeProto, ValueInfoProto, TensorProto, mapping)
+            from onnx import (checker, helper, NodeProto, ValueInfoProto, TensorProto)
             from onnx.helper import make_tensor_value_info
             from onnx.defs import onnx_opset_version
         except ImportError:
@@ -279,11 +279,6 @@ class MXNetGraph(object):
                 graph_input_idx += 1
 
             else:
-                # Handle no input case
-                intype = 1  # Float32 in tensor type
-                if len(in_type) > 0:
-                    intype = in_type[0]
-
                 # Handling graph layers
                 converted, dtypes = MXNetGraph.convert_layer(
                     node,

--- a/python/mxnet/contrib/onnx/mx2onnx/export_onnx.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/export_onnx.py
@@ -290,8 +290,6 @@ class MXNetGraph(object):
                     is_input=False,
                     mx_graph=mx_graph,
                     weights=weights,
-                    in_shape=in_shape,
-                    in_type=intype,
                     proc_nodes=all_processed_nodes,
                     initializer=initializer,
                     outputs_lookup=outputs_lookup,

--- a/python/mxnet/contrib/onnx/mx2onnx/export_onnx.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/export_onnx.py
@@ -342,14 +342,9 @@ class MXNetGraph(object):
                                     for i in range(len(dtypes))]
                 else:
                     # in case dtypes is None, we just default to the dtype of the first input
-                    #TODO
-                    #assert len(node["inputs"]) > 0
-                    if len(node["inputs"]) > 0:
-                        first_input = node["inputs"][0]
-                        first_input_dtype = outputs_lookup[first_input[0]][first_input[1]].dtype
-                    else:
-                        #print('no inputs')
-                        first_input_dtype = mapping.TENSOR_TYPE_TO_NP_TYPE[in_type]
+                    assert len(node["inputs"]) > 0
+                    first_input = node["inputs"][0]
+                    first_input_dtype = outputs_lookup[first_input[0]][first_input[1]].dtype
                     node_outputs = [NodeOutput(n, first_input_dtype)
                                     for n in node_output_names]
                 outputs_lookup.append(node_outputs)

--- a/tests/python-pytest/onnx/test_operators.py
+++ b/tests/python-pytest/onnx/test_operators.py
@@ -471,7 +471,7 @@ def test_onnx_export_contrib_BilinearResize2D(tmp_path, dtype, params):
 @pytest.mark.parametrize('topk', [2, 3, 4])
 @pytest.mark.parametrize('valid_thresh', [0.3, 0.4, 0.8])
 @pytest.mark.parametrize('overlap_thresh', [0.4, 0.7, 1.0])
-def test_onnx_export_contrib_box_nms_manual(tmp_path, topk, valid_thresh, overlap_thresh):
+def test_onnx_export_contrib_box_nms(tmp_path, topk, valid_thresh, overlap_thresh):
     # Note that ONNX NMS op only supports float32
 
     # Also note that onnxruntime's nms has slightly different implementation in handling

--- a/tests/python-pytest/onnx/test_operators.py
+++ b/tests/python-pytest/onnx/test_operators.py
@@ -113,15 +113,22 @@ def test_onnx_export_ones(tmp_path, dtype, shape):
     x = mx.nd.array([0])
     op_export_test('ones', M, [x], tmp_path, dummy_input=True)
 
-def test_onnx_export_zeros_like(tmp_path):
-    M = def_model('zeros_like')
-    x = mx.nd.array([[-2,-1,0],[0,50,99],[4,5,6],[7,8,9]], dtype='float32')
+
+@pytest.mark.parametrize('dtype', [None, 'float32', 'float64', 'int32', 'int64'])
+@pytest.mark.parametrize('shape', [(1), (1,2), (2,3,4), (5,6,7)])
+def test_onnx_export_zeros_like(tmp_path, dtype, shape):
+    M = def_model('zeros_like', dtype=dtype)
+    x = mx.random.uniform(0, 1, shape, dtype='float32')
     op_export_test('zeros_like', M, [x], tmp_path)
 
-def test_onnx_export_ones_like(tmp_path):
-    M = def_model('ones_like')
-    x = mx.nd.array([[-2,-1,0],[0,50,99],[4,5,6],[7,8,9]], dtype='float32')
+
+@pytest.mark.parametrize('dtype', [None, 'float32', 'float64', 'int32', 'int64'])
+@pytest.mark.parametrize('shape', [(1), (1,2), (2,3,4), (5,6,7)])
+def test_onnx_export_ones_like(tmp_path, dtype, shape):
+    M = def_model('ones_like', dtype=dtype)
+    x = mx.random.uniform(0, 1, shape, dtype='float32')
     op_export_test('ones_like', M, [x], tmp_path)
+
 
 @pytest.mark.parametrize("dtype", ["float32", "float64"])
 @pytest.mark.parametrize("axis", [None,0,1])


### PR DESCRIPTION
Previously we do not have any mechanism for inferring dtypes for intermediate nodes. This is a issue for nodes such as plus_scalar, arange_like etc where we need to make explicitly set the output type based on the input type. Previously we just use a global default value but obviously this is not correct. This pr attempts to introduce proper type inference in the onnx support module