### PR TITLE
[v1.x] ONNX export for large model

### DIFF
--- a/python/mxnet/onnx/README.md
+++ b/python/mxnet/onnx/README.md
@@ -64,7 +64,7 @@ Parameters:
     input_shape : List of tuple
         This is the old name of in_shapes. We keep this parameter name for backward compatibility
     large_model : Boolean
-        Whether to export a model that is larger than 2 GB. If true will save param tensors in seperate
+        Whether to export a model that is larger than 2 GB. If true will save param tensors in separate
         files along with .onnx model file. This feature is supported since onnx 1.8.0
 
 Returns:
@@ -79,7 +79,7 @@ When the model has multiple inputs, all the input shapes and dtypes must be prov
 We can set `dynamic=True` to turn on support for dynamic input shapes. Note that even with dynamic shapes, a set of static input shapes still need to be specified in `in_shapes`; on top of that, we'll also need to specify which dimensions of the input shapes are dynamic in `dynamic_input_shapes`. We can simply set the dynamic dimensions as `None`, e.g. `(1, 3, None, None)`, or use strings in place of the `None`'s for better understandability in the exported onnx graph, e.g. `(1, 3, 'Height', 'Width')`
 
 #### Export Large Model
-Uses can set `large_model=True` to exoprt models that are larger than 2GB. In this case, all parameter tensors will be saved into seperate files along with the .onnx model file.
+Uses can set `large_model=True` to export models that are larger than 2GB. In this case, all parameter tensors will be saved into separate files along with the .onnx model file.
 
 ```python
 # The batch dimension will be dynamic in this case

--- a/python/mxnet/onnx/README.md
+++ b/python/mxnet/onnx/README.md
@@ -63,6 +63,9 @@ Parameters:
         This is the old name of in_types. We keep this parameter name for backward compatibility
     input_shape : List of tuple
         This is the old name of in_shapes. We keep this parameter name for backward compatibility
+    large_model : Boolean
+        Whether to export a model that is larger than 2 GB. If true will save param tensors in seperate
+        files along with .onnx model file. This feature is supported since onnx 1.8.0
 
 Returns:
 
@@ -74,6 +77,9 @@ When the model has multiple inputs, all the input shapes and dtypes must be prov
 
 #### Dynamic Shape Input
 We can set `dynamic=True` to turn on support for dynamic input shapes. Note that even with dynamic shapes, a set of static input shapes still need to be specified in `in_shapes`; on top of that, we'll also need to specify which dimensions of the input shapes are dynamic in `dynamic_input_shapes`. We can simply set the dynamic dimensions as `None`, e.g. `(1, 3, None, None)`, or use strings in place of the `None`'s for better understandability in the exported onnx graph, e.g. `(1, 3, 'Height', 'Width')`
+
+#### Export Large Model
+Uses can set `large_model=True` to exoprt models that are larger than 2GB. In this case, all parameter tensors will be saved into seperate files along with the .onnx model file.
 
 ```python
 # The batch dimension will be dynamic in this case

