### PR TITLE
[BUGFIX] Fix for test_lans failure

### DIFF
--- a/src/operator/contrib/multi_lamb.cc
+++ b/src/operator/contrib/multi_lamb.cc
@@ -167,7 +167,7 @@ std::vector<std::string> LAMBParamToVector(uint32_t num_tensors,
   return ret;
 }
 
-inline uint32_t NumTensors(const nnvm::NodeAttrs& attrs) {
+static inline uint32_t NumTensors(const nnvm::NodeAttrs& attrs) {
   return static_cast<uint32_t>(dmlc::get<MultiLAMBParam>(attrs.parsed).num_tensors);
 }
 

--- a/src/operator/contrib/multi_lans.cc
+++ b/src/operator/contrib/multi_lans.cc
@@ -183,7 +183,7 @@ std::vector<std::string> LANSParamToVector(uint32_t num_tensors,
   return ret;
 }
 
-inline uint32_t NumTensors(const nnvm::NodeAttrs& attrs) {
+static inline uint32_t NumTensors(const nnvm::NodeAttrs& attrs) {
   return static_cast<uint32_t>(dmlc::get<MultiLANSParam>(attrs.parsed).num_tensors);
 }
 


### PR DESCRIPTION
## Description ##
The issue appears while building MxNet with CMAKE_BUILD_TYPE=Debug option and running unittest_ubuntu_python3_cpu scenario. This change make NumTensors function unique to multi_lans.cc & multi_lamb.cc.

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
