### PR TITLE
[BUGFIX][v1.x] Fix a bug for 1bit quantizer

### DIFF
--- a/src/kvstore/gradient_compression.cc
+++ b/src/kvstore/gradient_compression.cc
@@ -72,7 +72,7 @@ void GradientCompression::SetTwoBitCompression(const float threshold) {
 std::string GradientCompression::EncodeParams() {
   using namespace std;  // to reduce length of next line
   string rval = get_type_str();
-  if (type_ == CompressionType::kTwoBit) {
+  if (type_ != CompressionType::kNone) {
     rval += "," + to_string(threshold_);
   }
   return rval;


### PR DESCRIPTION
## Description ##
Fix a bug for encoding parameters in _gradient_compression.cc_, which may lead to inconsistent threshold on worker and server when using 1bit quantizer (if the threshod is set to a non-zero value).

releated pr: [#17952](https://github.com/apache/incubator-mxnet/pull/17952)

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
