### PR TITLE
[TUTORIAL] fix typo in documents of `docs/python_docs/python/tutorials/`

### DIFF
--- a/docs/python_docs/python/tutorials/deploy/export/onnx.md
+++ b/docs/python_docs/python/tutorials/deploy/export/onnx.md
@@ -121,7 +121,7 @@ input_shape = (1,3,224,224)
 onnx_file = './mxnet_exported_resnet50.onnx'
 ```
 
-We have defined the input parameters required for the `export_model` API. Now, we are ready to covert the MXNet model into ONNX format.
+We have defined the input parameters required for the `export_model` API. Now, we are ready to convert the MXNet model into ONNX format.
 
 ```{.python .input}
 # Invoke export model API. It returns path of the converted onnx model

--- a/docs/python_docs/python/tutorials/deploy/inference/image_classification_jetson.md
+++ b/docs/python_docs/python/tutorials/deploy/inference/image_classification_jetson.md
@@ -15,7 +15,7 @@
 <!--- specific language governing permissions and limitations -->
 <!--- under the License. -->
 
-# Image Classication using pretrained ResNet-50 model on Jetson module
+# Image Classification using pretrained ResNet-50 model on Jetson module
 
 This tutorial shows how to install MXNet v1.6 with Jetson support and use it to deploy a pre-trained MXNet model for image classification on a Jetson module.
 
@@ -25,7 +25,7 @@ This tutorial shows how to:
 
 1. Install MXNet v1.6 along with its dependencies on a Jetson module (This tutorial has been tested on Jetson Xavier AGX and Jetson Nano modules)
 
-2. Deploy a pre-trained MXNet model for image classifcation on the module
+2. Deploy a pre-trained MXNet model for image classification on the module
 
 ## Who's this tutorial for?
 
@@ -71,7 +71,7 @@ And we are done. You can test the installation now by importing mxnet from pytho
 
 ## Running a pre-trained ResNet-50 model on Jetson
 
-We are now ready to run a pre-trained model and run inference on a Jetson module. In this tutorial we are using ResNet-50 model trained on Imagenet dataset. We run the following classification script with either cpu/gpu context using python3.
+We are now ready to run a pre-trained model and run inference on a Jetson module. In this tutorial we are using ResNet-50 model trained on ImageNet dataset. We run the following classification script with either cpu/gpu context using python3.
 
 ```{.python .input}
 from mxnet import gluon

--- a/docs/python_docs/python/tutorials/extend/customop.md
+++ b/docs/python_docs/python/tutorials/extend/customop.md
@@ -91,7 +91,7 @@ class SigmoidProp(mx.operator.CustomOpProp):
 
     def infer_shape(self, in_shapes):
         """Calculate output shapes from input shapes. This can be
-        omited if all your inputs and outputs have the same shape.
+        omitted if all your inputs and outputs have the same shape.
 
         in_shapes : list of shape. Shape is described by a tuple of int.
         """

--- a/docs/python_docs/python/tutorials/getting-started/crash-course/1-nparray.md
+++ b/docs/python_docs/python/tutorials/getting-started/crash-course/1-nparray.md
@@ -77,7 +77,7 @@ NumPy arrays.
 (x.shape, x.size, x.dtype)
 ```
 
