### PR TITLE
[v1.x] ONNX export support broadcast_not_equal 

### DIFF
--- a/python/mxnet/onnx/mx2onnx/_export_onnx.py
+++ b/python/mxnet/onnx/mx2onnx/_export_onnx.py
@@ -352,7 +352,7 @@ class MXNetGraph(object):
                 )
             if isinstance(converted, list):
                 # Collect all the node's output names
-                node_possible_names = [name] + [name + str(i) for i in range(10)]
+                node_possible_names = [name] + [name + str(i) for i in range(100)]
                 node_output_names = []
                 # Collect all the graph's output names
                 graph_output_names = []

--- a/python/mxnet/onnx/mx2onnx/_op_translations/_op_translations_opset12.py
+++ b/python/mxnet/onnx/mx2onnx/_op_translations/_op_translations_opset12.py
@@ -2314,6 +2314,26 @@ def convert_broadcast_equal(node, **kwargs):
     return nodes
 
 
+@mx_op.register("broadcast_not_equal")
+def convert_broadcast_not_equal(node, **kwargs):
+    """Map MXNet's broadcast_not_equal operator attributes to onnx's Equal operator
+    and return the created node.
+    """
+    from onnx.helper import make_node
+    name, input_nodes, _ = get_inputs(node, kwargs)
+    input_dtypes = get_input_dtypes(node, kwargs)
+
+    dtype = input_dtypes[0]
+    dtype_t = onnx.mapping.NP_TYPE_TO_TENSOR_TYPE[dtype]
+
+    nodes = [
+        make_node("Equal", input_nodes, [name+"_equal"]),
+        make_node("Not", [name+"_equal"], [name+"_not"]),
+        make_node("Cast", [name+"_not"], [name], name=name, to=int(dtype_t))
+    ]
+    return nodes
+
+
 @mx_op.register("broadcast_logical_and")
 def convert_broadcast_logical_and(node, **kwargs):
     """Map MXNet's broadcast logical and operator attributes to onnx's And operator

--- a/tests/python-pytest/onnx/test_operators.py
+++ b/tests/python-pytest/onnx/test_operators.py
@@ -393,6 +393,17 @@ def test_onnx_export_broadcast_equal(tmp_path, dtype):
     op_export_test('broadcast_equal', M, [x, y], tmp_path)
 
 
+@pytest.mark.parametrize('dtype', ['float32', 'float64', 'int32', 'int64'])
+def test_onnx_export_broadcast_not_equal(tmp_path, dtype):
+    M = def_model('broadcast_not_equal')
+    x = mx.nd.zeros((4,5,6), dtype=dtype)
+    y = mx.nd.ones((4,5,6), dtype=dtype)
+    op_export_test('broadcast_not_equal', M, [x, y], tmp_path)
+    x1 = mx.nd.ones((4,5,6), dtype=dtype)
+    y1 = mx.nd.ones((5,6), dtype=dtype)
+    op_export_test('broadcast_not_equal', M, [x1, y1], tmp_path)
+
+
 @pytest.mark.parametrize('dtype', ['float16', 'float32', 'float64', 'int32', 'int64'])
 def test_onnx_export_broadcast_minimum(tmp_path, dtype):
     M = def_model('broadcast_minimum')


### PR DESCRIPTION
## Description ##
ONNX export support broadcast_not_equal. Also increate node output number. The changes are required by customer model from Ads team.

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
