### PR TITLE
[FFI] part5: npx.batch_dot, npx.arange_like, npx.broadcast_like

### DIFF
--- a/python/mxnet/base.py
+++ b/python/mxnet/base.py
@@ -798,7 +798,8 @@ _NP_EXT_OP_IMPLEMENTED_SET = {'_npx_softmax', '_npx_log_softmax', '_npx_masked_s
                               '_npx_masked_log_softmax', '_npx_activation',
                               '_npx_batch_norm', '_npx_fully_connected', '_npx_pick',
                               '_npx_convolution', '_npx_deconvolution', '_npx_pooling',
-                              '_npx_dropout', '_npx_one_hot', '_npx_rnn'}
+                              '_npx_dropout', '_npx_one_hot', '_npx_rnn', '_npx_batch_dot',
+                              '_npx_broadcast_like', '_npx_arange_like'}
 
 _NP_INTERNAL_OP_PREFIX = '_npi_'
 

--- a/python/mxnet/ndarray/numpy_extension/_op.py
+++ b/python/mxnet/ndarray/numpy_extension/_op.py
@@ -27,7 +27,8 @@ from ...util import set_module
 
 __all__ = ['softmax', 'log_softmax', 'masked_softmax', 'masked_log_softmax',
            'activation', 'batch_norm', 'fully_connected', 'pick', 'convolution',
-           'deconvolution', 'pooling', 'dropout', 'one_hot', 'rnn']
+           'deconvolution', 'pooling', 'dropout', 'one_hot', 'rnn',
+           'batch_dot', 'broadcast_like', 'arange_like']
 
 
 # pylint: disable=too-many-arguments
@@ -1057,3 +1058,132 @@ def rnn(data=None, parameters=None, state=None, state_cell=None, sequence_length
                                      state_size, num_layers, bidirectional, state_outputs,
                                      mode, p, use_sequence_length, projection_size,
                                      lstm_state_clip_min, lstm_state_clip_max, lstm_state_clip_nan)
