### PR TITLE
[BUGFIX] Fix UnicodeDecodeError in src (#20286)

### DIFF
--- a/src/operator/numpy/linalg/np_norm-inl.h
+++ b/src/operator/numpy/linalg/np_norm-inl.h
@@ -217,7 +217,7 @@ struct NumpyNormParam : public dmlc::Parameter<NumpyNormParam> {
   int flag;
   DMLC_DECLARE_PARAMETER(NumpyNormParam) {
     DMLC_DECLARE_FIELD(ord).set_default(2)
-    .describe("Order of the norm. inf means numpy’s inf object.");
+    .describe("Order of the norm. inf means numpy's inf object.");
     DMLC_DECLARE_FIELD(axis).set_default(dmlc::optional<mxnet::TShape>())
     .describe(R"code(If axis is an integer, it specifies the axis of x along
      which to compute the vector norms. If axis is a 2-tuple,

--- a/src/operator/numpy/np_fill_diagonal_op-inl.h
+++ b/src/operator/numpy/np_fill_diagonal_op-inl.h
@@ -46,7 +46,7 @@ struct NumpyFillDiagonalParam : public dmlc::Parameter<NumpyFillDiagonalParam> {
                 "its type must be compatible with that of the array a.");
     DMLC_DECLARE_FIELD(wrap)
     .set_default(false)
-    .describe("The diagonal “wrapped” after N columns."
+    .describe("The diagonal 'wrapped' after N columns."
               "You can have this behavior with this option. "
               "This affects only tall matrices.");
   }

--- a/src/operator/numpy/np_matrix_op-inl.h
+++ b/src/operator/numpy/np_matrix_op-inl.h
@@ -665,7 +665,7 @@ struct NumpyRollaxisParam : public dmlc::Parameter<NumpyRollaxisParam> {
     DMLC_DECLARE_FIELD(start)
     .set_default(0)
     .describe("The axis is rolled until it lies before this position. "
-              "The default, 0, results in a “complete” roll.");
+              "The default, 0, results in a 'complete' roll.");
   }
   void SetAttrDict(std::unordered_map<std::string, std::string>* dict) {
     std::ostringstream axis_s, start_s;


### PR DESCRIPTION
## Description ##
(Brief description on what this PR is about)
On Windows, with package built in VS 2019, the mxnet Python module can not be imported due to UnicodeDecodeError.
UnicodeDecodeError: 'utf-8' codec can't decode bytes in position 23-24: invalid continuation byte

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ]Fix illegal characters in src

## Comments ##
 Replace invalid characters “’” and "“" to "'" 
