### PR TITLE
[FEATURE] Performance improvement by asymmetric quantization Quantize+FC

### DIFF
--- a/python/mxnet/contrib/quantization.py
+++ b/python/mxnet/contrib/quantization.py
@@ -1005,7 +1005,7 @@ def quantize_net_v2(network, quantized_dtype='auto', quantize_mode='full', quant
             net.optimize_for(x=data_nd, backend="OneDNNShiftedQuantization")
             tmp_file = os.path.join(tmpdirname, 'model')
             net.export(tmp_file)
-            net = SymbolBlock.imports(tmp_file+'-symbol.json', data_names, tmp_file+'-0000.params')
+            net = SymbolBlock.imports(tmp_file + '-symbol.json', data_names, tmp_file + '-0000.params')
     return net
 
 def quantize_net(network, quantized_dtype='auto', quantize_mode='full',

--- a/python/mxnet/contrib/quantization.py
+++ b/python/mxnet/contrib/quantization.py
@@ -1002,7 +1002,7 @@ def quantize_net_v2(network, quantized_dtype='auto', quantize_mode='full', quant
         net.collect_params().load(param_name, cast_dtype=True, dtype_source='saved')
         net.collect_params().reset_ctx(ctx)
         if quantized_dtype == 'auto':
-            net.optimize_for(*data_nd, backend="OneDNNShiftedQuantization")
+            net.optimize_for(x=data_nd, backend="OneDNNShiftedQuantization")
             tmp_file = os.path.join(tmpdirname, 'model')
             net.export(tmp_file)
             net = SymbolBlock.imports(tmp_file+'-symbol.json', data_names, tmp_file+'-0000.params')

--- a/src/operator/quantization/mkldnn/mkldnn_quantize_v2-inl.h
+++ b/src/operator/quantization/mkldnn/mkldnn_quantize_v2-inl.h
@@ -172,10 +172,7 @@ void SgMKLDNNQuantizeOperator::Forward(const OpContext &ctx, const std::vector<N
     CommitOutput(outputs[0], o_mem);
     if (shifted) {
       uint8_t *raw_out_mem = static_cast<uint8_t *>(o_mem.second->get_data_handle());
-      #pragma omp parallel for simd
-      for (size_t i = 0; i < outputs[0].shape().Size(); i++) {
-        raw_out_mem[i] = cached_shift_;
-      }
+      std::fill_n(raw_out_mem, outputs[0].shape().Size(), cached_shift_);
     }
     MKLDNNStream::Get()->Submit();
   }

--- a/src/operator/quantization/quantization_utils.h
+++ b/src/operator/quantization/quantization_utils.h
@@ -187,12 +187,12 @@ inline size_t ConfigReduce(mshadow::Stream<xpu>* s,
   return broadcast::ReduceWorkspaceSize<NDim, DType>(s, *dst_shape, kWriteTo, *src_shape);
 }
 
-enum QuantizeOutType { kAuto = 0, kInt8, kUint8 };
+enum QuantizeOutType { qAuto = 0, qInt8, qUint8 };
 
 template<typename Param>
 static mshadow::TypeFlag GetQuantizeOutputType(const Param &param) {
   auto out_type = mshadow::kInt8;
-  if (param.out_type == QuantizeOutType::kAuto) {
+  if (param.out_type == QuantizeOutType::qAuto) {
     if (param.min_calib_range.has_value() && param.max_calib_range.has_value()) {
       if (param.min_calib_range.value() >= 0.0) {
         out_type = mshadow::kUint8;
@@ -200,9 +200,9 @@ static mshadow::TypeFlag GetQuantizeOutputType(const Param &param) {
         out_type = mshadow::kInt8;
       }
     }
-  } else if (param.out_type == QuantizeOutType::kInt8) {
+  } else if (param.out_type == QuantizeOutType::qInt8) {
     out_type = mshadow::kInt8;
-  } else if (param.out_type == QuantizeOutType::kUint8) {
+  } else if (param.out_type == QuantizeOutType::qUint8) {
     out_type = mshadow::kUint8;
   } else {
     LOG(FATAL) << "Unsupported out_type in params: " <<param.out_type;

--- a/src/operator/quantization/quantize_graph_pass.cc
+++ b/src/operator/quantization/quantize_graph_pass.cc
@@ -31,6 +31,7 @@
 #include <unordered_set>
 #include <vector>
 #include "quantize_v2-inl.h"
+#include "../nn/mkldnn/mkldnn_fully_connected-inl.h"
 #include "../../common/utils.h"
 
 namespace mxnet {
@@ -578,6 +579,161 @@ Graph SetCalibTableToQuantizedGraph(Graph&& g) {
   return g;
 }
 
+static NDArray* FindInArgByName(const Graph &g, const std::string& name) {
+  const std::vector<std::string>& in_arg_names =
+      g.GetAttr<std::vector<std::string>>("in_arg_names");
+  size_t i =
+      std::distance(in_arg_names.begin(),
+                    std::find(in_arg_names.begin(), in_arg_names.end(), name));
+  if (i == in_arg_names.size()) {
+    throw std::runtime_error(name + " not found in in_arg_names");
+  }
+  return g.GetAttr<NDArray **>("in_args")[i];
+}
+
+static inline bool IsFC(const ObjectPtr& n) {
+#if MXNET_USE_MKLDNN == 1
+  if (n->op() == Op::Get("_sg_mkldnn_fully_connected")) {
+    auto const& param = nnvm::get<MKLDNNFCFullParam>(n->attrs.parsed);
+    if (param.default_param.no_bias == false &&
+        n->inputs[2].node->is_variable()) {
+      if (!(param.mkldnn_param.channel_wise_quantize.has_value() &&
+            param.mkldnn_param.channel_wise_quantize.value())) {
+        return true;
+      }
+    }
+  }
+#endif
+  return false;
+}
+
+static inline bool IsQuantize(const ObjectPtr& n) {
+  if (n->op() == Op::Get("_contrib_quantize_v2")) {
+    auto const &param = nnvm::get<QuantizeV2Param>(n->attrs.parsed);
+    if (param.min_calib_range.has_value() &&
+        param.min_calib_range.value() < 0.0f) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Rescales weights, min_weight and max_weight. Returns bias_int32_rescale.
+static inline float RescaleWeights(const Graph &g, const ObjectPtr &fc, NDArray* weight_tensor) {
+  ObjectPtr &quantize = fc->inputs[0].node;
+  auto min_data = std::stof(quantize->attrs.dict.at("min_calib_range"));
+  auto max_data = std::stof(quantize->attrs.dict.at("max_calib_range"));
+
+  float *min_weight = FindInArgByName(g, fc->inputs[5].node->attrs.name)->data().dptr<float>();
+  float *max_weight = FindInArgByName(g, fc->inputs[6].node->attrs.name)->data().dptr<float>();
+  float min_bias = *FindInArgByName(g, fc->inputs[7].node->attrs.name)->data().dptr<float>();
+  float max_bias = *FindInArgByName(g, fc->inputs[8].node->attrs.name)->data().dptr<float>();
+
+  float data_scale_ = kUint8Range / (max_data - min_data);
+  float weight_scale = GetQuantizeScale(kInt8, *min_weight, *max_weight);
+  float bias_scale = GetQuantizeScale(kInt8, min_bias, max_bias);
+  float bias_int32_rescale = data_scale_ * weight_scale / bias_scale;
+
+  // // TODO(zhennan): mkldnn has bug to handle INT_MAX in bias, so set the
+  // // maximum value of bias to INT_MAX / 2.
+  float bias_max_rescale = mshadow::red::limits::MaxValue<int32_t>() / 2 /
+                           MaxAbs(min_bias, max_bias) / bias_scale;
+  if (bias_int32_rescale > bias_max_rescale) {
+    LOG(INFO) << "RESCALING WEIGHTS!";
+    // avoid overflow on bias
+    bias_int32_rescale = bias_max_rescale;
+    float weight_rescale =
+        bias_int32_rescale * bias_scale / data_scale_ / weight_scale;
+
+    size_t weight_size = weight_tensor->shape().Size();
+    int8_t *weight_ptr = weight_tensor->data().dptr<int8_t>();
+    for (int32_t i = 0; i < static_cast<int32_t>(weight_size); ++i) {
+      weight_ptr[i] = std::round(weight_ptr[i] * weight_rescale);
+    }
+    *min_weight *= weight_rescale;
+    *max_weight *= weight_rescale;
+  }
+  return bias_int32_rescale;
+}
+
+static inline void ShiftBias(int32_t* bias_ptr_int32, size_t bias_size,
+                             NDArray* weight_tensor, int32_t shift_value) {
+  // create shift matrix
+  // (M, K) * (K, N) = (M, N) where N = 1 (shift size)
+  int8_t *weight_ptr = weight_tensor->data().dptr<int8_t>();
+  size_t M = weight_tensor->shape()[0];
+  size_t K = weight_tensor->shape()[1];
+  int32_t shift_matrix[M];
+  for (int i = 0; i < M; i++) {
+    shift_matrix[i] = 0;
+    for (int j = 0; j < K; j++) {
+      int i_j_index = i * K + j;
+      shift_matrix[i] += shift_value * weight_ptr[i_j_index];
+    }
+  }
+  // shift bias
+  for (int32_t i = 0; i < static_cast<int32_t>(bias_size); ++i) {
+    bias_ptr_int32[i] -= shift_matrix[i];
+  }
+}
+
+Graph OneDNNShiftedQuantization(Graph &&g) {
+  static bool disable_shifted_quant = dmlc::GetEnv("MXNET_DISABLE_SHIFTED_QUANTIZATION", false);
+  LOG(INFO) << "Running OneDNN shifted quantization: " << !disable_shifted_quant;
+  // No change to aux params
+  g.attrs["new_aux_names"] = std::make_shared<nnvm::any>(std::vector<std::string>());
+  g.attrs["new_aux"] = std::make_shared<nnvm::any>(std::vector<NDArray *>());
+
+  // New args to replace the old
+  std::vector<std::string> new_arg_names;
+  std::vector<NDArray *> new_arg_vector;
+
+#if MXNET_USE_MKLDNN == 1
+  if (!disable_shifted_quant) {
+    DFSVisit(g.outputs, [&](const ObjectPtr &fc) {
+      // Find Quantize->FC pattern and rescale bias from int8 to int32 and shift
+      if (IsFC(fc)) {
+        ObjectPtr &quantize = fc->inputs[0].node;
+        if (IsQuantize(quantize)) {
+          ObjectPtr& bias_node = fc->inputs[2].node;
+          std::string bias_name_old = bias_node->attrs.name;
+          std::string bias_name_s32 = bias_node->attrs.name + "_s32";
+          bias_node = CreateNode("nullptr", bias_name_s32);
+          new_arg_names.push_back(bias_name_s32);
+
+          quantize->attrs.dict["shifted"] = "True";
+          if (quantize->op()->attr_parser) quantize->op()->attr_parser(&(quantize->attrs));
+
+          NDArray *weight_tensor = FindInArgByName(g, fc->inputs[1].node->attrs.name);
+
+          float bias_int32_rescale = RescaleWeights(g, fc, weight_tensor);
+
+          NDArray* bias_in_arg_ptr = FindInArgByName(g, bias_name_old);
+          new_arg_vector.push_back(
+              new NDArray(kDefaultStorage, bias_in_arg_ptr->shape(),
+                          Context::CPU(), false, mshadow::kInt32));
+          int32_t *bias_ptr_int32 = new_arg_vector.back()->data().dptr<int32_t>();
+          size_t bias_size = bias_in_arg_ptr->shape().Size();
+          int8_t *bias_ptr_old = bias_in_arg_ptr->data().dptr<int8_t>();
+
+          for (size_t i = 0; i < bias_size; ++i) {
+            bias_ptr_int32[i] = std::round(bias_ptr_old[i] * bias_int32_rescale);
+          }
+          float min_data = std::stof(quantize->attrs.dict.at("min_calib_range"));
+          float max_data = std::stof(quantize->attrs.dict.at("max_calib_range"));
+          float data_scale = kUint8Range / (max_data - min_data);
+          uint32_t shift_value = static_cast<uint32_t>(-std::round(data_scale * min_data));
+          ShiftBias(bias_ptr_int32, bias_size, weight_tensor, shift_value);
+        }
+      }
+    });
+  }
+#endif
+  g.attrs["new_arg_names"] = std::make_shared<nnvm::any>(new_arg_names);
+  g.attrs["new_args"] = std::make_shared<nnvm::any>(new_arg_vector);
+  return g;
+}
+
 NNVM_REGISTER_PASS(QuantizeGraph)
 .describe("")
 .set_body(QuantizeGraph)
@@ -587,6 +743,11 @@ NNVM_REGISTER_PASS(QuantizeGraph)
 NNVM_REGISTER_PASS(SetCalibTableToQuantizedGraph)
 .describe("")
 .set_body(SetCalibTableToQuantizedGraph)
+.set_change_graph(true);
+
+NNVM_REGISTER_PASS(OneDNNShiftedQuantization)
+.describe("Enables shifted quantization.")
+.set_body(OneDNNShiftedQuantization)
 .set_change_graph(true);
 
 }  // namespace op

--- a/src/operator/quantization/quantize_graph_pass.cc
+++ b/src/operator/quantization/quantize_graph_pass.cc
@@ -668,7 +668,7 @@ static inline void ShiftBias(int32_t* bias_ptr_int32, size_t bias_size,
 }
 
 Graph OneDNNShiftedQuantization(Graph &&g) {
-  static bool disable_shifted_quant = dmlc::GetEnv("MXNET_DISABLE_SHIFTED_QUANTIZATION", true);
+  bool disable_shifted_quant = dmlc::GetEnv("MXNET_DISABLE_SHIFTED_QUANTIZATION", true);
   LOG(INFO) << "Running OneDNN shifted quantization: " << !disable_shifted_quant;
   // No change to aux params
   g.attrs["new_aux_names"] = std::make_shared<nnvm::any>(std::vector<std::string>());

--- a/src/operator/quantization/quantize_graph_pass.cc
+++ b/src/operator/quantization/quantize_graph_pass.cc
@@ -667,8 +667,9 @@ static inline void ShiftBias(int32_t* bias_ptr_int32, size_t bias_size,
   }
 }
 
-Graph OneDNNShiftedQuantization(Graph &&g) {
-  bool disable_shifted_quant = dmlc::GetEnv("MXNET_DISABLE_SHIFTED_QUANTIZATION_OPTIMIZATIONS", true);
+Graph OneDNNShiftedQuantization(Graph&& g) {
+  bool disable_shifted_quant =
+      dmlc::GetEnv("MXNET_DISABLE_SHIFTED_QUANTIZATION_OPTIMIZATIONS", true);
   LOG(INFO) << "Running OneDNN shifted quantization: " << !disable_shifted_quant;
   // No change to aux params
   g.attrs["new_aux_names"] = std::make_shared<nnvm::any>(std::vector<std::string>());

--- a/src/operator/quantization/quantize_graph_pass.cc
+++ b/src/operator/quantization/quantize_graph_pass.cc
@@ -664,9 +664,9 @@ static inline void ShiftBias(int32_t* bias_ptr_int32, size_t bias_size,
   size_t M = weight_tensor->shape()[0];
   size_t K = weight_tensor->shape()[1];
   int32_t shift_matrix[M];
-  for (int i = 0; i < M; i++) {
+  for (size_t i = 0; i < M; i++) {
     shift_matrix[i] = 0;
-    for (int j = 0; j < K; j++) {
+    for (size_t j = 0; j < K; j++) {
       int i_j_index = i * K + j;
       shift_matrix[i] += shift_value * weight_ptr[i_j_index];
     }
@@ -717,7 +717,8 @@ Graph OneDNNShiftedQuantization(Graph &&g) {
           int8_t *bias_ptr_old = bias_in_arg_ptr->data().dptr<int8_t>();
 
           for (size_t i = 0; i < bias_size; ++i) {
-            bias_ptr_int32[i] = std::round(bias_ptr_old[i] * bias_int32_rescale);
+            bias_ptr_int32[i] = static_cast<int32_t>(
+                std::round(bias_ptr_old[i] * bias_int32_rescale));
           }
           float min_data = std::stof(quantize->attrs.dict.at("min_calib_range"));
           float max_data = std::stof(quantize->attrs.dict.at("max_calib_range"));

--- a/src/operator/quantization/quantize_graph_pass.cc
+++ b/src/operator/quantization/quantize_graph_pass.cc
@@ -687,6 +687,8 @@ Graph OneDNNShiftedQuantization(Graph &&g) {
         if (IsQuantize(quantize)) {
           ObjectPtr& bias_node = fc->inputs[2].node;
           std::string bias_name_old = bias_node->attrs.name;
+          NDArray* bias_in_arg_ptr = FindInArgByName(g, bias_name_old);
+          if (bias_in_arg_ptr->dtype() != mshadow::kInt8) return;
           std::string bias_name_s32 = bias_node->attrs.name + "_s32";
           bias_node = CreateNode("nullptr", bias_name_s32);
           new_arg_names.push_back(bias_name_s32);
@@ -698,7 +700,6 @@ Graph OneDNNShiftedQuantization(Graph &&g) {
 
           float bias_int32_rescale = RescaleWeights(g, fc, weight_tensor);
 
-          NDArray* bias_in_arg_ptr = FindInArgByName(g, bias_name_old);
           new_arg_vector.push_back(
               new NDArray(kDefaultStorage, bias_in_arg_ptr->shape(),
                           Context::CPU(), false, mshadow::kInt32));

--- a/src/operator/quantization/quantize_graph_pass.cc
+++ b/src/operator/quantization/quantize_graph_pass.cc
@@ -678,7 +678,7 @@ static inline void ShiftBias(int32_t* bias_ptr_int32, size_t bias_size,
 }
 
 Graph OneDNNShiftedQuantization(Graph &&g) {
-  static bool disable_shifted_quant = dmlc::GetEnv("MXNET_DISABLE_SHIFTED_QUANTIZATION", false);
+  static bool disable_shifted_quant = dmlc::GetEnv("MXNET_DISABLE_SHIFTED_QUANTIZATION", true);
   LOG(INFO) << "Running OneDNN shifted quantization: " << !disable_shifted_quant;
   // No change to aux params
   g.attrs["new_aux_names"] = std::make_shared<nnvm::any>(std::vector<std::string>());

--- a/src/operator/quantization/quantize_graph_pass.cc
+++ b/src/operator/quantization/quantize_graph_pass.cc
@@ -585,7 +585,7 @@ static NDArray* FindInArgByName(const Graph &g, const std::string& name) {
   size_t i = std::distance(in_arg_names.begin(),
                            std::find(in_arg_names.begin(), in_arg_names.end(), name));
   if (i == in_arg_names.size()) {
-    throw std::runtime_error(name + " not found in in_arg_names");
+    LOG(FATAL) << name << " not found in in_arg_names";
   }
   return g.GetAttr<NDArray **>("in_args")[i];
 }
@@ -668,7 +668,7 @@ static inline void ShiftBias(int32_t* bias_ptr_int32, size_t bias_size,
 }
 
 Graph OneDNNShiftedQuantization(Graph &&g) {
-  bool disable_shifted_quant = dmlc::GetEnv("MXNET_DISABLE_SHIFTED_QUANTIZATION", true);
+  bool disable_shifted_quant = dmlc::GetEnv("MXNET_DISABLE_SHIFTED_QUANTIZATION_OPTIMIZATIONS", true);
   LOG(INFO) << "Running OneDNN shifted quantization: " << !disable_shifted_quant;
   // No change to aux params
   g.attrs["new_aux_names"] = std::make_shared<nnvm::any>(std::vector<std::string>());
@@ -716,7 +716,7 @@ Graph OneDNNShiftedQuantization(Graph &&g) {
           float data_scale = kUint8Range / (max_data - min_data);
           int32_t shift_value = static_cast<int32_t>(std::round(data_scale * -min_data));
           ShiftBias(bias_ptr_int32, bias_size, weight_tensor, shift_value);
-          LOG(INFO) << "fused QUANTIZE->FC";
+          LOG(INFO) << "applied shifted quantization on QUANTIZE->FC";
         }
       }
     });

--- a/src/operator/quantization/quantize_graph_pass.cc
+++ b/src/operator/quantization/quantize_graph_pass.cc
@@ -658,7 +658,7 @@ static inline float RescaleWeights(const Graph &g, const ObjectPtr &fc, NDArray*
 
 static inline void ShiftBias(int32_t* bias_ptr_int32, size_t bias_size,
                              NDArray* weight_tensor, int32_t shift_value) {
-  CHECK_EQ(weight_tensor->shape()[0], bias_size);
+  CHECK_EQ(static_cast<size_t>(weight_tensor->shape()[0]), bias_size);
   int8_t* weight_ptr = weight_tensor->data().dptr<int8_t>();
   for (dim_t i = 0; i < weight_tensor->shape()[0]; ++i) {
     for (dim_t j = 0; j < weight_tensor->shape()[1]; j++) {

--- a/src/operator/quantization/quantize_graph_pass.cc
+++ b/src/operator/quantization/quantize_graph_pass.cc
@@ -629,8 +629,8 @@ static inline float RescaleWeights(const Graph &g, const ObjectPtr &fc, NDArray*
   float max_bias = *FindInArgByName(g, fc->inputs[8].node->attrs.name)->data().dptr<float>();
 
   float data_scale_ = kUint8Range / (max_data - min_data);
-  float weight_scale = GetQuantizeScale(kInt8, *min_weight, *max_weight);
-  float bias_scale = GetQuantizeScale(kInt8, min_bias, max_bias);
+  float weight_scale = GetQuantizeScale(mshadow::kInt8, *min_weight, *max_weight);
+  float bias_scale = GetQuantizeScale(mshadow::kInt8, min_bias, max_bias);
   float bias_int32_rescale = data_scale_ * weight_scale / bias_scale;
 
   // // TODO(zhennan): mkldnn has bug to handle INT_MAX in bias, so set the
@@ -714,8 +714,9 @@ Graph OneDNNShiftedQuantization(Graph &&g) {
           float min_data = std::stof(quantize->attrs.dict.at("min_calib_range"));
           float max_data = std::stof(quantize->attrs.dict.at("max_calib_range"));
           float data_scale = kUint8Range / (max_data - min_data);
-          uint32_t shift_value = static_cast<uint32_t>(std::round(data_scale * -min_data));
+          int32_t shift_value = static_cast<int32_t>(std::round(data_scale * -min_data));
           ShiftBias(bias_ptr_int32, bias_size, weight_tensor, shift_value);
+          LOG(INFO) << "fused QUANTIZE->FC";
         }
       }
     });

--- a/src/operator/quantization/quantize_v2-inl.h
+++ b/src/operator/quantization/quantize_v2-inl.h
@@ -44,10 +44,10 @@ struct QuantizeV2Param : public dmlc::Parameter<QuantizeV2Param> {
   dmlc::optional<bool> shifted;
   DMLC_DECLARE_PARAMETER(QuantizeV2Param) {
     DMLC_DECLARE_FIELD(out_type)
-      .add_enum("auto", QuantizeOutType::kAuto)
-      .add_enum("int8", QuantizeOutType::kInt8)
-      .add_enum("uint8", QuantizeOutType::kUint8)
-      .set_default(QuantizeOutType::kInt8)
+      .add_enum("auto", QuantizeOutType::qAuto)
+      .add_enum("int8", QuantizeOutType::qInt8)
+      .add_enum("uint8", QuantizeOutType::qUint8)
+      .set_default(QuantizeOutType::qInt8)
       .describe("Output data type. `auto` can be specified to automatically determine output type "
                 "according to min_calib_range.");
     DMLC_DECLARE_FIELD(min_calib_range)

--- a/src/operator/quantization/quantize_v2-inl.h
+++ b/src/operator/quantization/quantize_v2-inl.h
@@ -41,6 +41,7 @@ struct QuantizeV2Param : public dmlc::Parameter<QuantizeV2Param> {
   int out_type;
   dmlc::optional<float> min_calib_range;
   dmlc::optional<float> max_calib_range;
+  dmlc::optional<bool> shifted;
   DMLC_DECLARE_PARAMETER(QuantizeV2Param) {
     DMLC_DECLARE_FIELD(out_type)
       .add_enum("auto", QuantizeOutType::kAuto)
@@ -57,6 +58,9 @@ struct QuantizeV2Param : public dmlc::Parameter<QuantizeV2Param> {
       .set_default(dmlc::optional<float>())
       .describe("The maximum scalar value in the form of float32. If present, it will be used to "
                 "quantize the fp32 data into int8 or uint8.");
+    DMLC_DECLARE_FIELD(shifted)
+      .set_default(dmlc::optional<bool>())
+      .describe("Whether quantization ouptut should be shifted.");
   }
 };
 
@@ -130,7 +134,7 @@ static inline bool QuantizeV2Type(const nnvm::NodeAttrs &attrs, std::vector<int>
   CHECK(in_attrs->at(0) == mshadow::kFloat32 || in_attrs->at(0) == mshadow::kUint8 ||
         in_attrs->at(0) == mshadow::kInt8);
   auto out_type = GetQuantizeOutputType(param);
-  if (out_type == mshadow::kUint8) {
+  if (out_type == mshadow::kUint8 || (param.shifted.has_value() && param.shifted.value())) {
     TYPE_ASSIGN_CHECK(*out_attrs, 0, mshadow::kUint8);
   } else if (out_type == mshadow::kInt8) {
     TYPE_ASSIGN_CHECK(*out_attrs, 0, mshadow::kInt8);

--- a/src/operator/quantization/requantize-inl.h
+++ b/src/operator/quantization/requantize-inl.h
@@ -43,10 +43,10 @@ struct RequantizeParam : public dmlc::Parameter<RequantizeParam> {
   dmlc::optional<float> max_calib_range;  // max float value calculated from calibration dataset
   DMLC_DECLARE_PARAMETER(RequantizeParam) {
     DMLC_DECLARE_FIELD(out_type)
-      .add_enum("auto", QuantizeOutType::kAuto)
-      .add_enum("int8", QuantizeOutType::kInt8)
-      .add_enum("uint8", QuantizeOutType::kUint8)
-      .set_default(QuantizeOutType::kInt8)
+      .add_enum("auto", QuantizeOutType::qAuto)
+      .add_enum("int8", QuantizeOutType::qInt8)
+      .add_enum("uint8", QuantizeOutType::qUint8)
+      .set_default(QuantizeOutType::qInt8)
       .describe("Output data type. `auto` can be specified to automatically determine output type "
                 "according to min_calib_range.");
     DMLC_DECLARE_FIELD(min_calib_range)

--- a/src/operator/subgraph/mkldnn/mkldnn_fc.cc
+++ b/src/operator/subgraph/mkldnn/mkldnn_fc.cc
@@ -536,10 +536,15 @@ static bool SgMKLDNNFCInferType(const nnvm::NodeAttrs &attrs,
     } else {
         TYPE_ASSIGN_CHECK(*in_types, 1, mshadow::kInt8);
         if (!full_param.default_param.no_bias) {
-            CHECK(in_types->at(2) ==  mshadow::kInt8 ||
+          if (in_types->at(2) == -1) {
+            TYPE_ASSIGN_CHECK(*in_types, 2, mshadow::kInt32);
+          } else {
+            CHECK(in_types->at(2) == mshadow::kInt8 ||
                   in_types->at(2) == mshadow::kInt32)
-                << "QuantizedFullyConnected only supports int8/int32 bias, while "
+                << "QuantizedFullyConnected only supports int8/int32 bias, "
+                   "while "
                 << in_types->at(2) << " is given.";
+          }
         }
         for (size_t i = base_num_inputs; i < in_types->size(); ++i) {
           TYPE_ASSIGN_CHECK(*in_types, i, mshadow::kFloat32);

--- a/src/operator/subgraph/mkldnn/mkldnn_fc.cc
+++ b/src/operator/subgraph/mkldnn/mkldnn_fc.cc
@@ -26,18 +26,21 @@
 
 #if MXNET_USE_MKLDNN == 1
 
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
-#include <string>
-#include "../common.h"
-#include "../../nn/mkldnn/mkldnn_base-inl.h"
-#include "../../nn/mkldnn/mkldnn_ops-inl.h"
-#include "../../nn/mkldnn/mkldnn_fully_connected-inl.h"
 #include "../../nn/mkldnn/mkldnn_act-inl.h"
-#include "../../tensor/matrix_op-inl.h"
+#include "../../nn/mkldnn/mkldnn_base-inl.h"
+#include "../../nn/mkldnn/mkldnn_fully_connected-inl.h"
+#include "../../nn/mkldnn/mkldnn_ops-inl.h"
 #include "../../quantization/quantization_utils.h"
-#include "mkldnn_fc-inl.h"
+#include "../../tensor/matrix_op-inl.h"
+#include "../common.h"
 #include "mkldnn_common.h"
+#include "mkldnn_fc-inl.h"
 
 namespace mxnet {
 namespace op {
@@ -211,7 +214,7 @@ void SgMKLDNNFCOp::Forward(const OpContext &ctx,
     bool support_channelwise_scale = false;
     if (mkldnn_param.quantized) {
       CHECK(data.dtype() == mshadow::kInt8 || data.dtype() == mshadow::kUint8);
-      data_scale_ = GetQuantizeScale(data.dtype(), cached_min_data_, cached_max_data_);
+        data_scale_ = GetQuantizeScale(data.dtype(), cached_min_data_, cached_max_data_);
 
       bool fuse_requantize = false;
       // Channelwise scaling is only supported when fusion is enabled (requantize or dequantize).
@@ -250,34 +253,38 @@ void SgMKLDNNFCOp::Forward(const OpContext &ctx,
         weight_scales_[0] =
           GetQuantizeScale(cached_weight_.dtype(), cached_min_weight_, cached_max_weight_);
         if (has_bias) {
-          float bias_scale = GetQuantizeScale(mshadow::kInt8, cached_min_bias_, cached_max_bias_);
-          float bias_int32_rescale = data_scale_ * weight_scales_[0] / bias_scale;
-          // TODO(zhennan): mkldnn has bug to handle INT_MAX in bias, so set the maximum value
-          // of bias to INT_MAX / 2.
-          float bias_max_rescale =
-              MaxValue<int32_t>() / 2 / MaxAbs(cached_min_bias_, cached_max_bias_) / bias_scale;
-          if (bias_int32_rescale > bias_max_rescale) {
-            // avoid overflow on bias
-            bias_int32_rescale = bias_max_rescale;
-            float weight_rescale =
-              bias_int32_rescale * bias_scale / data_scale_ / weight_scales_[0];
-            int8_t *weight_ptr = weight.data().dptr<int8_t>();
-            size_t weight_size = weight.shape().Size();
-            #pragma omp parallel for num_threads(nthreads)
-            for (index_t i = 0; i < static_cast<index_t>(weight_size); ++i) {
-              weight_ptr[i] = std::round(weight_ptr[i] * weight_rescale);
+          if (cached_bias_.dtype() == mshadow::kInt8) {
+            float bias_scale = GetQuantizeScale(mshadow::kInt8, cached_min_bias_, cached_max_bias_);
+
+            float bias_int32_rescale = data_scale_ * weight_scales_[0] / bias_scale;
+            // TODO(zhennan): mkldnn has bug to handle INT_MAX in bias, so set the maximum value
+            // of bias to INT_MAX / 2.
+            float bias_max_rescale =
+                MaxValue<int32_t>() / 2 / MaxAbs(cached_min_bias_, cached_max_bias_) / bias_scale;
+            if (bias_int32_rescale > bias_max_rescale) {
+              // avoid overflow on bias
+              bias_int32_rescale = bias_max_rescale;
+              float weight_rescale =
+                bias_int32_rescale * bias_scale / data_scale_ / weight_scales_[0];
+              int8_t *weight_ptr = weight.data().dptr<int8_t>();
+              size_t weight_size = weight.shape().Size();
+              #pragma omp parallel for num_threads(nthreads)
+              for (index_t i = 0; i < static_cast<index_t>(weight_size); ++i) {
+                weight_ptr[i] = std::round(weight_ptr[i] * weight_rescale);
+              }
+              weight_scales_[0] *= weight_rescale;
             }
-            weight_scales_[0] *= weight_rescale;
-          }
-          NDArray bias = in_data[fullc::kBias];
-          cached_bias_ =
-              NDArray(bias.storage_type(), bias.shape(), bias.ctx(), true, mshadow::kInt32);
-          int8_t *bias_ptr = bias.data().dptr<int8_t>();
-          int32_t *quantized_bias_ptr = cached_bias_.data().dptr<int32_t>();
-          size_t bias_size = bias.shape().Size();
-          #pragma omp parallel for num_threads(nthreads)
-          for (index_t i = 0; i < static_cast<index_t>(bias_size); ++i) {
-            quantized_bias_ptr[i] = std::round(bias_ptr[i] * bias_int32_rescale);
+            NDArray bias = in_data[fullc::kBias];
+            cached_bias_ =
+                NDArray(bias.storage_type(), bias.shape(), bias.ctx(), true, mshadow::kInt32);
+            int8_t *bias_ptr = bias.data().dptr<int8_t>();
+            int32_t *quantized_bias_ptr = cached_bias_.data().dptr<int32_t>();
+            size_t bias_size = bias.shape().Size();
+
+            #pragma omp parallel for num_threads(nthreads)
+            for (index_t i = 0; i < static_cast<index_t>(bias_size); ++i) {
+              quantized_bias_ptr[i] = std::round(bias_ptr[i] * bias_int32_rescale);
+            }
           }
         }
       }
@@ -522,16 +529,21 @@ static bool SgMKLDNNFCInferType(const nnvm::NodeAttrs &attrs,
           in_types->at(0) == mshadow::kUint8)
         << "QuantizedFullyConnected only supports int8/uint8 input, while "
         << in_types->at(0) << " is given.";
-    for (size_t i = 1; i < in_types->size(); ++i) {
-      if (channel_wise) {
+    if (channel_wise) {
+      for (size_t i = 1; i < in_types->size(); ++i) {
         TYPE_ASSIGN_CHECK(*in_types, i, mshadow::kFloat32);
-      } else {
-        if (i < base_num_inputs) {
-          TYPE_ASSIGN_CHECK(*in_types, i, mshadow::kInt8);
-        } else {
+      }
+    } else {
+        TYPE_ASSIGN_CHECK(*in_types, 1, mshadow::kInt8);
+        if (!full_param.default_param.no_bias) {
+            CHECK(in_types->at(2) ==  mshadow::kInt8 ||
+                  in_types->at(2) == mshadow::kInt32)
+                << "QuantizedFullyConnected only supports int8/int32 bias, while "
+                << in_types->at(2) << " is given.";
+        }
+        for (size_t i = base_num_inputs; i < in_types->size(); ++i) {
           TYPE_ASSIGN_CHECK(*in_types, i, mshadow::kFloat32);
         }
-      }
     }
 
     if (full_param.mkldnn_param.enable_float_output) {

--- a/src/operator/subgraph/mkldnn/mkldnn_fc.cc
+++ b/src/operator/subgraph/mkldnn/mkldnn_fc.cc
@@ -214,7 +214,7 @@ void SgMKLDNNFCOp::Forward(const OpContext &ctx,
     bool support_channelwise_scale = false;
     if (mkldnn_param.quantized) {
       CHECK(data.dtype() == mshadow::kInt8 || data.dtype() == mshadow::kUint8);
-        data_scale_ = GetQuantizeScale(data.dtype(), cached_min_data_, cached_max_data_);
+      data_scale_ = GetQuantizeScale(data.dtype(), cached_min_data_, cached_max_data_);
 
       bool fuse_requantize = false;
       // Channelwise scaling is only supported when fusion is enabled (requantize or dequantize).

--- a/tests/python/mkl/test_quantization_mkldnn.py
+++ b/tests/python/mkl/test_quantization_mkldnn.py
@@ -20,7 +20,6 @@ import mxnet as mx
 
 os.environ['ENABLE_MKLDNN_QUANTIZATION_TEST'] = '1'
 os.environ['MXNET_SUBGRAPH_BACKEND'] = 'NONE'
-os.environ['MXNET_DISABLE_SHIFTED_QUANTIZATION'] = '0'
 curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
 sys.path.insert(0, os.path.join(curr_path, '../quantization'))
 from test_quantization import *
@@ -30,4 +29,3 @@ if __name__ == '__main__':
     nose.runmodule()
     del os.environ['ENABLE_MKLDNN_QUANTIZATION_TEST']
     del os.environ['MXNET_SUBGRAPH_BACKEND']
-    del os.environ['MXNET_DISABLE_SHIFTED_QUANTIZATION']

--- a/tests/python/mkl/test_quantization_mkldnn.py
+++ b/tests/python/mkl/test_quantization_mkldnn.py
@@ -20,6 +20,7 @@ import mxnet as mx
 
 os.environ['ENABLE_MKLDNN_QUANTIZATION_TEST'] = '1'
 os.environ['MXNET_SUBGRAPH_BACKEND'] = 'NONE'
+os.environ['MXNET_DISABLE_SHIFTED_QUANTIZATION'] = '0'
 curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
 sys.path.insert(0, os.path.join(curr_path, '../quantization'))
 from test_quantization import *
@@ -29,3 +30,4 @@ if __name__ == '__main__':
     nose.runmodule()
     del os.environ['ENABLE_MKLDNN_QUANTIZATION_TEST']
     del os.environ['MXNET_SUBGRAPH_BACKEND']
+    del os.environ['MXNET_DISABLE_SHIFTED_QUANTIZATION']

--- a/tests/python/quantization/test_quantization.py
+++ b/tests/python/quantization/test_quantization.py
@@ -1256,6 +1256,10 @@ def test_get_optimal_thresholds():
 
 @with_seed()
 def test_onednn_shifted_quantization():
+    if not is_test_for_mkldnn():
+        print("Test only for mkldnn")
+        return
+
     def collect_param(fc_layer, p):
         param = fc_layer.collect_params(p)[p]._reduce()
         return param
@@ -1309,13 +1313,6 @@ def test_onednn_shifted_quantization():
     # Shifted quantization should set new bias to FC and add shift to output of quantize
     # b'=b-shift*w because FC(x+shift,w,b)=(x+shift)*w+b
     def check(number, qdtype):
-        if is_test_for_native_cpu():
-            print('skipped testing test_quantize_model_with_forward for native cpu since it is not supported yet')
-            return
-        elif is_test_for_gpu():
-            print('skipped testing test_quantize_model_with_forward for gpu uint8 since it is not supported yet')
-            return
-
         random_data = mx.nd.random_normal(shape=(1, 32))
         fc_layer = get_fc_layer(random_data)
 

--- a/tests/python/quantization/test_quantization.py
+++ b/tests/python/quantization/test_quantization.py
@@ -22,7 +22,8 @@ import os
 import mxnet as mx
 import numpy as np
 from mxnet.gluon.model_zoo import vision
-from mxnet.test_utils import assert_almost_equal, assert_exception, rand_ndarray, rand_shape_nd, same, DummyIter, environment
+from mxnet.test_utils import assert_almost_equal, assert_exception, rand_ndarray, rand_shape_nd, same, DummyIter
+from mxnet.test_utils import environment
 from common import with_seed
 from mxnet.module import Module
 from mxnet.io import NDArrayIter
@@ -1326,14 +1327,14 @@ def test_onednn_shifted_quantization():
         out_q = fc_layer_quantized(random_data)
         out_q.wait_to_read()
 
-        assert_almost_equal(out, out_q)
+        assert_almost_equal(out, out_q, rtol=1e-3, atol=1e-3)
 
         if qdtype == 'auto':
             assert quantize_attrs['shifted'] == 'True'
             bias_s32 = collect_param(fc_layer_quantized, 'dense%d_bias_quantize_s32' % number)
             assert bias_s32.dtype == np.int32
             bias_shifted = get_shifted_bias(quantize_attrs, weights_int8, weights_scale, bias_int8, bias_scale)
-            assert_almost_equal(bias_s32, bias_shifted)
+            assert_almost_equal(bias_s32, bias_shifted, rtol=1e-3, atol=1e-3)
         else:
             assert 'shifted' not in quantize_attrs
             bias = collect_param(fc_layer_quantized, 'dense%d_bias_quantize' % number)

--- a/tests/python/quantization/test_quantization.py
+++ b/tests/python/quantization/test_quantization.py
@@ -22,8 +22,8 @@ import os
 import mxnet as mx
 import numpy as np
 from mxnet.gluon.model_zoo import vision
-from mxnet.test_utils import assert_almost_equal, assert_exception, rand_ndarray, rand_shape_nd, same, DummyIter
-from mxnet.test_utils import environment
+from mxnet.test_utils import assert_almost_equal, assert_almost_equal_with_err, assert_exception
+from mxnet.test_utils import rand_ndarray, rand_shape_nd, same, DummyIter, environment
 from common import with_seed
 from mxnet.module import Module
 from mxnet.io import NDArrayIter
@@ -1327,7 +1327,10 @@ def test_onednn_shifted_quantization():
         out_q = fc_layer_quantized(random_data)
         out_q.wait_to_read()
 
-        assert_almost_equal(out, out_q, rtol=1e-3, atol=1e-3)
+        min_range = mx.nd.min(out).asscalar()
+        max_range = mx.nd.max(out).asscalar()
+        atol = 0.1 * max(abs(min_range), abs(max_range))
+        assert_almost_equal_with_err(out.asnumpy(), out_q.asnumpy(), rtol=0.1, atol=atol, etol=0.2)
 
         if qdtype == 'auto':
             assert quantize_attrs['shifted'] == 'True'

--- a/tests/python/quantization/test_quantization.py
+++ b/tests/python/quantization/test_quantization.py
@@ -1343,7 +1343,7 @@ def test_onednn_shifted_quantization():
             bias = collect_param(fc_layer_quantized, 'dense%d_bias_quantize' % number)
             assert bias.dtype == np.int8
 
-    with environment({'MXNET_DISABLE_SHIFTED_QUANTIZATION': '0'}):
+    with environment({'MXNET_DISABLE_SHIFTED_QUANTIZATION_OPTIMIZATIONS': '0'}):
         for i, qdtype in enumerate(['int8', 'uint8', 'auto']):
             check(i, qdtype)
 


### PR DESCRIPTION
## Description ##
This PR introduces a pass that transforms OneDNN operators pair quantize->FC so that oneDNN performs faster u8s8s32 inner_product implementation instead of slower s8s8s32. Currently the speedup is unfortunately not visible possibly because of overhead of extra computation. It might be improved in the future if OneDNN optimizes zero_point in reorder.

This is basically doing asymmetric quantization.
This pass tells the quantize operator to shift the input values to positive and modifies scale so that it uses full uint8 range. To compensate that it is re-calculating the bias (b'=b-shift*w). The bias after the pass is stored in int32 so it is no longer calculated in initial FC forward pass which was beneficial in case of dynamic batching which re-initialized operators. In the image below the shift value of 128 is now changed to min_calib_range.
![image](https://user-images.githubusercontent.com/17185347/118282201-5529d680-b4ce-11eb-96ca-f282b5782698.png)

This feature is by default disabled for now and it can be enabled by environment flag `MXNET_DISABLE_SHIFTED_QUANTIZATION=0`.

This pass is a gateway to the following next optimizations:
FC->FC
Conv->FC
FC->SelfAttn

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

## Comments ##
I also fixed linter errors `include_what_you_use`.