### PR TITLE
[CD] Fix the name of the pip wheels in CD

### DIFF
--- a/ci/Jenkinsfile_utils.groovy
+++ b/ci/Jenkinsfile_utils.groovy
@@ -153,8 +153,7 @@ def docker_run(platform, function_name, use_nvidia = false, shared_mem = '500m',
     env_vars = [env_vars]
   }
   env_vars << "BRANCH=${env.BRANCH_NAME}"
-  env_vars = env_vars.collect { "-e ${it}" }
-  def env_vars_str = env_vars.join(' ')
+  def env_vars_str = "-e " + env_vars.join(', ')
   command = command.replaceAll('%ENV_VARS%', env_vars_str)
   command = command.replaceAll('%BUILD_ARGS%', build_args.length() > 0 ? "${build_args}" : '')
   command = command.replaceAll('%USE_NVIDIA%', use_nvidia ? '--nvidiadocker' : '')

--- a/ci/Jenkinsfile_utils.groovy
+++ b/ci/Jenkinsfile_utils.groovy
@@ -153,7 +153,7 @@ def docker_run(platform, function_name, use_nvidia = false, shared_mem = '500m',
     env_vars = [env_vars]
   }
   env_vars << "BRANCH=${env.BRANCH_NAME}"
-  def env_vars_str = "-e " + env_vars.join(', ')
+  def env_vars_str = "-e " + env_vars.join(' ')
   command = command.replaceAll('%ENV_VARS%', env_vars_str)
   command = command.replaceAll('%BUILD_ARGS%', build_args.length() > 0 ? "${build_args}" : '')
   command = command.replaceAll('%USE_NVIDIA%', use_nvidia ? '--nvidiadocker' : '')

--- a/ci/build.py
+++ b/ci/build.py
@@ -277,7 +277,7 @@ def main() -> int:
     command = list(chain.from_iterable(args.command))
     environment = dict([(e.split('=')[:2] if '=' in e else (e, os.environ[e]))
                         for e in args.environment])
-    print(environment)
+
     if args.list:
         print(list_platforms())
     elif args.platform:

--- a/ci/build.py
+++ b/ci/build.py
@@ -120,6 +120,8 @@ def container_run(platform: str,
         'CCACHE_LOGFILE': '/tmp/ccache.log',  # a container-scoped log, useful for ccache verification.
     })
     environment.update({k: os.environ[k] for k in ['CCACHE_MAXSIZE'] if k in os.environ})
+    if 'RELEASE_BUILD' not in environment:
+        environment['RELEASE_BUILD'] = 'false'
 
     tag = get_docker_tag(platform=platform, registry=docker_registry)
     mx_root = get_mxnet_root()
@@ -128,6 +130,9 @@ def container_run(platform: str,
     os.makedirs(local_build_folder, exist_ok=True)
     os.makedirs(local_ccache_dir, exist_ok=True)
     logging.info("Using ccache directory: %s", local_ccache_dir)
+
+    # Log enviroment
+    logging.info("environment : ", environment)
 
     # Build docker command
     docker_arg_list = [
@@ -144,9 +149,11 @@ def container_run(platform: str,
         # temp dir should be local and not shared
         '-e', 'CCACHE_TEMPDIR={}'.format(environment['CCACHE_TEMPDIR']),
         # this path is inside the container as /work/ccache is mounted
-        '-e', "CCACHE_DIR={}".format(environment['CCACHE_DIR']),
+        '-e', 'CCACHE_DIR={}'.format(environment['CCACHE_DIR']),
         # a container-scoped log, useful for ccache verification.
-        '-e', "CCACHE_LOGFILE={}".format(environment['CCACHE_LOGFILE']),
+        '-e', 'CCACHE_LOGFILE={}'.format(environment['CCACHE_LOGFILE']),
+        # whether this is a release build or not
+        '-e', 'RELEASE_BUILD={}'.format(environment['RELEASE_BUILD']),
     ]
     docker_arg_list += [tag]
     docker_arg_list.extend(command)

--- a/ci/build.py
+++ b/ci/build.py
@@ -132,7 +132,7 @@ def container_run(platform: str,
     logging.info("Using ccache directory: %s", local_ccache_dir)
 
     # Log enviroment
-    logging.info("environment : ", environment)
+    logging.info("environment ---> {0}".format(environment))
 
     # Build docker command
     docker_arg_list = [
@@ -277,7 +277,7 @@ def main() -> int:
     command = list(chain.from_iterable(args.command))
     environment = dict([(e.split('=')[:2] if '=' in e else (e, os.environ[e]))
                         for e in args.environment])
-
+    print(environment)
     if args.list:
         print(list_platforms())
     elif args.platform:

--- a/tools/pip/setup.py
+++ b/tools/pip/setup.py
@@ -58,6 +58,10 @@ if not travis_tag and not is_release:
 elif travis_tag.startswith('patch-'):
     __version__ = os.environ['TRAVIS_TAG'].split('-')[1]
 
+# release tag
+elif is_release:
+    __version__ += 'RELEASE'
+
 
 DEPENDENCIES = [
     'numpy<2.0.0,>1.16.0',

--- a/tools/pip/setup.py
+++ b/tools/pip/setup.py
@@ -45,7 +45,7 @@ LIB_PATH = libinfo['find_lib_path']()
 __version__ = libinfo['__version__']
 
 # set by the CD pipeline
-is_release = os.environ.get("IS_RELEASE", "").strip()
+is_release = os.environ.get("RELEASE_BUILD", "False").strip().lower() in ['true', '1']
 
 # set by the travis build pipeline
 travis_tag = os.environ.get("TRAVIS_TAG", "").strip()

--- a/tools/pip/setup.py
+++ b/tools/pip/setup.py
@@ -58,11 +58,6 @@ if not travis_tag and not is_release:
 elif travis_tag.startswith('patch-'):
     __version__ = os.environ['TRAVIS_TAG'].split('-')[1]
 
-# release tag
-elif is_release:
-    __version__ += 'RELEASE'
-
-
 DEPENDENCIES = [
     'numpy<2.0.0,>1.16.0',
     'requests>=2.20.0,<3',


### PR DESCRIPTION
Now when we trigger a cd release build we get pip wheels with "REALEASE" attached to the file name. e.g.  `mxnet-2.0.0RELEASE-py3-none-manylinux2014_x86_64.whl`

Refer to https://dist.mxnet.io/python