-You could also specifiy the datatype when you create your ndarray.
+You could also specify the datatype when you create your ndarray.
 
 ```{.python .input}
 x = np.full((2, 3), 1, dtype="int8") 

--- a/docs/python_docs/python/tutorials/getting-started/crash-course/2-create-nn.md
+++ b/docs/python_docs/python/tutorials/getting-started/crash-course/2-create-nn.md
@@ -24,7 +24,7 @@ import the neural network modules from `gluon`. Gluon includes built-in neural
 network layers in the following two modules:
 
 1. `mxnet.gluon.nn`: NN module that maintained by the mxnet team
-2. `mxnet.gluon.contrib.nn`: Experiemental module that is contributed by the
+2. `mxnet.gluon.contrib.nn`: Experimental module that is contributed by the
 community
 
 Use the following commands to import the packages required for this step.

--- a/docs/python_docs/python/tutorials/getting-started/crash-course/5-datasets.md
+++ b/docs/python_docs/python/tutorials/getting-started/crash-course/5-datasets.md
@@ -129,7 +129,7 @@ With both `DataLoader`s defined, you can now train a model to classify each imag
 
 Gluon has a number of different Dataset classes for working with your own image data straight out-of-the-box. You can get started quickly using the mxnet.gluon.data.vision.datasets.ImageFolderDataset which loads images directly from a user-defined folder, and infers the label (i.e. class) from the folders.
 
-Here you will run through an example for image classification, but a similar process applies for other vision tasks. If you already have your own collection of images to work with you should partition your data into training and test sets, and place all objects of the same class into seperate folders. Similar to:
+Here you will run through an example for image classification, but a similar process applies for other vision tasks. If you already have your own collection of images to work with you should partition your data into training and test sets, and place all objects of the same class into separate folders. Similar to:
 
 ```
 ./images/train/car/abc.jpg

--- a/docs/python_docs/python/tutorials/getting-started/crash-course/6-train-nn.md
+++ b/docs/python_docs/python/tutorials/getting-started/crash-course/6-train-nn.md
@@ -173,8 +173,8 @@ This class is very useful to create a transformation pipeline for your images.
 
 You have to compose two different transformation pipelines, one for training
 and the other one for validating and testing. This is because each pipeline
-serves different pursposes. You need to downsize, convert to tensor and normalize
-images across all the different datsets; however, you typically do not want to randomly flip
+serves different purposes. You need to downsize, convert to tensor and normalize
+images across all the different datasets; however, you typically do not want to randomly flip
 or add color jitter to the validation or test images since you could reduce performance.
 
 ```{.python .input}

--- a/docs/python_docs/python/tutorials/getting-started/crash-course/7-use-gpus.md
+++ b/docs/python_docs/python/tutorials/getting-started/crash-course/7-use-gpus.md
@@ -36,7 +36,7 @@ npx.num_gpus() #This command provides the number of GPUs MXNet can access
 
 ## Allocate data to a GPU
 
-MXNet's ndarray is very similar to NumPy's. One major difference is that MXNet's ndarray has a `context` attribute specifieing which device an array is on. By default, arrays are stored on `npx.cpu()`. To change it to the first GPU, you can use the following code, `npx.gpu()` or `npx.gpu(0)` to indicate the first GPU.
+MXNet's ndarray is very similar to NumPy's. One major difference is that MXNet's ndarray has a `context` attribute specifying which device an array is on. By default, arrays are stored on `npx.cpu()`. To change it to the first GPU, you can use the following code, `npx.gpu()` or `npx.gpu(0)` to indicate the first GPU.
 
 ```{.python .input}
 gpu = npx.gpu() if npx.num_gpus() > 0 else npx.cpu()
