### PR TITLE
[BUGFIX] Fix AmpCast for float16

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -288,6 +288,7 @@ List of Contributors
 * [Joe Evans](https://github.com/josephevans)
 * [Nikolay Ulmasov](https://github.com/r3stl355)
 * [Paweł Głomski](https://github.com/PawelGlomski-Intel)
+* [Andrzej Kotlowski](https://github.com/anko-intel)
 
 Label Bot
 ---------

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -4334,8 +4334,7 @@ def test_cast_float32_to_float16():
                     fp32_val, model_fp16_val, np_fp16_val)
 
     check_cast(mx.sym.Cast, input_np, expected_output)
-    if default_context().device_type == 'gpu':
-        check_cast(mx.sym.amp_cast, input_np, expected_output)
+    check_cast(mx.sym.amp_cast, input_np, expected_output)
 
 
 def test_amp_multicast():


### PR DESCRIPTION
Forward port #19749  from v1.x to master.

* Fix AmpCast for float16

OneDNN doesn't support float16 format so fallback to standard
implementation is needed.
It fixes issue #19631.

* Enable amp_cast test for float16 on CPU context