--- a/python/mxnet/onnx/mx2onnx/_export_model.py
+++ b/python/mxnet/onnx/mx2onnx/_export_model.py
@@ -85,8 +85,8 @@ def export_model(sym, params, in_shapes=None, in_types=np.float32,
     input_shape : List of tuple
         This is the old name of in_shapes. We keep this parameter name for backward compatibility
     large_model : Boolean
-        Whether the model is larger than 2 GB. If true will save large param tensors in a seperate file with .data suffix. 
-        e.g. the output will be model.onnx and model.onnx.data
+        Whether to export a model that is larger than 2 GB. If true will save param tensors in seperate files along with .onnx model file.
+        This feature is supported since onnx 1.8.0
 
     Returns
     -------
@@ -154,10 +154,9 @@ def export_model(sym, params, in_shapes=None, in_types=np.float32,
         except: # pylint: disable=bare-except
             logging.info("Shape inference failed, original export is kept.")
 
-    large_model = True
     if large_model:
         from onnx.external_data_helper import convert_model_to_external_data
-        convert_model_to_external_data(onnx_model, all_tensors_to_one_file=True, location=onnx_file_path+'.data', size_threshold=1024)
+        convert_model_to_external_data(onnx_model, all_tensors_to_one_file=False, location=onnx_file_path+'.data')
     onnx.save_model(onnx_model, onnx_file_path)
     onnx.checker.check_model(onnx_file_path)
     return onnx_file_path

--- a/python/mxnet/onnx/mx2onnx/_export_model.py
+++ b/python/mxnet/onnx/mx2onnx/_export_model.py
@@ -21,7 +21,6 @@
 """Exports an MXNet model to the ONNX model format"""
 import logging
 import numpy as np
-import onnx
 
 from mxnet.base import string_types
 from mxnet import symbol
@@ -100,6 +99,7 @@ def export_model(sym, params, in_shapes=None, in_types=np.float32,
     """
 
     try:
+        import onnx
         from onnx import helper, mapping, shape_inference
         from onnx.defs import onnx_opset_version
     except ImportError:
@@ -157,6 +157,7 @@ def export_model(sym, params, in_shapes=None, in_types=np.float32,
     if large_model:
         from onnx.external_data_helper import convert_model_to_external_data
         convert_model_to_external_data(onnx_model, all_tensors_to_one_file=False, location=onnx_file_path+'.data')
+
     onnx.save_model(onnx_model, onnx_file_path)
     onnx.checker.check_model(onnx_file_path)
     return onnx_file_path

--- a/python/mxnet/onnx/mx2onnx/_export_model.py
+++ b/python/mxnet/onnx/mx2onnx/_export_model.py
@@ -85,8 +85,8 @@ def export_model(sym, params, in_shapes=None, in_types=np.float32,
     input_shape : List of tuple
         This is the old name of in_shapes. We keep this parameter name for backward compatibility
     large_model : Boolean
-        Whether to export a model that is larger than 2 GB. If true will save param tensors in seperate files along with .onnx model file.
-        This feature is supported since onnx 1.8.0
+        Whether to export a model that is larger than 2 GB. If true will save param tensors in seperate 
+        files along with .onnx model file. This feature is supported since onnx 1.8.0
 
     Returns
     -------

--- a/python/mxnet/onnx/mx2onnx/_export_model.py
+++ b/python/mxnet/onnx/mx2onnx/_export_model.py
@@ -85,7 +85,7 @@ def export_model(sym, params, in_shapes=None, in_types=np.float32,
     input_shape : List of tuple
         This is the old name of in_shapes. We keep this parameter name for backward compatibility
     large_model : Boolean
-        Whether to export a model that is larger than 2 GB. If true will save param tensors in seperate 
+        Whether to export a model that is larger than 2 GB. If true will save param tensors in seperate
         files along with .onnx model file. This feature is supported since onnx 1.8.0
 
     Returns

--- a/python/mxnet/onnx/mx2onnx/_export_model.py
+++ b/python/mxnet/onnx/mx2onnx/_export_model.py
@@ -84,7 +84,7 @@ def export_model(sym, params, in_shapes=None, in_types=np.float32,
     input_shape : List of tuple
         This is the old name of in_shapes. We keep this parameter name for backward compatibility
     large_model : Boolean
-        Whether to export a model that is larger than 2 GB. If true will save param tensors in seperate
+        Whether to export a model that is larger than 2 GB. If true will save param tensors in separate
         files along with .onnx model file. This feature is supported since onnx 1.8.0
 
     Returns

--- a/python/mxnet/onnx/mx2onnx/_export_onnx.py
+++ b/python/mxnet/onnx/mx2onnx/_export_onnx.py
@@ -275,7 +275,7 @@ class MXNetGraph(object):
             ONNX graph
         """
         try:
-            from onnx import (checker, helper, NodeProto, ValueInfoProto, TensorProto)
+            from onnx import (helper, NodeProto, ValueInfoProto, TensorProto)
             from onnx.helper import make_tensor_value_info
             from onnx.defs import onnx_opset_version
         except ImportError:

--- a/python/mxnet/onnx/mx2onnx/_export_onnx.py
+++ b/python/mxnet/onnx/mx2onnx/_export_onnx.py
@@ -442,5 +442,4 @@ class MXNetGraph(object):
 
         graph.initializer.extend(initializer)
 
-        checker.check_graph(graph)
         return graph

--- a/python/mxnet/onnx/mx2onnx/_op_translations/_op_translations_opset12.py
+++ b/python/mxnet/onnx/mx2onnx/_op_translations/_op_translations_opset12.py
@@ -223,15 +223,9 @@ def convert_weights_and_inputs(node, **kwargs):
 
         tensor_node = onnx.helper.make_tensor_value_info(name, data_type, dims)
 
-        initializer.append(
-            onnx.helper.make_tensor(
-                name=name,
-                data_type=data_type,
-                dims=dims,
-                vals=np_arr.flatten().tolist(),
-                raw=False
-            )
-        )
+        from onnx import numpy_helper
+        tensor = numpy_helper.from_array(np_arr, name=name)
+        initializer.append(tensor)
 
         return [tensor_node], (np_arr.dtype,)
     else:

--- a/tests/python-pytest/onnx/test_onnxruntime_cv.py
+++ b/tests/python-pytest/onnx/test_onnxruntime_cv.py
@@ -61,6 +61,12 @@ class GluonModel():
                              dynamic_input_shapes=dynamic_input_shapes)
         return onnx_file
 
+    def export_onnx_large_model(self):
+        onnx_file = self.modelpath + ".onnx"
+        mx.onnx.export_model(self.modelpath + "-symbol.json", self.modelpath + "-0000.params",
+                             [self.input_shape], self.input_dtype, onnx_file, large_model=True)
+        return onnx_file
+
     def export_onnx_argaux(self):
         onnx_file = self.modelpath + ".onnx"
         sym_file = self.modelpath + "-symbol.json"
@@ -322,7 +328,11 @@ def test_obj_detection_model_inference_onnxruntime(tmp_path, model, obj_detectio
     try:
         tmp_path = str(tmp_path)
         M = GluonModel(model, (1,3,512,512), 'float32', tmp_path)
-        onnx_file = M.export_onnx()
+        if model in ['yolo3_darknet53_coco']:
+            # test for large_model feature
+            onnx_file = M.export_onnx_large_model()
+        else:
+            onnx_file = M.export_onnx()
         # create onnxruntime session using the generated onnx file
         ses_opt = onnxruntime.SessionOptions()
         ses_opt.log_severity_level = 3


### PR DESCRIPTION
## Description ##
Add ONNX export for large model (currently it fails due to protobuf 2GB limit). When `large_model=True`, the param tensors will be saved into separate data files along with the onnx model file, which allows large models to export.

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