@@ -53,7 +53,7 @@ gpu_1 = npx.gpu(1) if npx.num_gpus() > 1 else npx.cpu()
 x.copyto(gpu_1)
 ```
 
-MXNet requries that users explicitly move data between devices. But several operators such as `print`, and `asnumpy`, will implicitly move data to main memory.
+MXNet requires that users explicitly move data between devices. But several operators such as `print`, and `asnumpy`, will implicitly move data to main memory.
 
 ## Choosing GPU Ids
 If you have multiple GPUs on your machine, MXNet can access each of them through 0-indexing with `npx`. As you saw before, the first GPU was accessed using `npx.gpu(0)`, and the second using `npx.gpu(1)`. This extends to however many GPUs your machine has. So if your machine has eight GPUs, the last GPU is accessed using `npx.gpu(7)`. This allows you to select which GPUs to use for operations and training. You might find it particularly useful when you want to leverage multiple GPUs while training neural networks.
@@ -130,7 +130,7 @@ net(x)
 
 ## Training with multiple GPUs
 
-Finally, you will see how you can use multiple GPUs to jointly train a neural network through data parallelism. To elaborate on what data parallelism is, assume there are *n* GPUs, then you can split each data batch into *n* parts, and use a GPU on each of these parts to run the forward and backward passes on the seperate chunks of the data.
+Finally, you will see how you can use multiple GPUs to jointly train a neural network through data parallelism. To elaborate on what data parallelism is, assume there are *n* GPUs, then you can split each data batch into *n* parts, and use a GPU on each of these parts to run the forward and backward passes on the separate chunks of the data.
 
 First copy the data definitions with the following commands, and the transform functions from the tutorial [Training Neural Networks](6-train-nn.md).
 

--- a/docs/python_docs/python/tutorials/getting-started/gluon_from_experiment_to_deployment.md
+++ b/docs/python_docs/python/tutorials/getting-started/gluon_from_experiment_to_deployment.md
@@ -249,7 +249,7 @@ In the previous example output, we trained the model using an [AWS p3.8xlarge in
 ### Save the fine-tuned model
 
 
-We now have a trained our custom model. This can be serialized into model files using the export function. The export function will export the model architecture into a `.json` file and model parameters into a `.params` file.
+We now have trained our custom model. This can be serialized into model files using the export function. The export function will export the model architecture into a `.json` file and model parameters into a `.params` file.
 
 
 

--- a/docs/python_docs/python/tutorials/getting-started/to-mxnet/pytorch.md
+++ b/docs/python_docs/python/tutorials/getting-started/to-mxnet/pytorch.md
@@ -147,7 +147,7 @@ With a Sequential block, layers are executed one after the other. To have a diff
 
 ### 3. Loss function and optimization algorithm
 
-The next step is to define the loss function and pick an optimization algorithm. Both PyTorch and Apache MXNet provide multiple options to chose from, and for our particular case we are going to use the cross-entropy loss function and the Stochastic Gradient Descent (SGD) optimization algorithm.
+The next step is to define the loss function and pick an optimization algorithm. Both PyTorch and Apache MXNet provide multiple options to choose from, and for our particular case we are going to use the cross-entropy loss function and the Stochastic Gradient Descent (SGD) optimization algorithm.
 
 **PyTorch:**
 
@@ -249,7 +249,7 @@ Here is the list of function names in PyTorch Tensor that are different from Apa
 | Element-wise division of t1, t2, multiply v, and add t | `torch.addcdiv(t, v, t1, t2)` | `t + v*(t1/t2)`                              |
 | Matrix product and accumulation| `torch.addmm(M, mat1, mat2)`             | `nd.linalg_gemm(M, mat1, mat2)`                           |
 | Outer-product of two vector add a matrix | `m.addr(vec1, vec2)`           | Not available                                             |
-| Element-wise applies function | `x.apply_(calllable)`                     | Not available, but there is `nd.custom(x, 'op')`          |
+| Element-wise applies function | `x.apply_(callable)`                     | Not available, but there is `nd.custom(x, 'op')`          |
 | Element-wise inverse sine     | `x.asin()` or `torch.asin(x)`             | `nd.arcsin(x)`                                            |
 | Element-wise inverse tangent  | `x.atan()` or `torch.atan(x)`             | `nd.arctan(x)`                                            |
 | Tangent of two tensor         | `x.atan2(y)` or `torch.atan2(x, y)`       | Not available                                             |
@@ -272,7 +272,7 @@ Here is the list of function names in PyTorch Tensor that are different from Apa
 | Fractional portion of a tensor| `x.frac()`                                | `x - nd.trunc(x)`                                         |
 | Gathers values along an axis specified by dim | `torch.gather(x, 1,  torch.LongTensor([[0,0],[1,0]]))` | `nd.gather_nd(x, nd.array([[[0,0],[1,1]],[[0,0],[1,0]]]))`  |
 | Solves least square & least norm | `B.gels(A)`                            | Not available                                             |
-| Draws from geometirc distribution | `x.geometric_(p)`                     | Not available                                             |
+| Draws from geometric distribution | `x.geometric_(p)`                     | Not available                                             |
 | Device context of a tensor    | `print(x)` will print which device x is on| `x.context`                                               |
 | Repeats tensor                | `x.repeat(4,2)`                           | `x.tile(4,2)`                                             |
 | Data type of a tensor         | `x.type()`                                | `x.dtype`                                                 |
@@ -283,9 +283,9 @@ Here is the list of function names in PyTorch Tensor that are different from Apa
 | Eigendecomposition for symmetric matrix | `e, v = a.symeig()`             | `v, e = nd.linalg.syevd(a)`                               |
 | Transpose                     | `x.t()`                                   | `x.T`                                                     |
 | Sample uniformly              | `torch.uniform_()`                        | `nd.sample_uniform()`                                     |
-| Inserts a new dimesion        | `x.unsqueeze()`                           | `nd.expand_dims(x)`                                       |
+| Inserts a new dimension        | `x.unsqueeze()`                           | `nd.expand_dims(x)`                                       |
 | Reshape                       | `x.view(16)`                              | `x.reshape((16,))`                                          |
-| Veiw as a specified tensor    | `x.view_as(y)`                            | `x.reshape_like(y)`                                       |
+| View as a specified tensor    | `x.view_as(y)`                            | `x.reshape_like(y)`                                       |
 | Returns a copy of the tensor after casting to a specified type | `x.type(type)` | `x.astype(dtype)`                                   |
 | Copies the value of one tensor to another | `dst.copy_(src)`              | `src.copyto(dst)`                                         |
 | Returns a zero tensor with specified shape | `x = torch.zeros(2,3)`       | `x = nd.zeros((2,3))`                                     |
@@ -411,7 +411,7 @@ Gluon provide several predefined metrics which can online evaluate the performan
 
 | Function               | PyTorch                           | MXNet Gluon                              |
 |------------------------|-----------------------------------|------------------------------------------|
-| metric |  Not available   | `metric = mx.metric.Accuracy()`<br/>`with autograd.record():`<br/>&nbsp;&nbsp;&nbsp;&nbsp;`output = net(data)`<br/>&nbsp;&nbsp;&nbsp;&nbsp;`L = loss(ouput, label)`<br/>&nbsp;&nbsp;&nbsp;&nbsp;`loss(ouput, label).backward()`<br/>`trainer.step(batch_size)`<br/>`metric.update(label, output)`  |
+| metric |  Not available   | `metric = mx.metric.Accuracy()`<br/>`with autograd.record():`<br/>&nbsp;&nbsp;&nbsp;&nbsp;`output = net(data)`<br/>&nbsp;&nbsp;&nbsp;&nbsp;`L = loss(output, label)`<br/>&nbsp;&nbsp;&nbsp;&nbsp;`loss(output, label).backward()`<br/>`trainer.step(batch_size)`<br/>`metric.update(label, output)`  |
 
 ### Data visualization
 

--- a/docs/python_docs/python/tutorials/performance/backend/mkldnn/mkldnn_readme.md
+++ b/docs/python_docs/python/tutorials/performance/backend/mkldnn/mkldnn_readme.md
@@ -115,8 +115,8 @@ LIBRARY_PATH=$(brew --prefix llvm)/lib/ make -j $(sysctl -n hw.ncpu) CC=$(brew -
 
 <h2 id="3">Windows</h2>
 
-On Windows, you can use [Micrsoft Visual Studio 2015](https://www.visualstudio.com/vs/older-downloads/) and [Microsoft Visual Studio 2017](https://www.visualstudio.com/downloads/) to compile MXNet with Intel ONEDNN.
-[Micrsoft Visual Studio 2015](https://www.visualstudio.com/vs/older-downloads/) is recommended.
+On Windows, you can use [Microsoft Visual Studio 2015](https://www.visualstudio.com/vs/older-downloads/) and [Microsoft Visual Studio 2017](https://www.visualstudio.com/downloads/) to compile MXNet with Intel ONEDNN.
+[Microsoft Visual Studio 2015](https://www.visualstudio.com/vs/older-downloads/) is recommended.
 
 **Visual Studio 2015**
 
@@ -154,7 +154,7 @@ msbuild mxnet.sln /p:Configuration=Release;Platform=x64 /maxcpucount
 ```
    These commands produce mxnet library called ```libmxnet.dll``` in the ```./build/Release/``` or ```./build/Debug``` folder. Also ```libmkldnn.dll``` with be in the ```./build/3rdparty/onednn/src/Release/```
 
