### PR TITLE
Update ci/dev_menu.py file

### DIFF
--- a/ci/dev_menu.py
+++ b/ci/dev_menu.py
@@ -122,7 +122,7 @@ COMMANDS = OrderedDict([
         "pytest -v tests/python/unittest/"
     ),
     ('[Docker] Build the MXNet binary - outputs to "lib/"',
-        "ci/build.py --platform ubuntu_cpu /work/runtime_functions.sh build_ubuntu_cpu_docs"),
+        "ci/build.py --platform ubuntu_cpu /work/runtime_functions.sh build_ubuntu_cpu"),
     ('[Docker] Build the Jekyll website - outputs to "docs/static_site/build/html/"',
         "ci/build.py --platform ubuntu_cpu_jekyll /work/runtime_functions.sh build_jekyll_docs"),
     ('[Docker] Build the Python API docs - outputs to "docs/python_docs/python/build/_build/html/"',
@@ -154,7 +154,7 @@ COMMANDS = OrderedDict([
     ('[Docker] Python3 ARMv7 unittests (QEMU)',
     [
         "ci/build.py -p armv7",
-        "ci/build.py -p test.armv7 /work/runtime_functions.sh unittest_ubuntu_python3_armv7"
+        "ci/build.py -p test.armv7 /work/runtime_functions.sh unittest_ubuntu_python3_arm"
     ]),
     ('Clean (RESET HARD) repository (Warning! erases local changes / DATA LOSS)',
        Confirm("ci/docker/runtime_functions.sh clean_repo"))


### PR DESCRIPTION
## Description ##
Some functions have been renamed or removed from runtime_functions.sh file
but their calls have not been updated in dev_menu.py file yet. This change
updates the build commands in dev_menu.py file, so that the function names
used within them match those from runtime_functions.sh file.

## Checklist ##
### Changes ###
- [x] Update all deprecated function calls in ci/dev_meny.py file
