### PR TITLE
Fix ChooseBlas.cmake for CMake build dir name

### DIFF
--- a/cmake/ChooseBlas.cmake
+++ b/cmake/ChooseBlas.cmake
@@ -80,7 +80,7 @@ set(FORTRAN_DIR \\\"\$\{CMAKE_Fortran_IMPLICIT_LINK_DIRECTORIES\}\\\")
         COMMAND ${CMAKE_COMMAND} .
       )
       set(FORTRAN_DIR "")
-      include(build/temp/FortranDir.cmake)
+      include(${CMAKE_CURRENT_BINARY_DIR}/temp/FortranDir.cmake)
       find_library(FORTRAN_LIB NAMES gfortran HINTS ${FORTRAN_DIR})
       message("FORTRAN_DIR is ${FORTRAN_DIR}")
       message("FORTRAN_LIB is ${FORTRAN_LIB}")


### PR DESCRIPTION
## Description ##
Fix ChooseBlas.cmake by correctly including FortranDir.cmake when the CMake build dir has a different name than `build`.