+
+
+# pylint: disable=too-many-arguments
+@set_module('mxnet.ndarray.numpy_extension')
+def batch_dot(a, b, transpose_a=False, transpose_b=False, forward_stype="default"):
+    r"""Batchwise dot product.
+
+    ``batch_dot`` is used to compute dot product of ``x`` and ``y`` when ``x`` and
+    ``y`` are data in batch, namely N-D (N >= 3) arrays in shape of `(B0, ..., B_i, :, :)`.
+
+    For example, given ``x`` with shape `(B_0, ..., B_i, N, M)` and ``y`` with shape
+    `(B_0, ..., B_i, M, K)`, the result array will have shape `(B_0, ..., B_i, N, K)`,
+    which is computed by::
+
+       batch_dot(x,y)[b_0, ..., b_i, :, :] = dot(x[b_0, ..., b_i, :, :], y[b_0, ..., b_i, :, :])
+
+    Parameters
+    ----------
+    lhs : NDArray
+        The first input
+    rhs : NDArray
+        The second input
+    transpose_a : boolean, optional, default=0
+        If true then transpose the first input before dot.
+    transpose_b : boolean, optional, default=0
+        If true then transpose the second input before dot.
+    forward_stype : {None, 'csr', 'default', 'row_sparse'},optional, default='None'
+        The desired storage type of the forward output given by user,
+        if thecombination of input storage types and this hint does not matchany implemented ones,
+        the dot operator will perform fallback operationand still produce
+        an output of the desired storage type.
+
+    Returns
+    -------
+    out : NDArray or list of NDArrays
+        The output of this function.
+    """
+    return _api_internal.batch_dot(a, b, transpose_a, transpose_b, forward_stype)
+
+
+# pylint: disable=too-many-arguments
+@set_module('mxnet.ndarray.numpy_extension')
+def broadcast_like(lhs, rhs, lhs_axes=None, rhs_axes=None):
+    r"""Broadcasts lhs to have the same shape as rhs.
+
+    Broadcasting is a mechanism that allows NDArrays to perform arithmetic operations
+    with arrays of different shapes efficiently without creating multiple copies of arrays.
+    Also see, `Broadcasting <https://docs.scipy.org/doc/numpy/user/basics.broadcasting.html>`_
+    for more explanation.
+
+    Broadcasting is allowed on axes with size 1, such as from `(2,1,3,1)` to
+    `(2,8,3,9)`. Elements will be duplicated on the broadcasted axes.
+
+    Parameters
+    ----------
+    lhs : NDArray
+        First input.
+    rhs : NDArray
+        Second input.
+    lhs_axes : Shape or None, optional, default=None
+        Axes to perform broadcast on in the first input array
+    rhs_axes : Shape or None, optional, default=None
+        Axes to copy from the second input array
+
+    Returns
+    -------
+    out : NDArray or list of NDArrays
+        The output of this function.
+
+    example
+    -------
+    >>> a = np.array([[1,2,3]])
+    >>> b = np.array([[5,6,7],[7,8,9]])
+    >>> npx.broadcast_like(a, b)
+    array([[1., 2., 3.],
+           [1., 2., 3.]])
+    >>> a = np.array([9])
+    >>> b = np.array([1,2,3,4,5])
+    >>> npx.broadcast_like(a, b, lhs_axes=(0,), rhs_axes=(-1,))
+    array([9., 9., 9., 9., 9.])
+    """
+    return _api_internal.broadcast_like(lhs, rhs, lhs_axes, rhs_axes)
+
+
+# pylint: disable=too-many-arguments
+@set_module('mxnet.ndarray.numpy_extension')
+def arange_like(data, start=0.0, step=1.0, repeat=1, ctx=None, axis=None):
+    r"""Return an array with evenly spaced values. If axis is not given, the output will 
+    have the same shape as the input array. Otherwise, the output will be a 1-D array with size of 
+    the specified axis in input shape.
+
+    Parameters
+    ----------
+    data : NDArray
+        The input
+    start : double, optional, default=0
+        Start of interval. The interval includes this value. The default start value is 0.
+    step : double, optional, default=1
+        Spacing between values.
+    repeat : int, optional, default='1'
+        The repeating time of all elements.
+        E.g repeat=3, the element a will be repeated three times --> a, a, a.
+    ctx : string, optional, default=''
+        Context of output, in format [cpu|gpu|cpu_pinned](n).Only used for imperative calls.
+    axis : int or None, optional, default='None'
+        Arange elements according to the size of a certain axis of input array.
+        The negative numbers are interpreted counting from the backward.
+        If not provided, will arange elements according to the input shape.
+
+    Returns
+    -------
+    out : NDArray or list of NDArrays
+        The output of this function.
+
+    Example
+    -------
+    >>> x = np.random.uniform(0, 1, size=(3,4))
+    >>> x
+    array([[0.5488135 , 0.5928446 , 0.71518934, 0.84426576],
+           [0.60276335, 0.8579456 , 0.5448832 , 0.8472517 ],
+           [0.4236548 , 0.6235637 , 0.6458941 , 0.3843817 ]])
+    >>> npx.arange_like(x, start=0)
+    array([[ 0.,  1.,  2.,  3.],
+           [ 4.,  5.,  6.,  7.],
+           [ 8.,  9., 10., 11.]])
+    >>> npx.arange_like(x, start=0, axis=-1)
+    array([0., 1., 2., 3.])
+    """
+    return _api_internal.arange_like(data, start, step, repeat, ctx, axis)

--- a/python/mxnet/ndarray/numpy_extension/_op.py
+++ b/python/mxnet/ndarray/numpy_extension/_op.py
@@ -1145,8 +1145,8 @@ def broadcast_like(lhs, rhs, lhs_axes=None, rhs_axes=None):
 # pylint: disable=too-many-arguments
 @set_module('mxnet.ndarray.numpy_extension')
 def arange_like(data, start=0.0, step=1.0, repeat=1, ctx=None, axis=None):
-    r"""Return an array with evenly spaced values. If axis is not given, the output will 
-    have the same shape as the input array. Otherwise, the output will be a 1-D array with size of 
+    r"""Return an array with evenly spaced values. If axis is not given, the output will
+    have the same shape as the input array. Otherwise, the output will be a 1-D array with size of
     the specified axis in input shape.
 
     Parameters

