### PR TITLE
[v2.0] Make npx.savez support list and dict

### DIFF
--- a/python/mxnet/numpy_extension/utils.py
+++ b/python/mxnet/numpy_extension/utils.py
@@ -105,10 +105,21 @@ def savez(file, *args, **kwds):
     """
 
     if len(args):
-        for i, arg in enumerate(args):
-            name = 'arr_{}'.format(str(i))
-            assert name not in kwds, 'Naming conflict between arg {} and kwargs.'.format(str(i))
-            kwds[name] = arg
+        if isinstance(args[0], (list, tuple)):
+            assert len(args) == 1, 'Only accepts dict str->ndarray or list of ndarrays.'
+            for i, arg in enumerate(args[0]):
+                name = 'arr_{}'.format(str(i))
+                assert name not in kwds, 'Naming conflict between arg {} and kwargs.'.format(str(i))
+                kwds[name] = arg
+        elif isinstance(args[0], dict):
+            assert len(args) == 1, 'Only accepts dict str->ndarray or list of ndarrays.'
+            kwds = args[0]
+        else:
+            assert isinstance(args[0], NDArray), 'Only accepts dict str->ndarray or list of ndarrays.'
+            for i, arg in enumerate(args):
+                name = 'arr_{}'.format(str(i))
+                assert name not in kwds, 'Naming conflict between arg {} and kwargs.'.format(str(i))
+                kwds[name] = arg
 
     str_keys = kwds.keys()
     nd_vals = kwds.values()

--- a/tests/python/unittest/test_numpy_ndarray.py
+++ b/tests/python/unittest/test_numpy_ndarray.py
@@ -1012,7 +1012,8 @@ def test_np_save_load_large_ndarrays(load_fn, tmp_path):
 @use_np
 @pytest.mark.serial
 @pytest.mark.parametrize('load_fn', [_np.load, npx.load])
-def test_np_save_load_ndarrays(load_fn):
+@pytest.mark.parametrize('positional', [True, False])
+def test_np_save_load_ndarrays(load_fn, positional):
     shapes = [(2, 0, 1), (0,), (), (), (0, 4), (), (3, 0, 0, 0), (2, 1), (0, 5, 0), (4, 5, 6), (0, 0, 0)]
     array_list = [_np.random.randint(0, 10, size=shape) for shape in shapes]
     array_list = [np.array(arr, dtype=arr.dtype) for arr in array_list]
@@ -1028,7 +1029,10 @@ def test_np_save_load_ndarrays(load_fn):
     # test save/load a list of ndarrays
     with TemporaryDirectory() as work_dir:
         fname = os.path.join(work_dir, 'dataset.npz')
-        npx.savez(fname, *array_list)
+        if positional:
+            npx.savez(fname, *array_list)
+        else:
+            npx.savez(fname, array_list)
         if load_fn is _np.load:
             with load_fn(fname) as array_dict_loaded:  # Ensure NPZFile is closed
                 array_list_loaded = [
@@ -1053,7 +1057,10 @@ def test_np_save_load_ndarrays(load_fn):
         arr_dict[k] = v
     with TemporaryDirectory() as work_dir:
         fname = os.path.join(work_dir, 'dataset.npz')
-        npx.savez(fname, **arr_dict)
+        if positional:
+            npx.savez(fname, **arr_dict)
+        else:
+            npx.savez(fname, arr_dict)
         if load_fn is _np.load:
             with load_fn(fname) as arr_dict_loaded:  # Ensure NPZFile is closed
                 assert isinstance(arr_dict_loaded, _np.lib.npyio.NpzFile)


### PR DESCRIPTION
## Description ##
Currently, npx.savez only support positional arguments. This PR will make npx.savez support list and dict as follows:
```
from mxnet import np, npx

x = np.arange(4)
y = np.zeros(4)
npx.savez('x-files', [x, y])
x2, y2 = npx.load('x-files').values()

mydict = {'x': x, 'y': y}
npx.savez('mydict', mydict)
mydict2 = npx.load('mydict')
```

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
