### PR TITLE
[submodule] Upgrade oneDNN to v2.2

### DIFF
--- a/src/operator/nn/mkldnn/mkldnn_convolution.cc
+++ b/src/operator/nn/mkldnn/mkldnn_convolution.cc
@@ -418,8 +418,7 @@ void MKLDNNConvolutionForwardFullFeature(const MKLDNNConvFullParam &param, const
       weight.MKLDNNDataReorderAsync(fwd->GetPd().weights_desc());
       weight_mem = GetWeights(weight, fwd->GetPd().weights_desc(), param.conv_param.num_group);
     } else {
-      weight_mem = weight.GetMKLDNNData();
-      CHECK(weight_mem->get_desc() == fwd->GetPd().weights_desc());
+      weight_mem = weight.GetMKLDNNDataReorder(fwd->GetPd().weights_desc());
     }
   }
   mkldnn_output_t out_mem;

--- a/tests/cpp/operator/mkldnn_test.cc
+++ b/tests/cpp/operator/mkldnn_test.cc
@@ -100,7 +100,7 @@ static void VerifyDefMem(const mkldnn::memory &mem) {
 
 TEST(MKLDNN_UTIL_FUNC, MemFormat) {
   // Check whether the number of format is correct.
-  CHECK_EQ(mkldnn_format_tag_last, 222);
+  CHECK_EQ(mkldnn_format_tag_last, 363);
   CHECK_EQ(mkldnn_nchw, 5);
   CHECK_EQ(mkldnn_oihw, 5);
 }


### PR DESCRIPTION
## Description ##
This change simply upgrades oneDNN used in MXNet to v2.2.

## Checklist ##

### Changes ###
- [x] Upgrade oneDNN used in MXNet to v2.2.1

## Comments ##
- This change involves removal of a descriptor check and replacing it with explicite data reordering