--- a/python/mxnet/numpy_extension/_op.py
+++ b/python/mxnet/numpy_extension/_op.py
@@ -1062,8 +1062,8 @@ def broadcast_like(lhs, rhs, lhs_axes=None, rhs_axes=None):
 # pylint: disable=too-many-arguments, unused-argument
 @set_module('mxnet.numpy_extension')
 def arange_like(data, start=0.0, step=1.0, repeat=1, ctx=None, axis=None):
-    r"""Return an array with evenly spaced values. If axis is not given, the output will 
-    have the same shape as the input array. Otherwise, the output will be a 1-D array with size of 
+    r"""Return an array with evenly spaced values. If axis is not given, the output will
+    have the same shape as the input array. Otherwise, the output will be a 1-D array with size of
     the specified axis in input shape.
 
     Parameters

--- a/python/mxnet/numpy_extension/_op.py
+++ b/python/mxnet/numpy_extension/_op.py
@@ -23,7 +23,8 @@ from ..util import set_module
 
 __all__ = ['softmax', 'log_softmax', 'masked_softmax', 'masked_log_softmax',
            'activation', 'batch_norm', 'fully_connected', 'pick', 'convolution',
-           'deconvolution', 'pooling', 'dropout', 'one_hot', 'rnn']
+           'deconvolution', 'pooling', 'dropout', 'one_hot', 'rnn',
+           'batch_dot', 'broadcast_like', 'arange_like']
 
 
 # pylint: disable=too-many-arguments
@@ -973,3 +974,134 @@ def rnn(data=None, parameters=None, state=None, state_cell=None, sequence_length
                           projection_size=projection_size, lstm_state_clip_min=lstm_state_clip_min,
                           lstm_state_clip_max=lstm_state_clip_max,
                           lstm_state_clip_nan=lstm_state_clip_nan)
