### PR TITLE
[v1.x] Split ONNX CV tests in nightly CI

### DIFF
--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -1594,13 +1594,22 @@ nightly_estimator() {
     nosetests test_sentiment_rnn.py
 }
 
-nightly_onnx_cv_tests() {
+nightly_onnx_cv_batch1_tests() {
     set -ex
     export PYTHONPATH=./python/
     export MXNET_SUBGRAPH_VERBOSE=0
     export DMLC_LOG_STACK_TRACE_DEPTH=10
     COV_ARG="--cov=./ --cov-report=xml --cov-append"
-    pytest $COV_ARG --verbose tests/python-pytest/onnx/test_onnxruntime_cv.py
+    pytest $COV_ARG -v -m onnx_cv_batch1 tests/python-pytest/onnx/test_onnxruntime_cv.py
+}
+
+nightly_onnx_cv_batch2_tests() {
+    set -ex
+    export PYTHONPATH=./python/
+    export MXNET_SUBGRAPH_VERBOSE=0
+    export DMLC_LOG_STACK_TRACE_DEPTH=10
+    COV_ARG="--cov=./ --cov-report=xml --cov-append"
+    pytest $COV_ARG -v -m onnx_cv_batch2 tests/python-pytest/onnx/test_onnxruntime_cv.py
 }
 
 nightly_onnx_nlp_tests() {

--- a/pytest.ini
+++ b/pytest.ini
@@ -17,13 +17,15 @@
 
 [pytest]
 markers =
-    seed: set the python, numpy and mxnet random seeds to a specified value for test reproducibility
+    seed: set the python, numpy and mxnet random seeds to a specified value for test reproducibility.
     serial: mark a test that requires more resources to run that are thus only suitable for serial run.
     remote_required: mark a test that requires internet access.
     gpu: mark a test that requires GPU.
-    integration: mark an integration test
-    onnx_coverage: ONNX coverage test
+    integration: mark an integration test.
+    onnx_coverage: ONNX coverage test.
     garbage_expected: this test leaks ndarray references. The tested functionality is broken or there is a Python bug.
+    onnx_cv_batch1: mark a test that runs in batch1 of nightly ONNX CV tests.
+    onnx_cv_batch2: mark a test that runs in batch2 of nightly ONNX CV tests.
 
 env =
     MXNET_HOME=tests/data

--- a/tests/nightly/JenkinsfileForBinaries
+++ b/tests/nightly/JenkinsfileForBinaries
@@ -94,11 +94,19 @@ core_logic: {
         }
       }
     },
-    'ONNX-CV: CPU': {
+    'ONNX-CV-batch1: CPU': {
       node(NODE_LINUX_CPU) {
         ws('workspace/onnx-cv-test-cpu') {
           utils.unpack_and_init('cpu_int64', mx_cmake_lib)
-          utils.docker_run('ubuntu_nightly_cpu', 'nightly_onnx_cv_tests', false)
+          utils.docker_run('ubuntu_nightly_cpu', 'nightly_onnx_cv_batch1_tests', false)
+        }
+      }
+    },
+    'ONNX-CV-batch2: CPU': {
+      node(NODE_LINUX_CPU) {
+        ws('workspace/onnx-cv-test-cpu') {
+          utils.unpack_and_init('cpu_int64', mx_cmake_lib)
+          utils.docker_run('ubuntu_nightly_cpu', 'nightly_onnx_cv_batch2_tests', false)
         }
       }
     },

--- a/tests/python-pytest/onnx/test_onnxruntime_cv.py
+++ b/tests/python-pytest/onnx/test_onnxruntime_cv.py
@@ -88,6 +88,7 @@ def obj_class_test_images(tmpdir_factory):
         paths.append(fn)
     return paths
 
+@pytest.mark.onnx_cv_batch1
 @pytest.mark.parametrize('model', [
     'alexnet',
     'cifar_resnet20_v1',
@@ -215,6 +216,7 @@ def obj_detection_test_images(tmpdir_factory):
     return paths
 
 
+@pytest.mark.onnx_cv_batch2
 @pytest.mark.parametrize('model', [
     'center_net_resnet18_v1b_voc',
     'center_net_resnet50_v1b_voc',
@@ -335,6 +337,7 @@ def img_segmentation_test_images(tmpdir_factory):
         paths.append(fn)
     return paths
 
+@pytest.mark.onnx_cv_batch2
 @pytest.mark.parametrize('model', [
     'fcn_resnet50_ade',
     'fcn_resnet101_ade',
@@ -401,6 +404,7 @@ def pose_estimation_test_images(tmpdir_factory):
         paths.append(fn)
     return paths
 
+@pytest.mark.onnx_cv_batch1
 @pytest.mark.parametrize('model', [
     'simple_pose_resnet18_v1b',
     'simple_pose_resnet50_v1b',
@@ -462,6 +466,7 @@ def act_recognition_test_data(tmpdir_factory):
         paths.append(fn)
     return paths
 
+@pytest.mark.onnx_cv_batch2
 @pytest.mark.parametrize('model', [
     'inceptionv1_kinetics400',
     'resnet18_v1b_kinetics400',
@@ -507,6 +512,7 @@ def test_action_recognition_model_inference_onnxruntime(tmp_path, model, act_rec
 
 
 @with_seed()
+@pytest.mark.onnx_cv_batch1
 @pytest.mark.integration
 @pytest.mark.parametrize('model_name', ['mobilenet1.0', 'inceptionv3', 'darknet53', 'resnest14'])
 def test_dynamic_shape_cv_inference_onnxruntime(tmp_path, model_name):


### PR DESCRIPTION
## Description ##
(Brief description on what this PR is about)

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
Split ONNX CV tests in nightly CI to further reduce test time and address timeout issue: https://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/NightlyTestsForBinaries/detail/v1.x/26/pipeline
### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
