### PR TITLE
[v1.x] ONNX Add an option to un-interleave BERT

### DIFF
--- a/python/mxnet/onnx/mx2onnx/__init__.py
+++ b/python/mxnet/onnx/mx2onnx/__init__.py
@@ -19,5 +19,4 @@
 """ONNX Export module"""
 
 from ._export_model import export_model, get_operator_support
-from ._op_translations import _op_translations_opset12
-from ._op_translations import _op_translations_opset13
+from ._op_translations import *

--- a/python/mxnet/onnx/mx2onnx/_export_model.py
+++ b/python/mxnet/onnx/mx2onnx/_export_model.py
@@ -51,7 +51,7 @@ def get_operator_support(opset_version=None):
 def export_model(sym, params, in_shapes=None, in_types=np.float32,
                  onnx_file_path='model.onnx', verbose=False, dynamic=False,
                  dynamic_input_shapes=None, run_shape_inference=False, input_type=None,
-                 input_shape=None):
+                 input_shape=None, model_specific_logics=None):
     """Exports the MXNet model file, passed as a parameter, into ONNX model.
     Accepts both symbol,parameter objects as well as json and params filepaths as input.
     Operator support and coverage -
@@ -83,6 +83,8 @@ def export_model(sym, params, in_shapes=None, in_types=np.float32,
         This is the old name of in_types. We keep this parameter name for backward compatibility
     in_shapes : List of tuple
         This is the old name of in_shapes. We keep this parameter name for backward compatibility
+    model_specific_logics: str
+        Specifies if model-specific conversion logic should be used. Refer to ./_op_translations/
 
     Returns
     -------
@@ -122,12 +124,14 @@ def export_model(sym, params, in_shapes=None, in_types=np.float32,
         onnx_graph = converter.create_onnx_graph_proto(sym_obj, params_obj, in_shapes,
                                                        in_types_t,
                                                        verbose=verbose, opset_version=opset_version,
-                                                       dynamic=dynamic, dynamic_input_shapes=dynamic_input_shapes)
+                                                       dynamic=dynamic, dynamic_input_shapes=dynamic_input_shapes,
+                                                       model_specific_logics=model_specific_logics)
     elif isinstance(sym, symbol.Symbol) and isinstance(params, dict):
         onnx_graph = converter.create_onnx_graph_proto(sym, params, in_shapes,
                                                        in_types_t,
                                                        verbose=verbose, opset_version=opset_version,
-                                                       dynamic=dynamic, dynamic_input_shapes=dynamic_input_shapes)
+                                                       dynamic=dynamic, dynamic_input_shapes=dynamic_input_shapes,
+                                                       model_specific_logics=model_specific_logics)
     elif isinstance(sym, symbol.Symbol) and isinstance(params, list) and len(params) == 2:
         # when params contains arg_params and aux_params
         p = {}

--- a/python/mxnet/onnx/mx2onnx/_export_onnx.py
+++ b/python/mxnet/onnx/mx2onnx/_export_onnx.py
@@ -92,13 +92,24 @@ class MXNetGraph(object):
         op = str(node["op"])
         opset_version = kwargs.get("opset_version", onnx_opset_version())
         # fallback to older opset versions if op is not registered in current version
+        convert_func = None
         for op_version in range(opset_version, 11, -1):
             if op_version not in MXNetGraph.registry_ or op not in MXNetGraph.registry_[op_version]:
-                if opset_version == 12:
-                    raise AttributeError("No conversion function registered for op type %s yet." % op)
                 continue
             convert_func = MXNetGraph.registry_[op_version][op]
             break
+
+        model_specific_logics = kwargs.get("model_specific_logics", None)
+        if model_specific_logics:
+            assert model_specific_logics in MXNetGraph.registry_,\
+                "Model specific converion logics for %s is not found" % model_specific_logics
+            if op in  MXNetGraph.registry_[model_specific_logics]:
+                logging.info("Found model-specific %s conversion logic for model %s",
+                             op, model_specific_logics)
+                convert_func = MXNetGraph.registry_[model_specific_logics][op]
+
+        if convert_func is None:
+            raise AttributeError("No conversion function registered for op type %s yet." % op)
 
         ret = convert_func(node, **kwargs)
         # in case the conversion function does not specify the returned dtype, we just return None
@@ -239,7 +250,7 @@ class MXNetGraph(object):
                      for k, v in weights_dict.items()])
 
     def create_onnx_graph_proto(self, sym, params, in_shapes, in_types, verbose=False, opset_version=None,
-                                dynamic=True, dynamic_input_shapes=None):
+                                dynamic=True, dynamic_input_shapes=None, model_specific_logics=None):
         """Convert MXNet graph to ONNX graph
 
         Parameters
