### PR TITLE
[v1.x] use gcc-8.5 instead of gcc-10 for aarch64 build

### DIFF
--- a/ci/docker/install/ubuntu_aarch64_publish.sh
+++ b/ci/docker/install/ubuntu_aarch64_publish.sh
@@ -39,9 +39,9 @@ apt-get install -y git \
     gnupg \
     gnupg2 \
     gnupg-agent \
-    gcc \
-    g++ \
-    gfortran \
+    gcc-8 \
+    g++-8 \
+    gfortran-8 \
     libc6-lse \
     pandoc \
     python3 \
@@ -65,6 +65,7 @@ mkdir build && cd build
 make -j$(nproc)
 sudo make install-strip
 cd ..
+rm -rf gcc-8.5.0.tar.xz
 export export PATH=/usr/local/gcc-8.5.0/bin:$PATH
 export LD_LIBRARY_PATH=/usr/local/gcc-8.5.0/lib64:$LD_LIBRARY_PATH
 update-alternatives --install /usr/bin/gcc gcc /usr/local/gcc-8.5.0/bin/gcc-8.5 100 --slave /usr/bin/g++ g++ /usr/local/gcc-8.5.0/bin/g++-8.5 --slave /usr/bin/gcov gcov /usr/local/gcc-8.5.0/bin/gcov-8.5 --slave /usr/bin/gfortran gfortran /usr/local/gcc-8.5.0/bin/gfortran-8.5

--- a/ci/docker/install/ubuntu_aarch64_publish.sh
+++ b/ci/docker/install/ubuntu_aarch64_publish.sh
@@ -39,9 +39,6 @@ apt-get install -y git \
     gnupg \
     gnupg2 \
     gnupg-agent \
-    gcc-8 \
-    g++-8 \
-    gfortran-8 \
     libc6-lse \
     pandoc \
     python3 \

--- a/ci/docker/install/ubuntu_aarch64_publish.sh
+++ b/ci/docker/install/ubuntu_aarch64_publish.sh
@@ -50,7 +50,7 @@ apt-get install -y git \
 
 # build gcc-8.5 from source
 apt update
-apt install m4 flex bison
+apt install -y flex bison
 wget https://ftpmirror.gnu.org/gcc/gcc-8.5.0/gcc-8.5.0.tar.xz
 tar xf gcc-8.5.0.tar.xz
 cd gcc-8.5.0/

--- a/ci/docker/install/ubuntu_aarch64_publish.sh
+++ b/ci/docker/install/ubuntu_aarch64_publish.sh
@@ -39,6 +39,9 @@ apt-get install -y git \
     gnupg \
     gnupg2 \
     gnupg-agent \
+    gcc \
+    g++ \
+    gfortran \
     libc6-lse \
     pandoc \
     python3 \

--- a/config/distribution/linux_aarch64_cpu.cmake
+++ b/config/distribution/linux_aarch64_cpu.cmake
@@ -16,7 +16,7 @@
 # under the License.
 
 set(CMAKE_BUILD_TYPE "Distribution" CACHE STRING "Build type")
-set(CFLAGS "-march=armv8-a" CACHE STRING "CFLAGS")
+set(CFLAGS "-march=armv8-a+crc+crypto -moutline-atomics" CACHE STRING "CFLAGS")
 set(CXXFLAGS "-march=armv8-a" CACHE STRING "CXXFLAGS")
 
 set(USE_CUDA OFF CACHE BOOL "Build with CUDA support")

--- a/tools/dependencies/openblas.sh
+++ b/tools/dependencies/openblas.sh
@@ -19,7 +19,7 @@
 
 # This script builds the static library of openblas that can be used as dependency of mxnet.
 set -ex
-OPENBLAS_VERSION=0.3.7
+OPENBLAS_VERSION=0.3.10
 if [[ ((! -e $DEPS_PATH/lib/libopenblas.a) && -z "$CMAKE_STATICBUILD") ||
           ((! -e $DEPS_PATH/lib/libopenblas.so) && -v CMAKE_STATICBUILD) ]]; then
     # download and build openblas
