### PR TITLE
[BUGFIX] Fix UnicodeDecodeError in method doc (#20214)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1663,7 +1663,7 @@ Note: this feature is still experimental, for more details, refer to [design doc
 
 #### Python
 * Python BucketingModule bind() with grad_req = 'add' (#13984)
-* Refine runtime feature discovery python API and add documentation to … (#14130)
+* Refine runtime feature discovery python API and add documentation to ... (#14130)
 * Runtime feature detection (#13549)
 * Add dtype visualization to plot_network (#14066)
 * [MXNET-1359] Adds a multiclass-MCC metric derived from Pearson (#14461)
@@ -2187,7 +2187,7 @@ Note: this feature is still experimental, for more details, refer to [design doc
 * Fix crash in random.shuffle operator (#15041)
 * [MXNET-1406] [BUG] Fix DLManagedTensor deleter (#15016)
 * Fixes lint issue in AMP (#15015)
-* Fixed issue where the estimator was printing beyond the dataset size … (#14464)
+* Fixed issue where the estimator was printing beyond the dataset size ... (#14464)
 * Fixes cuDNN version for CUDA 9.0 build environment (#15001)
 * Fix the incorrect MKLDNN/MKL logic in cmake  (#14877)
 * Fixed and re-enables TensorRT steps (#14960)

--- a/src/operator/numpy/np_pad_op-inl.h
+++ b/src/operator/numpy/np_pad_op-inl.h
@@ -100,7 +100,7 @@ struct NumpyPadParam : public dmlc::Parameter<NumpyPadParam> {
   DMLC_DECLARE_PARAMETER(NumpyPadParam) {
     DMLC_DECLARE_FIELD(pad_width)
         .describe("Number of values padded to the edges of each axis. "
-                  "((before_1, after_1), … (before_N,"
+                  "((before_1, after_1), ... (before_N,"
                   "after_N)) unique pad widths for each axis. ((before, after),) "
                   "yields same before and"
                   "after pad for each axis. "
@@ -128,7 +128,7 @@ struct NumpyPadParam : public dmlc::Parameter<NumpyPadParam> {
             "vector along each axis.");
     DMLC_DECLARE_FIELD(constant_values)
         .set_default(0.0)
-        .describe("Used in ‘constant’. The values to set the padded values for each axis."
+        .describe("Used in 'constant'. The values to set the padded values for each axis."
                   "((before_1, after_1), ... (before_N, after_N)) unique pad constants for"
                   "each axis."
                   "((before, after),) yields same before and after constants for each axis."
@@ -137,9 +137,9 @@ struct NumpyPadParam : public dmlc::Parameter<NumpyPadParam> {
                   "Default is 0.");
     DMLC_DECLARE_FIELD(reflect_type)
         .set_default("even")
-        .describe("Used in ‘reflect’, and ‘symmetric’. "
-                  "The ‘even’ style is the default with an unaltered reflection around "
-                  "the edge value. For the ‘odd’ style,"
+        .describe("Used in 'reflect', and 'symmetric'. "
+                  "The 'even' style is the default with an unaltered reflection around "
+                  "the edge value. For the 'odd' style,"
                   "the extended part of the array is created by subtracting the "
                   "reflected values from two times the edge value.");
   }


### PR DESCRIPTION
## Description ##
On Windows, with package built in VS 2019, the mxnet Python module cannot be imported due to UnicodeDecodeError.

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Fix illegal characters in code and doc

## Comments ##
- Changed '…', '‘' and '’' to "..." and '''.
