### PR TITLE
[1.x] [FEATURE] Add API to control denormalized computations

### DIFF
--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -264,9 +264,10 @@ MXNET_DLL int MXRandomSeedContext(int seed, int dev_type, int dev_id);
 /*!
  * \brief Change floating-point calculations when dealing with denormalized values.
  * \param value state of flush-to-zero and denormals-are-zero to set.
+ * \param prev_state state of flush-to-zero and denormals-are-zero before setting new state.
  * \return 0 when success, -1 when failure happens.
  */
-MXNET_DLL int MXSetFlushDenorms(bool value);
+MXNET_DLL int MXSetFlushDenorms(bool value, bool* prev_state);
 
 /*!
  * \brief Notify the engine about a shutdown,

--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -263,6 +263,9 @@ MXNET_DLL int MXRandomSeedContext(int seed, int dev_type, int dev_id);
 
 /*!
  * \brief Change floating-point calculations when dealing with denormalized values.
+ * Currently this option is only supported in CPU backend.
+ * Flushing denormalized values to zero is enabled by default.
+ *
  * \param value state of flush-to-zero and denormals-are-zero to set.
  * \param prev_state state of flush-to-zero and denormals-are-zero before setting new state.
  * \return 0 when success, -1 when failure happens.

--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -262,6 +262,13 @@ MXNET_DLL int MXRandomSeed(int seed);
 MXNET_DLL int MXRandomSeedContext(int seed, int dev_type, int dev_id);
 
 /*!
+ * \brief Change floating-point calculations when dealing with denormalized values.
+ * \param value state of flush-to-zero and denormals-are-zero to set.
+ * \return 0 when success, -1 when failure happens.
+ */
+MXNET_DLL int MXFTZDenorms(bool value);
+
+/*!
  * \brief Notify the engine about a shutdown,
  *  This can help engine to print less messages into display.
  *

--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -266,7 +266,7 @@ MXNET_DLL int MXRandomSeedContext(int seed, int dev_type, int dev_id);
  * \param value state of flush-to-zero and denormals-are-zero to set.
  * \return 0 when success, -1 when failure happens.
  */