@@ -36,8 +36,7 @@ if [[ ((! -e $DEPS_PATH/lib/libopenblas.a) && -z "$CMAKE_STATICBUILD") ||
     if [[ ! $ARCH == 'aarch64' ]]; then
         CXX="g++ -fPIC" CC="gcc -fPIC" $MAKE DYNAMIC_ARCH=1 USE_OPENMP=1
     else
-        # openblas build fails with gcc-8.5, hence using gcc-8.4 explicitly
-        CXX="g++-8 -fPIC" CC="gcc-8 -fPIC" FC="gfortran-8" $MAKE DYNAMIC_ARCH=1 USE_OPENMP=1
+        $MAKE DYNAMIC_ARCH=1 USE_OPENMP=1
     fi
 
     if [[ -v CMAKE_STATICBUILD ]]; then

--- a/tools/dependencies/openblas.sh
+++ b/tools/dependencies/openblas.sh
@@ -33,7 +33,13 @@ if [[ ((! -e $DEPS_PATH/lib/libopenblas.a) && -z "$CMAKE_STATICBUILD") ||
     cd $DEPS_PATH/OpenBLAS-$OPENBLAS_VERSION
 
     # Adding NO_DYNAMIC=1 flag causes make install to fail
-    CXX="g++ -fPIC" CC="gcc -fPIC" $MAKE DYNAMIC_ARCH=1 USE_OPENMP=1
+    echo $CXX
+    echo $CC
+    echo $FC
+    echo $(gcc --version)
+    echo $(g++ --version)
+    echo $(gfortran --version)
+    $MAKE DYNAMIC_ARCH=1 USE_OPENMP=1
 
     if [[ -v CMAKE_STATICBUILD ]]; then
         # We link and redistribute libopenblas.so for cmake staticbuild

--- a/tools/dependencies/openblas.sh
+++ b/tools/dependencies/openblas.sh
@@ -33,7 +33,12 @@ if [[ ((! -e $DEPS_PATH/lib/libopenblas.a) && -z "$CMAKE_STATICBUILD") ||
     cd $DEPS_PATH/OpenBLAS-$OPENBLAS_VERSION
 
     # Adding NO_DYNAMIC=1 flag causes make install to fail
-    CXX="g++-7 -fPIC" CC="gcc-7 -fPIC" FC="gfortran-7" $MAKE DYNAMIC_ARCH=1 USE_OPENMP=1
+    if [[ ! $ARCH == 'aarch64' ]]; then
+        CXX="g++ -fPIC" CC="gcc -fPIC" $MAKE DYNAMIC_ARCH=1 USE_OPENMP=1
+    else
+        # openblas build fails with gcc-8.5, hence using gcc-8.4 explicitly
+        CXX="g++-8 -fPIC" CC="gcc-8 -fPIC" FC="gfortran-8" $MAKE DYNAMIC_ARCH=1 USE_OPENMP=1
+    fi
 
     if [[ -v CMAKE_STATICBUILD ]]; then
         # We link and redistribute libopenblas.so for cmake staticbuild

--- a/tools/dependencies/openblas.sh
+++ b/tools/dependencies/openblas.sh
@@ -33,13 +33,7 @@ if [[ ((! -e $DEPS_PATH/lib/libopenblas.a) && -z "$CMAKE_STATICBUILD") ||
     cd $DEPS_PATH/OpenBLAS-$OPENBLAS_VERSION
 
     # Adding NO_DYNAMIC=1 flag causes make install to fail
-    echo $CXX
-    echo $CC
-    echo $FC
-    echo $(gcc --version)
-    echo $(g++ --version)
-    echo $(gfortran --version)
-    $MAKE DYNAMIC_ARCH=1 USE_OPENMP=1
+    CXX="g++-7 -fPIC" CC="gcc-7 -fPIC" FC="gfortran-7" $MAKE DYNAMIC_ARCH=1 USE_OPENMP=1
 
     if [[ -v CMAKE_STATICBUILD ]]; then
         # We link and redistribute libopenblas.so for cmake staticbuild


### PR DESCRIPTION
## Description ##
In order to get the advantage of LSE support while supporting all AArch64 platforms, we used gcc-10 on u18 base docker image as it supports the build flag `-moutline-atomics`. But using gcc-10 also creates a dependency of generated MXNet wheel on GLIBCXX_3.4.26, and so we need to upgrade libstdc++6 package on u18 to get the wheel working. On u20, the wheel works fine.

2 weeks ago gcc-8.5 was launched that added support for the build flag `-moutline-atomics`. Since there is no ubuntu/canonical package for gcc-8.5, I tried building it from source and it works, with the advantage over gcc-10 that we dont need to upgrade libstdc++6 on u18.

### Changes ###
- [x] Add LSE support to glibc with the package `libc6-lse`.
- [x] Use build flag `-march=armv8-a+crc+crypto` instead of `-march=armv8` earlier to get the benefit of crc and crypto extension.
- [x] Install gcc-8 (gcc-8.4) as openblas build fails with gcc-8.5 and so using gcc-8.4 to build it.
