### PR TITLE
[v1.x] Disable codecov.

### DIFF
--- a/ci/Jenkinsfile_utils.groovy
+++ b/ci/Jenkinsfile_utils.groovy
@@ -112,7 +112,8 @@ def get_git_commit_hash() {
 }
 
 def publish_test_coverage() {
-    sh "curl -s https://codecov.io/bash | bash"
+    // disable codecov
+    // sh "curl -s https://codecov.io/bash | bash"
 }
 
 def collect_test_results_unix(original_file_name, new_file_name) {


### PR DESCRIPTION
## Description ##
Disable publishing to CodeCov. Leave function in place so we can easily migrate to another solution if needed.