### PR TITLE
[v1.x] ONNX export support for RNN and sum_axis

### DIFF
--- a/python/mxnet/onnx/mx2onnx/_op_translations/_op_translations_opset12.py
+++ b/python/mxnet/onnx/mx2onnx/_op_translations/_op_translations_opset12.py
@@ -4768,8 +4768,8 @@ def convert_RNN(node, **kwargs):
                 make_node('Reshape', [name+'_B1_1d', name+'_B_shape'], [name+'_B1']),
                 # Layer 1 RNN
                 make_node('RNN', [name+'_rnn0_out', name+'_W1', name+'_R1', name+'_B1', name+'_seq_len',
-                                  name+'_initial_h1'], [name+'_rnn1_out_', name+'_rnn1_h'], 
-                                  hidden_size=state_size, activations=activations),
+                                  name+'_initial_h1'], [name+'_rnn1_out_', name+'_rnn1_h'],
+                          hidden_size=state_size, activations=activations),
                 make_node('Squeeze', [name+'_rnn1_out_'], [name], axes=[1]),
                 make_node('Concat', [name+'_rnn0_h', name+'_rnn1_h'], [name+'1'], axis=0)
             ]
@@ -4786,7 +4786,7 @@ def convert_RNN(node, **kwargs):
             nodes += [
                 make_node('Shape', [data], [name+'_data_shape']),
                 make_node('Split', [name+'_data_shape'],
-                                   [name+'_seq_length', name+'_batch_size', name+'_input_size'], name='split0'),
+                          [name+'_seq_length', name+'_batch_size', name+'_input_size'], name='split0'),
                 # get W
                 make_node('Mul', [name+'_state_size', name+'_input_size'], [name+'_mul0']),
                 make_node('Slice', [param, name+'_0', name+'_mul0'], [name+'_W_1d']),

--- a/python/mxnet/onnx/mx2onnx/_op_translations/_op_translations_opset12.py
+++ b/python/mxnet/onnx/mx2onnx/_op_translations/_op_translations_opset12.py
@@ -2168,6 +2168,12 @@ def convert_sum(node, **kwargs):
         )
     return [node]
 
+@mx_op.register("sum_axis")
+def convert_sum_axis(node, **kwargs):
+    """Map MXNet's sum_axis operator.
+       sum_axis is equivalent to sum in MXNet
+    """
+    return convert_sum(node, **kwargs)
 
 @mx_op.register("shape_array")
 def convert_shape(node, **kwargs):
@@ -4474,14 +4480,14 @@ def convert_RNN(node, **kwargs):
     data = input_nodes[0]
     param = input_nodes[1]
     initial_h = input_nodes[2]
-
+    
     nodes = []
+    create_tensor([0], name+'_0', kwargs['initializer'])
 
     mode = str(attrs.get('mode'))
     if mode == 'lstm':
         initial_c = input_nodes[3]
         if num_layers == 2:
-            create_tensor([0], name+'_0', kwargs['initializer'])
             create_tensor([8*state_size], name+'_8*state_size', kwargs['initializer'])
             create_tensor([4*state_size*state_size], name+'_4*state_size^2', kwargs['initializer'])
             create_tensor([1, 4*state_size, state_size], name+'_WR_shape', kwargs['initializer'])
@@ -4553,7 +4559,6 @@ def convert_RNN(node, **kwargs):
                 make_node('Concat', [name+'_lstm0_c', name+'_lstm1_c'], [name+'2'], axis=0),
             ]
         elif num_layers == 1:
-            create_tensor([0], name+'_0', kwargs['initializer'])
             create_tensor([1], name+'_1', kwargs['initializer'])
             create_tensor([4*state_size], name+'_4*state_size', kwargs['initializer'])
             create_tensor([8*state_size], name+'_8*state_size', kwargs['initializer'])
@@ -4598,7 +4603,6 @@ def convert_RNN(node, **kwargs):
 
     elif mode == 'gru':
         if num_layers == 2:
-            create_tensor([0], name+'_0', kwargs['initializer'])
             create_tensor([6*state_size], name+'_6*state_size', kwargs['initializer'])
             create_tensor([3*state_size*state_size], name+'_3*state_size^2', kwargs['initializer'])
             create_tensor([1, 3*state_size, state_size], name+'_WR_shape', kwargs['initializer'])
@@ -4669,7 +4673,7 @@ def convert_RNN(node, **kwargs):
             ]
 
         elif num_layers == 1:
-            create_tensor([0], name+'_0', kwargs['initializer'])
+
             create_tensor([1], name+'_1', kwargs['initializer'])
             create_tensor([3*state_size], name+'_3*state_size', kwargs['initializer'])
             create_tensor([6*state_size], name+'_6*state_size', kwargs['initializer'])
@@ -4711,7 +4715,101 @@ def convert_RNN(node, **kwargs):
             ]
         else:
             raise NotImplementedError('Currently RNN onnx export only supports num_layers equals to 1 or 2')