@@ -260,6 +271,8 @@ class MXNetGraph(object):
             If True will allow for dynamic input shapes to the model
         dynamic_input_shapes: list of tuple
             Specifies the dynamic input_shapes. If None then all dimensions are set to None
+        model_specific_logics: str
+            Specifies if model-specific conversion logic should be used. Refer to ./_op_translations/
 
         Returns
         -------
@@ -335,7 +348,8 @@ class MXNetGraph(object):
                     in_type=in_types[graph_input_idx],
                     proc_nodes=all_processed_nodes,
                     initializer=initializer,
-                    outputs_lookup=outputs_lookup)
+                    outputs_lookup=outputs_lookup,
+                )
                 graph_input_idx += 1
             else:
                 # Handle graph layers
@@ -348,7 +362,8 @@ class MXNetGraph(object):
                     initializer=initializer,
                     outputs_lookup=outputs_lookup,
                     idx=idx,
-                    opset_version=opset_version
+                    opset_version=opset_version,
+                    model_specific_logics=model_specific_logics
                 )
             if isinstance(converted, list):
                 # Collect all the node's output names

--- a/python/mxnet/onnx/mx2onnx/_op_translations/__init__.py
+++ b/python/mxnet/onnx/mx2onnx/_op_translations/__init__.py
@@ -18,5 +18,6 @@
 # coding: utf-8
 """ONNX export op translation"""
 
+from . import _gluonnlp_bert
 from . import _op_translations_opset12
-from . import _op_translations_opset13
+from . import _op_translations_opset13 