+
+
+# pylint: disable=too-many-arguments, unused-argument
+@set_module('mxnet.numpy_extension')
+def batch_dot(a, b, transpose_a=False, transpose_b=False, forward_stype="default"):
+    r"""Batchwise dot product.
+
+    ``batch_dot`` is used to compute dot product of ``x`` and ``y`` when ``x`` and
+    ``y`` are data in batch, namely N-D (N >= 3) arrays in shape of `(B0, ..., B_i, :, :)`.
+
+    For example, given ``x`` with shape `(B_0, ..., B_i, N, M)` and ``y`` with shape
+    `(B_0, ..., B_i, M, K)`, the result array will have shape `(B_0, ..., B_i, N, K)`,
+    which is computed by::
+
+       batch_dot(x,y)[b_0, ..., b_i, :, :] = dot(x[b_0, ..., b_i, :, :], y[b_0, ..., b_i, :, :])
+
+    Parameters
+    ----------
+    lhs : NDArray
+        The first input
+    rhs : NDArray
+        The second input
+    transpose_a : boolean, optional, default=0
+        If true then transpose the first input before dot.
+    transpose_b : boolean, optional, default=0
+        If true then transpose the second input before dot.
+    forward_stype : {None, 'csr', 'default', 'row_sparse'},optional, default='None'
+        The desired storage type of the forward output given by user,
+        if thecombination of input storage types and this hint does not matchany implemented ones,
+        the dot operator will perform fallback operationand still produce
+        an output of the desired storage type.
+
+    Returns
+    -------
+    out : NDArray or list of NDArrays
+        The output of this function.
+    """
+    return _mx_nd_npx.batch_dot(a=a, b=b, transpose_a=transpose_a,
+                                transpose_b=transpose_b, forward_stype=forward_stype)
+
+
+# pylint: disable=too-many-arguments, unused-argument
+@set_module('mxnet.numpy_extension')
+def broadcast_like(lhs, rhs, lhs_axes=None, rhs_axes=None):
+    r"""Broadcasts lhs to have the same shape as rhs.
+
+    Broadcasting is a mechanism that allows NDArrays to perform arithmetic operations
+    with arrays of different shapes efficiently without creating multiple copies of arrays.
+    Also see, `Broadcasting <https://docs.scipy.org/doc/numpy/user/basics.broadcasting.html>`_
+    for more explanation.
+
+    Broadcasting is allowed on axes with size 1, such as from `(2,1,3,1)` to
+    `(2,8,3,9)`. Elements will be duplicated on the broadcasted axes.
+
+    Parameters
+    ----------
+    lhs : NDArray
+        First input.
+    rhs : NDArray
+        Second input.
+    lhs_axes : Shape or None, optional, default=None
+        Axes to perform broadcast on in the first input array
+    rhs_axes : Shape or None, optional, default=None
+        Axes to copy from the second input array
+
+    Returns
+    -------
+    out : NDArray or list of NDArrays
+        The output of this function.
+
+    example
+    -------
+    >>> a = np.array([[1,2,3]])
+    >>> b = np.array([[5,6,7],[7,8,9]])
+    >>> npx.broadcast_like(a, b)
+    array([[1., 2., 3.],
+           [1., 2., 3.]])
+    >>> a = np.array([9])
+    >>> b = np.array([1,2,3,4,5])
+    >>> npx.broadcast_like(a, b, lhs_axes=(0,), rhs_axes=(-1,))
+    array([9., 9., 9., 9., 9.])
+    """
+    return _mx_nd_npx.broadcast_like(lhs=lhs, rhs=rhs, lhs_axes=lhs_axes, rhs_axes=rhs_axes)
+
+
+# pylint: disable=too-many-arguments, unused-argument
+@set_module('mxnet.numpy_extension')
+def arange_like(data, start=0.0, step=1.0, repeat=1, ctx=None, axis=None):
+    r"""Return an array with evenly spaced values. If axis is not given, the output will 
+    have the same shape as the input array. Otherwise, the output will be a 1-D array with size of 
+    the specified axis in input shape.
+
+    Parameters
+    ----------
+    data : NDArray
+        The input
+    start : double, optional, default=0
+        Start of interval. The interval includes this value. The default start value is 0.
+    step : double, optional, default=1
+        Spacing between values.
+    repeat : int, optional, default='1'
+        The repeating time of all elements.
+        E.g repeat=3, the element a will be repeated three times --> a, a, a.
+    ctx : string, optional, default=''
+        Context of output, in format [cpu|gpu|cpu_pinned](n).Only used for imperative calls.
+    axis : int or None, optional, default='None'
+        Arange elements according to the size of a certain axis of input array.
+        The negative numbers are interpreted counting from the backward.
+        If not provided, will arange elements according to the input shape.
+
+    Returns
+    -------
+    out : NDArray or list of NDArrays
+        The output of this function.
+
+    Example
+    -------
+    >>> x = np.random.uniform(0, 1, size=(3,4))
+    >>> x
+    array([[0.5488135 , 0.5928446 , 0.71518934, 0.84426576],
+           [0.60276335, 0.8579456 , 0.5448832 , 0.8472517 ],
+           [0.4236548 , 0.6235637 , 0.6458941 , 0.3843817 ]])
+    >>> npx.arange_like(x, start=0)
+    array([[ 0.,  1.,  2.,  3.],
+           [ 4.,  5.,  6.,  7.],
+           [ 8.,  9., 10., 11.]])
+    >>> npx.arange_like(x, start=0, axis=-1)
+    array([0., 1., 2., 3.])
+    """
+    return _mx_nd_npx.arange_like(data=data, start=start, step=step, repeat=repeat,
+                                  ctx=ctx, axis=axis)

