### PR TITLE
[v1.x] ONNX fix embedding dtype and output order

### DIFF
--- a/python/mxnet/onnx/mx2onnx/_export_onnx.py
+++ b/python/mxnet/onnx/mx2onnx/_export_onnx.py
@@ -392,8 +392,17 @@ class MXNetGraph(object):
                 # if node_output_names is empty then we use the last returned node as output
                 if not node_output_names:
                     node_output_names = [converted[-1].name]
-                # process node outputs (sort by alphabetical order)
-                node_output_names.sort()
+                # process node outputs (sort by output index)
+                def str2int(s):
+                    import re
+                    i = re.search(r'\d{0,2}$', s).group()
+                    if i == '':
+                        return 0
+                    else:
+                        return int(i)
+
+                sorted(node_output_names, key=str2int)
+
                 # match the output names to output dtypes
                 if dtypes is not None:
                     assert len(node_output_names) == len(dtypes)

--- a/python/mxnet/onnx/mx2onnx/_op_translations/_op_translations_opset12.py
+++ b/python/mxnet/onnx/mx2onnx/_op_translations/_op_translations_opset12.py
@@ -3094,13 +3094,14 @@ def convert_embedding(node, **kwargs):
 
     name, input_nodes, attrs = get_inputs(node, kwargs)
     axis = int(attrs.get('axis', 0))
+    dtype = str(attrs.get('dtype', 'float32'))
 
     nodes = [
         make_node('Cast', [input_nodes[0]], [name+'_indices_casted'], to=int(TensorProto.INT64)),
         make_node('Gather', [input_nodes[1], name+'_indices_casted'], [name], axis=axis, name=name)
     ]
 
-    return nodes
+    return nodes, (dtype, )
 
 
 @mx_op.register("stack")


### PR DESCRIPTION
## Description ##
Fix output dtype of `embedding` and output order when having more than 10 output nodes.

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