-5. Make sure that all the dll files used above(such as `libmkldnn.dll`, `libmklml*.dll`, `libiomp5.dll`, `libopenblas*.dll`, etc) are added to the system PATH. For convinence, you can put all of them to ```\windows\system32```. Or you will come across `Not Found Dependencies` when loading MXNet.
+5. Make sure that all the dll files used above(such as `libmkldnn.dll`, `libmklml*.dll`, `libiomp5.dll`, `libopenblas*.dll`, etc) are added to the system PATH. For convenience, you can put all of them to ```\windows\system32```. Or you will come across `Not Found Dependencies` when loading MXNet.
 
 **Visual Studio 2017**
 
@@ -227,7 +227,7 @@ You can find step-by-step guidance to do profiling for ONEDNN primitives in [Pro
 
 <h2 id="5">Enable MKL BLAS</h2>
 
-With MKL BLAS, the performace is expected to furtherly improved with variable range depending on the computation load of the models.
+With MKL BLAS, the performance is expected to furtherly improved with variable range depending on the computation load of the models.
 You can redistribute not only dynamic libraries but also headers, examples and static libraries on accepting the license [Intel Simplified license](https://software.intel.com/en-us/license/intel-simplified-software-license).
 Installing the full MKL installation enables MKL support for all operators under the linalg namespace.
 

--- a/docs/python_docs/python/tutorials/performance/backend/profiler.md
+++ b/docs/python_docs/python/tutorials/performance/backend/profiler.md
@@ -211,11 +211,11 @@ Let's zoom in to check the time taken by operators
 The above picture visualizes the sequence in which the operators were executed and the time taken by each operator.
 
 ### Profiling ONEDNN Operators
-Reagrding ONEDNN operators, the library has already provided the internal profiling tool. Firstly, you need set `MKLDNN_VERBOSE=1` to enable internal profiler.
+Regarding ONEDNN operators, the library has already provided the internal profiling tool. Firstly, you need set `MKLDNN_VERBOSE=1` to enable internal profiler.
 
 `$ MKLDNN_VERBOSE=1 python my_script.py > mkldnn_verbose.log`
 
-Now, the detailed profiling insights of each ONEDNN prmitive are saved into `mkldnn_verbose.log` (like below).
+Now, the detailed profiling insights of each ONEDNN primitive are saved into `mkldnn_verbose.log` (like below).
 
 ```
 dnnl_verbose,info,DNNL v1.1.2 (commit cb2cc7ac17ff4e2ef50805c7048d33256d82be4d)
@@ -286,7 +286,7 @@ Here, we have created a custom operator called `MyAddOne`, and within its `forwa
 
 As shown by the screenshot, in the **Custom Operator** domain where all the custom operator-related events fall into, we can easily visualize the execution time of each segment of `MyAddOne`. We can tell that `MyAddOne::pure_python` is executed first. We also know that `CopyCPU2CPU` and `_plus_scalr` are two "sub-operators" of `MyAddOne` and the sequence in which they are executed.
 
-Please note that: to be able to see the previously described information, you need to set `profile_imperative` to `True` even when you are using custom operators in [symbolic mode](https://mxnet.apache.org/versions/master/tutorials/basic/symbol.html) (refer to the code snippet below, which is the symbolic-mode equivelent of the code example above). The reason is that within custom operators, pure python code and sub-operators are still called imperatively. 
+Please note that: to be able to see the previously described information, you need to set `profile_imperative` to `True` even when you are using custom operators in [symbolic mode](https://mxnet.apache.org/versions/master/tutorials/basic/symbol.html) (refer to the code snippet below, which is the symbolic-mode equivalent of the code example above). The reason is that within custom operators, pure python code and sub-operators are still called imperatively. 
 
 ```{.python .input} 
 # Set profile_all to True


### PR DESCRIPTION
## Description ##
fix typo in documents of `docs/python_docs/python/tutorials/`