--- a/src/api/operator/numpy_extension/npx_arange_like_op.cc
+++ b/src/api/operator/numpy_extension/npx_arange_like_op.cc
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file npx_arange_like_op.cc
+ * \brief Implementation of the API of functions in src/operator/numpy_extension/npx_arange_like_op.cc
+ */
+#include <mxnet/api_registry.h>
+#include <mxnet/runtime/packed_func.h>
+#include "../utils.h"
+#include "../../../operator/tensor/init_op.h"
+
+namespace mxnet {
+
+MXNET_REGISTER_API("_npx.arange_like")
+.set_body([](runtime::MXNetArgs args, runtime::MXNetRetValue* ret) {
+  using namespace runtime;
+  nnvm::NodeAttrs attrs;
+  const nnvm::Op* op = Op::Get("_npx_arange_like");
+  op::RangeLikeParam param;
+  // inputs
+  int num_inputs = 1;
+  NDArray* inputs[] = {args[0].operator mxnet::NDArray*()};
+  // start
+  if (args[1].type_code() == kNull) {
+    param.start = 0.0;
+  } else {
+    param.start = args[1].operator double();
+  }
+  // step
+  if (args[2].type_code() == kNull) {
+    param.step = 1.0;
+  } else {
+    param.step = args[2].operator double();
+  }
+  // repeat
+  if (args[3].type_code() == kNull) {
+    param.repeat = 1;
+  } else {
+    param.repeat = args[3].operator int();
+  }
+  // ctx
+  if (args[4].type_code() != kNull) {
+    attrs.dict["ctx"] = args[4].operator std::string();
+  }
+  // axis
+  if (args[5].type_code() == kNull) {
+    param.axis = dmlc::nullopt;
+  } else {
+    param.axis = args[5].operator int();
+  }
+  attrs.op = op;
+  attrs.parsed = param;
+  SetAttrDict<op::RangeLikeParam>(&attrs);
+
+  // outputs
+  int num_outputs = 0;
+  auto ndoutputs = Invoke(op, &attrs, num_inputs, inputs, &num_outputs, nullptr);
+  *ret = reinterpret_cast<mxnet::NDArray*>(ndoutputs[0]);
+});
+
+}  // namespace mxnet

--- a/src/api/operator/numpy_extension/npx_batch_dot_op.cc
+++ b/src/api/operator/numpy_extension/npx_batch_dot_op.cc
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file npx_batch_dot_op.cc
+ * \brief Implementation of the API of functions in src/operator/numpy_extension/npx_batch_dot_op.cc
+ */
+#include <mxnet/api_registry.h>
+#include <mxnet/runtime/packed_func.h>
+#include "../utils.h"
+#include "../../../operator/tensor/dot-inl.h"
+
+namespace mxnet {
+
+inline int String2ForwardStype(const std::string& s) {
+  using namespace op;
+  if (s == "default") {
+    return kDefaultStorage;
+  } else if (s == "row_sparse") {
+    return kRowSparseStorage;
+  } else if (s == "csr") {
+    return kCSRStorage;
+  } else {
+    LOG(FATAL) << "unknown forward storage type " << s;
+  }
+  LOG(FATAL) << "should not reach here ";
+  return 0;
+}
+
+MXNET_REGISTER_API("_npx.batch_dot")
+.set_body([](runtime::MXNetArgs args, runtime::MXNetRetValue* ret) {
+  using namespace runtime;
+  nnvm::NodeAttrs attrs;
+  const nnvm::Op* op = Op::Get("_npx_batch_dot");
+  op::DotParam param;
+  // inputs
+  int num_inputs = 2;
+  std::vector<NDArray*> inputs;
+  inputs.reserve(num_inputs);
+  for (int i = 0; i < num_inputs; ++i) {
+    inputs.push_back(args[i].operator mxnet::NDArray*());
+  }
+  // transpose_a
+  if (args[2].type_code() == kNull) {
+    param.transpose_a = false;
+  } else {
+    param.transpose_a = args[2].operator bool();
+  }
+  // transpose_b
+  if (args[3].type_code() == kNull) {
+    param.transpose_b = false;
+  } else {
+    param.transpose_b = args[3].operator bool();
+  }
+  // forward_stype
+  if (args[4].type_code() == kNull) {
+    param.forward_stype = dmlc::nullopt;
+  } else {
+    param.forward_stype = String2ForwardStype(args[4].operator std::string());
+  }
+  attrs.parsed = param;
+  attrs.op = op;
+  SetAttrDict<op::DotParam>(&attrs);
+  int num_outputs = 1;
+  auto ndoutputs = Invoke(op, &attrs, num_inputs, inputs.data(), &num_outputs, nullptr);
+  *ret = ndoutputs[0];
+});
+
+}  // namespace mxnet

