### PR TITLE
ci: enable devtoolset-9 during test on centos7

### DIFF
--- a/ci/docker/Dockerfile.build.centos7
+++ b/ci/docker/Dockerfile.build.centos7
@@ -53,7 +53,7 @@ RUN yum -y check-update || true && \
         protobuf-devel \
         # CentOS Software Collections https://www.softwarecollections.org
         devtoolset-7 \
-        devtoolset-8 \
+        devtoolset-9 \
         rh-python36 \
         rh-maven35 \
         # Libraries

--- a/ci/docker/Dockerfile.build.centos7
+++ b/ci/docker/Dockerfile.build.centos7
@@ -53,6 +53,7 @@ RUN yum -y check-update || true && \
         protobuf-devel \
         # CentOS Software Collections https://www.softwarecollections.org
         devtoolset-7 \
+        devtoolset-8 \
         devtoolset-9 \
         rh-python36 \
         rh-maven35 \

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -1288,7 +1288,11 @@ checkout() {
 build_static_libmxnet() {
     set -ex
     pushd .
-    source /opt/rh/devtoolset-9/enable
+    if [[ ${mxnet_variant} =~ cu10[0-9]+$ ]]; then
+        source /opt/rh/devtoolset-8/enable
+    else
+        source /opt/rh/devtoolset-9/enable
+    fi
     source /opt/rh/rh-python36/enable
     # Opt in to newer GCC C++ ABI. devtoolset defaults to ABI Version 2.
     export CXXFLAGS="-fabi-version=11 -fabi-compat-version=7"

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -111,20 +111,29 @@ build_dynamic_libmxnet() {
     gather_licenses
 
     cd /work/build
-    source /opt/rh/devtoolset-9/enable
     # Opt in to newer GCC C++ ABI. devtoolset defaults to ABI Version 2.
     export CXXFLAGS="-fabi-version=11 -fabi-compat-version=7"
     if [[ ${mxnet_variant} = "cpu" ]]; then
+        source /opt/rh/devtoolset-9/enable
         cmake -DUSE_BLAS=Open \
             -DUSE_ONEDNN=ON \
             -DUSE_CUDA=OFF \
             -G Ninja /work/mxnet
     elif [[ ${mxnet_variant} = "native" ]]; then
+        source /opt/rh/devtoolset-9/enable
         cmake -DUSE_BLAS=Open \
             -DUSE_ONEDNN=OFF \
             -DUSE_CUDA=OFF \
             -G Ninja /work/mxnet
+    elif [[ ${mxnet_variant} =~ cu11[0-9]+$ ]]; then
+        source /opt/rh/devtoolset-9/enable
+        cmake -DUSE_BLAS=Open \
+              -DUSE_ONEDNN=ON \
+              -DUSE_DIST_KVSTORE=ON \
+              -DUSE_CUDA=ON \
+              -G Ninja /work/mxnet
     elif [[ ${mxnet_variant} =~ cu[0-9]+$ ]]; then
+        source /opt/rh/devtoolset-8/enable
         cmake -DUSE_BLAS=Open \
             -DUSE_ONEDNN=ON \
             -DUSE_DIST_KVSTORE=ON \
@@ -1362,7 +1371,7 @@ build_static_python_cu102() {
     set -ex
     pushd .
     export mxnet_variant=cu102
-    source /opt/rh/devtoolset-9/enable
+    source /opt/rh/devtoolset-8/enable
     source /opt/rh/rh-python36/enable
     # Opt in to newer GCC C++ ABI. devtoolset defaults to ABI Version 2.
     export CXXFLAGS="-fabi-version=11 -fabi-compat-version=7"

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -1288,6 +1288,7 @@ checkout() {
 build_static_libmxnet() {
     set -ex
     pushd .
+    local mxnet_variant=${1:?"This function requires a python command as the first argument"}
     if [[ ${mxnet_variant} =~ cu10[0-9]+$ ]]; then
         source /opt/rh/devtoolset-8/enable
     else
@@ -1296,7 +1297,6 @@ build_static_libmxnet() {
     source /opt/rh/rh-python36/enable
     # Opt in to newer GCC C++ ABI. devtoolset defaults to ABI Version 2.
     export CXXFLAGS="-fabi-version=11 -fabi-compat-version=7"
-    local mxnet_variant=${1:?"This function requires a python command as the first argument"}
     source tools/staticbuild/build.sh ${mxnet_variant}
     popd
 }

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -722,6 +722,7 @@ sanity_python() {
 # $1 -> mxnet_variant: The variant of the libmxnet.so library
 cd_unittest_ubuntu() {
     set -ex
+    source /opt/rh/devtoolset-8/enable
     source /opt/rh/rh-python36/enable
     export PYTHONPATH=./python/
     export MXNET_ONEDNN_DEBUG=0  # Ignored if not present
@@ -853,6 +854,7 @@ unittest_cpp() {
 
 unittest_centos7_cpu() {
     set -ex
+    source /opt/rh/devtoolset-8/enable
     source /opt/rh/rh-python36/enable
     cd /work/mxnet
     export DMLC_LOG_STACK_TRACE_DEPTH=100
@@ -865,6 +867,7 @@ unittest_centos7_cpu() {
 
 unittest_centos7_gpu() {
     set -ex
+    source /opt/rh/devtoolset-8/enable
     source /opt/rh/rh-python36/enable
     cd /work/mxnet
     export CUDNN_VERSION=${CUDNN_VERSION:-7.0.3}
@@ -1316,6 +1319,7 @@ cd_package_pypi() {
 # Sanity checks wheel file
 cd_integration_test_pypi() {
     set -ex
+    source /opt/rh/devtoolset-8/enable
     source /opt/rh/rh-python36/enable
 
     # install mxnet wheel package

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -111,7 +111,7 @@ build_dynamic_libmxnet() {
     gather_licenses
 
     cd /work/build
-    source /opt/rh/devtoolset-8/enable
+    source /opt/rh/devtoolset-9/enable
     # Opt in to newer GCC C++ ABI. devtoolset defaults to ABI Version 2.
     export CXXFLAGS="-fabi-version=11 -fabi-compat-version=7"
     if [[ ${mxnet_variant} = "cpu" ]]; then
@@ -722,7 +722,6 @@ sanity_python() {
 # $1 -> mxnet_variant: The variant of the libmxnet.so library
 cd_unittest_ubuntu() {
     set -ex
-    source /opt/rh/devtoolset-8/enable
     source /opt/rh/rh-python36/enable
     export PYTHONPATH=./python/
     export MXNET_ONEDNN_DEBUG=0  # Ignored if not present
@@ -854,7 +853,6 @@ unittest_cpp() {
 
 unittest_centos7_cpu() {
     set -ex
-    source /opt/rh/devtoolset-8/enable
     source /opt/rh/rh-python36/enable
     cd /work/mxnet
     export DMLC_LOG_STACK_TRACE_DEPTH=100
@@ -867,7 +865,6 @@ unittest_centos7_cpu() {
 
 unittest_centos7_gpu() {
     set -ex
-    source /opt/rh/devtoolset-8/enable
     source /opt/rh/rh-python36/enable
     cd /work/mxnet
     export CUDNN_VERSION=${CUDNN_VERSION:-7.0.3}
@@ -1282,7 +1279,7 @@ checkout() {
 build_static_libmxnet() {
     set -ex
     pushd .
-    source /opt/rh/devtoolset-8/enable
+    source /opt/rh/devtoolset-9/enable
     source /opt/rh/rh-python36/enable
     # Opt in to newer GCC C++ ABI. devtoolset defaults to ABI Version 2.
     export CXXFLAGS="-fabi-version=11 -fabi-compat-version=7"
@@ -1307,7 +1304,7 @@ ci_package_pypi() {
 cd_package_pypi() {
     set -ex
     pushd .
-    source /opt/rh/devtoolset-8/enable
+    source /opt/rh/devtoolset-9/enable
     source /opt/rh/rh-python36/enable
     # Opt in to newer GCC C++ ABI. devtoolset defaults to ABI Version 2.
     export CXXFLAGS="-fabi-version=11 -fabi-compat-version=7"
@@ -1319,7 +1316,7 @@ cd_package_pypi() {
 # Sanity checks wheel file
 cd_integration_test_pypi() {
     set -ex
-    source /opt/rh/devtoolset-8/enable
+    source /opt/rh/devtoolset-9/enable
     source /opt/rh/rh-python36/enable
 
     # install mxnet wheel package
@@ -1353,7 +1350,7 @@ build_static_python_cpu() {
     set -ex
     pushd .
     export mxnet_variant=cpu
-    source /opt/rh/devtoolset-8/enable
+    source /opt/rh/devtoolset-9/enable
     source /opt/rh/rh-python36/enable
     # Opt in to newer GCC C++ ABI. devtoolset defaults to ABI Version 2.
     export CXXFLAGS="-fabi-version=11 -fabi-compat-version=7"
@@ -1365,7 +1362,7 @@ build_static_python_cu102() {
     set -ex
     pushd .
     export mxnet_variant=cu102
-    source /opt/rh/devtoolset-8/enable
+    source /opt/rh/devtoolset-9/enable
     source /opt/rh/rh-python36/enable
     # Opt in to newer GCC C++ ABI. devtoolset defaults to ABI Version 2.
     export CXXFLAGS="-fabi-version=11 -fabi-compat-version=7"


### PR DESCRIPTION
ensure /opt/rh/devtoolset-8/root/usr/lib/gcc/x86_64-redhat-linux/8/libgomp.so
can be used instead of ancient /usr/lib/gcc/x86_64-redhat-linux/4.8.2/libgomp.so