### PR TITLE
[v1.8] Fix version dropdown in python doc pages

### DIFF
--- a/docs/python_docs/themes/mx-theme/mxtheme/header_top.html
+++ b/docs/python_docs/themes/mx-theme/mxtheme/header_top.html
@@ -20,13 +20,14 @@
         <a class="page-link page-current" href="{{theme_relative_url}}api">Docs & Tutorials</a>
         <a class="page-link" href="https://github.com/apache/incubator-mxnet">GitHub</a>
         <div class="dropdown">
-          <span class="dropdown-header">1.7
+          <span class="dropdown-header">1.8.0
             <svg class="dropdown-caret" viewBox="0 0 32 32" class="icon icon-caret-bottom" aria-hidden="true"><path class="dropdown-caret-path" d="M24 11.305l-7.997 11.39L8 11.305z"></path></svg>
           </span>
           <div class="dropdown-content">
             <a class="dropdown-option" href="/">master</a><br>
-            <a class="dropdown-option-active" href="/versions/1.7/">1.7</a><br>
-            <a class="dropdown-option" href="/versions/1.6/">1.6</a><br>
+            <a class="dropdown-option-active" href="/versions/1.8.0/">1.8.0</a><br>
+            <a class="dropdown-option" href="/versions/1.7.0/">1.7.0</a><br>
+            <a class="dropdown-option" href="/versions/1.6.0/">1.6.0</a><br>
             <a class="dropdown-option" href="/versions/1.5.0/">1.5.0</a><br>
             <a class="dropdown-option" href="/versions/1.4.1/">1.4.1</a><br>
             <a class="dropdown-option" href="/versions/1.3.1/">1.3.1</a><br>

--- a/docs/python_docs/themes/mx-theme/mxtheme/header_top.html
+++ b/docs/python_docs/themes/mx-theme/mxtheme/header_top.html
@@ -1,6 +1,6 @@
 <header class="site-header" role="banner">
   <div class="wrapper">
-      <a class="site-title" rel="author" href="{{theme_relative_url}}"><img
+      <a class="site-title" rel="author" href="/versions/1.8.0/"><img
             src="{{pathto('_static/mxnet_logo.png', 1)}}" class="site-header-logo"></a>
     <nav class="site-nav">
       <input type="checkbox" id="nav-trigger" class="nav-trigger"/>
@@ -13,11 +13,11 @@
       </label>
 
       <div class="trigger">
-        <a class="page-link" href="{{theme_relative_url}}get_started">Get Started</a>
-        <a class="page-link" href="{{theme_relative_url}}blog">Blog</a>
-        <a class="page-link" href="{{theme_relative_url}}features">Features</a>
-        <a class="page-link" href="{{theme_relative_url}}ecosystem">Ecosystem</a>
-        <a class="page-link page-current" href="{{theme_relative_url}}api">Docs & Tutorials</a>
+        <a class="page-link" href="/versions/1.8.0/get_started">Get Started</a>
+        <a class="page-link" href="/versions/1.8.0/blog">Blog</a>
+        <a class="page-link" href="/versions/1.8.0/features">Features</a>
+        <a class="page-link" href="/versions/1.8.0/ecosystem">Ecosystem</a>
+        <a class="page-link page-current" href="/versions/1.8.0/api">Docs & Tutorials</a>
         <a class="page-link" href="https://github.com/apache/incubator-mxnet">GitHub</a>
         <div class="dropdown">
           <span class="dropdown-header">1.8.0


### PR DESCRIPTION
## Description ##
Fix version dropdown in python doc pages

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
