### PR TITLE
[BUGFIX]try avoid the error in operator/tensor/amp_cast.h

### DIFF
--- a/3rdparty/mshadow/mshadow/base.h
+++ b/3rdparty/mshadow/mshadow/base.h
@@ -1364,8 +1364,7 @@ struct minimum {
   default:                                          \
     LOG(FATAL) << "Unknown type enum " << type;     \
   }
-// amp_cast.h is using this MSHADOW_TYPE_SWITCH_WITH_BOOL in order to
-// avoid 'Unsupport enum type 12' error.
+
 #define MSHADOW_TYPE_SWITCH_WITH_BOOL(type, DType, ...)       \
   switch (type) {                                             \
   case mshadow::kFloat32:                                     \

--- a/3rdparty/mshadow/mshadow/base.h
+++ b/3rdparty/mshadow/mshadow/base.h
@@ -1062,7 +1062,6 @@ struct minimum {
 };
 }  // namespace red
 
-#ifndef __NVCC__
 #define MSHADOW_TYPE_SWITCH(type, DType, ...)       \
   switch (type) {                                   \
   case mshadow::kFloat32:                           \
@@ -1116,55 +1115,6 @@ struct minimum {
   default:                                          \
     LOG(FATAL) << "Unknown type enum " << type;     \
   }
-#else
-#define MSHADOW_TYPE_SWITCH(type, DType, ...)       \
-  switch (type) {                                   \
-  case mshadow::kFloat32:                           \
-    {                                               \
-      typedef float DType;                          \
-      {__VA_ARGS__}                                 \
-    }                                               \
-    break;                                          \
-  case mshadow::kFloat64:                           \
-    {                                               \
-      typedef double DType;                         \
-      {__VA_ARGS__}                                 \
-    }                                               \
-    break;                                          \
-  case mshadow::kFloat16:                           \
-    {                                               \
-      typedef mshadow::half::half_t DType;          \
-      {__VA_ARGS__}                                 \
-    }                                               \
-    break;                                          \
-  case mshadow::kUint8:                             \
-    {                                               \
-      typedef uint8_t DType;                        \
-      {__VA_ARGS__}                                 \
-    }                                               \
-    break;                                          \
-  case mshadow::kInt8:                              \
-    {                                               \
-      typedef int8_t DType;                         \
-      {__VA_ARGS__}                                 \
-    }                                               \
-    break;                                          \
-  case mshadow::kInt32:                             \
-    {                                               \
-      typedef int32_t DType;                        \
-      {__VA_ARGS__}                                 \
-    }                                               \
-    break;                                          \
-  case mshadow::kInt64:                             \
-    {                                               \
-      typedef int64_t DType;                        \
-      {__VA_ARGS__}                                 \
-    }                                               \
-    break;                                          \
-  default:                                          \
-    LOG(FATAL) << "Unknown type enum " << type;     \
-  }
-#endif
 
 #define MSHADOW_SGL_DBL_TYPE_SWITCH(type, DType, ...)  \
   switch (type) {                                      \
@@ -1205,6 +1155,12 @@ struct minimum {
       {__VA_ARGS__}                                 \
     }                                               \
     break;                                          \
+  case mshadow::kBfloat16:                          \
+    {                                               \
+      typedef mshadow::bfloat::bf16_t DType;        \
+      {__VA_ARGS__}                                 \
+    }                                               \
+    break;                                          \
   case mshadow::kUint8:                             \
     LOG(FATAL) << "This operation only support "    \
                   "floating point types not uint8"; \
@@ -1225,7 +1181,6 @@ struct minimum {
     LOG(FATAL) << "Unknown type enum " << type;     \
   }
 
-#ifndef __NVCC__
 #define MSHADOW_REAL_TYPE_SWITCH_EX(type$, DType$, DLargeType$, ...)  \
   switch (type$) {                                  \
   case mshadow::kFloat32:                           \
@@ -1275,50 +1230,7 @@ struct minimum {
   default:                                          \
     LOG(FATAL) << "Unknown type enum " << type$;    \
   }
-#else
-#define MSHADOW_REAL_TYPE_SWITCH_EX(type$, DType$, DLargeType$, ...)  \
-  switch (type$) {                                  \
-  case mshadow::kFloat32:                           \
-    {                                               \
-      typedef float DType$;                         \
-      typedef float DLargeType$;                    \
-      {__VA_ARGS__}                                 \
-    }                                               \
-    break;                                          \
-  case mshadow::kFloat64:                           \
-    {                                               \
-      typedef double DType$;                        \
-      typedef double DLargeType$;                   \
-      {__VA_ARGS__}                                 \
-    }                                               \
-    break;                                          \
-  case mshadow::kFloat16:                           \
-    {                                               \
-      typedef mshadow::half::half_t DType$;         \
-      typedef float DLargeType$;                    \
-      {__VA_ARGS__}                                 \
-    }                                               \
-    break;                                          \
-  case mshadow::kUint8:                             \
-    LOG(FATAL) << "This operation only support "    \
-                  "floating point types not uint8"; \
-    break;                                          \
-  case mshadow::kInt8:                              \
-    LOG(FATAL) << "This operation only support "    \
-                  "floating point types not int8";  \
-    break;                                          \
-  case mshadow::kInt32:                             \
-    LOG(FATAL) << "This operation only support "    \
-                  "floating point types, not int32";\
-    break;                                          \
-  case mshadow::kInt64:                             \
-    LOG(FATAL) << "This operation only support "    \
-                  "floating point types, not int64";\
-    break;                                          \
-  default:                                          \
-    LOG(FATAL) << "Unknown type enum " << type$;    \
-  }
-#endif
+
 #define MSHADOW_LAYOUT_SWITCH(layout, Layout, ...)  \
   switch (layout) {                                 \
   case mshadow::kNCHW:                              \
@@ -1441,6 +1353,8 @@ inline std::string dtype_string(const int dtype) {
       return "double";
     case mshadow::kFloat16:
       return "half";
+    case mshadow::kBfloat16:
+      return "half2";
     case mshadow::kUint8:
       return "unsigned char";
     case mshadow::kInt8:

--- a/3rdparty/mshadow/mshadow/base.h
+++ b/3rdparty/mshadow/mshadow/base.h
@@ -1062,6 +1062,7 @@ struct minimum {
 };
 }  // namespace red
 
+#ifndef __NVCC__
 #define MSHADOW_TYPE_SWITCH(type, DType, ...)       \
   switch (type) {                                   \
   case mshadow::kFloat32:                           \
@@ -1115,6 +1116,55 @@ struct minimum {
   default:                                          \
     LOG(FATAL) << "Unknown type enum " << type;     \
   }
+#else
+#define MSHADOW_TYPE_SWITCH(type, DType, ...)       \
+  switch (type) {                                   \
+  case mshadow::kFloat32:                           \
+    {                                               \
+      typedef float DType;                          \
+      {__VA_ARGS__}                                 \
+    }                                               \
+    break;                                          \
+  case mshadow::kFloat64:                           \
+    {                                               \
+      typedef double DType;                         \
+      {__VA_ARGS__}                                 \
+    }                                               \
+    break;                                          \
+  case mshadow::kFloat16:                           \
+    {                                               \
+      typedef mshadow::half::half_t DType;          \
+      {__VA_ARGS__}                                 \
+    }                                               \
+    break;                                          \
+  case mshadow::kUint8:                             \
+    {                                               \
+      typedef uint8_t DType;                        \
+      {__VA_ARGS__}                                 \
+    }                                               \
+    break;                                          \
+  case mshadow::kInt8:                              \
+    {                                               \
+      typedef int8_t DType;                         \
+      {__VA_ARGS__}                                 \
+    }                                               \
+    break;                                          \
+  case mshadow::kInt32:                             \
+    {                                               \
+      typedef int32_t DType;                        \
+      {__VA_ARGS__}                                 \
+    }                                               \
+    break;                                          \
+  case mshadow::kInt64:                             \
+    {                                               \
+      typedef int64_t DType;                        \
+      {__VA_ARGS__}                                 \
+    }                                               \
+    break;                                          \
+  default:                                          \
+    LOG(FATAL) << "Unknown type enum " << type;     \
+  }
+#endif
 
 #define MSHADOW_SGL_DBL_TYPE_SWITCH(type, DType, ...)  \
   switch (type) {                                      \
@@ -1155,12 +1205,6 @@ struct minimum {
       {__VA_ARGS__}                                 \
     }                                               \
     break;                                          \
-  case mshadow::kBfloat16:                          \
-    {                                               \
-      typedef mshadow::bfloat::bf16_t DType;        \
-      {__VA_ARGS__}                                 \
-    }                                               \
-    break;                                          \
   case mshadow::kUint8:                             \
     LOG(FATAL) << "This operation only support "    \
                   "floating point types not uint8"; \
@@ -1181,6 +1225,7 @@ struct minimum {
     LOG(FATAL) << "Unknown type enum " << type;     \
   }
 
+#ifndef __NVCC__
 #define MSHADOW_REAL_TYPE_SWITCH_EX(type$, DType$, DLargeType$, ...)  \
   switch (type$) {                                  \
   case mshadow::kFloat32:                           \
@@ -1230,7 +1275,50 @@ struct minimum {
   default:                                          \
     LOG(FATAL) << "Unknown type enum " << type$;    \
   }
-
+#else
+#define MSHADOW_REAL_TYPE_SWITCH_EX(type$, DType$, DLargeType$, ...)  \
+  switch (type$) {                                  \
+  case mshadow::kFloat32:                           \
+    {                                               \
+      typedef float DType$;                         \
+      typedef float DLargeType$;                    \
+      {__VA_ARGS__}                                 \
+    }                                               \
+    break;                                          \
+  case mshadow::kFloat64:                           \
+    {                                               \
+      typedef double DType$;                        \
+      typedef double DLargeType$;                   \
+      {__VA_ARGS__}                                 \
+    }                                               \
+    break;                                          \
+  case mshadow::kFloat16:                           \
+    {                                               \
+      typedef mshadow::half::half_t DType$;         \
+      typedef float DLargeType$;                    \
+      {__VA_ARGS__}                                 \
+    }                                               \
+    break;                                          \
+  case mshadow::kUint8:                             \
+    LOG(FATAL) << "This operation only support "    \
+                  "floating point types not uint8"; \
+    break;                                          \
+  case mshadow::kInt8:                              \
+    LOG(FATAL) << "This operation only support "    \
+                  "floating point types not int8";  \
+    break;                                          \
+  case mshadow::kInt32:                             \
+    LOG(FATAL) << "This operation only support "    \
+                  "floating point types, not int32";\
+    break;                                          \
+  case mshadow::kInt64:                             \
+    LOG(FATAL) << "This operation only support "    \
+                  "floating point types, not int64";\
+    break;                                          \
+  default:                                          \
+    LOG(FATAL) << "Unknown type enum " << type$;    \
+  }
+#endif
 #define MSHADOW_LAYOUT_SWITCH(layout, Layout, ...)  \
   switch (layout) {                                 \
   case mshadow::kNCHW:                              \
@@ -1276,7 +1364,8 @@ struct minimum {
   default:                                          \
     LOG(FATAL) << "Unknown type enum " << type;     \
   }
-
+// amp_cast.h is using this MSHADOW_TYPE_SWITCH_WITH_BOOL in order to
+// avoid 'Unsupport enum type 12' error.
 #define MSHADOW_TYPE_SWITCH_WITH_BOOL(type, DType, ...)       \
   switch (type) {                                             \
   case mshadow::kFloat32:                                     \
@@ -1353,8 +1442,6 @@ inline std::string dtype_string(const int dtype) {
       return "double";
     case mshadow::kFloat16:
       return "half";
-    case mshadow::kBfloat16:
-      return "half2";
     case mshadow::kUint8:
       return "unsigned char";
     case mshadow::kInt8:

--- a/src/operator/tensor/amp_cast.h
+++ b/src/operator/tensor/amp_cast.h
@@ -133,9 +133,9 @@ void AMPCastCompute(const nnvm::NodeAttrs& attrs,
   using namespace mshadow;
   using namespace mshadow::expr;
   Stream<xpu> *s = ctx.get_stream<xpu>();
-  MSHADOW_TYPE_SWITCH(outputs[0].type_flag_, DstDType, {
+  MSHADOW_TYPE_SWITCH_WITH_BOOL(outputs[0].type_flag_, DstDType, {
     Tensor<xpu, 1, DstDType> out = outputs[0].FlatTo1D<xpu, DstDType>(s);
-    MSHADOW_TYPE_SWITCH(inputs[0].type_flag_, SrcDType, {
+    MSHADOW_TYPE_SWITCH_WITH_BOOL(inputs[0].type_flag_, SrcDType, {
       Tensor<xpu, 1, SrcDType> data = inputs[0].FlatTo1D<xpu, SrcDType>(s);
       if (outputs[0].type_flag_ != inputs[0].type_flag_ ||
           req[0] != kWriteInplace) {
@@ -155,9 +155,9 @@ void AMPMultiCastCompute(const nnvm::NodeAttrs& attrs,
   using namespace mshadow::expr;
   Stream<xpu> *s = ctx.get_stream<xpu>();
   for (size_t i = 0; i < outputs.size(); ++i) {
-    MSHADOW_TYPE_SWITCH(outputs[i].type_flag_, DstDType, {
+    MSHADOW_TYPE_SWITCH_WITH_BOOL(outputs[i].type_flag_, DstDType, {
       Tensor<xpu, 1, DstDType> out = outputs[i].FlatTo1D<xpu, DstDType>(s);
-      MSHADOW_TYPE_SWITCH(inputs[i].type_flag_, SrcDType, {
+      MSHADOW_TYPE_SWITCH_WITH_BOOL(inputs[i].type_flag_, SrcDType, {
         Tensor<xpu, 1, SrcDType> data = inputs[i].FlatTo1D<xpu, SrcDType>(s);
         if (outputs[i].type_flag_ != inputs[i].type_flag_ ||
             req[i] != kWriteInplace) {


### PR DESCRIPTION
I'm trying to avoid the error generated by amp using bfloat16

The error is due to:
```
/me/prog/prog-amp.py:77: UserWarning: All children of this Sequential layer 'compose1_' are HybridBlocks. Consider using HybridSequential for the best performance.
  transform_test.hybridize(static_alloc=True,static_shape=True)
Traceback (most recent call last):
  File "/me/prog/prog-amp.py", line 359, in <module>
    loss0   = loss_fn(output, label)
  File "/me/incubator-mxnet/python/mxnet/ndarray/ndarray.py", line 314, in __mul__
    return multiply(self, other)
  File "/me/incubator-mxnet/python/mxnet/ndarray/ndarray.py", line 3757, in multiply
    return _ufunc_helper(
  File "/me/incubator-mxnet/python/mxnet/ndarray/ndarray.py", line 3576, in _ufunc_helper
    return fn_array(lhs, rhs)
  File "/me/incubator-mxnet/python/mxnet/contrib/amp/amp.py", line 109, in _new_fun
    return f(*args, **kwargs)
  File "<string>", line 52, in broadcast_mul
  File "/me/incubator-mxnet/python/mxnet/_ctypes/ndarray.py", line 82, in _imperative_invoke
    check_call(_LIB.MXImperativeInvokeEx(
  File "/me/incubator-mxnet/python/mxnet/base.py", line 246, in check_call
    raise get_last_ffi_error()
mxnet.base.MXNetError: Traceback (most recent call last):
  File "/me/incubator-mxnet/src/io/../operator/elemwise_op_common.h", line 135
MXNetError: Check failed: assign(&dattr, vec.at(i)): Incompatible attr in node  at 1-th input: expected bfloat16, got float32
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "/me/incubator-mxnet/python/mxnet/base.py", line 587, in _notify_shutdown
    check_call(_LIB.MXNotifyShutdown())
  File "/me/incubator-mxnet/python/mxnet/base.py", line 246, in check_call
    raise get_last_ffi_error()
mxnet.base.MXNetError: Traceback (most recent call last):
  File "/me/incubator-mxnet/src/operator/tensor/./amp_cast.h", line 136
MXNetError: Unknown type enum 12
```
which is tested under mxnet v1.x, but seems also affect v2.0

since 30-series RTX card support bfloat16, there is no need to disable it using `#ifndef __NVCC__` explicitly, 

I don't know whether it works, but things could not be worse.

## Description ##
```
import mxnet as mx
try:
  from mxnet.contrib import amp
except:
  from mxnet import amp

#amp.init('float16') # Ok
amp.init('bfloat16') # Error in previous version
net=mx.gluon.nn.Sequential()
net.hidden=mx.gluon.nn.Dense(400)
net.out=mx.gluon.nn.Dense(10)
ctx=mx.gpu()
net.initialize(ctx=ctx)
trainer = mx.gluon.Trainer(net.collect_params(), 'sgd')
amp.init_trainer(trainer)
with mx.autograd.record():
  loss=net(mx.nd.array([32,28,28],ctx=ctx))

loss.backward()
trainer.step(1)
```
such code will fail in previous version of mxnet, and here I provide a workaround.
further modification of bf16 is needed.


## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##

Actually this PR does nothing, Further support of bf16 (including a very important operator `convolution`) is required but I know nothing about cudnn.
