### PR TITLE
[BUGFIX] add inline for __half2float_warp

### DIFF
--- a/3rdparty/mshadow/mshadow/half.h
+++ b/3rdparty/mshadow/mshadow/half.h
@@ -43,7 +43,7 @@
   #include <cuda_fp16.h>
   #if defined(__CUDA_ARCH__)
     /*! \brief __half2float_warp */
-    __host__ __device__ float __half2float_warp(const volatile __half& h) { /* NOLINT(*) */
+    MSHADOW_XINLINE float __half2float_warp(const volatile __half& h) { /* NOLINT(*) */
       __half val;
 #if CUDA_VERSION >= 9000
       val = const_cast<__half&>(h);


### PR DESCRIPTION
I had to add inline here, otherwise I face multiple definition error when building operator extension libraries as [here](https://github.com/apache/incubator-mxnet/discussions/20141).
