### PR TITLE
[Dummy] Attempt to fix ONNX dynamic shape for TRT

### DIFF
--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -1709,6 +1709,36 @@ def convert_reshape(node, **kwargs):
         ]
         return nodes
 
+    if targ_shape == [-1, 0] and reverse == 'True':
+        create_tensor([-1], name+'_m1', kwargs['initializer'])
+        nodes = [
+            make_node('Shape', [input_nodes[0]], [name+'_shape']),
+            make_node('Shape', [name+'_shape'], [name+'_dim']),
+            make_node('Add', [name+'_dim', name+'_m1'], [name+'_dim_m1']),
+            make_node('Slice', [name+'_shape', name+'_dim_m1', name+'_dim'], [name+'_dim_last']),
+            make_node('Concat', [name+'_m1', name+'_dim_last'], [name+'_shape_new'], axis=0),
+            make_node('Reshape', [input_nodes[0], name+'_shape_new'], [name], name=name)
+        ]
+        return nodes
+
+    if targ_shape == [12, -1, 0] and reverse == 'True':
+        #create_tensor([-1], name+'_m1', kwargs['initializer'])
+        #create_tensor([12], name+'_12', kwargs['initializer'])
+        #nodes = [
+        #    make_node('Shape', [input_nodes[0]], [name+'_shape']),
+        #    make_node('Shape', [name+'_shape'], [name+'_dim']),
+        #    make_node('Add', [name+'_dim', name+'_m1'], [name+'_dim_m1']),
+        #    make_node('Slice', [name+'_shape', name+'_dim_m1', name+'_dim'], [name+'_dim_last']),
+        #    make_node('Concat', [name+'_12', name+'_m1', name+'_dim_last'], [name+'_shape_new'], axis=0),
+        #    make_node('Reshape', [input_nodes[0], name+'_shape_new'], [name], name=name)
+        #]
+        #return nodes
+        reverse = 'False'
+        targ_shape = [12, 64, 768]
+
+    if targ_shape == [12, -1] and reverse == 'True':
+        reverse = 'False'
+
     not_supported_shape = [-2, -3, -4]
     for val in targ_shape:
         if val in not_supported_shape:
@@ -3005,7 +3035,7 @@ def convert_arange_like(node, **kwargs):
         raise AttributeError("ONNX opset 11 or greater is required to export this operator")
 
     # use the same dtype as the that of the input node
-    dtype = input_dtypes[0]
+    dtype = np.dtype('int32')
     dtype_t = onnx.mapping.NP_TYPE_TO_TENSOR_TYPE[dtype]
     axis = attrs.get('axis', 'None')
     start = attrs.get('start', 0.)
@@ -3017,6 +3047,10 @@ def convert_arange_like(node, **kwargs):
     create_const_scalar_node(name+"_start", np.dtype(dtype).type(start), kwargs)
     create_const_scalar_node(name+"_step", np.dtype(dtype).type(step), kwargs)
     create_const_scalar_node(name+"_half_step", np.dtype(dtype).type(float(step)*0.5), kwargs)
+
+
+    dtype_true = input_dtypes[0]
+    dtype_true_t = onnx.mapping.NP_TYPE_TO_TENSOR_TYPE[dtype_true]
 
     nodes = []
     if axis == 'None':
@@ -3045,7 +3079,8 @@ def convert_arange_like(node, **kwargs):
             make_node("Mul", [name+"_cast0_out", name+"_step"], [name+"_mul0_out"]),
             make_node("Add", [name+"_mul0_out", name+"_start"], [name+"_add1_out"]),
             make_node("Sub", [name+"_add1_out", name+"_half_step"], [name+"_sub0_out"]),
-            make_node("Range", [name+"_start", name+"_sub0_out", name+"_step"], [name], name=name)
+            make_node("Range", [name+"_start", name+"_sub0_out", name+"_step"], [name+'_range']),
+            make_node('Cast', [name+'_range'], [name], to=dtype_true_t)
         ]
 
     return nodes

--- a/python/mxnet/contrib/onnx/mx2onnx/export_model.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/export_model.py
@@ -30,7 +30,7 @@ from ._export_helper import load_module
 
 def export_model(sym, params, in_shapes=None, in_types=np.float32,
                  onnx_file_path='model.onnx', verbose=False, opset_version=None,
-                 dynamic=False, dynamic_input_shapes=None, run_shape_inference=False, input_type=None,
+                 dynamic=False, dynamic_input_shapes=None, dynamic_output_shapes=None, run_shape_inference=False, input_type=None,
                  input_shape=None):
     """Exports the MXNet model file, passed as a parameter, into ONNX model.
     Accepts both symbol,parameter objects as well as json and params filepaths as input.
@@ -102,12 +102,14 @@ def export_model(sym, params, in_shapes=None, in_types=np.float32,
         onnx_graph = converter.create_onnx_graph_proto(sym_obj, params_obj, in_shapes,
                                                        in_types_t,
                                                        verbose=verbose, opset_version=opset_version,
-                                                       dynamic=dynamic, dynamic_input_shapes=dynamic_input_shapes)
+                                                       dynamic=dynamic, dynamic_input_shapes=dynamic_input_shapes,
+                                                       dynamic_output_shapes=dynamic_output_shapes)
     elif isinstance(sym, symbol.Symbol) and isinstance(params, dict):
         onnx_graph = converter.create_onnx_graph_proto(sym, params, in_shapes,
                                                        in_types_t,
                                                        verbose=verbose, opset_version=opset_version,
-                                                       dynamic=dynamic, dynamic_input_shapes=dynamic_input_shapes)
+                                                       dynamic=dynamic, dynamic_input_shapes=dynamic_input_shapes,
+                                                       dynamic_output_shapes=dynamic_output_shapes)
     else:
         raise ValueError("Input sym and params should either be files or objects")
 

--- a/python/mxnet/contrib/onnx/mx2onnx/export_onnx.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/export_onnx.py
@@ -123,7 +123,7 @@ class MXNetGraph(object):
 
     @staticmethod
     def get_outputs(sym, params, in_shapes, output_label, in_types, dynamic=False,
-                    dynamic_input_shapes=None):
+                    dynamic_input_shapes=None, dynamic_output_shapes=None):
         """Helper function to collect the output names, types, and shapes
 
         Parameters