--- a/src/api/operator/numpy_extension/npx_broadcast_like_op.cc
+++ b/src/api/operator/numpy_extension/npx_broadcast_like_op.cc
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file npx_broadcast_like_op.cc
+ * \brief Implementation of the API of functions in src/operator/numpy_extension/npx_broadcast_like_op.cc
+ */
+#include <mxnet/api_registry.h>
+#include <mxnet/runtime/packed_func.h>
+#include "../utils.h"
+#include "../../../operator/tensor/broadcast_reduce_op.h"
+
+namespace mxnet {
+
+MXNET_REGISTER_API("_npx.broadcast_like")
+.set_body([](runtime::MXNetArgs args, runtime::MXNetRetValue* ret) {
+  using namespace runtime;
+  nnvm::NodeAttrs attrs;
+  const nnvm::Op* op = Op::Get("_npx_broadcast_like");
+  op::BroadcastLikeParam param;
+  // inputs
+  int num_inputs = 2;
+  std::vector<NDArray*> inputs;
+  inputs.reserve(num_inputs);
+  for (int i = 0; i < num_inputs; ++i) {
+    inputs.push_back(args[i].operator mxnet::NDArray*());
+  }
+  // lhs_axes
+  if (args[2].type_code() == kNull) {
+    param.lhs_axes = dmlc::optional<mxnet::TShape>();
+  } else {
+    param.lhs_axes = mxnet::TShape(args[2].operator ObjectRef());
+  }
+  // rhs_axes
+  if (args[2].type_code() == kNull) {
+    param.rhs_axes = dmlc::optional<mxnet::TShape>();
+  } else {
+    param.rhs_axes = mxnet::TShape(args[2].operator ObjectRef());
+  }
+
+  attrs.op = op;
+  attrs.parsed = param;
+  SetAttrDict<op::BroadcastLikeParam>(&attrs);
+
+  // outputs
+  int num_outputs = 0;
+  auto ndoutputs = Invoke(op, &attrs, num_inputs, inputs.data(), &num_outputs, nullptr);
+  *ret = reinterpret_cast<mxnet::NDArray*>(ndoutputs[0]);
+});
+
+}  // namespace mxnet

--- a/src/operator/tensor/broadcast_reduce_op.h
+++ b/src/operator/tensor/broadcast_reduce_op.h
@@ -201,6 +201,21 @@ struct BroadcastLikeParam : public dmlc::Parameter<BroadcastLikeParam> {
     DMLC_DECLARE_FIELD(rhs_axes).set_default(dmlc::optional<mxnet::TShape>())
       .describe("Axes to copy from the second input array");
   }