--- a/python/mxnet/onnx/mx2onnx/_op_translations/_gluonnlp_bert.py
+++ b/python/mxnet/onnx/mx2onnx/_op_translations/_gluonnlp_bert.py
@@ -1,0 +1,254 @@
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# coding: utf-8
+"""GluonNLP BERT specific translation logics"""
+
+
+import re
+import logging
+import numpy as np
+from .._export_onnx import MXNetGraph as mx_op
+try:
+    import onnx
+except ImportError:
+    onnx = None
+
+
+def get_cheat_sheet():
+    cheat_sheet = {
+        'qkv_hidden': 768,
+        'num_heads': 12,
+        'head_dim': 64
+    }
+
+    return cheat_sheet
+
+
+def get_inputs(node, kwargs):
+    """Helper function to get inputs"""
+    name = node["name"]
+    outputs_lookup = kwargs["outputs_lookup"]
+    inputs = node["inputs"]
+    attrs = node.get("attrs", {})
+
+    input_nodes = []
+    for ip in inputs:
+        input_node_name = outputs_lookup[ip[0]][ip[1]].name
+        input_nodes.append(input_node_name)
+
+    return name, input_nodes, attrs
+
+
+def get_input_dtypes(node, kwargs):
+    outputs_lookup = kwargs['outputs_lookup']
+    inputs = node['inputs']
+    input_dtypes = []
+    for ip in inputs:
+        input_node_dtype = outputs_lookup[ip[0]][ip[1]].dtype
+        input_dtypes.append(input_node_dtype)
+    return input_dtypes
+
+
+def get_boolean_attribute_value(attrs, attr_name):
+    """ Helper function to convert a string version
+    of Boolean attributes to integer for ONNX.
+    Takes attribute dictionary and attr_name as
+    parameters.
+    """
+    return 1 if attrs.get(attr_name, 0) in ["True", "1"] else 0
+
+
+def create_tensor(tensor_list, tensor_name, initializer, dtype='int64'):
+    """Helper function to create a tensor value node and a
+    initializer tensor node with constant value."""
+    tensor_np = np.array(tensor_list, dtype=dtype)
+    data_type = onnx.mapping.NP_TYPE_TO_TENSOR_TYPE[tensor_np.dtype]
+    dims = np.shape(tensor_np)
+    if dtype == np.float16:
+        tensor_np = tensor_np.view(dtype=np.uint16)
+    initializer.append(
+        onnx.helper.make_tensor(
+            name=tensor_name,
+            data_type=data_type,
+            dims=dims,
+            vals=tensor_np.flatten().tolist(),
+            raw=False
+        )
+    )
+
+
+@mx_op.register("FullyConnected", opset_version='gluonnlp_bert')
+def convert_fully_connected(node, **kwargs):
+    """Map MXNet's FullyConnected operator attributes to onnx's Gemm operator
+    and return the created node.
+    """
+    from onnx.helper import make_node
+    name, input_nodes, attrs = get_inputs(node, kwargs)
+    input_dtypes = get_input_dtypes(node, kwargs)
+    dtype = input_dtypes[0]
+    flatten = get_boolean_attribute_value(attrs, 'flatten')
+    no_bias = get_boolean_attribute_value(attrs, 'no_bias')
+    num_hidden = int(attrs.get('num_hidden'))
+
+    nodes = []
+
+    if 'dotproductselfattentioncell' in name:
+        cheat_sheet = get_cheat_sheet()
+        qkv_hidden = cheat_sheet['qkv_hidden']
+        num_heads = cheat_sheet['num_heads']
+        head_dim = cheat_sheet['head_dim']
+        create_tensor([num_heads, 3 * head_dim, qkv_hidden], name+'_interleaved_w_shape', kwargs['initializer'])
+        create_tensor([num_heads, 3 * head_dim], name+'_interleaved_b_shape', kwargs['initializer'])
+        create_tensor([qkv_hidden, qkv_hidden], name+'_w_shape', kwargs['initializer'])
+        create_tensor([qkv_hidden], name+'_b_shape', kwargs['initializer'])
+        nodes += [
+            make_node('Reshape', [input_nodes[1], name+'_interleaved_w_shape'], [name+'_interleaved_w']),
+            make_node('Split', [name+'_interleaved_w'], [name+'_q_w_', name+'_k_w_', name+'_v_w_'], axis=1),
+            make_node('Reshape', [name+'_q_w_', name+'_w_shape'], [name+'_q_w_reshaped']),
+            make_node('Reshape', [name+'_k_w_', name+'_w_shape'], [name+'_k_w_reshaped']),
+            make_node('Reshape', [name+'_v_w_', name+'_w_shape'], [name+'_v_w_reshaped']),
+            make_node('Transpose', [name+'_q_w_reshaped'], [name+'_q_w']),
+            make_node('Transpose', [name+'_k_w_reshaped'], [name+'_k_w']),
+            make_node('Transpose', [name+'_v_w_reshaped'], [name+'_v_w']),
+            make_node('Reshape', [input_nodes[2], name+'_interleaved_b_shape'], [name+'_interleaved_b']),
+            make_node('Split', [name+'_interleaved_b'], [name+'_q_b_', name+'_k_b_', name+'_v_b_'], axis=1),
+            make_node('Reshape', [name+'_q_b_', name+'_b_shape'], [name+'_q_b']),
+            make_node('Reshape', [name+'_k_b_', name+'_b_shape'], [name+'_k_b']),
+            make_node('Reshape', [name+'_v_b_', name+'_b_shape'], [name+'_v_b']),
+            make_node('MatMul', [input_nodes[0], name+'_q_w'], [name+'_q_']),
+            make_node('MatMul', [input_nodes[0], name+'_k_w'], [name+'_k_']),
+            make_node('MatMul', [input_nodes[0], name+'_v_w'], [name+'_v_']),
+            make_node('Add', [name+'_q_', name+'_q_b'], [name+'0']),
+            make_node('Add', [name+'_k_', name+'_k_b'], [name+'1']),
+            make_node('Add', [name+'_v_', name+'_v_b'], [name+'2']),
+        ]
+        return nodes
+
+    if flatten:
+        nodes += [
+            make_node('Flatten', [input_nodes[0]], [name+'_data_flattened'])
+        ]
+    else:
+        nodes += [
+            make_node('Shape', [input_nodes[0]], [name+'_orig_shape']),
+            make_node('Shape', [name+'_orig_shape'], [name+'_dim']),
+            make_node('Flatten', [input_nodes[0]], [name+'_data_flattened'], axis=-1),
+        ]
+    in_nodes = [name+'_data_flattened', input_nodes[1]]
+    if no_bias:
+        create_const_scalar_node(name+'_bias', np.int32(0).astype(dtype), kwargs)
+        in_nodes.append(name+'_bias')
+    else:
+        in_nodes.append(input_nodes[2])
+    if flatten:
+        nodes += [
+            make_node('Gemm', in_nodes, [name], alpha=1.0, beta=1.0, transA=0, transB=1, name=name)
+        ]
+    else:
+        create_tensor([0], name+'_0', kwargs['initializer'])
+        create_tensor([1], name+'_1', kwargs['initializer'])
+        create_tensor([num_hidden], name+'_num_hidden', kwargs['initializer'])
+        nodes += [
+            make_node('Gemm', in_nodes, [name+'_gemm'], alpha=1.0, beta=1.0, transA=0, transB=1),
+            make_node('Sub', [name+'_dim', name+'_1'], [name+'dim_minus_1']),
+            make_node('Slice', [name+'_orig_shape', name+'_0', name+'dim_minus_1'],
+                      [name+'_shape_sliced']),
+            make_node('Concat', [name+'_shape_sliced', name+'_num_hidden'],
+                      [name+'_shape_new'], axis=0),
+            make_node('Reshape', [name+'_gemm', name+'_shape_new'], [name], name=name)
+        ]
+    return nodes
+
+
+@mx_op.register("_contrib_interleaved_matmul_selfatt_qk", opset_version='gluonnlp_bert')
+def convert_matmul_selfatt_qk(node, **kwargs):
+    """Map MXNet's _contrib_interleaved_matmul_selfatt_qk operator
+    """
+    from onnx.helper import make_node
+    from onnx import TensorProto
+    import copy
+
+    inp0 = node['inputs'][0]
+    inp1 = copy.deepcopy(inp0)
+    inp1[1] = 1
+    node['inputs'] = [inp0, inp1]
+    name, input_nodes, attrs = get_inputs(node, kwargs)
+
+    cheat_sheet = get_cheat_sheet()
+    qkv_hidden = cheat_sheet['qkv_hidden']
+    num_heads = cheat_sheet['num_heads']
+    head_dim = cheat_sheet['head_dim']
+
+    create_tensor([-1], name+'_m1', kwargs['initializer'])
+    create_tensor([int(head_dim ** 0.5)], name+'_sqrt_head_dim', kwargs['initializer'], dtype='float32')
+    create_tensor([0, 0, num_heads, head_dim], name+"_qkv_shape", kwargs['initializer'])
+    nodes = [
+        make_node('Shape', [input_nodes[0]], [name+'_shape']),
+        make_node('Split', [name+'_shape'], [name+'_sq', name+'_bs', name+'___'], axis=0),
+        make_node('Reshape', [input_nodes[0], name+'_qkv_shape'], [name+'_q_']),
+        make_node('Reshape', [input_nodes[1], name+'_qkv_shape'], [name+'_k_']),
+        make_node('Transpose', [name+'_q_'], [name+'_q'], perm=[1, 2, 0, 3]),
+        make_node('Transpose', [name+'_k_'], [name+'_k'], perm=[1, 2, 3, 0]),
+        make_node('MatMul', [name+'_q', name+'_k'], [name+'_qk']),
+        make_node('Concat', [name+'_m1', name+'_sq', name+'_sq'], [name+'_out_shape'], axis=0),
+        make_node('Reshape', [name+'_qk', name+'_out_shape'], [name+'_qk_reshaped']),
+        make_node('Div', [name+'_qk_reshaped', name+'_sqrt_head_dim'], [name])
+    ]
+
+    return nodes
+
+
+@mx_op.register("_contrib_interleaved_matmul_selfatt_valatt", opset_version='gluonnlp_bert')
+def convert_contrib_interleaved_matmul_selfatt_valatt(node, **kwargs):
+    """Map MXNet's _contrib_interleaved_matmul_selfatt_valatt operator attributes to onnx's operator.
+    """
+    from onnx.helper import make_node
+    inp0 = node['inputs'][0]
+    inp0[1] = 2
+    inp1 = node['inputs'][1]
+    node['inputs'] = [inp0, inp1]
+    name, input_nodes, attrs = get_inputs(node, kwargs)
+
+    cheat_sheet = get_cheat_sheet()
+    qkv_hidden = cheat_sheet['qkv_hidden']
+    num_heads = cheat_sheet['num_heads']
+    head_dim = cheat_sheet['head_dim']
+
+    create_tensor([head_dim], name+'_head_dim', kwargs["initializer"])
+    create_tensor([0], name+'_0', kwargs["initializer"])
+    create_tensor([-1], name+'_m1', kwargs["initializer"])
+    create_tensor([0, 0, num_heads, head_dim], name+"_qkv_shape", kwargs["initializer"])
+    create_tensor([0, 0, -1], name+"_out_shape", kwargs["initializer"])
+    nodes = [
+        make_node('Shape', [input_nodes[0]], [name+'_shape']),
+        make_node('Split', [name+'_shape'], [name+'_sq', name+'_bs', name+'___'], axis=0),
+        make_node('Reshape', [input_nodes[0], name+"_qkv_shape"], [name+'_v__']),
+        make_node('Transpose', [name+'_v__'], [name+'_v_'], perm=[1, 2, 0, 3]),
+        make_node('Concat', [name+'_m1', name+'_sq', name+'_head_dim'], [name+'_v_shape'], axis=0),
+        make_node('Reshape', [name+'_v_', name+'_v_shape'], [name+'_v']),
+        make_node('MatMul', [input_nodes[1], name+'_v'], [name+'_matmul']),
+        make_node('Concat', [name+'_bs', name+'_m1', name+'_sq', name+'_head_dim'],
+                  [name+'_before_transpose'], axis=0),
+        make_node('Reshape', [name+'_matmul', name+'_before_transpose'], [name+'_bt']),
+        make_node('Transpose', [name+'_bt'], [name+'_transpose'], perm=[2, 0, 1, 3]),
+        make_node('Reshape', [name+'_transpose', name+'_out_shape'], [name])
+    ]
+
+    return nodes
+


### PR DESCRIPTION
Add model (BERT) specific logic to un-interleave the self attention mat mul. This can potentially speed up inference with trt 8.0 whose compiler can recognize the new pattern.

usage `model_specific_logics='gluonnlp_bert'`
```
converted_model_path = mx.onnx.export_model(sym_file, params_file, input_shapes,
                                                            input_types, onnx_file, model_specific_logics='gluonnlp_bert')
```
The first screenshot is the old graph, the second is the new graph. Note that use of `onnx-sim` is required 
![image](https://user-images.githubusercontent.com/16669457/117230463-01363800-add2-11eb-94bf-357595d0c70d.png)
![image](https://user-images.githubusercontent.com/16669457/117230472-05625580-add2-11eb-8c18-cdcf2e86de6e.png)