-MXNET_DLL int MXFTZDenorms(bool value);
+MXNET_DLL int MXSetFlushDenorms(bool value);
 
 /*!
  * \brief Notify the engine about a shutdown,

--- a/python/mxnet/base.py
+++ b/python/mxnet/base.py
@@ -350,7 +350,7 @@ __version__ = libinfo.__version__
 # library instance of mxnet
 _LIB = _load_lib()
 
-check_call(_LIB.MXSetFlushDenorms(ctypes.c_bool(True)))
+check_call(_LIB.MXSetFlushDenorms(ctypes.c_bool(True), ctypes.byref(ctypes.c_bool())))
 
 # type definitions
 mx_int = ctypes.c_int

--- a/python/mxnet/base.py
+++ b/python/mxnet/base.py
@@ -350,6 +350,8 @@ __version__ = libinfo.__version__
 # library instance of mxnet
 _LIB = _load_lib()
 
+check_call(_LIB.MXFTZDenorms(ctypes.c_bool(True)))
+
 # type definitions
 mx_int = ctypes.c_int
 mx_uint = ctypes.c_uint

--- a/python/mxnet/base.py
+++ b/python/mxnet/base.py
@@ -350,7 +350,7 @@ __version__ = libinfo.__version__
 # library instance of mxnet
 _LIB = _load_lib()
 
-check_call(_LIB.MXFTZDenorms(ctypes.c_bool(True)))
+check_call(_LIB.MXSetFlushDenorms(ctypes.c_bool(True)))
 
 # type definitions
 mx_int = ctypes.c_int

--- a/python/mxnet/base.py
+++ b/python/mxnet/base.py
@@ -350,8 +350,8 @@ __version__ = libinfo.__version__
 # library instance of mxnet
 _LIB = _load_lib()
 
-check_call(_LIB.MXSetFlushDenorms(ctypes.c_bool(True), ctypes.byref(ctypes.c_bool())))
-
+check_call(_LIB.MXSetFlushDenorms(ctypes.c_bool(True),
+                                  ctypes.byref(ctypes.c_bool())))
 # type definitions
 mx_int = ctypes.c_int
 mx_uint = ctypes.c_uint

--- a/python/mxnet/util.py
+++ b/python/mxnet/util.py
@@ -850,12 +850,13 @@ def setenv(name, value):
     check_call(_LIB.MXSetEnv(c_str(name), passed_value))
 
 def set_flush_denorms(value):
-    """Change floating-point calculations when dealing with denormalized values.
+    """Change floating-point calculations on CPU when dealing with denormalized values.
        This is only applicable to architectures which supports flush-to-zero.
        Denormalized values are positive and negative values that are very close to 0
        (exponent is the smallest possible value).
        Flushing denormalized values to 0 can speedup calculations if such values occurs,
        but if fulfilling whole IEEE 754 standard is required this option should be disabled.
+
     Parameters
     ----------
     value : bool

--- a/python/mxnet/util.py
+++ b/python/mxnet/util.py
@@ -861,5 +861,7 @@ def set_flush_denorms(value):
     value : bool
         State of flush-to-zero and denormals-are-zero in MXCSR register
     """
+    ret = ctypes.c_bool()
     passed_value = ctypes.c_bool(value)
-    check_call(_LIB.MXSetFlushDenorms(passed_value))
+    check_call(_LIB.MXSetFlushDenorms(passed_value, ctypes.byref(ret)))
+    return ret.value

--- a/python/mxnet/util.py
+++ b/python/mxnet/util.py
@@ -856,11 +856,17 @@ def set_flush_denorms(value):
        (exponent is the smallest possible value).
        Flushing denormalized values to 0 can speedup calculations if such values occurs,
        but if fulfilling whole IEEE 754 standard is required this option should be disabled.
+       Flushing denormalized values is enabled in MXNet by default.
 
     Parameters
     ----------
     value : bool
         State of flush-to-zero and denormals-are-zero in MXCSR register
+
+    Returns
+    -------
+    prev_state : bool
+        Previous state of flush-to-zero in MXCSR register
     """
     ret = ctypes.c_bool()
     passed_value = ctypes.c_bool(value)

--- a/python/mxnet/util.py
+++ b/python/mxnet/util.py
@@ -849,13 +849,17 @@ def setenv(name, value):
     passed_value = None if value is None else c_str(value)
     check_call(_LIB.MXSetEnv(c_str(name), passed_value))
 
-def ftz_denorms(value):
+def set_flush_denorms(value):
     """Change floating-point calculations when dealing with denormalized values.
-
+       This is only applicable to architectures which supports flush-to-zero.
+       Denormalized values are positive and negative values that are very close to 0
+       (exponent is the smallest possible value).
+       Flushing denormalized values to 0 can speedup calculations if such values occurs,
+       but if IEEE 754 standard is required this option should be disabled.
     Parameters
     ----------
     value : bool
         State of flush-to-zero and denormals-are-zero in MXCSR register 
     """
     passed_value = ctypes.c_bool(value)
-    check_call(_LIB.MXFTZDenorms(passed_value))
+    check_call(_LIB.MXSetFlushDenorms(passed_value))

--- a/python/mxnet/util.py
+++ b/python/mxnet/util.py
@@ -859,7 +859,7 @@ def set_flush_denorms(value):
     Parameters
     ----------
     value : bool
-        State of flush-to-zero and denormals-are-zero in MXCSR register 
+        State of flush-to-zero and denormals-are-zero in MXCSR register
     """
     passed_value = ctypes.c_bool(value)
     check_call(_LIB.MXSetFlushDenorms(passed_value))

--- a/python/mxnet/util.py
+++ b/python/mxnet/util.py
@@ -855,7 +855,7 @@ def set_flush_denorms(value):
        Denormalized values are positive and negative values that are very close to 0
        (exponent is the smallest possible value).
        Flushing denormalized values to 0 can speedup calculations if such values occurs,
-       but if IEEE 754 standard is required this option should be disabled.
+       but if fulfilling whole IEEE 754 standard is required this option should be disabled.
     Parameters
     ----------
     value : bool

--- a/python/mxnet/util.py
+++ b/python/mxnet/util.py
@@ -848,3 +848,14 @@ def setenv(name, value):
     """
     passed_value = None if value is None else c_str(value)
     check_call(_LIB.MXSetEnv(c_str(name), passed_value))
+
+def ftz_denorms(value):
+    """Change floating-point calculations when dealing with denormalized values.
+
+    Parameters
+    ----------
+    value : bool
+        State of flush-to-zero and denormals-are-zero in MXCSR register 
+    """
+    passed_value = ctypes.c_bool(value)
+    check_call(_LIB.MXFTZDenorms(passed_value))

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -59,6 +59,11 @@
 #include "../common/utils.h"
 #include "nnvm/pass_functions.h"
 
+#if defined(__x86_64__) || defined(_M_X64)
+#include <immintrin.h>
+#include <xmmintrin.h>
+#endif
+
 using namespace mxnet;
 
 // Internal function to get the information

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -60,10 +60,12 @@
 #include "nnvm/pass_functions.h"
 
 // FTZ only applies to SSE and AVX instructions.
-#define SUPPORT_FTZ_DMZ defined(__SSE__)    || \
-                        defined(__x86_64__) || \
-                        defined(_M_X64)     || \
-                        (defined(_M_IX86_FP) && _M_IX86_FP >= 1)
+#if defined(__SSE__) || defined(__x86_64__) || defined(_M_X64) || \
+    (defined(_M_IX86_FP) && _M_IX86_FP >= 1)
+#define SUPPORT_FTZ_DMZ 1
+#else
+#define SUPPORT_FTZ_DMZ 0
+#endif
 
 #if SUPPORT_FTZ_DMZ
 #include <immintrin.h>

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -1580,8 +1580,9 @@ int MXRandomSeedContext(int seed, int dev_type, int dev_id) {
 
 int MXSetFlushDenorms(bool value, bool* prev_state) {
   API_BEGIN();
-  // FTZ only applies to SSE and AVX instructions.
   *prev_state = false;
+
+  // FTZ only applies to SSE and AVX instructions.
   #if defined(__SSE__) || defined(_M_X64) || (defined(_M_IX86_FP) && _M_IX86_FP >= 1)
     std::function<bool()> is_dmz_flag_available = []() {
       // Intel 64 and IA-32 Architectures Software Developer’s Manual: Vol. 1
@@ -1602,16 +1603,23 @@ int MXSetFlushDenorms(bool value, bool* prev_state) {
       return dmz_flag;
     };
 
-    const unsigned int DMZ_STATE = value ? _MM_DENORMALS_ZERO_ON : _MM_DENORMALS_ZERO_OFF;
-    const unsigned int FTZ_STATE = value ? _MM_FLUSH_ZERO_ON : _MM_FLUSH_ZERO_OFF;
+    Engine::Get()->PushSync(
+      [value, prev_state, is_dmz_flag_available](RunContext rctx) {
+        const unsigned int DMZ_STATE = value ? _MM_DENORMALS_ZERO_ON : _MM_DENORMALS_ZERO_OFF;
+        const unsigned int FTZ_STATE = value ? _MM_FLUSH_ZERO_ON : _MM_FLUSH_ZERO_OFF;
+        *prev_state = _MM_GET_FLUSH_ZERO_MODE();
+        _MM_SET_FLUSH_ZERO_MODE(FTZ_STATE);
 
-    *prev_state = _MM_GET_FLUSH_ZERO_MODE();
-    _MM_SET_FLUSH_ZERO_MODE(FTZ_STATE);
-    // If the DAZ flag is not supported, then it is a reserved bit and attempting to write a 1
-    // to it will cause a general-protection exception (#GP)
-    if (is_dmz_flag_available()) {
-      _MM_SET_DENORMALS_ZERO_MODE(DMZ_STATE);
-    }
+        // If the DAZ flag is not supported, then it is a reserved bit and attempting to write a 1
+        // to it will cause a general-protection exception (#GP)
+        if (is_dmz_flag_available()) {
+          _MM_SET_DENORMALS_ZERO_MODE(DMZ_STATE);
+        }
+      }, Context::CPU(), {}, {},
+      FnProperty::kNormal, 0, "SetFlushDenorms");
+
+    Engine::Get()->WaitForAll();
+
   #endif
 
   API_END();

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -1573,7 +1573,7 @@ int MXRandomSeedContext(int seed, int dev_type, int dev_id) {
   API_END();
 }
 
-int MXFTZDenorms(bool value) {
+int MXSetFlushDenorms(bool value) {
   API_BEGIN();
   // FTZ only applies to SSE and AVX instructions.
   #if defined(__SSE__) || defined(_M_X64) || (defined(_M_IX86_FP) && _M_IX86_FP >= 1)

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -1578,9 +1578,10 @@ int MXRandomSeedContext(int seed, int dev_type, int dev_id) {
   API_END();
 }
 
-int MXSetFlushDenorms(bool value) {
+int MXSetFlushDenorms(bool value, bool* prev_state) {
   API_BEGIN();
   // FTZ only applies to SSE and AVX instructions.
+  *prev_state = false;
   #if defined(__SSE__) || defined(_M_X64) || (defined(_M_IX86_FP) && _M_IX86_FP >= 1)
     std::function<bool()> is_dmz_flag_available = []() {
       // Intel 64 and IA-32 Architectures Software Developer’s Manual: Vol. 1
@@ -1604,6 +1605,7 @@ int MXSetFlushDenorms(bool value) {
     const unsigned int DMZ_STATE = value ? _MM_DENORMALS_ZERO_ON : _MM_DENORMALS_ZERO_OFF;
     const unsigned int FTZ_STATE = value ? _MM_FLUSH_ZERO_ON : _MM_FLUSH_ZERO_OFF;
 
+    *prev_state = _MM_GET_FLUSH_ZERO_MODE();
     _MM_SET_FLUSH_ZERO_MODE(FTZ_STATE);
     // If the DAZ flag is not supported, then it is a reserved bit and attempting to write a 1
     // to it will cause a general-protection exception (#GP)

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -70,8 +70,11 @@
 #if SUPPORT_FTZ_DMZ
 #include <immintrin.h>
 #include <xmmintrin.h>
+#endif
+#if SUPPORT_FTZ_DMZ && !defined(_MSC_VER)
 #include <x86intrin.h>
 #endif
+
 
 using namespace mxnet;
 

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -1573,6 +1573,42 @@ int MXRandomSeedContext(int seed, int dev_type, int dev_id) {
   API_END();
 }
 
+int MXFTZDenorms(bool value) {
+  API_BEGIN();
+  // FTZ only applies to SSE and AVX instructions.
+  #if defined(__SSE__) || defined(_M_X64) || (defined(_M_IX86_FP) && _M_IX86_FP >= 1)
+    auto is_dmz_flag_available = []() {
+      // Intel 64 and IA-32 Architectures Software Developer’s Manual: Vol. 1
+      // "Checking for the DAZ Flag in the MXCSR Register"
+      constexpr unsigned int mxcsr_mask_offset = 28;
+      constexpr unsigned int dmz_flag_offset = 5;
+      constexpr unsigned int fxsave_req_bytes = 512;
+
+      char* fxsave_area_ptr = reinterpret_cast<char*>(malloc(fxsave_req_bytes));
+      memset(fxsave_area_ptr, 0, fxsave_req_bytes);  // fill memory with 0
+      _fxsave(fxsave_area_ptr);
+
+      char* mxcsr_mask_ptr = fxsave_area_ptr + mxcsr_mask_offset;
+      uint32_t mxcsr_mask = *(reinterpret_cast<uint32_t*>((mxcsr_mask_ptr)));
+      bool dmz_flag = (mxcsr_mask >> dmz_flag_offset) & 0x1;
+      free(fxsave_area_ptr);
+      return dmz_flag;
+    };
+
+    const unsigned int DMZ_STATE = value ? _MM_DENORMALS_ZERO_ON : _MM_DENORMALS_ZERO_OFF;
+    const unsigned int FTZ_STATE = value ? _MM_FLUSH_ZERO_ON : _MM_FLUSH_ZERO_OFF;
+
+    _MM_SET_FLUSH_ZERO_MODE(FTZ_STATE);
+    // If the DAZ flag is not supported, then it is a reserved bit and attempting to write a 1
+    // to it will cause a general-protection exception (#GP)
+    if (is_dmz_flag_available()) {
+      _MM_SET_DENORMALS_ZERO_MODE(DMZ_STATE);
+    }
+  #endif
+
+  API_END();
+}
+
 int MXNotifyShutdown() {
   API_BEGIN();
   mxnet::op::custom::CustomOperator::Get()->Stop();

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -59,9 +59,16 @@
 #include "../common/utils.h"
 #include "nnvm/pass_functions.h"
 
-#if defined(__x86_64__) || defined(_M_X64)
+// FTZ only applies to SSE and AVX instructions.
+#define SUPPORT_FTZ_DMZ defined(__SSE__)    || \
+                        defined(__x86_64__) || \
+                        defined(_M_X64)     || \
+                        (defined(_M_IX86_FP) && _M_IX86_FP >= 1)
+
+#if SUPPORT_FTZ_DMZ
 #include <immintrin.h>
 #include <xmmintrin.h>
+#include <x86intrin.h>
 #endif
 
 using namespace mxnet;
@@ -1582,8 +1589,7 @@ int MXSetFlushDenorms(bool value, bool* prev_state) {
   API_BEGIN();
   *prev_state = false;
 
-  // FTZ only applies to SSE and AVX instructions.
-  #if defined(__SSE__) || defined(_M_X64) || (defined(_M_IX86_FP) && _M_IX86_FP >= 1)
+  #if SUPPORT_FTZ_DMZ
     std::function<bool()> is_dmz_flag_available = []() {
       // Intel 64 and IA-32 Architectures Software Developer’s Manual: Vol. 1
       // "Checking for the DAZ Flag in the MXCSR Register"

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -1582,7 +1582,7 @@ int MXSetFlushDenorms(bool value) {
   API_BEGIN();
   // FTZ only applies to SSE and AVX instructions.
   #if defined(__SSE__) || defined(_M_X64) || (defined(_M_IX86_FP) && _M_IX86_FP >= 1)
-    auto is_dmz_flag_available = []() {
+    std::function<bool()> is_dmz_flag_available = []() {
       // Intel 64 and IA-32 Architectures Software Developer’s Manual: Vol. 1
       // "Checking for the DAZ Flag in the MXCSR Register"
       constexpr unsigned int mxcsr_mask_offset = 28;
@@ -1595,6 +1595,7 @@ int MXSetFlushDenorms(bool value) {
 
       char* mxcsr_mask_ptr = fxsave_area_ptr + mxcsr_mask_offset;
       uint32_t mxcsr_mask = *(reinterpret_cast<uint32_t*>((mxcsr_mask_ptr)));
+      // DMZ flag is supported if sixth bit of MXCSR_MASK is hot
       bool dmz_flag = (mxcsr_mask >> dmz_flag_offset) & 0x1;
       free(fxsave_area_ptr);
       return dmz_flag;

--- a/tests/python/unittest/test_numpy_interoperability.py
+++ b/tests/python/unittest/test_numpy_interoperability.py
@@ -22,9 +22,11 @@ from distutils.version import StrictVersion
 import sys
 import platform
 import itertools
-import numpy as _np
 import unittest
+
 from mxnet import np
+from mxnet import util
+import numpy as _np
 from mxnet.test_utils import assert_almost_equal
 from mxnet.test_utils import use_np
 from mxnet.test_utils import is_op_runnable
@@ -3008,6 +3010,7 @@ def _check_interoperability_helper(op_name, rel_tol, abs_tol, *args, **kwargs):
         assert False
     if not is_op_runnable():
         return
+
     out = onp_op(*args, **kwargs)
     expected_out = _get_numpy_op_output(onp_op, *args, **kwargs)
     if isinstance(out, (tuple, list)):
@@ -3077,7 +3080,11 @@ def test_np_array_function_protocol():
 @use_np
 @with_array_ufunc_protocol
 def test_np_array_ufunc_protocol():
-    check_interoperability(_NUMPY_ARRAY_UFUNC_LIST)
+    prev_state = util.set_flush_denorms(False)
+    try:
+        check_interoperability(_NUMPY_ARRAY_UFUNC_LIST)
+    finally:
+        util.set_flush_denorms(prev_state)
 
 
 @with_seed()

--- a/tests/python/unittest/test_numpy_interoperability.py
+++ b/tests/python/unittest/test_numpy_interoperability.py
@@ -3009,7 +3009,6 @@ def _check_interoperability_helper(op_name, rel_tol, abs_tol, *args, **kwargs):
         assert False
     if not is_op_runnable():
         return
-
     out = onp_op(*args, **kwargs)
     expected_out = _get_numpy_op_output(onp_op, *args, **kwargs)
     if isinstance(out, (tuple, list)):

--- a/tests/python/unittest/test_numpy_interoperability.py
+++ b/tests/python/unittest/test_numpy_interoperability.py
@@ -24,8 +24,7 @@ import platform
 import itertools
 import unittest
 
-from mxnet import np
-from mxnet import util
+from mxnet import np, util
 import numpy as _np
 from mxnet.test_utils import assert_almost_equal
 from mxnet.test_utils import use_np


### PR DESCRIPTION
## Description ##
This is implementation of RFC https://github.com/apache/incubator-mxnet/issues/19361 and connected with issue https://github.com/apache/incubator-mxnet/issues/19218

```
>>> import mxnet as mx
>>> mx.nd.array([9e-45])

[0.]
<NDArray 1 @cpu(0)>
>>> mx.util.set_flush_denorms(False)
>>> mx.nd.array([9e-45])

[8.e-45]
<NDArray 1 @cpu(0)>
>>> mx.util.set_flush_denorms(True)
>>> mx.nd.array([9e-45])

[0.]
<NDArray 1 @cpu(0)>
>>> exit
```

As stated in RFC handling denormalized values is enabled by default and API for changing this behavior is available for the user

## Checklist ##
### Essentials ###
- [X] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [] All changes have test coverage
- [X] Code is well-documented