@@ -183,6 +183,8 @@ class MXNetGraph(object):
         if dynamic:
             # Keep the dimensionality of the output shapes but change the values to None
             out_shapes = [tuple(None for _ in i_s) for i_s in out_shapes]
+            if dynamic_output_shapes is not None:
+                out_shapes = dynamic_output_shapes
 
             if dynamic_input_shapes is None:
                 # Set all dimensions to None
@@ -214,6 +216,7 @@ class MXNetGraph(object):
 
         # Bind output shapes/types with output names
         graph_outputs = {n: {'shape': s, 'dtype': d} for n, s, d in zip(out_names, out_shapes, out_types)}
+        
 
         return in_shapes, graph_outputs
 
@@ -224,7 +227,7 @@ class MXNetGraph(object):
                      for k, v in weights_dict.items()])
 
     def create_onnx_graph_proto(self, sym, params, in_shapes, in_types, verbose=False, opset_version=None,
-                                dynamic=True, dynamic_input_shapes=None):
+                                dynamic=True, dynamic_input_shapes=None, dynamic_output_shapes=None):
         """Convert MXNet graph to ONNX graph
 
         Parameters
@@ -287,7 +290,8 @@ class MXNetGraph(object):
 
         # Determine graph output names, shapes, and dtypes. Also update in_shapes
         in_shapes, graph_outputs = MXNetGraph.get_outputs(sym, params, in_shapes, output_label,
-                                                          in_types, dynamic, dynamic_input_shapes)
+                                                          in_types, dynamic, dynamic_input_shapes,
+                                                          dynamic_output_shapes)
         appeared_names = set()
         graph_input_idx = 0
         for idx, node in enumerate(mx_graph):


### PR DESCRIPTION
This PR adds an option to specify the output shapes of a dynamic onnx graph. I also fixed an issue with the Range operator (TRT Range only supports INT32). However, I was still unable to run the dynamic bert graph on TRT. I tried it with trtexec and this is the error I got:
```
[03/23/2021-23:03:08] [I] [TRT] Input filename:   /bert_dy.onnx
[03/23/2021-23:03:08] [I] [TRT] ONNX IR version:  0.0.7
[03/23/2021-23:03:08] [I] [TRT] Opset version:    12
[03/23/2021-23:03:08] [I] [TRT] Producer name:    
[03/23/2021-23:03:08] [I] [TRT] Producer version: 
[03/23/2021-23:03:08] [I] [TRT] Domain:           
[03/23/2021-23:03:08] [I] [TRT] Model version:    0
[03/23/2021-23:03:08] [I] [TRT] Doc string:       
[03/23/2021-23:03:08] [I] [TRT] ----------------------------------------------------------------
[03/23/2021-23:03:09] [W] [TRT] /home/jenkins/workspace/OSS/L0_MergeRequest/oss/parsers/onnx/onnx2trt_utils.cpp:226: Your ONNX model has been generated with INT64 weights, while TensorRT does not natively support INT64. Attempting to cast down to INT32.
[03/23/2021-23:03:09] [W] [TRT] /home/jenkins/workspace/OSS/L0_MergeRequest/oss/parsers/onnx/onnx2trt_utils.cpp:254: One or more weights outside the range of INT32 was clamped
terminate called after throwing an instance of 'std::length_error'
  what():  cannot create std::vector larger than max_size()
Aborted (core dumped)
```

Both the raw export and the simplified graph by onnx-simplifier had this same error. 

This is how I exported bert:

```python
dynamic_input_shapes = [('batch', 'sequence'), ('batch', 'sequence'), ('batch',)]
        dynamic_output_shapes = [('batch', 'sequence', 768), ('batch', 768)]
        input_shapes = [(batch, seq_length), (batch, seq_length), (batch,)]
        input_types = [np.float32, np.float32, np.float32]

        converted_model_path = mx.contrib.onnx.export_model(sym_file, params_file, input_shapes,
                                                            input_types, onnx_file,
                                                            dynamic=True,
                                                            dynamic_input_shapes=dynamic_input_shapes,
                                                            dynamic_output_shapes=dynamic_output_shapes)
```

<img width="838" alt="Screen Shot 2021-03-23 at 4 15 56 PM" src="https://user-images.githubusercontent.com/16669457/112230965-0dd04980-8bf3-11eb-9da0-c69146e2652d.png">

We can see now the input and output shapes should be correct. This export also ran fine with onnxruntime. So I suspect there might be some incompatibility issue on TRT's side? I was not able to debug the above error message so I thought maybe the Nvidia team might be able to provide some insights? @TristonC @MoisesHer 