+        
+    elif mode in ['rnn_tanh', 'rnn_relu']:
+        activations = ['Tanh']
+        if mode == 'rnn_relu':
+            activations = ['Relu']
+        if num_layers == 2:
 
+            create_tensor([2*state_size], name+'_2*state_size', kwargs['initializer'])
+            create_tensor([state_size*state_size], name+'_state_size^2', kwargs['initializer'])
+            create_tensor([1, state_size, state_size], name+'_WR_shape', kwargs['initializer'])
+            create_tensor([1, 2*state_size], name+'_B_shape', kwargs['initializer'])
+            create_tensor([4*state_size*state_size], name+'_WR_offset', kwargs['initializer'])
+
+            nodes += [
+                make_node('Shape', [data], [name+'_data_shape']),
+                make_node('Split', [name+'_data_shape'], [name+'_seq_length', name+'_batch_size', name+'_input_size']),
+
+                # Layer 0
+                # get W
+                make_node('Slice', [param, name+'_0', name+'_state_size^2'], [name+'_W0_1d']),
+                make_node('Reshape', [name+'_W0_1d', name+'_WR_shape'], [name+'_W0']),
+                # get R
+                make_node('Add', [name+'_state_size^2', name+'_state_size^2'], [name+'_R0_offset']),
+                make_node('Slice', [param, name+'_state_size^2', name+'_R0_offset'], [name+'_R0_1d']),
+                make_node('Reshape', [name+'_R0_1d', name+'_WR_shape'], [name+'_R0']),
+                # get B
+                make_node('Add', [name+'_WR_offset', name+'_2*state_size'], [name+'_B0_offset']),
+                make_node('Slice', [param, name+'_WR_offset', name+'_B0_offset'], [name+'_B0_1d']),
+                make_node('Reshape', [name+'_B0_1d', name+'_B_shape'], [name+'_B0']),
+                # get initial states
+                make_node('Split', [initial_h], [name+'_initial_h0', name+'_initial_h1'], axis=0),
+                # get seq_len
+                make_node('Tile', [name+'_seq_length', name+'_batch_size'], [name+'_seq_len_']),
+                make_node("Cast", [name+'_seq_len_'], [name+"_seq_len"], to=int(TensorProto.INT32)),
+                # Layer 0 RNN
+                make_node('RNN', [data, name+'_W0', name+'_R0', name+'_B0', name+'_seq_len',
+                                name+'_initial_h0'],
+                        [name+'_rnn0_out_', name+'_rnn0_h'], hidden_size=state_size, activations=activations),
+                make_node('Squeeze', [name+'_rnn0_out_'], [name+'_rnn0_out'], axes=[1]),
+
+                # Layer 1
+                # get W
+                make_node('Add', [name+'_R0_offset', name+'_state_size^2'], [name+'_W1_offset']),
+                make_node('Slice', [param, name+'_R0_offset', name+'_W1_offset'], [name+'_W1_1d']),
+                make_node('Reshape', [name+'_W1_1d', name+'_WR_shape'], [name+'_W1']),
+                # get R
+                make_node('Slice', [param, name+'_W1_offset', name+'_WR_offset'], [name+'_R1_1d']),
+                make_node('Reshape', [name+'_R1_1d', name+'_WR_shape'], [name+'_R1']),
+                # get B
+                make_node('Add', [name+'_B0_offset', name+'_2*state_size'], [name+'_B1_offset']),
+                make_node('Slice', [param, name+'_B0_offset', name+'_B1_offset'], [name+'_B1_1d']),
+                make_node('Reshape', [name+'_B1_1d', name+'_B_shape'], [name+'_B1']),
+                # Layer 1 RNN
+                make_node('RNN', [name+'_rnn0_out', name+'_W1', name+'_R1', name+'_B1', name+'_seq_len',
+                                name+'_initial_h1'],
+                        [name+'_rnn1_out_', name+'_rnn1_h'], hidden_size=state_size, activations=activations),
+                make_node('Squeeze', [name+'_rnn1_out_'], [name], axes=[1]),
+                make_node('Concat', [name+'_rnn0_h', name+'_rnn1_h'], [name+'1'], axis=0)
+            ]
+
+        elif num_layers == 1:
+
+            create_tensor([1], name+'_1', kwargs['initializer'])
+            create_tensor([state_size], name+'_state_size', kwargs['initializer'])
+            create_tensor([2*state_size], name+'_2*state_size', kwargs['initializer'])
+            create_tensor([state_size*state_size], name+'_state_size^2', kwargs['initializer'])
+            create_tensor([1, state_size, state_size], name+'_R_shape', kwargs['initializer'])
+            create_tensor([1, 2*state_size], name+'_B_shape', kwargs['initializer'])
+
+            nodes += [
+                make_node('Shape', [data], [name+'_data_shape']),
+                make_node('Split', [name+'_data_shape'], [name+'_seq_length', name+'_batch_size', name+'_input_size'], name='split0'),
+                # get W
+                make_node('Mul', [name+'_state_size', name+'_input_size'], [name+'_mul0']),
+                make_node('Slice', [param, name+'_0', name+'_mul0'], [name+'_W_1d']),
+                make_node('Concat', [name+'_1', name+'_state_size', name+'_input_size'], [name+'_W_shape'], axis=0),
+                make_node('Reshape', [name+'_W_1d', name+'_W_shape'], [name+'_W']),
+                # get R
+                make_node('Add', [name+'_mul0', name+'_state_size^2'], [name+'_add0']),
+                make_node('Slice', [param, name+'_mul0', name+'_add0'], [name+'_R_1d']),
+                make_node('Reshape', [name+'_R_1d', name+'_R_shape'], [name+'_R']),
+                # get B
+                make_node('Add', [name+'_add0', name+'_2*state_size'], [name+'_add1']),
+                make_node('Slice', [param, name+'_add0', name+'_add1'], [name+'_B_1d']),
+                make_node('Reshape', [name+'_B_1d', name+'_B_shape'], [name+'_B']),
+                # get seq_len
+                make_node('Tile', [name+'_seq_length', name+'_batch_size'], [name+'_seq_len_']),
+                make_node("Cast", [name+'_seq_len_'], [name+"_seq_len"], to=int(TensorProto.INT32)),
+                # compute RNN
+                make_node('RNN', [data, name+'_W', name+'_R', name+'_B', name+'_seq_len', initial_h],
+                        [name+'0_', name+'1'], hidden_size=state_size, activations=activations),
+                make_node('Squeeze', [name+'0_'], [name], axes=[1]),
+            ]
+        else:
+            raise NotImplementedError('Currently RNN onnx export only supports num_layers equals to 1 or 2')
     else:
         raise NotImplementedError(f"Currently RNN onnx export does not support {mode} mode")
     return nodes

