### PR TITLE
Mark test_layer_norm and test_norm flaky

### DIFF
--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -3410,6 +3410,7 @@ def check_layer_normalization(in_shape, axis, eps, dtype=np.float32,
                             gt_beta_grad + init_beta_grad, backward_check_eps, backward_check_eps)
 
 
+@pytest.mark.flaky
 def test_norm():
     try:
         import scipy
@@ -3490,6 +3491,7 @@ def test_norm():
     (np.float32, 1E-3, 1E-3, [(10, 6, 5), (10, 10), (128 * 32, 512)], [True, True, False]),
     (np.float64, 1E-4, 1E-4, [(10, 6, 5), (10, 10), (128 * 32, 512)], [True, True, False])
 ])
+@pytest.mark.flaky
 def test_layer_norm(enforce_safe_acc, dtype, forward_check_eps, backward_check_eps,
                     in_shape_l, finite_grad_check_l):
     with environment('MXNET_SAFE_ACCUMULATION', enforce_safe_acc):


### PR DESCRIPTION
## Description ##
These two tests sometimes take longer than 20mins to run. 
```
[2021-03-25T17:51:39.813Z] 1200.88s call     tests/python/unittest/test_operator.py::test_layer_norm[float32-0.001-0.001-in_shape_l1-finite_grad_check_l1-1]

[2021-03-25T17:51:39.813Z] 1200.40s call     tests/python/unittest/test_operator.py::test_layer_norm[float64-0.0001-0.0001-in_shape_l2-finite_grad_check_l2-1]

[2021-03-25T17:51:39.813Z] 1200.14s call     tests/python/unittest/test_operator.py::test_norm
```
https://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/mxnet-validation%2Fcentos-cpu/detail/PR-20087/9/pipeline
## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
