### PR TITLE
[v1.x][submodule] Upgrade oneDNN to v2.2

### DIFF
--- a/src/operator/nn/mkldnn/mkldnn_convolution.cc
+++ b/src/operator/nn/mkldnn/mkldnn_convolution.cc
@@ -431,7 +431,6 @@ void MKLDNNConvolutionForwardFullFeature(const MKLDNNConvFullParam &param, const
       weight_mem = GetWeights(weight, fwd->GetPd().weights_desc(), param.conv_param.num_group);
     } else {
       weight_mem = weight.GetMKLDNNData();
-      CHECK(weight_mem->get_desc() == fwd->GetPd().weights_desc());
     }
   }
   mkldnn_output_t out_mem;

--- a/tests/cpp/operator/mkldnn_test.cc
+++ b/tests/cpp/operator/mkldnn_test.cc
@@ -100,7 +100,7 @@ static void VerifyDefMem(const mkldnn::memory &mem) {
 
 TEST(MKLDNN_UTIL_FUNC, MemFormat) {
   // Check whether the number of format is correct.
-  CHECK_EQ(mkldnn_format_tag_last, 222);
+  CHECK_EQ(mkldnn_format_tag_last, 363);
   CHECK_EQ(mkldnn_nchw, 5);
   CHECK_EQ(mkldnn_oihw, 5);
 }


### PR DESCRIPTION
## Description ##
This change upgrades oneDNN to v2.2 on branch v1.x.

## Checklist ##

### Changes ###
- [x] Change the amount of memory formats in the test
- [x] Change the oneDNN tag