+  void SetAttrDict(std::unordered_map<std::string, std::string>* dict) {
+    std::ostringstream lhs_axes_s, rhs_axes_s;
+    if (lhs_axes.has_value()) {
+      lhs_axes_s << lhs_axes.value();
+    } else {
+      lhs_axes_s << lhs_axes;
+    }
+    (*dict)["lhs_axes"] = lhs_axes_s.str();
+    if (rhs_axes.has_value()) {
+      rhs_axes_s << rhs_axes.value();
+    } else {
+      rhs_axes_s << rhs_axes;
+    }
+    (*dict)["rhs_axes"] = rhs_axes_s.str();
+  }
 };
 
 /*

--- a/src/operator/tensor/dot-inl.h
+++ b/src/operator/tensor/dot-inl.h
@@ -64,6 +64,33 @@ struct DotParam : public dmlc::Parameter<DotParam> {
       .add_enum("csr", kCSRStorage)
       .set_default(dmlc::optional<int>());
   }
+  std::string ForwardStype2String(int forward_stype) {
+    switch (forward_stype) {
+      case kDefaultStorage:
+        return "default";
+      case kRowSparseStorage:
+        return "row_sparse";
+      case kCSRStorage:
+        return "csr";
+      default:
+        LOG(FATAL) << "Unknown forward stype enum " << forward_stype;
+    }
+    LOG(FATAL) << "should not reach here ";
+    return "";
+  }
+  void SetAttrDict(std::unordered_map<std::string, std::string>* dict) {
+    std::ostringstream transpose_a_s, transpose_b_s, forward_stype_s;
+    transpose_a_s << transpose_a;
+    transpose_b_s << transpose_b;
+    forward_stype_s << forward_stype;
+    (*dict)["transpose_a"] = transpose_a_s.str();
+    (*dict)["transpose_b"] = transpose_b_s.str();
+    if (forward_stype.has_value()) {
+      (*dict)["forward_stype"] = ForwardStype2String(forward_stype.value());
+    } else {
+      (*dict)["forward_stype"] = forward_stype_s.str();
+    }
+  }
 };
 
 template<typename xpu>

--- a/src/operator/tensor/dot-inl.h
+++ b/src/operator/tensor/dot-inl.h
@@ -27,6 +27,7 @@
 
 #include <mxnet/operator_util.h>
 #include <vector>
+#include <string>
 #include <algorithm>
 #include <utility>
 #include <type_traits>

--- a/src/operator/tensor/init_op.h
+++ b/src/operator/tensor/init_op.h
@@ -273,6 +273,17 @@ struct RangeLikeParam : public dmlc::Parameter<RangeLikeParam> {
               " The negative numbers are interpreted counting from the backward."
               " If not provided, will arange elements according to the input shape.");
   }
+  void SetAttrDict(std::unordered_map<std::string, std::string>* dict) {
+    std::ostringstream start_s, step_s, repeat_s, axis_s;
+    start_s << start;
+    step_s << step;
+    repeat_s << repeat;
+    axis_s << axis;
+    (*dict)["start"] = start_s.str();
+    (*dict)["step"] = step_s.str();
+    (*dict)["repeat"] = repeat_s.str();
+    (*dict)["axis"] = axis_s.str();
+  }
 };
 
 /*! \brief Initialize and fill output with an arbitrary value */

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -10156,6 +10156,16 @@ def test_npx_stop_gradient():
                     assert_almost_equal(new_grad, old_grad + 1)
 
 
+def test_npx_broadcast_like_different_types():
+    x = mx.np.zeros((2, 1))
+    y = mx.np.ones((2, 2))
+
+    y = mx.np.array(y).astype('int32')
+    z = mx.npx.broadcast_like(x, y)
+    assert_almost_equal(z.asnumpy(), np.array([[0,0],[0,0]]))
+    assert x.dtype == z.dtype
+
+
 @use_np
 def test_np_elementwise_ops_on_misaligned_input():
     a = np.array([1,2,3,4], dtype='float16')


### PR DESCRIPTION
## Description ##
part5 of #20096
Benchmarks
npx.batch_dot
```python
setup = """
from mxnet import np, npx
npx.set_np()
a = np.arange(24).reshape(2, 3, 4)
b = np.arange(24).reshape(2, 4, 3)
"""
stmt = """
out = npx.batch_dot(a, b, transpose_a=False, transpose_b=False, forward_stype="default")
"""
timer = timeit.Timer(setup=setup,
                     stmt=stmt)
num_repeat = 1000
print(min(timer.repeat(repeat=10, number=num_repeat)) / num_repeat)

legacy
0.00012874629299999984
New FFI
8.044332199999981e-05
```

npx.arange_like
```python
setup = """
from mxnet import np, npx
npx.set_np()
inp = np.zeros((10, 2))
"""
stmt = """
out = npx.arange_like(inp, start=0.0, step=1.0, repeat=1, axis=None)
"""
timer = timeit.Timer(setup=setup,
                     stmt=stmt)
num_repeat = 1000
print(min(timer.repeat(repeat=10, number=num_repeat)) / num_repeat)

legacy
0.00011809111199999967
New FFI
7.085974700000009e-05
```

npx.broadcast_like
```python
setup = """
from mxnet import np, npx
npx.set_np()
a = np.ones((1, 2))
b = np.zeros((10, 2))
"""
stmt = """
out = npx.broadcast_like(a, b, lhs_axes=None, rhs_axes=None)"""
timer = timeit.Timer(setup=setup,
                     stmt=stmt)
num_repeat = 1000
print(min(timer.repeat(repeat=10, number=num_repeat)) / num_repeat)

legacy
0.00010836260899999983
New FFI
7.267426700000002e-05
```
## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