--- a/python/mxnet/onnx/mx2onnx/_op_translations/_op_translations_opset12.py
+++ b/python/mxnet/onnx/mx2onnx/_op_translations/_op_translations_opset12.py
@@ -2137,7 +2137,9 @@ def convert_square(node, **kwargs):
     )
     return [tensor_node, node]
 
+# sum_axis is equivalent to sum in MXNet
 @mx_op.register("sum")
+@mx_op.register("sum_axis")
 def convert_sum(node, **kwargs):
     """Map MXNet's sum operator attributes to onnx's ReduceSum operator
     and return the created node.
@@ -2168,12 +2170,6 @@ def convert_sum(node, **kwargs):
         )
     return [node]
 
-@mx_op.register("sum_axis")
-def convert_sum_axis(node, **kwargs):
-    """Map MXNet's sum_axis operator.
-       sum_axis is equivalent to sum in MXNet
-    """
-    return convert_sum(node, **kwargs)
 
 @mx_op.register("shape_array")
 def convert_shape(node, **kwargs):

--- a/python/mxnet/onnx/mx2onnx/_op_translations/_op_translations_opset12.py
+++ b/python/mxnet/onnx/mx2onnx/_op_translations/_op_translations_opset12.py
@@ -4480,7 +4480,7 @@ def convert_RNN(node, **kwargs):
     data = input_nodes[0]
     param = input_nodes[1]
     initial_h = input_nodes[2]
-    
+
     nodes = []
     create_tensor([0], name+'_0', kwargs['initializer'])
 
@@ -4715,7 +4715,7 @@ def convert_RNN(node, **kwargs):
             ]
         else:
             raise NotImplementedError('Currently RNN onnx export only supports num_layers equals to 1 or 2')
-        
+
     elif mode in ['rnn_tanh', 'rnn_relu']:
         activations = ['Tanh']
         if mode == 'rnn_relu':
@@ -4750,9 +4750,8 @@ def convert_RNN(node, **kwargs):
                 make_node('Tile', [name+'_seq_length', name+'_batch_size'], [name+'_seq_len_']),
                 make_node("Cast", [name+'_seq_len_'], [name+"_seq_len"], to=int(TensorProto.INT32)),
                 # Layer 0 RNN
-                make_node('RNN', [data, name+'_W0', name+'_R0', name+'_B0', name+'_seq_len',
-                                name+'_initial_h0'],
-                        [name+'_rnn0_out_', name+'_rnn0_h'], hidden_size=state_size, activations=activations),
+                make_node('RNN', [data, name+'_W0', name+'_R0', name+'_B0', name+'_seq_len', name+'_initial_h0'],
+                                 [name+'_rnn0_out_', name+'_rnn0_h'], hidden_size=state_size, activations=activations),
                 make_node('Squeeze', [name+'_rnn0_out_'], [name+'_rnn0_out'], axes=[1]),
 
                 # Layer 1
@@ -4768,9 +4767,8 @@ def convert_RNN(node, **kwargs):
                 make_node('Slice', [param, name+'_B0_offset', name+'_B1_offset'], [name+'_B1_1d']),
                 make_node('Reshape', [name+'_B1_1d', name+'_B_shape'], [name+'_B1']),
                 # Layer 1 RNN
-                make_node('RNN', [name+'_rnn0_out', name+'_W1', name+'_R1', name+'_B1', name+'_seq_len',
-                                name+'_initial_h1'],
-                        [name+'_rnn1_out_', name+'_rnn1_h'], hidden_size=state_size, activations=activations),
+                make_node('RNN', [name+'_rnn0_out', name+'_W1', name+'_R1', name+'_B1', name+'_seq_len', name+'_initial_h1'],
+                                 [name+'_rnn1_out_', name+'_rnn1_h'], hidden_size=state_size, activations=activations),
                 make_node('Squeeze', [name+'_rnn1_out_'], [name], axes=[1]),
                 make_node('Concat', [name+'_rnn0_h', name+'_rnn1_h'], [name+'1'], axis=0)
             ]
@@ -4786,7 +4784,8 @@ def convert_RNN(node, **kwargs):
 
             nodes += [
                 make_node('Shape', [data], [name+'_data_shape']),
-                make_node('Split', [name+'_data_shape'], [name+'_seq_length', name+'_batch_size', name+'_input_size'], name='split0'),
+                make_node('Split', [name+'_data_shape'], [name+'_seq_length', 
+                                    name+'_batch_size', name+'_input_size'], name='split0'),
                 # get W
                 make_node('Mul', [name+'_state_size', name+'_input_size'], [name+'_mul0']),
                 make_node('Slice', [param, name+'_0', name+'_mul0'], [name+'_W_1d']),
@@ -4805,7 +4804,7 @@ def convert_RNN(node, **kwargs):
                 make_node("Cast", [name+'_seq_len_'], [name+"_seq_len"], to=int(TensorProto.INT32)),
                 # compute RNN
                 make_node('RNN', [data, name+'_W', name+'_R', name+'_B', name+'_seq_len', initial_h],
-                        [name+'0_', name+'1'], hidden_size=state_size, activations=activations),
+                                 [name+'0_', name+'1'], hidden_size=state_size, activations=activations),
                 make_node('Squeeze', [name+'0_'], [name], axes=[1]),
             ]
         else:

--- a/python/mxnet/onnx/mx2onnx/_op_translations/_op_translations_opset12.py
+++ b/python/mxnet/onnx/mx2onnx/_op_translations/_op_translations_opset12.py
@@ -4751,7 +4751,7 @@ def convert_RNN(node, **kwargs):
                 make_node("Cast", [name+'_seq_len_'], [name+"_seq_len"], to=int(TensorProto.INT32)),
                 # Layer 0 RNN
                 make_node('RNN', [data, name+'_W0', name+'_R0', name+'_B0', name+'_seq_len', name+'_initial_h0'],
-                                 [name+'_rnn0_out_', name+'_rnn0_h'], hidden_size=state_size, activations=activations),
+                          [name+'_rnn0_out_', name+'_rnn0_h'], hidden_size=state_size, activations=activations),
                 make_node('Squeeze', [name+'_rnn0_out_'], [name+'_rnn0_out'], axes=[1]),
 
                 # Layer 1
@@ -4767,8 +4767,9 @@ def convert_RNN(node, **kwargs):
                 make_node('Slice', [param, name+'_B0_offset', name+'_B1_offset'], [name+'_B1_1d']),
                 make_node('Reshape', [name+'_B1_1d', name+'_B_shape'], [name+'_B1']),
                 # Layer 1 RNN
-                make_node('RNN', [name+'_rnn0_out', name+'_W1', name+'_R1', name+'_B1', name+'_seq_len', name+'_initial_h1'],
-                                 [name+'_rnn1_out_', name+'_rnn1_h'], hidden_size=state_size, activations=activations),
+                make_node('RNN', [name+'_rnn0_out', name+'_W1', name+'_R1', name+'_B1', name+'_seq_len',
+                                  name+'_initial_h1'], [name+'_rnn1_out_', name+'_rnn1_h'], 
+                                  hidden_size=state_size, activations=activations),
                 make_node('Squeeze', [name+'_rnn1_out_'], [name], axes=[1]),
                 make_node('Concat', [name+'_rnn0_h', name+'_rnn1_h'], [name+'1'], axis=0)
             ]
@@ -4784,8 +4785,8 @@ def convert_RNN(node, **kwargs):
 
             nodes += [
                 make_node('Shape', [data], [name+'_data_shape']),
-                make_node('Split', [name+'_data_shape'], [name+'_seq_length', 
-                                    name+'_batch_size', name+'_input_size'], name='split0'),
+                make_node('Split', [name+'_data_shape'],
+                                   [name+'_seq_length', name+'_batch_size', name+'_input_size'], name='split0'),
                 # get W
                 make_node('Mul', [name+'_state_size', name+'_input_size'], [name+'_mul0']),
                 make_node('Slice', [param, name+'_0', name+'_mul0'], [name+'_W_1d']),
@@ -4804,7 +4805,7 @@ def convert_RNN(node, **kwargs):
                 make_node("Cast", [name+'_seq_len_'], [name+"_seq_len"], to=int(TensorProto.INT32)),
                 # compute RNN
                 make_node('RNN', [data, name+'_W', name+'_R', name+'_B', name+'_seq_len', initial_h],
-                                 [name+'0_', name+'1'], hidden_size=state_size, activations=activations),
+                          [name+'0_', name+'1'], hidden_size=state_size, activations=activations),
                 make_node('Squeeze', [name+'0_'], [name], axes=[1]),
             ]
         else:

--- a/python/mxnet/onnx/mx2onnx/_op_translations/_op_translations_opset13.py
+++ b/python/mxnet/onnx/mx2onnx/_op_translations/_op_translations_opset13.py
@@ -1313,7 +1313,7 @@ def convert_RNN(node, **kwargs):
                 # Layer 0 RNN
                 make_node('RNN', [data, name+'_W0', name+'_R0', name+'_B0', name+'_seq_len',
                                   name+'_initial_h0'], [name+'_rnn0_out_', name+'_rnn0_h'],
-                                  hidden_size=state_size, activations=activations),
+                          hidden_size=state_size, activations=activations),
                 make_node('Squeeze', [name+'_rnn0_out_', name+'_1'], [name+'_rnn0_out']),
 
                 # Layer 1
@@ -1331,7 +1331,7 @@ def convert_RNN(node, **kwargs):
                 # Layer 1 RNN
                 make_node('RNN', [name+'_rnn0_out', name+'_W1', name+'_R1', name+'_B1', name+'_seq_len',
                                   name+'_initial_h1'], [name+'_rnn1_out_', name+'_rnn1_h'],
-                                  hidden_size=state_size, activations=activations),
+                          hidden_size=state_size, activations=activations),
                 make_node('Squeeze', [name+'_rnn1_out_', name+'_1'], [name]),
                 make_node('Concat', [name+'_rnn0_h', name+'_rnn1_h'], [name+'1'], axis=0)
             ]

--- a/python/mxnet/onnx/mx2onnx/_op_translations/_op_translations_opset13.py
+++ b/python/mxnet/onnx/mx2onnx/_op_translations/_op_translations_opset13.py
@@ -1312,8 +1312,7 @@ def convert_RNN(node, **kwargs):
                 make_node("Cast", [name+'_seq_len_'], [name+"_seq_len"], to=int(TensorProto.INT32)),
                 # Layer 0 RNN
                 make_node('RNN', [data, name+'_W0', name+'_R0', name+'_B0', name+'_seq_len',
-                                name+'_initial_h0'],
-                        [name+'_rnn0_out_', name+'_rnn0_h'], hidden_size=state_size, activations=activations),
+                                  name+'_initial_h0'], [name+'_rnn0_out_', name+'_rnn0_h'], hidden_size=state_size, activations=activations),
                 make_node('Squeeze', [name+'_rnn0_out_', name+'_1'], [name+'_rnn0_out']),
 
                 # Layer 1
@@ -1330,8 +1329,7 @@ def convert_RNN(node, **kwargs):
                 make_node('Reshape', [name+'_B1_1d', name+'_B_shape'], [name+'_B1']),
                 # Layer 1 RNN
                 make_node('RNN', [name+'_rnn0_out', name+'_W1', name+'_R1', name+'_B1', name+'_seq_len',
-                                name+'_initial_h1'],
-                        [name+'_rnn1_out_', name+'_rnn1_h'], hidden_size=state_size, activations=activations),
+                                  name+'_initial_h1'], [name+'_rnn1_out_', name+'_rnn1_h'], hidden_size=state_size, activations=activations),
                 make_node('Squeeze', [name+'_rnn1_out_', name+'_1'], [name]),
                 make_node('Concat', [name+'_rnn0_h', name+'_rnn1_h'], [name+'1'], axis=0)
             ]
@@ -1345,7 +1343,8 @@ def convert_RNN(node, **kwargs):
 
             nodes += [
                 make_node('Shape', [data], [name+'_data_shape']),
-                make_node('Split', [name+'_data_shape'], [name+'_seq_length', name+'_batch_size', name+'_input_size'], name='split0'),
+                make_node('Split', [name+'_data_shape'], [name+'_seq_length', name+'_batch_size',
+                                    name+'_input_size'], name='split0'),
                 # get W
                 make_node('Mul', [name+'_state_size', name+'_input_size'], [name+'_mul0']),
                 make_node('Slice', [param, name+'_0', name+'_mul0'], [name+'_W_1d']),
@@ -1364,7 +1363,7 @@ def convert_RNN(node, **kwargs):
                 make_node("Cast", [name+'_seq_len_'], [name+"_seq_len"], to=int(TensorProto.INT32)),
                 # compute RNN
                 make_node('RNN', [data, name+'_W', name+'_R', name+'_B', name+'_seq_len', initial_h],
-                        [name+'0_', name+'1'], hidden_size=state_size, activations=activations),
+                                 [name+'0_', name+'1'], hidden_size=state_size, activations=activations),
                 make_node('Squeeze', [name+'0_', name+'_1'], [name]),
             ]
         else:

--- a/python/mxnet/onnx/mx2onnx/_op_translations/_op_translations_opset13.py
+++ b/python/mxnet/onnx/mx2onnx/_op_translations/_op_translations_opset13.py
@@ -1312,7 +1312,8 @@ def convert_RNN(node, **kwargs):
                 make_node("Cast", [name+'_seq_len_'], [name+"_seq_len"], to=int(TensorProto.INT32)),
                 # Layer 0 RNN
                 make_node('RNN', [data, name+'_W0', name+'_R0', name+'_B0', name+'_seq_len',
-                                  name+'_initial_h0'], [name+'_rnn0_out_', name+'_rnn0_h'], hidden_size=state_size, activations=activations),
+                                  name+'_initial_h0'], [name+'_rnn0_out_', name+'_rnn0_h'],
+                                  hidden_size=state_size, activations=activations),
                 make_node('Squeeze', [name+'_rnn0_out_', name+'_1'], [name+'_rnn0_out']),
 
                 # Layer 1
@@ -1329,7 +1330,8 @@ def convert_RNN(node, **kwargs):
                 make_node('Reshape', [name+'_B1_1d', name+'_B_shape'], [name+'_B1']),
                 # Layer 1 RNN
                 make_node('RNN', [name+'_rnn0_out', name+'_W1', name+'_R1', name+'_B1', name+'_seq_len',
-                                  name+'_initial_h1'], [name+'_rnn1_out_', name+'_rnn1_h'], hidden_size=state_size, activations=activations),
+                                  name+'_initial_h1'], [name+'_rnn1_out_', name+'_rnn1_h'],
+                                  hidden_size=state_size, activations=activations),
                 make_node('Squeeze', [name+'_rnn1_out_', name+'_1'], [name]),
                 make_node('Concat', [name+'_rnn0_h', name+'_rnn1_h'], [name+'1'], axis=0)
             ]
@@ -1344,7 +1346,7 @@ def convert_RNN(node, **kwargs):
             nodes += [
                 make_node('Shape', [data], [name+'_data_shape']),
                 make_node('Split', [name+'_data_shape'], [name+'_seq_length', name+'_batch_size',
-                                    name+'_input_size'], name='split0'),
+                                                          name+'_input_size'], name='split0'),
                 # get W
                 make_node('Mul', [name+'_state_size', name+'_input_size'], [name+'_mul0']),
                 make_node('Slice', [param, name+'_0', name+'_mul0'], [name+'_W_1d']),
@@ -1363,7 +1365,7 @@ def convert_RNN(node, **kwargs):
                 make_node("Cast", [name+'_seq_len_'], [name+"_seq_len"], to=int(TensorProto.INT32)),
                 # compute RNN
                 make_node('RNN', [data, name+'_W', name+'_R', name+'_B', name+'_seq_len', initial_h],
-                                 [name+'0_', name+'1'], hidden_size=state_size, activations=activations),
+                          [name+'0_', name+'1'], hidden_size=state_size, activations=activations),
                 make_node('Squeeze', [name+'0_', name+'_1'], [name]),
             ]
         else:

--- a/python/mxnet/onnx/mx2onnx/_op_translations/_op_translations_opset13.py
+++ b/python/mxnet/onnx/mx2onnx/_op_translations/_op_translations_opset13.py
@@ -1047,11 +1047,12 @@ def convert_RNN(node, **kwargs):
     nodes = []
 
     mode = str(attrs.get('mode'))
+    create_tensor([0], name+'_0', kwargs['initializer'])
     create_tensor([1], name+'_1', kwargs['initializer'])
+
     if mode == 'lstm':
         initial_c = input_nodes[3]
         if num_layers == 2:
-            create_tensor([0], name+'_0', kwargs['initializer'])
             create_tensor([8*state_size], name+'_8*state_size', kwargs['initializer'])
             create_tensor([4*state_size*state_size], name+'_4*state_size^2', kwargs['initializer'])
             create_tensor([1, 4*state_size, state_size], name+'_WR_shape', kwargs['initializer'])
@@ -1123,7 +1124,6 @@ def convert_RNN(node, **kwargs):
                 make_node('Concat', [name+'_lstm0_c', name+'_lstm1_c'], [name+'2'], axis=0),
             ]
         elif num_layers == 1:
-            create_tensor([0], name+'_0', kwargs['initializer'])
             create_tensor([4*state_size], name+'_4*state_size', kwargs['initializer'])
             create_tensor([8*state_size], name+'_8*state_size', kwargs['initializer'])
             create_tensor([4*state_size*state_size], name+'_4*state_size^2', kwargs['initializer'])
@@ -1167,7 +1167,6 @@ def convert_RNN(node, **kwargs):
 
     elif mode == 'gru':
         if num_layers == 2:
-            create_tensor([0], name+'_0', kwargs['initializer'])
             create_tensor([6*state_size], name+'_6*state_size', kwargs['initializer'])
             create_tensor([3*state_size*state_size], name+'_3*state_size^2', kwargs['initializer'])
             create_tensor([1, 3*state_size, state_size], name+'_WR_shape', kwargs['initializer'])
@@ -1238,7 +1237,6 @@ def convert_RNN(node, **kwargs):
             ]
 
         elif num_layers == 1:
-            create_tensor([0], name+'_0', kwargs['initializer'])
             create_tensor([3*state_size], name+'_3*state_size', kwargs['initializer'])
             create_tensor([6*state_size], name+'_6*state_size', kwargs['initializer'])
             create_tensor([3*state_size*state_size], name+'_3*state_size^2', kwargs['initializer'])
@@ -1272,7 +1270,7 @@ def convert_RNN(node, **kwargs):
                 # get seq_len
                 make_node('Tile', [name+'_seq_length', name+'_batch_size'], [name+'_seq_len_']),
                 make_node("Cast", [name+'_seq_len_'], [name+"_seq_len"], to=int(TensorProto.INT32)),
-                # compute LSTM
+                # compute GRU
                 make_node('GRU', [data, name+'_W', name+'_R', name+'_B', name+'_seq_len', initial_h],
                           [name+'0_', name+'1'], hidden_size=state_size, linear_before_reset=1),
                 make_node('Squeeze', [name+'0_', name+'_1'], [name]),
@@ -1280,6 +1278,97 @@ def convert_RNN(node, **kwargs):
         else:
             raise NotImplementedError('Currently RNN onnx export only supports num_layers equals to 1 or 2')
 
+    elif mode in ['rnn_tanh', 'rnn_relu']:
+        activations = ['Tanh']
+        if mode == 'rnn_relu':
+            activations = ['Relu']
+        if num_layers == 2:
+            create_tensor([2*state_size], name+'_2*state_size', kwargs['initializer'])
+            create_tensor([state_size*state_size], name+'_state_size^2', kwargs['initializer'])
+            create_tensor([1, state_size, state_size], name+'_WR_shape', kwargs['initializer'])
+            create_tensor([1, 2*state_size], name+'_B_shape', kwargs['initializer'])
+            create_tensor([4*state_size*state_size], name+'_WR_offset', kwargs['initializer'])
+
+            nodes += [
+                make_node('Shape', [data], [name+'_data_shape']),
+                make_node('Split', [name+'_data_shape'], [name+'_seq_length', name+'_batch_size', name+'_input_size']),
+
+                # Layer 0
+                # get W
+                make_node('Slice', [param, name+'_0', name+'_state_size^2'], [name+'_W0_1d']),
+                make_node('Reshape', [name+'_W0_1d', name+'_WR_shape'], [name+'_W0']),
+                # get R
+                make_node('Add', [name+'_state_size^2', name+'_state_size^2'], [name+'_R0_offset']),
+                make_node('Slice', [param, name+'_state_size^2', name+'_R0_offset'], [name+'_R0_1d']),
+                make_node('Reshape', [name+'_R0_1d', name+'_WR_shape'], [name+'_R0']),
+                # get B
+                make_node('Add', [name+'_WR_offset', name+'_2*state_size'], [name+'_B0_offset']),
+                make_node('Slice', [param, name+'_WR_offset', name+'_B0_offset'], [name+'_B0_1d']),
+                make_node('Reshape', [name+'_B0_1d', name+'_B_shape'], [name+'_B0']),
+                # get initial states
+                make_node('Split', [initial_h], [name+'_initial_h0', name+'_initial_h1'], axis=0),
+                # get seq_len
+                make_node('Tile', [name+'_seq_length', name+'_batch_size'], [name+'_seq_len_']),
+                make_node("Cast", [name+'_seq_len_'], [name+"_seq_len"], to=int(TensorProto.INT32)),
+                # Layer 0 RNN
+                make_node('RNN', [data, name+'_W0', name+'_R0', name+'_B0', name+'_seq_len',
+                                name+'_initial_h0'],
+                        [name+'_rnn0_out_', name+'_rnn0_h'], hidden_size=state_size, activations=activations),
+                make_node('Squeeze', [name+'_rnn0_out_', name+'_1'], [name+'_rnn0_out']),
+
+                # Layer 1
+                # get W
+                make_node('Add', [name+'_R0_offset', name+'_state_size^2'], [name+'_W1_offset']),
+                make_node('Slice', [param, name+'_R0_offset', name+'_W1_offset'], [name+'_W1_1d']),
+                make_node('Reshape', [name+'_W1_1d', name+'_WR_shape'], [name+'_W1']),
+                # get R
+                make_node('Slice', [param, name+'_W1_offset', name+'_WR_offset'], [name+'_R1_1d']),
+                make_node('Reshape', [name+'_R1_1d', name+'_WR_shape'], [name+'_R1']),
+                # get B
+                make_node('Add', [name+'_B0_offset', name+'_2*state_size'], [name+'_B1_offset']),
+                make_node('Slice', [param, name+'_B0_offset', name+'_B1_offset'], [name+'_B1_1d']),
+                make_node('Reshape', [name+'_B1_1d', name+'_B_shape'], [name+'_B1']),
+                # Layer 1 RNN
+                make_node('RNN', [name+'_rnn0_out', name+'_W1', name+'_R1', name+'_B1', name+'_seq_len',
+                                name+'_initial_h1'],
+                        [name+'_rnn1_out_', name+'_rnn1_h'], hidden_size=state_size, activations=activations),
+                make_node('Squeeze', [name+'_rnn1_out_', name+'_1'], [name]),
+                make_node('Concat', [name+'_rnn0_h', name+'_rnn1_h'], [name+'1'], axis=0)
+            ]
+
+        elif num_layers == 1:
+            create_tensor([state_size], name+'_state_size', kwargs['initializer'])
+            create_tensor([2*state_size], name+'_2*state_size', kwargs['initializer'])
+            create_tensor([state_size*state_size], name+'_state_size^2', kwargs['initializer'])
+            create_tensor([1, state_size, state_size], name+'_R_shape', kwargs['initializer'])
+            create_tensor([1, 2*state_size], name+'_B_shape', kwargs['initializer'])
+
+            nodes += [
+                make_node('Shape', [data], [name+'_data_shape']),
+                make_node('Split', [name+'_data_shape'], [name+'_seq_length', name+'_batch_size', name+'_input_size'], name='split0'),
+                # get W
+                make_node('Mul', [name+'_state_size', name+'_input_size'], [name+'_mul0']),
+                make_node('Slice', [param, name+'_0', name+'_mul0'], [name+'_W_1d']),
+                make_node('Concat', [name+'_1', name+'_state_size', name+'_input_size'], [name+'_W_shape'], axis=0),
+                make_node('Reshape', [name+'_W_1d', name+'_W_shape'], [name+'_W']),
+                # get R
+                make_node('Add', [name+'_mul0', name+'_state_size^2'], [name+'_add0']),
+                make_node('Slice', [param, name+'_mul0', name+'_add0'], [name+'_R_1d']),
+                make_node('Reshape', [name+'_R_1d', name+'_R_shape'], [name+'_R']),
+                # get B
+                make_node('Add', [name+'_add0', name+'_2*state_size'], [name+'_add1']),
+                make_node('Slice', [param, name+'_add0', name+'_add1'], [name+'_B_1d']),
+                make_node('Reshape', [name+'_B_1d', name+'_B_shape'], [name+'_B']),
+                # get seq_len
+                make_node('Tile', [name+'_seq_length', name+'_batch_size'], [name+'_seq_len_']),
+                make_node("Cast", [name+'_seq_len_'], [name+"_seq_len"], to=int(TensorProto.INT32)),
+                # compute RNN
+                make_node('RNN', [data, name+'_W', name+'_R', name+'_B', name+'_seq_len', initial_h],
+                        [name+'0_', name+'1'], hidden_size=state_size, activations=activations),
+                make_node('Squeeze', [name+'0_', name+'_1'], [name]),
+            ]
+        else:
+            raise NotImplementedError('Currently RNN onnx export only supports num_layers equals to 1 or 2')
     else:
         raise NotImplementedError(f"Currently RNN onnx export does not support {mode} mode")
     return nodes

--- a/tests/python-pytest/onnx/test_operators.py
+++ b/tests/python-pytest/onnx/test_operators.py
@@ -1047,16 +1047,17 @@ def test_onnx_export_log2(tmp_path, dtype):
 
 @pytest.mark.parametrize('dtype', ['int32', 'int64', 'float16', 'float32', 'float64'])
 @pytest.mark.parametrize('axis', [None, 1, [1,2], -1])
-def test_onnx_export_sum(tmp_path, dtype, axis):
+@pytest.mark.parametrize('operator', ['sum', 'sum_axis'])
+def test_onnx_export_sum(tmp_path, dtype, axis, operator):
     if 'int' in dtype:
         x = mx.nd.random.randint(0, 10, (5, 6, 7, 8), dtype=dtype)
     else:
         x = mx.nd.random.normal(0, 10, (5, 6, 7, 8), dtype=dtype)
     if axis is not None:
-        M = def_model('sum', axis=axis)
+        M = def_model(operator, axis=axis)
     else:
-        M = def_model('sum')
-    op_export_test('sum', M, [x], tmp_path)
+        M = def_model(operator)
+    op_export_test(operator, M, [x], tmp_path)
 
 
 @pytest.mark.parametrize('dtype', ['float16', 'float32', 'float64', 'int32', 'int64'])


### PR DESCRIPTION
## Description ##
Add onnx conversion logic for RNN and sum_axis. Add unittest for the two.

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
