### PR TITLE
Reuse params from cached_op_args

### DIFF
--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -1072,7 +1072,9 @@ class HybridBlock(Block):
 
         # try to reuse cached_op_args for params
         if len(self._cached_op_args) > 0:
-            params = {param_tuple[1].name:param_tuple[1] for param_tuple in self._cached_op_args if isinstance(param_tuple[1], Parameter)}
+            params = {param_tuple[1].name:param_tuple[1]
+                      for param_tuple in self._cached_op_args
+                      if isinstance(param_tuple[1], Parameter)}
         else:
             params = self.collect_params()
         param_names = set(params.keys())

--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -1072,11 +1072,10 @@ class HybridBlock(Block):
 
         # try to reuse cached_op_args for params
         if len(self._cached_op_args) > 0:
-            params = {param_tuple[1].name:param_tuple[1] for param_tuple in self._cached_op_args}
+            params = {param_tuple[1].name:param_tuple[1] for param_tuple in self._cached_op_args if isinstance(param_tuple[1], Parameter)}
         else:
             params = self.collect_params()
         param_names = set(params.keys())
-
         for name in expected_names:
             assert name in param_names or name in data_names, \
                 "Unknown input to HybridBlock: %s" %name
@@ -1287,10 +1286,11 @@ class HybridBlock(Block):
         """
         if len(kwargs) > 0:
             self._backend_opts = kwargs
+        if not backend:
+            raise ValueError('Must specify "backend" to optimize_for')
 
-        if clear or not self._active:
-            self.hybridize(True, backend, clear, static_alloc, static_shape,
-                           inline_limit, forward_bulk_size, backward_bulk_size)
+        self.hybridize(True, backend, clear, static_alloc, static_shape,
+                       inline_limit, forward_bulk_size, backward_bulk_size)
 
         # do part of forward API call
         has_symbol, has_ndarray, ctx_set, _ = _gather_type_ctx_info([x] + list(args))

--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -1015,6 +1015,7 @@ class HybridBlock(Block):
         super(HybridBlock, self).__init__(prefix=prefix, params=params)
         self._cached_graph = ()
         self._cached_op = None
+        self._cached_op_args = []
         self._out_format = None
         self._in_format = None
         self._active = False
@@ -1066,10 +1067,16 @@ class HybridBlock(Block):
     def _build_cache(self, *args):
         data, out = self._get_graph(*args)
         data_names = {data.name: i for i, data in enumerate(data)}
-        params = self.collect_params()
         input_names = out.list_inputs()
-        param_names = set(params.keys())
         expected_names = set(input_names)
+
+        # try to reuse cached_op_args for params
+        if len(self._cached_op_args) > 0:
+            params = {param_tuple[1].name:param_tuple[1] for param_tuple in self._cached_op_args}
+        else:
+            params = self.collect_params()
+        param_names = set(params.keys())
+
         for name in expected_names:
             assert name in param_names or name in data_names, \
                 "Unknown input to HybridBlock: %s" %name
@@ -1307,6 +1314,7 @@ class HybridBlock(Block):
     def _clear_cached_op(self):
         self._cached_graph = ()
         self._cached_op = None
+        self._cached_op_args = []
 
     def register_child(self, block, name=None):
         if not isinstance(block, HybridBlock):


### PR DESCRIPTION
## Description ##
Reuse the params in `cached_op_args` for subsequent calls to `optimize_for`. Currently, if a new param is added during one call to `optimize_for` it is not available for subsequent calls. For example, if you run multiple graph passes then you would need to export/import to get the param. This PR checks if `cached_op_args` is set and reuses those, otherwise it just calls `collect_params` like normal. 

Also added a check for `backend` argument in `optimize_for` and cleaned up logic to call `hybridize` now that we're using a `clear` argument to control clearing the cached_graph (whereas before we werent calling hybridize in order to not clear the cached_graph). 

FYI @Kh4L 

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
