### PR TITLE
[website] Fix Jinja2 version for python doc

### DIFF
--- a/docs/python_docs/requirements
+++ b/docs/python_docs/requirements
@@ -18,7 +18,7 @@
 jupyter
 sphinx==2.4.0
 matplotlib
-notebook
+notebook==6.2.0
 nbconvert==5.6.1
 nbsphinx==0.4.3
 recommonmark==0.6.0

--- a/docs/python_docs/requirements
+++ b/docs/python_docs/requirements
@@ -16,9 +16,10 @@
 # under the License.
 
 jupyter
+Jinja2==2.11.3
 sphinx==2.4.0
 matplotlib
-notebook==6.2.0
+notebook
 nbconvert==5.6.1
 nbsphinx==0.4.3
 recommonmark==0.6.0


### PR DESCRIPTION
## Description ##
Fix Jinja2 version for python doc. Attempting to fix https://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/restricted-website-build-master/detail/restricted-website-build-master/2424/pipeline/80/

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
