### PR TITLE
[CI] Fix codecoverage

### DIFF
--- a/ci/Jenkinsfile_utils.groovy
+++ b/ci/Jenkinsfile_utils.groovy
@@ -112,7 +112,18 @@ def get_git_commit_hash() {
 }
 
 def publish_test_coverage() {
-    sh "curl -s https://codecov.io/bash | bash"
+    // CodeCovs auto detection has trouble with our CIs PR validation due the merging strategy
+    git_commit_hash = get_git_commit_hash()
+
+    if (env.CHANGE_ID) {
+      // PR execution
+      codecovArgs = "-B ${env.CHANGE_TARGET} -C ${git_commit_hash} -P ${env.CHANGE_ID}"
+    } else {
+      // Branch execution
+      codecovArgs = "-B ${env.BRANCH_NAME} -C ${git_commit_hash}"
+    }
+
+    sh "curl -s https://codecov.io/bash | bash -s - ${codecovArgs}"
 }
 
 def collect_test_results_unix(original_file_name, new_file_name) {

--- a/ci/Jenkinsfile_utils.groovy
+++ b/ci/Jenkinsfile_utils.groovy
@@ -117,10 +117,10 @@ def publish_test_coverage() {
 
     if (env.CHANGE_ID) {
       // PR execution
-      codecovArgs = "-f '*.xml' -B ${env.CHANGE_TARGET} -P ${env.CHANGE_ID} -C ${git_commit_hash}"
+      codecovArgs = "-B ${env.CHANGE_TARGET} -P ${env.CHANGE_ID} -C ${git_commit_hash}"
     } else {
       // Branch execution
-      codecovArgs = "-f '*.xml' -B ${env.BRANCH_NAME} -C ${git_commit_hash}"
+      codecovArgs = "-B ${env.BRANCH_NAME} -C ${git_commit_hash}"
     }
 
     sh "(curl -s https://codecov.io/bash | bash -s ${codecovArgs}) || true"

--- a/ci/Jenkinsfile_utils.groovy
+++ b/ci/Jenkinsfile_utils.groovy
@@ -117,13 +117,13 @@ def publish_test_coverage() {
 
     if (env.CHANGE_ID) {
       // PR execution
-      codecovArgs = "-B ${env.CHANGE_TARGET} -C ${git_commit_hash} -P ${env.CHANGE_ID}"
+      codecovArgs = "-B ${env.CHANGE_TARGET} -P ${env.CHANGE_ID} -C ${git_commit_hash}"
     } else {
       // Branch execution
       codecovArgs = "-B ${env.BRANCH_NAME} -C ${git_commit_hash}"
     }
 
-    sh "curl -s https://codecov.io/bash | bash -s - ${codecovArgs}"
+    sh "(curl -s https://codecov.io/bash | bash -s ${codecovArgs}) || true"
 }
 
 def collect_test_results_unix(original_file_name, new_file_name) {

--- a/ci/Jenkinsfile_utils.groovy
+++ b/ci/Jenkinsfile_utils.groovy
@@ -117,10 +117,10 @@ def publish_test_coverage() {
 
     if (env.CHANGE_ID) {
       // PR execution
-      codecovArgs = "-B ${env.CHANGE_TARGET} -P ${env.CHANGE_ID} -C ${git_commit_hash}"
+      codecovArgs = "-f '*.xml' -B ${env.CHANGE_TARGET} -P ${env.CHANGE_ID} -C ${git_commit_hash}"
     } else {
       // Branch execution
-      codecovArgs = "-B ${env.BRANCH_NAME} -C ${git_commit_hash}"
+      codecovArgs = "-f '*.xml' -B ${env.BRANCH_NAME} -C ${git_commit_hash}"
     }
 
     sh "(curl -s https://codecov.io/bash | bash -s ${codecovArgs}) || true"

--- a/ci/Jenkinsfile_utils.groovy
+++ b/ci/Jenkinsfile_utils.groovy
@@ -123,7 +123,7 @@ def publish_test_coverage() {
       codecovArgs = "-B ${env.BRANCH_NAME} -C ${git_commit_hash}"
     }
 
-    sh "pip install coverage==5.5 || (curl -s https://codecov.io/bash | bash -s ${codecovArgs}) || true"
+    sh "(curl -s https://codecov.io/bash | bash -s ${codecovArgs}) || true"
 }
 
 def collect_test_results_unix(original_file_name, new_file_name) {

--- a/ci/Jenkinsfile_utils.groovy
+++ b/ci/Jenkinsfile_utils.groovy
@@ -123,7 +123,7 @@ def publish_test_coverage() {
       codecovArgs = "-B ${env.BRANCH_NAME} -C ${git_commit_hash}"
     }
 
-    sh "(curl -s https://codecov.io/bash | bash -s ${codecovArgs}) || true"
+    sh "pip install coverage==5.5 || (curl -s https://codecov.io/bash | bash -s ${codecovArgs}) || true"
 }
 
 def collect_test_results_unix(original_file_name, new_file_name) {

--- a/ci/docker/install/requirements
+++ b/ci/docker/install/requirements
@@ -41,6 +41,7 @@ pytest-env==0.6.2
 pytest-cov==2.10.1
 pytest-xdist==2.1.0
 pytest-timeout==1.4.2
+coverage==5.5
 flaky==3.7.0
 setuptools==49.6.0  # https://github.com/pypa/setuptools/issues/2352
 wheel

--- a/ci/docker/install/requirements
+++ b/ci/docker/install/requirements
@@ -41,7 +41,6 @@ pytest-env==0.6.2
 pytest-cov==2.10.1
 pytest-xdist==2.1.0
 pytest-timeout==1.4.2
-coverage==5.5
 flaky==3.7.0
 setuptools==49.6.0  # https://github.com/pypa/setuptools/issues/2352
 wheel

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -774,6 +774,7 @@ unittest_ubuntu_python3_cpu() {
     MXNET_ENGINE_TYPE=NaiveEngine \
         OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'test_operator' -n 4 --durations=50 $PYTEST_COVERAGE_ARGUMENTS --cov-report xml:tests_unittest.xml --cov-append --verbose tests/python/unittest
     pytest -m 'serial' --durations=50 $PYTEST_COVERAGE_ARGUMENTS --cov-report xml:tests_unittest.xml --cov-append --verbose tests/python/unittest
+    coverage xml -i
 }
 
 unittest_ubuntu_python3_cpu_onednn() {
@@ -789,6 +790,7 @@ unittest_ubuntu_python3_cpu_onednn() {
                      OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'test_operator' -n 4 --durations=50 $PYTEST_COVERAGE_ARGUMENTS --cov-report xml:tests_unittest.xml --cov-append --verbose tests/python/unittest
     pytest -m 'serial' --durations=50 $PYTEST_COVERAGE_ARGUMENTS --cov-report xml:tests_unittest.xml --cov-append --verbose tests/python/unittest
     pytest --durations=50 $PYTEST_COVERAGE_ARGUMENTS --cov-report xml:tests_mkl.xml --verbose tests/python/mkl
+    coverage xml -i
 }
 
 unittest_ubuntu_python3_gpu() {
@@ -807,6 +809,7 @@ unittest_ubuntu_python3_gpu() {
         OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'test_operator' -n 4 --durations=50 $PYTEST_COVERAGE_ARGUMENTS --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu
     pytest -m 'serial' --durations=50 $PYTEST_COVERAGE_ARGUMENTS --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu
     pytest --durations=50 $PYTEST_COVERAGE_ARGUMENTS --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu/test_amp_init.py
+    coverage xml -i
 }
 
 unittest_ubuntu_python3_gpu_cython() {
@@ -827,6 +830,7 @@ unittest_ubuntu_python3_gpu_cython() {
         OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'test_operator' -n 4 --durations=50 $PYTEST_COVERAGE_ARGUMENTS --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu
     pytest -m 'serial' --durations=50 $PYTEST_COVERAGE_ARGUMENTS --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu
     pytest --durations=50 $PYTEST_COVERAGE_ARGUMENTS --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu/test_amp_init.py
+    coverage xml -i
 }
 
 unittest_ubuntu_python3_gpu_nocudnn() {
@@ -844,6 +848,7 @@ unittest_ubuntu_python3_gpu_nocudnn() {
         OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'test_operator' -n 4 --durations=50 $PYTEST_COVERAGE_ARGUMENTS --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu
     pytest -m 'serial' --durations=50 $PYTEST_COVERAGE_ARGUMENTS --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu
     pytest --durations=50 $PYTEST_COVERAGE_ARGUMENTS --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu/test_amp_init.py
+    coverage xml -i
 }
 
 unittest_cpp() {
@@ -862,6 +867,7 @@ unittest_centos7_cpu() {
         OMP_NUM_THREADS=$(expr $(nproc) / 4) python -m pytest -m 'not serial' -k 'test_operator' -n 4 --durations=50 $PYTEST_COVERAGE_ARGUMENTS --cov-report xml:tests_unittest.xml --cov-append --verbose tests/python/unittest
     python -m pytest -m 'serial' --durations=50 $PYTEST_COVERAGE_ARGUMENTS --cov-report xml:tests_unittest.xml --cov-append --verbose tests/python/unittest
     OMP_NUM_THREADS=$(expr $(nproc) / 4) python -m pytest -n 4 --durations=50 $PYTEST_COVERAGE_ARGUMENTS --cov-report xml:tests_train.xml --verbose tests/python/train
+    coverage xml -i
 }
 
 unittest_centos7_gpu() {
@@ -877,6 +883,7 @@ unittest_centos7_gpu() {
         OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'test_operator' -n 4 --durations=50 $PYTEST_COVERAGE_ARGUMENTS --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu
     pytest -m 'serial' --durations=50 $PYTEST_COVERAGE_ARGUMENTS --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu
     pytest --durations=50 $PYTEST_COVERAGE_ARGUMENTS --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu/test_amp_init.py
+    coverage xml -i
 }
 
 integrationtest_ubuntu_cpu_onnx() {

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -769,10 +769,10 @@ unittest_ubuntu_python3_cpu() {
     export MXNET_SUBGRAPH_VERBOSE=0
     export MXNET_ENABLE_CYTHON=0
     export DMLC_LOG_STACK_TRACE_DEPTH=100
-    OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'not test_operator' -n 4 --durations=50 --cov-report xml:tests_unittest.xml --verbose tests/python/unittest
+    OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'not test_operator' -n 4 --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_unittest.xml --verbose tests/python/unittest
     MXNET_ENGINE_TYPE=NaiveEngine \
-        OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'test_operator' -n 4 --durations=50 --cov-report xml:tests_unittest.xml --cov-append --verbose tests/python/unittest
-    pytest -m 'serial' --durations=50 --cov-report xml:tests_unittest.xml --cov-append --verbose tests/python/unittest
+        OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'test_operator' -n 4 --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_unittest.xml --cov-append --verbose tests/python/unittest
+    pytest -m 'serial' --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_unittest.xml --cov-append --verbose tests/python/unittest
 }
 
 unittest_ubuntu_python3_cpu_onednn() {
@@ -783,11 +783,11 @@ unittest_ubuntu_python3_cpu_onednn() {
     export MXNET_SUBGRAPH_VERBOSE=0
     export MXNET_ENABLE_CYTHON=0
     export DMLC_LOG_STACK_TRACE_DEPTH=100
-    OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'not test_operator' -n 4 --durations=50 --cov-report xml:tests_unittest.xml --verbose tests/python/unittest
+    OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'not test_operator' -n 4 --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_unittest.xml --verbose tests/python/unittest
     MXNET_ENGINE_TYPE=NaiveEngine \
-                     OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'test_operator' -n 4 --durations=50 --cov-report xml:tests_unittest.xml --cov-append --verbose tests/python/unittest
-    pytest -m 'serial' --durations=50 --cov-report xml:tests_unittest.xml --cov-append --verbose tests/python/unittest
-    pytest --durations=50 --cov-report xml:tests_mkl.xml --verbose tests/python/mkl
+                     OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'test_operator' -n 4 --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_unittest.xml --cov-append --verbose tests/python/unittest
+    pytest -m 'serial' --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_unittest.xml --cov-append --verbose tests/python/unittest
+    pytest --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_mkl.xml --verbose tests/python/mkl
 }
 
 unittest_ubuntu_python3_gpu() {
@@ -800,12 +800,12 @@ unittest_ubuntu_python3_gpu() {
     export MXNET_ENABLE_CYTHON=0
     export DMLC_LOG_STACK_TRACE_DEPTH=100
     MXNET_GPU_MEM_POOL_TYPE=Unpooled \
-        OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'not test_operator and not test_amp_init.py' -n 4 --durations=50 --cov-report xml:tests_gpu.xml --verbose tests/python/gpu
+        OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'not test_operator and not test_amp_init.py' -n 4 --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_gpu.xml --verbose tests/python/gpu
     MXNET_GPU_MEM_POOL_TYPE=Unpooled \
     MXNET_ENGINE_TYPE=NaiveEngine \
-        OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'test_operator' -n 4 --durations=50 --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu
-    pytest -m 'serial' --durations=50 --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu
-    pytest --durations=50 --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu/test_amp_init.py
+        OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'test_operator' -n 4 --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu
+    pytest -m 'serial' --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu
+    pytest --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu/test_amp_init.py
 }
 
 unittest_ubuntu_python3_gpu_cython() {
@@ -820,12 +820,12 @@ unittest_ubuntu_python3_gpu_cython() {
     export DMLC_LOG_STACK_TRACE_DEPTH=100
     check_cython
     MXNET_GPU_MEM_POOL_TYPE=Unpooled \
-        OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'not test_operator and not test_amp_init.py' -n 4 --durations=50 --cov-report xml:tests_gpu.xml --verbose tests/python/gpu
+        OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'not test_operator and not test_amp_init.py' -n 4 --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_gpu.xml --verbose tests/python/gpu
     MXNET_GPU_MEM_POOL_TYPE=Unpooled \
     MXNET_ENGINE_TYPE=NaiveEngine \
-        OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'test_operator' -n 4 --durations=50 --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu
-    pytest -m 'serial' --durations=50 --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu
-    pytest --durations=50 --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu/test_amp_init.py
+        OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'test_operator' -n 4 --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu
+    pytest -m 'serial' --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu
+    pytest --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu/test_amp_init.py
 }
 
 unittest_ubuntu_python3_gpu_nocudnn() {
@@ -837,12 +837,12 @@ unittest_ubuntu_python3_gpu_nocudnn() {
     export MXNET_ENABLE_CYTHON=0
     export DMLC_LOG_STACK_TRACE_DEPTH=100
     MXNET_GPU_MEM_POOL_TYPE=Unpooled \
-        OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'not test_operator and not test_amp_init.py' -n 4 --durations=50 --cov-report xml:tests_gpu.xml --verbose tests/python/gpu
+        OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'not test_operator and not test_amp_init.py' -n 4 --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_gpu.xml --verbose tests/python/gpu
     MXNET_GPU_MEM_POOL_TYPE=Unpooled \
     MXNET_ENGINE_TYPE=NaiveEngine \
-        OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'test_operator' -n 4 --durations=50 --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu
-    pytest -m 'serial' --durations=50 --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu
-    pytest --durations=50 --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu/test_amp_init.py
+        OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'test_operator' -n 4 --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu
+    pytest -m 'serial' --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu
+    pytest --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu/test_amp_init.py
 }
 
 unittest_cpp() {
@@ -856,11 +856,11 @@ unittest_centos7_cpu() {
     source /opt/rh/rh-python36/enable
     cd /work/mxnet
     export DMLC_LOG_STACK_TRACE_DEPTH=100
-    OMP_NUM_THREADS=$(expr $(nproc) / 4) python -m pytest -m 'not serial' -k 'not test_operator' -n 4 --durations=50 --cov-report xml:tests_unittest.xml --verbose tests/python/unittest
+    OMP_NUM_THREADS=$(expr $(nproc) / 4) python -m pytest -m 'not serial' -k 'not test_operator' -n 4 --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_unittest.xml --verbose tests/python/unittest
     MXNET_ENGINE_TYPE=NaiveEngine \
-        OMP_NUM_THREADS=$(expr $(nproc) / 4) python -m pytest -m 'not serial' -k 'test_operator' -n 4 --durations=50 --cov-report xml:tests_unittest.xml --cov-append --verbose tests/python/unittest
-    python -m pytest -m 'serial' --durations=50 --cov-report xml:tests_unittest.xml --cov-append --verbose tests/python/unittest
-    OMP_NUM_THREADS=$(expr $(nproc) / 4) python -m pytest -n 4 --durations=50 --cov-report xml:tests_train.xml --verbose tests/python/train
+        OMP_NUM_THREADS=$(expr $(nproc) / 4) python -m pytest -m 'not serial' -k 'test_operator' -n 4 --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_unittest.xml --cov-append --verbose tests/python/unittest
+    python -m pytest -m 'serial' --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_unittest.xml --cov-append --verbose tests/python/unittest
+    OMP_NUM_THREADS=$(expr $(nproc) / 4) python -m pytest -n 4 --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_train.xml --verbose tests/python/train
 }
 
 unittest_centos7_gpu() {
@@ -870,12 +870,12 @@ unittest_centos7_gpu() {
     export CUDNN_VERSION=${CUDNN_VERSION:-7.0.3}
     export DMLC_LOG_STACK_TRACE_DEPTH=100
     MXNET_GPU_MEM_POOL_TYPE=Unpooled \
-        OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'not test_operator and not test_amp_init.py' -n 4 --durations=50 --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu
+        OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'not test_operator and not test_amp_init.py' -n 4 --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu
     MXNET_GPU_MEM_POOL_TYPE=Unpooled \
     MXNET_ENGINE_TYPE=NaiveEngine \
-        OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'test_operator' -n 4 --durations=50 --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu
-    pytest -m 'serial' --durations=50 --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu
-    pytest --durations=50 --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu/test_amp_init.py
+        OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'test_operator' -n 4 --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu
+    pytest -m 'serial' --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu
+    pytest --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu/test_amp_init.py
 }
 
 integrationtest_ubuntu_cpu_onnx() {

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -22,6 +22,7 @@
 
 set -ex
 
+PYTEST_COVERAGE_ARGUMENTS="--cov=./contrib --cov=./python/mxnet"
 CI_CUDA_COMPUTE_CAPABILITIES="-gencode=arch=compute_52,code=sm_52 -gencode=arch=compute_70,code=sm_70"
 CI_CMAKE_CUDA_ARCH="5.2 7.0"
 
@@ -769,10 +770,10 @@ unittest_ubuntu_python3_cpu() {
     export MXNET_SUBGRAPH_VERBOSE=0
     export MXNET_ENABLE_CYTHON=0
     export DMLC_LOG_STACK_TRACE_DEPTH=100
-    OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'not test_operator' -n 4 --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_unittest.xml --verbose tests/python/unittest
+    OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'not test_operator' -n 4 --durations=50 $PYTEST_COVERAGE_ARGUMENTS --cov-report xml:tests_unittest.xml --verbose tests/python/unittest
     MXNET_ENGINE_TYPE=NaiveEngine \
-        OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'test_operator' -n 4 --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_unittest.xml --cov-append --verbose tests/python/unittest
-    pytest -m 'serial' --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_unittest.xml --cov-append --verbose tests/python/unittest
+        OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'test_operator' -n 4 --durations=50 $PYTEST_COVERAGE_ARGUMENTS --cov-report xml:tests_unittest.xml --cov-append --verbose tests/python/unittest
+    pytest -m 'serial' --durations=50 $PYTEST_COVERAGE_ARGUMENTS --cov-report xml:tests_unittest.xml --cov-append --verbose tests/python/unittest
 }
 
 unittest_ubuntu_python3_cpu_onednn() {
@@ -783,11 +784,11 @@ unittest_ubuntu_python3_cpu_onednn() {
     export MXNET_SUBGRAPH_VERBOSE=0
     export MXNET_ENABLE_CYTHON=0
     export DMLC_LOG_STACK_TRACE_DEPTH=100
-    OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'not test_operator' -n 4 --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_unittest.xml --verbose tests/python/unittest
+    OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'not test_operator' -n 4 --durations=50 $PYTEST_COVERAGE_ARGUMENTS --cov-report xml:tests_unittest.xml --verbose tests/python/unittest
     MXNET_ENGINE_TYPE=NaiveEngine \
-                     OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'test_operator' -n 4 --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_unittest.xml --cov-append --verbose tests/python/unittest
-    pytest -m 'serial' --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_unittest.xml --cov-append --verbose tests/python/unittest
-    pytest --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_mkl.xml --verbose tests/python/mkl
+                     OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'test_operator' -n 4 --durations=50 $PYTEST_COVERAGE_ARGUMENTS --cov-report xml:tests_unittest.xml --cov-append --verbose tests/python/unittest
+    pytest -m 'serial' --durations=50 $PYTEST_COVERAGE_ARGUMENTS --cov-report xml:tests_unittest.xml --cov-append --verbose tests/python/unittest
+    pytest --durations=50 $PYTEST_COVERAGE_ARGUMENTS --cov-report xml:tests_mkl.xml --verbose tests/python/mkl
 }
 
 unittest_ubuntu_python3_gpu() {
@@ -800,12 +801,12 @@ unittest_ubuntu_python3_gpu() {
     export MXNET_ENABLE_CYTHON=0
     export DMLC_LOG_STACK_TRACE_DEPTH=100
     MXNET_GPU_MEM_POOL_TYPE=Unpooled \
-        OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'not test_operator and not test_amp_init.py' -n 4 --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_gpu.xml --verbose tests/python/gpu
+        OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'not test_operator and not test_amp_init.py' -n 4 --durations=50 $PYTEST_COVERAGE_ARGUMENTS --cov-report xml:tests_gpu.xml --verbose tests/python/gpu
     MXNET_GPU_MEM_POOL_TYPE=Unpooled \
     MXNET_ENGINE_TYPE=NaiveEngine \
-        OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'test_operator' -n 4 --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu
-    pytest -m 'serial' --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu
-    pytest --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu/test_amp_init.py
+        OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'test_operator' -n 4 --durations=50 $PYTEST_COVERAGE_ARGUMENTS --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu
+    pytest -m 'serial' --durations=50 $PYTEST_COVERAGE_ARGUMENTS --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu
+    pytest --durations=50 $PYTEST_COVERAGE_ARGUMENTS --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu/test_amp_init.py
 }
 
 unittest_ubuntu_python3_gpu_cython() {
@@ -820,12 +821,12 @@ unittest_ubuntu_python3_gpu_cython() {
     export DMLC_LOG_STACK_TRACE_DEPTH=100
     check_cython
     MXNET_GPU_MEM_POOL_TYPE=Unpooled \
-        OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'not test_operator and not test_amp_init.py' -n 4 --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_gpu.xml --verbose tests/python/gpu
+        OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'not test_operator and not test_amp_init.py' -n 4 --durations=50 $PYTEST_COVERAGE_ARGUMENTS --cov-report xml:tests_gpu.xml --verbose tests/python/gpu
     MXNET_GPU_MEM_POOL_TYPE=Unpooled \
     MXNET_ENGINE_TYPE=NaiveEngine \
-        OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'test_operator' -n 4 --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu
-    pytest -m 'serial' --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu
-    pytest --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu/test_amp_init.py
+        OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'test_operator' -n 4 --durations=50 $PYTEST_COVERAGE_ARGUMENTS --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu
+    pytest -m 'serial' --durations=50 $PYTEST_COVERAGE_ARGUMENTS --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu
+    pytest --durations=50 $PYTEST_COVERAGE_ARGUMENTS --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu/test_amp_init.py
 }
 
 unittest_ubuntu_python3_gpu_nocudnn() {
@@ -837,12 +838,12 @@ unittest_ubuntu_python3_gpu_nocudnn() {
     export MXNET_ENABLE_CYTHON=0
     export DMLC_LOG_STACK_TRACE_DEPTH=100
     MXNET_GPU_MEM_POOL_TYPE=Unpooled \
-        OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'not test_operator and not test_amp_init.py' -n 4 --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_gpu.xml --verbose tests/python/gpu
+        OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'not test_operator and not test_amp_init.py' -n 4 --durations=50 $PYTEST_COVERAGE_ARGUMENTS --cov-report xml:tests_gpu.xml --verbose tests/python/gpu
     MXNET_GPU_MEM_POOL_TYPE=Unpooled \
     MXNET_ENGINE_TYPE=NaiveEngine \
-        OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'test_operator' -n 4 --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu
-    pytest -m 'serial' --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu
-    pytest --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu/test_amp_init.py
+        OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'test_operator' -n 4 --durations=50 $PYTEST_COVERAGE_ARGUMENTS --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu
+    pytest -m 'serial' --durations=50 $PYTEST_COVERAGE_ARGUMENTS --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu
+    pytest --durations=50 $PYTEST_COVERAGE_ARGUMENTS --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu/test_amp_init.py
 }
 
 unittest_cpp() {
@@ -856,11 +857,11 @@ unittest_centos7_cpu() {
     source /opt/rh/rh-python36/enable
     cd /work/mxnet
     export DMLC_LOG_STACK_TRACE_DEPTH=100
-    OMP_NUM_THREADS=$(expr $(nproc) / 4) python -m pytest -m 'not serial' -k 'not test_operator' -n 4 --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_unittest.xml --verbose tests/python/unittest
+    OMP_NUM_THREADS=$(expr $(nproc) / 4) python -m pytest -m 'not serial' -k 'not test_operator' -n 4 --durations=50 $PYTEST_COVERAGE_ARGUMENTS --cov-report xml:tests_unittest.xml --verbose tests/python/unittest
     MXNET_ENGINE_TYPE=NaiveEngine \
-        OMP_NUM_THREADS=$(expr $(nproc) / 4) python -m pytest -m 'not serial' -k 'test_operator' -n 4 --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_unittest.xml --cov-append --verbose tests/python/unittest
-    python -m pytest -m 'serial' --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_unittest.xml --cov-append --verbose tests/python/unittest
-    OMP_NUM_THREADS=$(expr $(nproc) / 4) python -m pytest -n 4 --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_train.xml --verbose tests/python/train
+        OMP_NUM_THREADS=$(expr $(nproc) / 4) python -m pytest -m 'not serial' -k 'test_operator' -n 4 --durations=50 $PYTEST_COVERAGE_ARGUMENTS --cov-report xml:tests_unittest.xml --cov-append --verbose tests/python/unittest
+    python -m pytest -m 'serial' --durations=50 $PYTEST_COVERAGE_ARGUMENTS --cov-report xml:tests_unittest.xml --cov-append --verbose tests/python/unittest
+    OMP_NUM_THREADS=$(expr $(nproc) / 4) python -m pytest -n 4 --durations=50 $PYTEST_COVERAGE_ARGUMENTS --cov-report xml:tests_train.xml --verbose tests/python/train
 }
 
 unittest_centos7_gpu() {
@@ -870,12 +871,12 @@ unittest_centos7_gpu() {
     export CUDNN_VERSION=${CUDNN_VERSION:-7.0.3}
     export DMLC_LOG_STACK_TRACE_DEPTH=100
     MXNET_GPU_MEM_POOL_TYPE=Unpooled \
-        OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'not test_operator and not test_amp_init.py' -n 4 --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu
+        OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'not test_operator and not test_amp_init.py' -n 4 --durations=50 $PYTEST_COVERAGE_ARGUMENTS --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu
     MXNET_GPU_MEM_POOL_TYPE=Unpooled \
     MXNET_ENGINE_TYPE=NaiveEngine \
-        OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'test_operator' -n 4 --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu
-    pytest -m 'serial' --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu
-    pytest --durations=50 --cov=./contrib --cov=./python/mxnet --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu/test_amp_init.py
+        OMP_NUM_THREADS=$(expr $(nproc) / 4) pytest -m 'not serial' -k 'test_operator' -n 4 --durations=50 $PYTEST_COVERAGE_ARGUMENTS --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu
+    pytest -m 'serial' --durations=50 $PYTEST_COVERAGE_ARGUMENTS --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu
+    pytest --durations=50 $PYTEST_COVERAGE_ARGUMENTS --cov-report xml:tests_gpu.xml --cov-append --verbose tests/python/gpu/test_amp_init.py
 }
 
 integrationtest_ubuntu_cpu_onnx() {


### PR DESCRIPTION
## Description ##
Looks like in some PRs, code coverage report will be submitted to some unknown places, like: 
https://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/mxnet-validation%2Fcentos-cpu/detail/PR-20105/8/pipeline/173/
Commit head is 622f0b3, but the report will be submitted to https://codecov.io/github/apache/incubator-mxnet/commit/395b8c9c168e7941c9d96e3a4a1328783cc72956

https://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/mxnet-validation%2Funix-cpu/detail/PR-20107/4/pipeline/295
Commit head is cab1562, but the report will be submitted to https://codecov.io/github/apache/incubator-mxnet/commit/b5b7dbc2374ceb7b595943b8d13abd60ba32841b

So, this PR will add codecovArgs back. 
## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
