### PR TITLE
[v1.x][CD] Fix CD cu102 110 112 cuda compatibility

### DIFF
--- a/ci/docker/Dockerfile.build.ubuntu_gpu_cu102
+++ b/ci/docker/Dockerfile.build.ubuntu_gpu_cu102
@@ -69,10 +69,6 @@ ENV CUDNN_VERSION=8.0.4.30
 COPY install/ubuntu_cudnn.sh /work/
 RUN /work/ubuntu_cudnn.sh
 
-# update the cuda compatibity package because cd host uses nvidia driver 460
-RUN apt-get update && apt-get install -y cuda-compat-11-2
-RUN ln -sfn /usr/local/cuda-11.2 /usr/local/cuda
-
 # Always last
 ARG USER_ID=0
 ARG GROUP_ID=0
@@ -80,6 +76,3 @@ COPY install/ubuntu_adduser.sh /work/
 RUN /work/ubuntu_adduser.sh
 
 COPY runtime_functions.sh /work/
-
-WORKDIR /work/mxnet
-ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/cuda/compat

--- a/ci/docker/Dockerfile.build.ubuntu_gpu_cu102
+++ b/ci/docker/Dockerfile.build.ubuntu_gpu_cu102
@@ -76,3 +76,5 @@ COPY install/ubuntu_adduser.sh /work/
 RUN /work/ubuntu_adduser.sh
 
 COPY runtime_functions.sh /work/
+
+WORKDIR /work/mxnet

--- a/ci/docker/Dockerfile.build.ubuntu_gpu_cu110
+++ b/ci/docker/Dockerfile.build.ubuntu_gpu_cu110
@@ -39,3 +39,5 @@ COPY install/ubuntu_adduser.sh /work/
 RUN /work/ubuntu_adduser.sh
 
 COPY runtime_functions.sh /work/
+
+WORKDIR /work/mxnet

--- a/ci/docker/Dockerfile.build.ubuntu_gpu_cu110
+++ b/ci/docker/Dockerfile.build.ubuntu_gpu_cu110
@@ -32,10 +32,6 @@ COPY install/ubuntu_python.sh /work/
 COPY install/requirements /work/
 RUN /work/ubuntu_python.sh
 
-# update the cuda compatibity package because cd host uses nvidia driver 460
-RUN apt-get update && apt-get install -y cuda-compat-11-2
-RUN ln -sfn /usr/local/cuda-11.2 /usr/local/cuda
-
 # Always last
 ARG USER_ID=0
 ARG GROUP_ID=0
@@ -43,6 +39,3 @@ COPY install/ubuntu_adduser.sh /work/
 RUN /work/ubuntu_adduser.sh
 
 COPY runtime_functions.sh /work/
-
-WORKDIR /work/mxnet
-ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/cuda/compat

--- a/ci/docker/Dockerfile.build.ubuntu_gpu_cu112
+++ b/ci/docker/Dockerfile.build.ubuntu_gpu_cu112
@@ -39,3 +39,5 @@ COPY install/ubuntu_adduser.sh /work/
 RUN /work/ubuntu_adduser.sh
 
 COPY runtime_functions.sh /work/
+
+WORKDIR /work/mxnet

--- a/ci/docker/Dockerfile.build.ubuntu_gpu_cu112
+++ b/ci/docker/Dockerfile.build.ubuntu_gpu_cu112
@@ -39,6 +39,3 @@ COPY install/ubuntu_adduser.sh /work/
 RUN /work/ubuntu_adduser.sh
 
 COPY runtime_functions.sh /work/
-
-WORKDIR /work/mxnet
-ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/cuda/compat


### PR DESCRIPTION
Since we updated the ami of the base machine the compat lib is no longer needed

test run passed here
https://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/restricted-mxnet-cd%2Fzhaoqi-mxnet-cd-release-job-1.x/detail/zhaoqi-mxnet-cd-release-job-1.x/5/pipeline