### PR TITLE
Decouple OneDNN data structures in MXNet C++ API

### DIFF
--- a/include/mxnet/ndarray.h
+++ b/include/mxnet/ndarray.h
@@ -37,9 +37,7 @@
 #include <memory>
 #include <string>
 #include <vector>
-#if MXNET_USE_MKLDNN == 1
-#include <mkldnn.hpp>
-#endif
+
 #include "./base.h"
 #include "./engine.h"
 #include "./storage.h"
@@ -711,12 +709,12 @@ class NDArray {
    * Create NDArray from mkldnn memory.
    * mkldnn_mem The mkldnn memory to be managed.
    */
-  explicit NDArray(const std::shared_ptr<mkldnn::memory>& mkldnn_mem);
+  explicit NDArray(const std::shared_ptr<void>& mkldnn_mem);
   /*
    * Create NDArray from mkldnn memory descriptor.
    * mem_pd The mkldnn memory descriptor to be created.
    */
-  explicit NDArray(const mkldnn::memory::desc& md);
+  explicit NDArray(const void* md);
   /*
    * Test if the data is stored in one of special MKLDNN format.
    */
@@ -739,29 +737,29 @@ class NDArray {
   /*
    * This function returns mkldnn::memory with the default primitive_desc.
    */
-  const mkldnn::memory* GetMKLDNNData() const;
+  const void* GetMKLDNNData() const;
   /*
    * This function returns mkldnn::memory with the given primitive_desc
    * as long as the array size meets the required size in the given
    * primitive_desc.
    */
-  const mkldnn::memory* GetMKLDNNData(const mkldnn::memory::desc& md) const;
+  const void* GetMKLDNNData(const void* md) const;
   /*
    * This function returns mkldnn::memory with the given primitive_desc.
    * The returned mkldnn::memory will have the same physical layout as
    * the given primitive_desc.
    */
-  const mkldnn::memory* GetMKLDNNDataReorder(const mkldnn::memory::desc& md) const;
+  const void* GetMKLDNNDataReorder(const void* md) const;
 
   /*
    * This function copies data from mkldnn memory.
    */
-  void CopyFrom(const mkldnn::memory& mem);
+  void CopyFrom(const void* mem);
   /*
    * This function allocates memory for array and creates mkldnn memory
    * with the specified format.
    */
-  mkldnn::memory* CreateMKLDNNData(const mkldnn::memory::desc& md);
+  void* CreateMKLDNNData(const void* md);
 
   /*
    * These are the async version of the methods above.
@@ -769,7 +767,7 @@ class NDArray {
    * the array are complete.
    */
   void Reorder2DefaultAsync() const;
-  void MKLDNNDataReorderAsync(const mkldnn::memory::desc& md) const;
+  void MKLDNNDataReorderAsync(const void* md) const;
 
   /*
    * This creates a new NDArray with the reordered data.
@@ -800,7 +798,7 @@ class NDArray {
   /*!
    * \ Fix mkldnn memory descriptor mismatch from NDArray.
    */
-  void UpdateMKLDNNMemDesc(const mkldnn::memory::desc& desc);
+  void UpdateMKLDNNMemDesc(const void* desc);
 #endif
 
   /*!
@@ -1087,7 +1085,7 @@ class NDArray {
     // save the result in shandle.
     void Reorder2Default();
     // Reroder data to a specified layout.
-    void MKLDNNDataReorder(const mkldnn::memory::desc& md);
+    void MKLDNNDataReorder(const void* md);
     bool IsMKLDNN() const;
     bool IsDefault() const;
 #endif

--- a/src/operator/nn/concat.cc
+++ b/src/operator/nn/concat.cc
@@ -22,30 +22,30 @@
  * \file concat.cc
  * \brief
  * \author Bing Xu
-*/
+ */
 
-#include "./concat-inl.h"
-#include "./mkldnn/mkldnn_ops-inl.h"
-#include "./mkldnn/mkldnn_base-inl.h"
 #include "../../common/utils.h"
+#include "./concat-inl.h"
+#include "./mkldnn/mkldnn_base-inl.h"
+#include "./mkldnn/mkldnn_ops-inl.h"
 
 namespace mxnet {
 namespace op {
 
 bool ConcatShape(const nnvm::NodeAttrs& attrs,
-                 mxnet::ShapeVector *in_shape,
-                 mxnet::ShapeVector *out_shape) {
+                 mxnet::ShapeVector* in_shape,
+                 mxnet::ShapeVector* out_shape) {
   using namespace mshadow;
   const ConcatParam& param_ = nnvm::get<ConcatParam>(attrs.parsed);
   CHECK_EQ(in_shape->size(), static_cast<size_t>(param_.num_args));
   mxnet::TShape dshape;
-  dim_t size = 0;
+  dim_t size                = 0;
   bool has_unknown_dim_size = false;
-  int axis = -1;
+  int axis                  = -1;
   for (int i = 0; i < param_.num_args; ++i) {
     mxnet::TShape tmp = (*in_shape)[i];
     if (tmp.ndim() > 0) {
-      axis = CheckAxis(param_.dim, tmp.ndim());
+      axis                 = CheckAxis(param_.dim, tmp.ndim());
       has_unknown_dim_size = !mxnet::dim_size_is_known(tmp, axis) || has_unknown_dim_size;
       size += tmp[axis];
       tmp[axis] = -1;
@@ -55,12 +55,13 @@ bool ConcatShape(const nnvm::NodeAttrs& attrs,
 
   mxnet::TShape tmp = (*out_shape)[0];
   if (tmp.ndim() > 0) {
-    axis = CheckAxis(param_.dim, tmp.ndim());
+    axis      = CheckAxis(param_.dim, tmp.ndim());
     tmp[axis] = -1;
     shape_assign(&dshape, tmp);
   }
 
-  if (dshape.ndim() == -1) return false;
+  if (dshape.ndim() == -1)
+    return false;
   CHECK_NE(dshape.ndim(), 0) << "zero-dimensional arrays cannot be concatenated";
 
   for (int i = 0; i < param_.num_args; ++i) {
@@ -68,7 +69,8 @@ bool ConcatShape(const nnvm::NodeAttrs& attrs,
         << "Incompatible input shape: expected " << dshape << ", got " << (*in_shape)[i];
   }
 
-  if (!has_unknown_dim_size) dshape[axis] = size;
+  if (!has_unknown_dim_size)
+    dshape[axis] = size;
   CHECK(shape_assign(&(*out_shape)[0], dshape))
       << "Incompatible output shape: expected " << dshape << ", got " << (*out_shape)[0];
 
@@ -80,8 +82,8 @@ bool ConcatShape(const nnvm::NodeAttrs& attrs,
 // The first (and sometimes the second) input may be unknown on the target axis.
 // If the two inputs are unknown, they always have the same shape.
 static bool RNNParamConcatShape(const nnvm::NodeAttrs& attrs,
-                                mxnet::ShapeVector *in_shape,
-                                mxnet::ShapeVector *out_shape) {
+                                mxnet::ShapeVector* in_shape,
+                                mxnet::ShapeVector* out_shape) {
   using namespace mshadow;
   const ConcatParam& param_ = nnvm::get<ConcatParam>(attrs.parsed);
   CHECK_EQ(in_shape->size(), static_cast<size_t>(param_.num_args));
@@ -106,31 +108,32 @@ static bool RNNParamConcatShape(const nnvm::NodeAttrs& attrs,
 
   mxnet::TShape tmp = (*out_shape)[0];
   if (tmp.ndim() > 0) {
-    axis = CheckAxis(param_.dim, tmp.ndim());
+    axis      = CheckAxis(param_.dim, tmp.ndim());
     tmp[axis] = -1;
     shape_assign(&dshape, tmp);
   }
 
-  if (!mxnet::ndim_is_known(dshape)) return false;
+  if (!mxnet::ndim_is_known(dshape))
+    return false;
 
   for (int i = 0; i < param_.num_args; ++i) {
     CHECK(shape_assign(&(*in_shape)[i], dshape))
         << "Incompatible input shape: expected " << dshape << ", got " << (*in_shape)[i];
   }
 
-  if (zero_indices.empty()) dshape[axis] = size;
+  if (zero_indices.empty())
+    dshape[axis] = size;
   CHECK(shape_assign(&(*out_shape)[0], dshape))
       << "Incompatible output shape: expected " << dshape << ", got " << (*out_shape)[0];
   if ((*out_shape)[0][axis] != -1 && !zero_indices.empty()) {
     int residual = (*out_shape)[0][axis] - size;
-    CHECK_GE(residual, 0)
-        << "Input size already exceeds output size. Residual: " << residual;
+    CHECK_GE(residual, 0) << "Input size already exceeds output size. Residual: " << residual;
     CHECK(zero_indices.size() <= 2 && zero_indices.size() > 0)
         << "Expecting 1 or 2 inputs that need shape inference. Got: " << zero_indices.size();
     bool need_infer = !shape_is_known((*out_shape)[0]);
     for (int i : zero_indices) {
       (*in_shape)[i][axis] = residual / zero_indices.size();
-      need_infer = need_infer || !shape_is_known((*in_shape)[i]);
+      need_infer           = need_infer || !shape_is_known((*in_shape)[i]);
     }
     return !need_infer;
   }
@@ -139,21 +142,20 @@ static bool RNNParamConcatShape(const nnvm::NodeAttrs& attrs,
 }
 
 bool ConcatType(const nnvm::NodeAttrs& attrs,
-                std::vector<int> *in_type,
-                std::vector<int> *out_type) {
+                std::vector<int>* in_type,
+                std::vector<int>* out_type) {
   const ConcatParam& param_ = nnvm::get<ConcatParam>(attrs.parsed);
-  int dtype = -1;
+  int dtype                 = -1;
 
   // checks uniformity of input
-  for (size_t i =0; i < in_type->size(); ++i) {
+  for (size_t i = 0; i < in_type->size(); ++i) {
     if (dtype == -1) {
       dtype = in_type->at(i);
     } else {
       CHECK(in_type->at(i) == dtype || in_type->at(i) == -1)
-          << "Non-uniform data type in "  << attrs.op->name
-          << ", expected data type " << mxnet::op::type_string(dtype)
-          << ", got data type " << mxnet::op::type_string(in_type->at(i))
-          << " for input " << i;
+          << "Non-uniform data type in " << attrs.op->name << ", expected data type "
+          << mxnet::op::type_string(dtype) << ", got data type "
+          << mxnet::op::type_string(in_type->at(i)) << " for input " << i;
     }
   }
 
@@ -166,18 +168,17 @@ bool ConcatType(const nnvm::NodeAttrs& attrs,
     for (size_t i = 0; i < nin; ++i) {
       in_type->push_back(dtype);
     }
-  // if out types are known in types are unknown
+    // if out types are known in types are unknown
   } else if ((*out_type)[0] != -1 && dtype == -1) {
     in_type->clear();
     for (size_t i = 0; i < nin; ++i) {
       in_type->push_back((*out_type)[0]);
     }
-  // if both out_types and in_types are known, and different
+    // if both out_types and in_types are known, and different
   } else if ((*out_type)[0] != -1 && dtype != -1 && ((*out_type)[0] != dtype)) {
     std::ostringstream os;
-    os << "Type inconsistent, Provided output type = "
-       << mxnet::op::type_string((*out_type)[0]) << ','
-       << " inferred type = " << mxnet::op::type_string(dtype);
+    os << "Type inconsistent, Provided output type = " << mxnet::op::type_string((*out_type)[0])
+       << ',' << " inferred type = " << mxnet::op::type_string(dtype);
     throw mxnet::op::InferTypeError(os.str(), 0);
   }
   return true;
@@ -186,29 +187,27 @@ bool ConcatType(const nnvm::NodeAttrs& attrs,
 inline static bool ConcatForwardInferStorageType(const nnvm::NodeAttrs& attrs,
                                                  const int dev_mask,
                                                  DispatchMode* dispatch_mode,
-                                                 std::vector<int> *in_attrs,
-                                                 std::vector<int> *out_attrs) {
+                                                 std::vector<int>* in_attrs,
+                                                 std::vector<int>* out_attrs) {
   CHECK(!in_attrs->empty());
   CHECK_EQ(out_attrs->size(), 1U);
-  auto& out_stype = out_attrs->at(0);
-  bool dispatched = false;
+  auto& out_stype          = out_attrs->at(0);
+  bool dispatched          = false;
   const ConcatParam& param = nnvm::get<ConcatParam>(attrs.parsed);
-  if (!dispatched && common::ContainsOnlyStorage(*in_attrs, kCSRStorage)
-      && param.dim == 0) {
-    dispatched = storage_type_assign(&out_stype, kCSRStorage,
-                                     dispatch_mode, DispatchMode::kFComputeEx);
+  if (!dispatched && common::ContainsOnlyStorage(*in_attrs, kCSRStorage) && param.dim == 0) {
+    dispatched =
+        storage_type_assign(&out_stype, kCSRStorage, dispatch_mode, DispatchMode::kFComputeEx);
   }
 #if MXNET_USE_MKLDNN == 1
-  if (!dispatched && dev_mask == mshadow::cpu::kDevMask
-      && common::ContainsOnlyStorage(*in_attrs, kDefaultStorage)
-      && param.dim > 0) {
-    dispatched = storage_type_assign(&out_stype, kDefaultStorage,
-                                     dispatch_mode, DispatchMode::kFComputeEx);
+  if (!dispatched && dev_mask == mshadow::cpu::kDevMask &&
+      common::ContainsOnlyStorage(*in_attrs, kDefaultStorage) && param.dim > 0) {
+    dispatched =
+        storage_type_assign(&out_stype, kDefaultStorage, dispatch_mode, DispatchMode::kFComputeEx);
   }
 #endif  // MXNET_USE_MKLDNN == 1
   if (!dispatched && common::ContainsOnlyStorage(*in_attrs, kDefaultStorage)) {
-    dispatched = storage_type_assign(&out_stype, kDefaultStorage,
-                                     dispatch_mode, DispatchMode::kFCompute);
+    dispatched =
+        storage_type_assign(&out_stype, kDefaultStorage, dispatch_mode, DispatchMode::kFCompute);
   }
   if (!dispatched) {
     dispatched = dispatch_fallback(out_attrs, dispatch_mode);
@@ -223,15 +222,14 @@ inline static bool ConcatForwardInferStorageType(const nnvm::NodeAttrs& attrs,
 inline static bool BackwardConcatStorageType(const nnvm::NodeAttrs& attrs,
                                              const int dev_mask,
                                              DispatchMode* dispatch_mode,
-                                             std::vector<int> *in_attrs,
-                                             std::vector<int> *out_attrs) {
+                                             std::vector<int>* in_attrs,
+                                             std::vector<int>* out_attrs) {
   DispatchMode wanted_mode;
 #if MXNET_USE_MKLDNN == 1
   const ConcatParam& param = nnvm::get<ConcatParam>(attrs.parsed);
   CHECK_EQ(out_attrs->size(), in_attrs->size() - 1);
-  if (dev_mask == mshadow::cpu::kDevMask
-      && common::ContainsOnlyStorage(*in_attrs, kDefaultStorage)
-      && param.dim > 0)
+  if (dev_mask == mshadow::cpu::kDevMask &&
+      common::ContainsOnlyStorage(*in_attrs, kDefaultStorage) && param.dim > 0)
     wanted_mode = DispatchMode::kFComputeEx;
   else
 #endif  // MXNET_USE_MKLDNN == 1
@@ -240,19 +238,23 @@ inline static bool BackwardConcatStorageType(const nnvm::NodeAttrs& attrs,
   if (!MKLDNNEnvSet())
     wanted_mode = DispatchMode::kFComputeFallback;
 #endif  // MXNET_USE_MKLDNN == 1
-  return storage_type_assign(out_attrs, mxnet::kDefaultStorage,
-                             dispatch_mode, wanted_mode);
+  return storage_type_assign(out_attrs, mxnet::kDefaultStorage, dispatch_mode, wanted_mode);
 }
 #if MXNET_USE_MKLDNN == 1
-bool SupportMKLDNNConcat(const std::vector<NDArray> &arrs) {
-  for (auto &arr : arrs) {
-    if (arr.IsView()) return false;
-    if (!(arr.dtype() == mshadow::kFloat32 || arr.dtype() == mshadow::kBfloat16)) return false;
+bool SupportMKLDNNConcat(const std::vector<NDArray>& arrs) {
+  for (auto& arr : arrs) {
+    if (arr.IsView())
+      return false;
+    if (!(arr.dtype() == mshadow::kFloat32 || arr.dtype() == mshadow::kBfloat16))
+      return false;
     // DO not support zero-size tensors.
-    if (arr.shape().Size() == 0) return false;
+    if (arr.shape().Size() == 0)
+      return false;
     int ndim = arr.shape().ndim();
-    const int mkldnn_ndims = arr.GetMKLDNNData()->get_desc().data.ndims;
-    if (!(ndim == 2 || ndim == 4) || ndim != mkldnn_ndims) return false;
+    const int mkldnn_ndims =
+        static_cast<const mkldnn::memory*>(arr.GetMKLDNNData())->get_desc().data.ndims;
+    if (!(ndim == 2 || ndim == 4) || ndim != mkldnn_ndims)
+      return false;
   }
   return true;
 }
@@ -265,7 +267,8 @@ static void ConcatComputeExCPU(const nnvm::NodeAttrs& attrs,
   CHECK(!inputs.empty());
   CHECK_EQ(outputs.size(), 1U);
   CHECK_EQ(req.size(), 1U);
-  if (req[0] == kNullOp) return;
+  if (req[0] == kNullOp)
+    return;
   if (common::ContainsOnlyStorage(inputs, kCSRStorage) &&
       outputs[0].storage_type() == kCSRStorage) {
     ConcatCSRImpl<cpu>(attrs, op_ctx, inputs, req, outputs);
@@ -299,7 +302,7 @@ static void ConcatGradComputeExCPU(const nnvm::NodeAttrs& attrs,
 #endif  // MXNET_USE_MKLDNN == 1
 
 struct ConcatGrad {
-  const char *op_name;
+  const char* op_name;
   std::vector<nnvm::NodeEntry> operator()(const nnvm::ObjectPtr& n,
                                           const std::vector<nnvm::NodeEntry>& ograds) const {
     CHECK_EQ(ograds.size(), 1);
@@ -315,38 +318,37 @@ struct ConcatGrad {
 
 DMLC_REGISTER_PARAMETER(ConcatParam);
 
-#define CONCAT_FORWARD_ATTRS \
-.set_num_inputs([](const NodeAttrs& attrs) { \
-  const ConcatParam& params = nnvm::get<ConcatParam>(attrs.parsed); \
-  return params.num_args; \
-}) \
-.set_num_outputs(1) \
-.set_attr_parser(ParamParser<ConcatParam>) \
-.set_attr<nnvm::FListInputNames>("FListInputNames", \
-    [](const NodeAttrs& attrs) { \
-  const ConcatParam& params = nnvm::get<ConcatParam>(attrs.parsed); \
-  std::vector<std::string> ret; \
-  for (int i = 0; i < params.num_args; ++i) { \
-    ret.push_back(std::string("arg") + std::to_string(i)); \
-  } \
-  return ret; \
-}) \
-.set_attr<nnvm::FListOutputNames>("FListOutputNames", \
-    [](const NodeAttrs& attrs) { \
-    return std::vector<std::string>{"output"}; \
-}) \
-.set_attr<nnvm::FInferType>("FInferType", ConcatType) \
-.set_attr<FInferStorageType>("FInferStorageType", ConcatForwardInferStorageType) \
-.set_attr<FCompute>("FCompute<cpu>", ConcatCompute<cpu>) \
-.set_attr<FComputeEx>("FComputeEx<cpu>", ConcatComputeExCPU) \
-.set_attr<nnvm::FGradient>("FGradient", ConcatGrad{"_backward_Concat"}) \
-.set_attr<std::string>("key_var_num_args", "num_args")
-
+#define CONCAT_FORWARD_ATTRS                                                                      \
+  .set_num_inputs([](const NodeAttrs& attrs) {                                                    \
+    const ConcatParam& params = nnvm::get<ConcatParam>(attrs.parsed);                             \
+    return params.num_args;                                                                       \
+  })                                                                                              \
+      .set_num_outputs(1)                                                                         \
+      .set_attr_parser(ParamParser<ConcatParam>)                                                  \
+      .set_attr<nnvm::FListInputNames>("FListInputNames",                                         \
+                                       [](const NodeAttrs& attrs) {                               \
+                                         const ConcatParam& params =                              \
+                                             nnvm::get<ConcatParam>(attrs.parsed);                \
+                                         std::vector<std::string> ret;                            \
+                                         for (int i = 0; i < params.num_args; ++i) {              \
+                                           ret.push_back(std::string("arg") + std::to_string(i)); \
+                                         }                                                        \
+                                         return ret;                                              \
+                                       })                                                         \
+      .set_attr<nnvm::FListOutputNames>(                                                          \
+          "FListOutputNames",                                                                     \
+          [](const NodeAttrs& attrs) { return std::vector<std::string>{"output"}; })              \
+      .set_attr<nnvm::FInferType>("FInferType", ConcatType)                                       \
+      .set_attr<FInferStorageType>("FInferStorageType", ConcatForwardInferStorageType)            \
+      .set_attr<FCompute>("FCompute<cpu>", ConcatCompute<cpu>)                                    \
+      .set_attr<FComputeEx>("FComputeEx<cpu>", ConcatComputeExCPU)                                \
+      .set_attr<nnvm::FGradient>("FGradient", ConcatGrad{"_backward_Concat"})                     \
+      .set_attr<std::string>("key_var_num_args", "num_args")
 
 NNVM_REGISTER_OP(Concat)
 MXNET_ADD_SPARSE_OP_ALIAS(concat)
-.add_alias("concat")
-.describe(R"code(Joins input arrays along a given axis.
+    .add_alias("concat")
+    .describe(R"code(Joins input arrays along a given axis.
 
 .. note:: `Concat` is deprecated. Use `concat` instead.
 
@@ -384,59 +386,60 @@ Example::
 
 )code" ADD_FILELINE)
 #if MXNET_USE_MKLDNN == 1
-.set_attr<FResourceRequest>("FResourceRequest", [](const NodeAttrs& n) {
-  return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
-})
-.set_attr<THasDeterministicOutput>("THasDeterministicOutput", true)
-.set_attr<bool>("TIsMKLDNN", true)
+    .set_attr<FResourceRequest>("FResourceRequest",
+                                [](const NodeAttrs& n) {
+                                  return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
+                                })
+    .set_attr<THasDeterministicOutput>("THasDeterministicOutput", true)
+    .set_attr<bool>("TIsMKLDNN", true)
 #endif  // MXNET_USE_MKLDNN == 1
-CONCAT_FORWARD_ATTRS
-.set_attr<mxnet::FInferShape>("FInferShape", ConcatShape)
-.add_argument("data", "NDArray-or-Symbol[]", "List of arrays to concatenate")
-.add_arguments(ConcatParam::__FIELDS__());
+        CONCAT_FORWARD_ATTRS.set_attr<mxnet::FInferShape>("FInferShape", ConcatShape)
+    .add_argument("data", "NDArray-or-Symbol[]", "List of arrays to concatenate")
+    .add_arguments(ConcatParam::__FIELDS__());
 
 NNVM_REGISTER_OP(_backward_Concat)
-.set_num_inputs([](const NodeAttrs& attrs) {
+    .set_num_inputs([](const NodeAttrs& attrs) {
 #if MXNET_USE_MKLDNN == 1
-  const ConcatParam& params = nnvm::get<ConcatParam>(attrs.parsed);
-  return 1 + params.num_args;
+      const ConcatParam& params = nnvm::get<ConcatParam>(attrs.parsed);
+      return 1 + params.num_args;
 #else
-  return 1;
+      return 1;
 #endif
-})
-.set_num_outputs([](const NodeAttrs& attrs) {
-  const ConcatParam& params = nnvm::get<ConcatParam>(attrs.parsed);
-  return params.num_args;
-})
-.set_attr_parser(ParamParser<ConcatParam>)
+    })
+    .set_num_outputs([](const NodeAttrs& attrs) {
+      const ConcatParam& params = nnvm::get<ConcatParam>(attrs.parsed);
+      return params.num_args;
+    })
+    .set_attr_parser(ParamParser<ConcatParam>)
 #if MXNET_USE_MKLDNN == 1
-.set_attr<FResourceRequest>("FResourceRequest", [](const NodeAttrs& n) {
-  return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
-})
+    .set_attr<FResourceRequest>("FResourceRequest",
+                                [](const NodeAttrs& n) {
+                                  return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
+                                })
 #endif  // MXNET_USE_MKLDNN == 1
-.set_attr<nnvm::TIsBackward>("TIsBackward", true)
-.set_attr<FInferStorageType>("FInferStorageType", BackwardConcatStorageType)
+    .set_attr<nnvm::TIsBackward>("TIsBackward", true)
+    .set_attr<FInferStorageType>("FInferStorageType", BackwardConcatStorageType)
 #if MXNET_USE_MKLDNN == 1
-.set_attr<bool>("TIsMKLDNN", true)
-.set_attr<FComputeEx>("FComputeEx<cpu>", ConcatGradComputeExCPU)
+    .set_attr<bool>("TIsMKLDNN", true)
+    .set_attr<FComputeEx>("FComputeEx<cpu>", ConcatGradComputeExCPU)
 #endif  // MXNET_USE_MKLDNN == 1
-.set_attr<FCompute>("FCompute<cpu>", ConcatGradCompute<cpu>);
+    .set_attr<FCompute>("FCompute<cpu>", ConcatGradCompute<cpu>);
 
 // _rnn_param_concat is a custom concat op with specialized infer_shape,
 // which handles the case where the first one or two inputs may have
 // unknown shape that can be inferred from output shape.
 NNVM_REGISTER_OP(_rnn_param_concat)
-.add_alias("_npi_rnn_param_concat")
+    .add_alias("_npi_rnn_param_concat")
 #if MXNET_USE_MKLDNN == 1
-.set_attr<FResourceRequest>("FResourceRequest", [](const NodeAttrs& n) {
-  return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
-})
+    .set_attr<FResourceRequest>("FResourceRequest",
+                                [](const NodeAttrs& n) {
+                                  return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
+                                })
 #endif  // MXNET_USE_MKLDNN == 1
-CONCAT_FORWARD_ATTRS
-.set_attr<THasDeterministicOutput>("THasDeterministicOutput", true)
-.set_attr<mxnet::FInferShape>("FInferShape", RNNParamConcatShape)
-.add_argument("data", "NDArray-or-Symbol[]", "List of arrays to concatenate")
-.add_arguments(ConcatParam::__FIELDS__());
+        CONCAT_FORWARD_ATTRS.set_attr<THasDeterministicOutput>("THasDeterministicOutput", true)
+    .set_attr<mxnet::FInferShape>("FInferShape", RNNParamConcatShape)
+    .add_argument("data", "NDArray-or-Symbol[]", "List of arrays to concatenate")
+    .add_arguments(ConcatParam::__FIELDS__());
 
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/nn/mkldnn/mkldnn_base-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_base-inl.h
@@ -175,8 +175,7 @@ static inline int GetMKLDNNCacheSize() {
   return mkldnn_cache_size;
 }
 
-// TODO(alex): (MXNET-1075) Will remove env variable and calculate cache size
-// during runtime
+// TODO(alex): (MXNET-1075) Will remove env variable and calculate cache size during runtime
 template <typename S, typename I, typename H>
 static typename std::unordered_map<S, I, H>::iterator AddToCache(std::unordered_map<S, I, H>* cache,
                                                                  const S& key,
@@ -227,7 +226,8 @@ static int GetTypeSize(int dtype) {
 
 static inline size_t GetArraySize(const NDArray& arr) {
   if (arr.IsMKLDNNData()) {
-    return arr.GetMKLDNNData()->get_desc().get_size();
+    auto arr_data = static_cast<const mkldnn::memory*>(arr.GetMKLDNNData());
+    return arr_data->get_desc().get_size();
   }
   return arr.shape().Size() * GetTypeSize(arr.dtype());
 }
@@ -540,8 +540,7 @@ static inline void InvalidateOutputs(const std::vector<NDArray>& arrs,
   }
 }
 
-// TODO(alexzai): (MXNET-856) Remove helper function after subgraph feature
-// added
+// TODO(alexzai): (MXNET-856) Remove helper function after subgraph feature added
 static inline void CreateDefaultInputs(const std::vector<NDArray>& arrs,
                                        std::vector<NDArray>* out_arrs) {
   out_arrs->clear();

--- a/src/operator/nn/mkldnn/mkldnn_concat.cc
+++ b/src/operator/nn/mkldnn/mkldnn_concat.cc
@@ -71,7 +71,7 @@ void MKLDNNConcatForward(const nnvm::NodeAttrs& attrs,
   data_md.reserve(num_in_data);
   data_mem.reserve(num_in_data);
   for (int i = 0; i < num_in_data; i++) {
-    const mkldnn::memory* tmp_mem = in_data[i].GetMKLDNNData();
+    const mkldnn::memory* tmp_mem = static_cast<const mkldnn::memory*>(in_data[i].GetMKLDNNData());
     mkldnn::memory::desc tmp_md   = tmp_mem->get_desc();
     data_md.push_back(tmp_md);
     data_mem.push_back(tmp_mem);
@@ -98,7 +98,7 @@ void MKLDNNConcatBackward(const nnvm::NodeAttrs& attrs,
   const ConcatParam& param = nnvm::get<ConcatParam>(attrs.parsed);
   const int num_in_data    = param.num_args;
   const int axis           = param.dim;
-  const auto gradz_mem     = inputs[0].GetMKLDNNData();
+  const auto gradz_mem     = static_cast<const mkldnn::memory*>(inputs[0].GetMKLDNNData());
   /* init the offset */
   mkldnn::memory::dims offsets(outputs[0].shape().ndim());
   for (auto& v : offsets) {
@@ -107,7 +107,7 @@ void MKLDNNConcatBackward(const nnvm::NodeAttrs& attrs,
 
   for (int i = 0; i < num_in_data; i++) {
     mkldnn::memory::dims diff_src_tz(outputs[i].shape().begin(), outputs[i].shape().end());
-    auto diff_src_md = outputs[i].GetMKLDNNData()->get_desc();
+    auto diff_src_md = static_cast<const mkldnn::memory*>(outputs[i].GetMKLDNNData())->get_desc();
     auto gradi_mem   = CreateMKLDNNMem(outputs[i], diff_src_md, req[i]);
 
     auto from_md = gradz_mem->get_desc().submemory_desc(diff_src_tz, offsets);

--- a/src/operator/nn/mkldnn/mkldnn_fully_connected.cc
+++ b/src/operator/nn/mkldnn/mkldnn_fully_connected.cc
@@ -79,8 +79,7 @@ mkldnn::inner_product_forward::primitive_desc GetFCFwdImpl(const MKLDNNFCFullPar
       return mkldnn::inner_product_forward::primitive_desc(desc, attr, engine);
     } catch (mkldnn::error& e) {
       if (e.status == mkldnn_unimplemented && full_param.mkldnn_param.quantized) {
-        LOG(ERROR) << "AVX512-BW support or MKLDNN v0.18 is required for INT8 "
-                      "fully_connected.";
+        LOG(ERROR) << "AVX512-BW support or MKLDNN v0.18 is required for INT8 fully_connected.";
       } else {
         LOG(ERROR) << e.message;
       }
@@ -201,7 +200,8 @@ void MKLDNNFCForwardFullFeature(const MKLDNNFCFullParam& full_param,
   NDArray weight = in_data[fullc::kWeight];
   NDArray data   = in_data[fullc::kData];
 
-  auto data_mem = data.GetMKLDNNDataReorder(fwd->fwd_pd.src_desc());
+  auto fwd_src_desc = fwd->fwd_pd.src_desc();
+  auto data_mem     = static_cast<const mkldnn::memory*>(data.GetMKLDNNDataReorder(&fwd_src_desc));
   const mkldnn::memory* weight_mem;
   if (ctx.is_train) {
     if (weight.IsMKLDNNData()) {
@@ -209,9 +209,10 @@ void MKLDNNFCForwardFullFeature(const MKLDNNFCFullParam& full_param,
     }
     weight_mem = GetWeights(weight, fwd->fwd_pd.weights_desc(), 1);
   } else {
-    weight_mem = weight.GetMKLDNNData();
+    weight_mem = static_cast<const mkldnn::memory*>(weight.GetMKLDNNData());
     if (weight_mem->get_desc() != fwd->fwd_pd.weights_desc()) {
-      weight.MKLDNNDataReorderAsync(fwd->fwd_pd.weights_desc());
+      auto fwd_weight_desc = fwd->fwd_pd.weights_desc();
+      weight.MKLDNNDataReorderAsync(&fwd_weight_desc);
       weight_mem = GetWeights(weight, fwd->fwd_pd.weights_desc(), 1);
     }
   }
@@ -224,7 +225,9 @@ void MKLDNNFCForwardFullFeature(const MKLDNNFCFullParam& full_param,
       {MKLDNN_ARG_DST, *out_mem.second},
   };
   if (!full_param.default_param.no_bias) {
-    auto bias_mem         = in_data[fullc::kBias].GetMKLDNNDataReorder(fwd->fwd_pd.bias_desc());
+    auto fwd_bias_desc = fwd->fwd_pd.bias_desc();
+    auto bias_mem      = static_cast<const mkldnn::memory*>(
+        in_data[fullc::kBias].GetMKLDNNDataReorder(&fwd_bias_desc));
     args[MKLDNN_ARG_BIAS] = *bias_mem;
   }
   MKLDNNStream::Get()->RegisterPrimArgs(fwd->GetFwd(), args);
@@ -298,8 +301,14 @@ void MKLDNNFCBackward(const nnvm::NodeAttrs& attrs,
   if (req[fullc::kWeight]) {
     mkldnn::inner_product_backward_weights::primitive_desc ipBwdWeights_pd = GetFCBwdWeights(
         data, weight, param.no_bias ? nullptr : &in_grad[fullc::kBias], out_grad, fwd_pd);
-    auto out_grad_mem   = out_grad.GetMKLDNNDataReorder(ipBwdWeights_pd.diff_dst_desc());
-    auto data_mem       = data.GetMKLDNNDataReorder(ipBwdWeights_pd.src_desc());
+
+    auto ipBwdWeights_diff_dst_desc = ipBwdWeights_pd.diff_dst_desc();
+    auto out_grad_mem               = static_cast<const mkldnn::memory*>(
+        out_grad.GetMKLDNNDataReorder(&ipBwdWeights_diff_dst_desc));
+
+    auto ipBwdWeights_src_desc = ipBwdWeights_pd.src_desc();
+    auto data_mem =
+        static_cast<const mkldnn::memory*>(data.GetMKLDNNDataReorder(&ipBwdWeights_src_desc));
     auto in_grad_weight = CreateMKLDNNWeightGrad(
         in_grad[fullc::kWeight], ipBwdWeights_pd.diff_weights_desc(), req[fullc::kWeight]);
     mkldnn_args_map_t args = {
@@ -322,8 +331,13 @@ void MKLDNNFCBackward(const nnvm::NodeAttrs& attrs,
   if (req[fullc::kData]) {
     mkldnn::inner_product_backward_data::primitive_desc ipBwdData_pd =
         GetFCBwdData(data, weight, out_grad, fwd_pd);
-    auto out_grad_mem = out_grad.GetMKLDNNDataReorder(ipBwdData_pd.diff_dst_desc());
-    auto weight_mem   = weight.GetMKLDNNDataReorder(ipBwdData_pd.weights_desc());
+    auto ipBwdData_diff_dst_desc = ipBwdData_pd.diff_dst_desc();
+    auto out_grad_mem =
+        static_cast<const mkldnn::memory*>(out_grad.GetMKLDNNDataReorder(&ipBwdData_diff_dst_desc));
+
+    auto ipBwdData_weight_desc = ipBwdData_pd.weights_desc();
+    auto weight_mem =
+        static_cast<const mkldnn::memory*>(weight.GetMKLDNNDataReorder(&ipBwdData_weight_desc));
     auto in_grad_mem =
         CreateMKLDNNMem(in_grad[fullc::kData], ipBwdData_pd.diff_src_desc(), req[fullc::kData]);
     mkldnn_args_map_t args = {{MKLDNN_ARG_DIFF_DST, *out_grad_mem},

--- a/src/operator/nn/mkldnn/mkldnn_log_softmax.cc
+++ b/src/operator/nn/mkldnn/mkldnn_log_softmax.cc
@@ -60,12 +60,7 @@ bool SupportMKLDNNLogSoftmax(const SoftmaxParam& param,
   const int axis      = CheckAxis(param.axis, ndim);
   // MKLDNN does not support temperature argument in their log_softmax function
   // now. Need update this once they start to support it.
-<<<<<<< HEAD
-  // Currently, MKLDNN shows bad performance when log_softmax is not performed
-  // on the last dimension
-=======
   // Currently, MKLDNN shows bad performance when log_softmax is not performed on the last dimension
->>>>>>> 5b414c93e (NDArry file has been modified, there are a few chnages:)
   if (param.temperature.has_value() || in_dtype != mshadow::kFloat32 || in_dtype != out_dtype ||
       axis != (ndim - 1)) {
     return false;

--- a/src/operator/nn/mkldnn/mkldnn_pooling.cc
+++ b/src/operator/nn/mkldnn/mkldnn_pooling.cc
@@ -42,8 +42,8 @@ void MKLDNNPoolingFwd::Init(const mxnet::NDArray& input,
                             const mkldnn::memory::dims& pad_r,
                             const bool is_train,
                             const mkldnn::algorithm alg_kind) {
-  const auto src_md           = input.GetMKLDNNData()->get_desc();
-  const auto dst_md           = GetMemDesc(output);
+  const auto src_md = static_cast<const mkldnn::memory*>(input.GetMKLDNNData())->get_desc();
+  const auto dst_md = GetMemDesc(output);
   const mkldnn::engine engine = CpuEngine::Get()->get_engine();
   if (alg_kind != mkldnn::algorithm::pooling_max && alg_kind != mkldnn::algorithm::pooling_avg &&
       alg_kind != mkldnn::algorithm::pooling_avg_include_padding &&
@@ -75,7 +75,7 @@ void MKLDNNPoolingFwd::Execute(const NDArray& in_data,
   if (in_data.IsView() && in_data.IsMKLDNNData())
     in_buffer = in_data.Reorder2Default();
 
-  auto input_mem     = in_buffer.GetMKLDNNData();
+  auto input_mem     = static_cast<const mkldnn::memory*>(in_buffer.GetMKLDNNData());
   auto output_mem_t_ = CreateMKLDNNMem(out_data, this->fwd_pd_->dst_desc(), req);
 
   mkldnn_args_map_t args = {
@@ -91,7 +91,11 @@ void MKLDNNPoolingFwd::Execute(const NDArray& in_data,
     }
 
     auto ws = std::make_shared<mkldnn::memory>(
-        (*(this->fwd_pd_)).workspace_desc(), engine, workspace->GetMKLDNNData()->get_data_handle());
+        (*(this->fwd_pd_)).workspace_desc(),
+        engine,
+        static_cast<const mkldnn::memory*>(
+            static_cast<const mkldnn::memory*>(workspace->GetMKLDNNData()))
+            ->get_data_handle());
     args[MKLDNN_ARG_WORKSPACE] = *ws;
   }
   if (this->fwd_) {
@@ -231,7 +235,7 @@ MKLDNNPoolingFwd& GetPoolingFwd(const PoolingParam& param,
   if (it == pooling_fwds.end()) {
     CHECK(param.kernel.ndim() == 1 || param.kernel.ndim() == 2 || param.kernel.ndim() == 3)
         << "Not Implemented";
-    auto data_md = data.GetMKLDNNData()->get_desc();
+    auto data_md = static_cast<const mkldnn::memory*>(data.GetMKLDNNData())->get_desc();
 
     const auto kernel_ndims = param.kernel.ndim();
     mkldnn::memory::dims kernel(kernel_ndims);
@@ -288,7 +292,7 @@ MKLDNNPoolingBwd& GetPoolingBwd(const PoolingParam& param,
 
   auto it = pooling_bwds.find(key);
   if (it == pooling_bwds.end()) {
-    auto input_mem                     = in_data.GetMKLDNNData();
+    auto input_mem = static_cast<const mkldnn::memory*>(in_data.GetMKLDNNData());
     const mkldnn::memory::desc data_md = input_mem->get_desc();
 
     auto dst_dims = mkldnn::memory::dims(out_grad.shape().begin(), out_grad.shape().end());
@@ -302,7 +306,8 @@ MKLDNNPoolingBwd& GetPoolingBwd(const PoolingParam& param,
     auto diff_src_dims = mkldnn::memory::dims(in_grad.shape().begin(), in_grad.shape().end());
     auto diff_src_md   = mkldnn::memory::desc(diff_src_dims, get_data_type(data_md), any);
     auto cpu_engine    = CpuEngine::Get()->get_engine();
-    auto alg           = GetMKLDNNPoolAlgo(param);
+    ;
+    auto alg = GetMKLDNNPoolAlgo(param);
 
     const int kernel_ndims = param.kernel.ndim();
     mkldnn::memory::dims kernel(kernel_ndims);
@@ -337,14 +342,16 @@ void MKLDNNPoolingGradCompute(const OpContext& ctx,
   TmpMemMgr::Get()->Init(ctx.requested[0]);
 
   auto& bwd              = GetPoolingBwd(param, in_data, in_grad, out_grad);
-  auto diff_dst_mem      = out_grad.GetMKLDNNDataReorder(bwd.pd.diff_dst_desc());
+  auto bwd_diff_dst_desc = bwd.pd.diff_dst_desc();
+  auto diff_dst_mem =
+      static_cast<const mkldnn::memory*>(out_grad.GetMKLDNNDataReorder(&bwd_diff_dst_desc));
   auto diff_src_mem      = CreateMKLDNNMem(in_grad, bwd.pd.diff_src_desc(), req);
   mkldnn_args_map_t args = {
       {MKLDNN_ARG_DIFF_DST, *diff_dst_mem},
       {MKLDNN_ARG_DIFF_SRC, *diff_src_mem.second},
   };
   if (MKLDNNRequireWorkspace(param) && workspace != nullptr) {
-    args[MKLDNN_ARG_WORKSPACE] = *(workspace->GetMKLDNNData());
+    args[MKLDNN_ARG_WORKSPACE] = *(static_cast<const mkldnn::memory*>(workspace->GetMKLDNNData()));
   }
 
   MKLDNNStream::Get()->RegisterPrimArgs(bwd.GetBwd(), args);

--- a/src/operator/nn/mkldnn/mkldnn_pooling.cc
+++ b/src/operator/nn/mkldnn/mkldnn_pooling.cc
@@ -306,8 +306,7 @@ MKLDNNPoolingBwd& GetPoolingBwd(const PoolingParam& param,
     auto diff_src_dims = mkldnn::memory::dims(in_grad.shape().begin(), in_grad.shape().end());
     auto diff_src_md   = mkldnn::memory::desc(diff_src_dims, get_data_type(data_md), any);
     auto cpu_engine    = CpuEngine::Get()->get_engine();
-    ;
-    auto alg = GetMKLDNNPoolAlgo(param);
+    auto alg           = GetMKLDNNPoolAlgo(param);
 
     const int kernel_ndims = param.kernel.ndim();
     mkldnn::memory::dims kernel(kernel_ndims);

--- a/src/operator/nn/mkldnn/mkldnn_slice.cc
+++ b/src/operator/nn/mkldnn/mkldnn_slice.cc
@@ -49,13 +49,8 @@ MKLDNNSliceFwd::MKLDNNSliceFwd(const SliceParam& param, const NDArray& in, const
     offsets[i] = s;
   }
 
-<<<<<<< HEAD
-  auto in_md  = in.GetMKLDNNData()->get_desc();
-  auto out_md = out.GetMKLDNNData()->get_desc();
-=======
   auto in_md  = static_cast<const mkldnn::memory*>(in.GetMKLDNNData())->get_desc();
   auto out_md = static_cast<const mkldnn::memory*>(out.GetMKLDNNData())->get_desc();
->>>>>>> 5b414c93e (NDArry file has been modified, there are a few chnages:)
   auto sub_md = in_md.submemory_desc(dims, offsets);
 
   auto engine = CpuEngine::Get()->get_engine();

--- a/src/operator/nn/mkldnn/mkldnn_slice.cc
+++ b/src/operator/nn/mkldnn/mkldnn_slice.cc
@@ -49,8 +49,13 @@ MKLDNNSliceFwd::MKLDNNSliceFwd(const SliceParam& param, const NDArray& in, const
     offsets[i] = s;
   }
 
+<<<<<<< HEAD
   auto in_md  = in.GetMKLDNNData()->get_desc();
   auto out_md = out.GetMKLDNNData()->get_desc();
+=======
+  auto in_md  = static_cast<const mkldnn::memory*>(in.GetMKLDNNData())->get_desc();
+  auto out_md = static_cast<const mkldnn::memory*>(out.GetMKLDNNData())->get_desc();
+>>>>>>> 5b414c93e (NDArry file has been modified, there are a few chnages:)
   auto sub_md = in_md.submemory_desc(dims, offsets);
 
   auto engine = CpuEngine::Get()->get_engine();
@@ -98,8 +103,8 @@ void MKLDNNSlice(const nnvm::NodeAttrs& attrs,
                  const NDArray& out) {
   const SliceParam& param = nnvm::get<SliceParam>(attrs.parsed);
   MKLDNNSliceFwd& fwd     = GetSliceForward(param, ctx.is_train, in, out);
-  auto in_mem             = in.GetMKLDNNData();
-  auto out_md             = out.GetMKLDNNData()->get_desc();
+  auto in_mem             = static_cast<const mkldnn::memory*>(in.GetMKLDNNData());
+  auto out_md             = static_cast<const mkldnn::memory*>(out.GetMKLDNNData())->get_desc();
   auto out_mem            = CreateMKLDNNMem(out, out_md, req);
   fwd.SetNewMem(*in_mem, *out_mem.second);
   fwd.Register();

--- a/src/operator/nn/mkldnn/mkldnn_softmax.cc
+++ b/src/operator/nn/mkldnn/mkldnn_softmax.cc
@@ -62,8 +62,7 @@ bool SupportMKLDNNSoftmax(const SoftmaxParam& param, const NDArray& data, const 
   const int axis      = CheckAxis(param.axis, ndim);
   // MKLDNN does not support temperature argument in their softmax function
   // now. Need update this once they start to support it.
-  // Currently, MKLDNN shows bad performance when softmax is not performed on
-  // the last dimension
+  // Currently, MKLDNN shows bad performance when softmax is not performed on the last dimension
   if (param.temperature.has_value() || in_dtype != mshadow::kFloat32 || in_dtype != out_dtype ||
       axis != (ndim - 1)) {
     return false;
@@ -111,7 +110,8 @@ static MKLDNNSoftmaxFwd& GetSoftmaxFwd(const SoftmaxParam& param,
 
   auto it = fwds.find(key);
   if (it == fwds.end()) {
-    MKLDNNSoftmaxFwd fwd(is_train, real_axis, *(data.GetMKLDNNData()));
+    MKLDNNSoftmaxFwd fwd(
+        is_train, real_axis, *(static_cast<const mkldnn::memory*>(data.GetMKLDNNData())));
     it = AddToCache(&fwds, key, fwd);
   }
   return it->second;
@@ -124,16 +124,16 @@ void MKLDNNSoftmaxForward(const nnvm::NodeAttrs& attrs,
                           const NDArray& out_data) {
   if (req == kNullOp)
     return;
-  // same as the FCompute path, softmax only supports kWriteTo and kWriteInplace
-  // for now.
+  // same as the FCompute path, softmax only supports kWriteTo and kWriteInplace for now.
   CHECK_NE(req, kAddTo);
 
   const SoftmaxParam& param = nnvm::get<SoftmaxParam>(attrs.parsed);
   int axis                  = CheckAxis(param.axis, in_data.shape().ndim());
   auto fwd                  = GetSoftmaxFwd(param, axis, ctx.is_train, in_data, out_data);
 
-  auto in_mem          = in_data.GetMKLDNNData();
-  auto out_mem         = out_data.GetMKLDNNData(fwd.pd.dst_desc());
+  auto in_mem          = static_cast<const mkldnn::memory*>(in_data.GetMKLDNNData());
+  auto fwd_desc        = fwd.pd.dst_desc();
+  auto out_mem         = static_cast<const mkldnn::memory*>(out_data.GetMKLDNNData(&fwd_desc));
   MKLDNNStream* stream = MKLDNNStream::Get();
   stream->RegisterPrimArgs(fwd.GetFwd(), {{MKLDNN_ARG_SRC, *in_mem}, {MKLDNN_ARG_DST, *out_mem}});
   stream->Submit();
@@ -176,8 +176,8 @@ static MKLDNNSoftmaxBwd& GetSoftmaxBwd(const SoftmaxParam& param,
 
   auto it = bwds.find(key);
   if (it == bwds.end()) {
-    auto diff_mem = data[0].GetMKLDNNData();
-    auto data_mem = data[1].GetMKLDNNData();
+    auto diff_mem = static_cast<const mkldnn::memory*>(data[0].GetMKLDNNData());
+    auto data_mem = static_cast<const mkldnn::memory*>(data[1].GetMKLDNNData());
     auto fwd_pd   = GetSoftmaxFwdPd(true, real_axis, *data_mem);
     MKLDNNSoftmaxBwd bwd(*diff_mem, *data_mem, real_axis, fwd_pd);
     it = AddToCache(&bwds, key, bwd);
@@ -195,8 +195,8 @@ void MKLDNNSoftmaxBackward(const nnvm::NodeAttrs& attrs,
   CHECK_EQ(in_data.size(), 2U);
   const SoftmaxParam& param = nnvm::get<SoftmaxParam>(attrs.parsed);
   int axis                  = CheckAxis(param.axis, in_data[1].shape().ndim());
-  auto diff_mem             = in_data[0].GetMKLDNNData();
-  auto data_mem             = in_data[1].GetMKLDNNData();
+  auto diff_mem             = static_cast<const mkldnn::memory*>(in_data[0].GetMKLDNNData());
+  auto data_mem             = static_cast<const mkldnn::memory*>(in_data[1].GetMKLDNNData());
   auto bwd                  = GetSoftmaxBwd(param, axis, in_data, out_data);
 
   auto out_mem           = CreateMKLDNNMem(out_data[0], bwd.pd.diff_src_desc(), req[0]);

--- a/src/operator/nn/mkldnn/mkldnn_softmax_output.cc
+++ b/src/operator/nn/mkldnn/mkldnn_softmax_output.cc
@@ -84,7 +84,7 @@ static MKLDNNSoftmaxOutputFwd& GetSoftmaxOutputForward(const SoftmaxOutputParam&
 
   auto it = fwds.find(key);
   if (it == fwds.end()) {
-    auto in_mem = *(in_data.GetMKLDNNData());
+    auto in_mem = *(static_cast<const mkldnn::memory*>(in_data.GetMKLDNNData()));
     MKLDNNSoftmaxOutputFwd fwd(param, ctx.is_train, axis, in_mem);
     it = AddToCache(&fwds, key, fwd);
   }
@@ -109,7 +109,7 @@ void MKLDNNSoftmaxOutputForward(const nnvm::NodeAttrs& attrs,
     idata = in_data[softmaxout_enum::kData].Reorder2Default();
   }
 
-  auto input_mem = idata.GetMKLDNNData();
+  auto input_mem = static_cast<const mkldnn::memory*>(idata.GetMKLDNNData());
   auto out_mem   = CreateMKLDNNMem(
       out_data[softmaxout_enum::kOut], input_mem->get_desc(), req[softmaxout_enum::kOut]);
 

--- a/src/operator/nn/mkldnn/mkldnn_sum.cc
+++ b/src/operator/nn/mkldnn/mkldnn_sum.cc
@@ -112,7 +112,7 @@ void MKLDNNSumForward(const nnvm::NodeAttrs& attrs,
   data_mem.reserve(num_inputs);
 
   for (int i = 0; i < num_inputs; ++i) {
-    const mkldnn::memory* in_mem = inputs[i].GetMKLDNNData();
+    const mkldnn::memory* in_mem = static_cast<const mkldnn::memory*>(inputs[i].GetMKLDNNData());
     mkldnn::memory::desc tmp_md  = in_mem->get_desc();
     data_md.push_back(tmp_md);
     data_mem.push_back(in_mem);

--- a/src/operator/nn/mkldnn/mkldnn_transpose.cc
+++ b/src/operator/nn/mkldnn/mkldnn_transpose.cc
@@ -66,7 +66,7 @@ class MKLDNNTransposeForward {
     }
 
     auto engine = CpuEngine::Get()->get_engine();
-    auto in_mem = data.GetMKLDNNData();
+    auto in_mem = static_cast<const mkldnn::memory*>(data.GetMKLDNNData());
     auto src_md = in_mem->get_desc();
     data_       = std::make_shared<mkldnn::memory>(src_md, engine, nullptr);
 
@@ -90,7 +90,8 @@ class MKLDNNTransposeForward {
 
   void SetNewMem(const NDArray& data, const NDArray& output) {
     if (data.IsMKLDNNData()) {
-      this->data_->set_data_handle(data.GetMKLDNNData()->get_data_handle());
+      this->data_->set_data_handle(
+          static_cast<const mkldnn::memory*>(data.GetMKLDNNData())->get_data_handle());
     } else {
       MSHADOW_TYPE_SWITCH(
           data.dtype(), DTYPE, { this->data_->set_data_handle(data.data().dptr<DTYPE>()); });

--- a/src/operator/operator_common.h
+++ b/src/operator/operator_common.h
@@ -425,8 +425,7 @@ inline std::vector<nnvm::NodeEntry> MakeGradNode(
   return CreateNodeEntries(p);
 }
 
-// quick helper to make gradient nodes that simply pass back zero. could be used
-// in output ops.
+// quick helper to make gradient nodes that simply pass back zero. could be used in output ops.
 inline std::vector<nnvm::NodeEntry> MakeZeroGradNodes(const nnvm::ObjectPtr& n,
                                                       const std::vector<nnvm::NodeEntry>& ograds) {
   std::vector<nnvm::NodeEntry> ret;
@@ -614,7 +613,8 @@ class OpSignature {
   void AddSign(const NDArray& arr) {
 #if MXNET_USE_MKLDNN == 1
     if (arr.IsMKLDNNData()) {
-      AddSign(*(arr.GetMKLDNNData()));
+      auto arr_data = static_cast<const mkldnn::memory*>(arr.GetMKLDNNData());
+      AddSign(*(arr_data));
     } else {
 #endif
       hash = hash * 2 + arr.dtype();

--- a/src/operator/quantization/mkldnn/mkldnn_dequantize-inl.h
+++ b/src/operator/quantization/mkldnn/mkldnn_dequantize-inl.h
@@ -62,7 +62,7 @@ void SgMKLDNNDequantizeOperator::Forward(const OpContext& ctx,
   NDArray in_buffer = inputs[0];
   if (inputs[0].IsView() && inputs[0].IsMKLDNNData())
     in_buffer = inputs[0].Reorder2Default();
-  auto i_mem     = in_buffer.GetMKLDNNData();
+  auto i_mem     = static_cast<const mkldnn::memory*>(in_buffer.GetMKLDNNData());
   float data_min = *inputs[1].data().dptr<float>();
   float data_max = *inputs[2].data().dptr<float>();
 

--- a/src/operator/quantization/mkldnn/mkldnn_quantize-inl.h
+++ b/src/operator/quantization/mkldnn/mkldnn_quantize-inl.h
@@ -70,7 +70,7 @@ static void MKLDNNQuantizeComputeKer(const std::vector<NDArray>& inputs,
   if (inputs[0].IsView() && inputs[0].IsMKLDNNData())
     in_buffer = inputs[0].Reorder2Default();
 
-  auto i_mem    = in_buffer.GetMKLDNNData();
+  auto i_mem    = static_cast<const mkldnn::memory*>(in_buffer.GetMKLDNNData());
   auto i_desc   = i_mem->get_desc();
   size_t i_ndim = in_buffer.shape().ndim();
   mkldnn::memory::desc o_desc;

--- a/src/operator/quantization/mkldnn/mkldnn_quantize_v2-inl.h
+++ b/src/operator/quantization/mkldnn/mkldnn_quantize_v2-inl.h
@@ -81,13 +81,14 @@ void SgMKLDNNQuantizeOperator::Forward(const OpContext& ctx,
       }
     }
     if (req[0] != kWriteInplace) {
-      const_cast<NDArray&>(outputs[0]).CopyFrom(*inputs[0].GetMKLDNNData());
+      const_cast<NDArray&>(outputs[0])
+          .CopyFrom(static_cast<const mkldnn::memory*>(inputs[0].GetMKLDNNData()));
       MKLDNNStream::Get()->Submit();
     }
   } else {
     if (in_buffer.IsView() && in_buffer.IsMKLDNNData())
       in_buffer = inputs[0].Reorder2Default();
-    auto i_mem = in_buffer.GetMKLDNNData();
+    auto i_mem = static_cast<const mkldnn::memory*>(in_buffer.GetMKLDNNData());
 
     if (param_.min_calib_range.has_value() && param_.max_calib_range.has_value()) {
       data_min = param_.min_calib_range.value();

--- a/src/operator/quantization/mkldnn/mkldnn_quantized_concat.cc
+++ b/src/operator/quantization/mkldnn/mkldnn_quantized_concat.cc
@@ -72,11 +72,11 @@ static void MKLDNNQuantizedConcatForward(const nnvm::NodeAttrs& attrs,
     auto i_scale = GetScale(in_data[i], data_min[i], data_max[i]);
     if (i_scale == out_scale) {
       CHECK(in_data[i].dtype() == out_dtype);
-      auto mem = in_data[i].GetMKLDNNData();
+      auto mem = static_cast<const mkldnn::memory*>(in_data[i].GetMKLDNNData());
       data_mem.push_back(mem);
       data_md.push_back(mem->get_desc());
     } else {
-      auto mem      = in_data[i].GetMKLDNNData();
+      auto mem      = static_cast<const mkldnn::memory*>(in_data[i].GetMKLDNNData());
       auto mem_desc = mem->get_desc();
       if (in_data[i].dtype() != out_dtype) {
         mem_desc.data.data_type = static_cast<mkldnn_data_type_t>(get_mkldnn_type(out_dtype));

--- a/src/operator/quantization/mkldnn/mkldnn_quantized_conv.cc
+++ b/src/operator/quantization/mkldnn/mkldnn_quantized_conv.cc
@@ -46,13 +46,15 @@ static void MKLDNNQuantizedConvForward(const nnvm::NodeAttrs& attrs,
   MKLDNNConvFullParam full_param;
   full_param.conv_param = param;
   full_param.mkldnn_param.Init(std::unordered_map<std::string, std::string>());
-  auto& fwd     = GetConvFwd(full_param,
+  auto& fwd         = GetConvFwd(full_param,
                          ctx.is_train,
                          in_data[conv::kData],
                          in_data[conv::kWeight],
                          param.no_bias ? nullptr : &in_data[conv::kBias],
                          out_data[conv::kOut]);
-  auto data_mem = in_data[conv::kData].GetMKLDNNDataReorder(fwd.GetPd().src_desc());
+  auto fwd_src_desc = fwd.GetPd().src_desc();
+  auto data_mem =
+      static_cast<const mkldnn::memory*>(in_data[conv::kData].GetMKLDNNDataReorder(&fwd_src_desc));
   const mkldnn::memory* weight_mem;
   // For inference, we want to reorder the weight array so we don't need to
   // reorder data every time.
@@ -60,16 +62,18 @@ static void MKLDNNQuantizedConvForward(const nnvm::NodeAttrs& attrs,
     // We also need to modify the layout on the original weight array.
     // Don't switch below sequence because naive engine will executes
     // pushAsync synchronously.
-    weight.MKLDNNDataReorderAsync(fwd.GetPd().weights_desc());
+    auto fwd_weight_desc = fwd.GetPd().weights_desc();
+    weight.MKLDNNDataReorderAsync(&fwd_weight_desc);
     weight_mem = GetWeights(weight, fwd.GetPd().weights_desc(), param.num_group);
   } else {
-    weight_mem = weight.GetMKLDNNData();
+    weight_mem = static_cast<const mkldnn::memory*>(weight.GetMKLDNNData());
   }
   auto out_mem = CreateMKLDNNMem(out_data[conv::kOut], fwd.GetPd().dst_desc(), req[conv::kOut]);
   mkldnn_args_map_t net_args;
   if (!param.no_bias) {
-    const mkldnn::memory* bias_mem =
-        in_data[conv::kBias].GetMKLDNNDataReorder(fwd.GetPd().bias_desc());
+    auto fwd_bias_desc             = fwd.GetPd().bias_desc();
+    const mkldnn::memory* bias_mem = static_cast<const mkldnn::memory*>(
+        in_data[conv::kBias].GetMKLDNNDataReorder(&fwd_bias_desc));
     net_args.insert({MKLDNN_ARG_BIAS, *bias_mem});
   }
   net_args.insert({MKLDNN_ARG_SRC, *data_mem});

--- a/src/operator/quantization/mkldnn/mkldnn_quantized_elemwise_add.cc
+++ b/src/operator/quantization/mkldnn/mkldnn_quantized_elemwise_add.cc
@@ -109,8 +109,10 @@ static void MKLDNNQuantizedElemwiseAddForward(const nnvm::NodeAttrs& attrs,
   const float dataA_absmax = MaxAbs(dataA_min, dataA_max);
   const float dataB_absmax = MaxAbs(dataB_min, dataB_max);
 
-  auto dataA_mem = in_data[quantized_elemwise_add_enum::kDataA].GetMKLDNNData();
-  auto dataB_mem = in_data[quantized_elemwise_add_enum::kDataB].GetMKLDNNData();
+  auto dataA_mem = static_cast<const mkldnn::memory*>(
+      in_data[quantized_elemwise_add_enum::kDataA].GetMKLDNNData());
+  auto dataB_mem = static_cast<const mkldnn::memory*>(
+      in_data[quantized_elemwise_add_enum::kDataB].GetMKLDNNData());
   const bool is_dataA_int8 =
       (in_data[quantized_elemwise_add_enum::kDataA].dtype() == mshadow::kInt8);
   const float dataA_range = is_dataA_int8 ? kInt8Range : kUint8Range;

--- a/src/operator/quantization/mkldnn/mkldnn_requantize-inl.h
+++ b/src/operator/quantization/mkldnn/mkldnn_requantize-inl.h
@@ -80,7 +80,7 @@ static void MKLDNNRequantizeForwardKer(const nnvm::NodeAttrs& attrs,
   if (inputs[0].IsView() && inputs[0].IsMKLDNNData())
     in_buffer = inputs[0].Reorder2Default();
 
-  auto i_mem            = in_buffer.GetMKLDNNData();
+  auto i_mem            = static_cast<const mkldnn::memory*>(in_buffer.GetMKLDNNData());
   auto i_desc           = i_mem->get_desc();
   auto o_desc           = i_desc;
   o_desc.data.data_type = get_mkldnn_type_t<DstType>();

--- a/src/operator/tensor/amp_cast.cc
+++ b/src/operator/tensor/amp_cast.cc
@@ -46,7 +46,7 @@ static void AMPCastExCPU(const nnvm::NodeAttrs& attrs,
     mkldnn::engine cpu_engine = mxnet::CpuEngine::Get()->get_engine();
     if (data.IsView() && data.IsMKLDNNData())
       data = data.Reorder2Default();
-    const auto i_mem            = data.GetMKLDNNData();
+    const auto i_mem            = static_cast<const mkldnn::memory*>(data.GetMKLDNNData());
     const size_t i_ndim         = data.shape().ndim();
     mkldnn::memory::dims i_dims = mkldnn::memory::dims(i_ndim);
     for (size_t i = 0; i < i_ndim; i++) {
@@ -94,7 +94,7 @@ static void AMPMultiCastExCPU(const nnvm::NodeAttrs& attrs,
     auto data = inputs[i];
     if (data.IsView() && data.IsMKLDNNData())
       data = data.Reorder2Default();
-    const auto i_mem            = data.GetMKLDNNData();
+    const auto i_mem            = static_cast<const mkldnn::memory*>(data.GetMKLDNNData());
     const size_t i_ndim         = data.shape().ndim();
     mkldnn::memory::dims i_dims = mkldnn::memory::dims(i_ndim);
     for (size_t j = 0; j < i_ndim; j++) {
@@ -170,8 +170,7 @@ NNVM_REGISTER_OP(_backward_amp_cast)
     .set_attr<FCompute>("FCompute<cpu>", AMPCastCompute<cpu>);
 
 NNVM_REGISTER_OP(amp_multicast)
-    .describe(
-        R"code(Cast function used by AMP, that casts its inputs to the common widest type.
+    .describe(R"code(Cast function used by AMP, that casts its inputs to the common widest type.
 
 It casts only between low precision float/FP32 and does not do anything for other types.
 

--- a/src/operator/tensor/cast_storage-inl.h
+++ b/src/operator/tensor/cast_storage-inl.h
@@ -410,8 +410,8 @@ void CastStorageComputeImpl(const OpContext& ctx, const NDArray& input, const ND
       // data first.
       if (input.IsMKLDNNData() && input.IsView())
         tmp_input = input.Reorder2Default();
-      const mkldnn::memory* in_mem = tmp_input.GetMKLDNNData();
-      const_cast<NDArray&>(output).CopyFrom(*in_mem);
+      const mkldnn::memory* in_mem = static_cast<const mkldnn::memory*>(tmp_input.GetMKLDNNData());
+      const_cast<NDArray&>(output).CopyFrom(in_mem);
       MKLDNNStream::Get()->Submit();
     } else {
       mxnet_op::copy(ctx.get_stream<xpu>(), output.data(), input.data());

--- a/tests/cpp/include/test_mkldnn.h
+++ b/tests/cpp/include/test_mkldnn.h
@@ -86,7 +86,7 @@ inline static void InitMKLDNNArray(NDArray* arr,
                                    bool is_rand = false,
                                    int max      = 50) {
   InitDefaultArray(arr, is_rand, max);
-  arr->MKLDNNDataReorderAsync(desc);
+  arr->MKLDNNDataReorderAsync(&desc);
   arr->WaitToRead();
 }
 
@@ -352,8 +352,8 @@ inline void PrintVerifyMsg(const NDArrayAttrs& arr1, const NDArrayAttrs& arr2) {
  * think we should pass them to all operators. In the inference mode, the MKLDNN
  * memory in the weight array will be reordered to 5 dimensions.
  *
- *  num_inputs / dim arguments used to scale shape (used for concat backwards to
- * enlarge input shapes)
+ *  num_inputs / dim arguments used to scale shape (used for concat backwards to enlarge input
+ * shapes)
  */
 inline std::vector<NDArrayAttrs> GetTestInputArrays(int types                = ArrayTypes::All,
                                                     bool rand                = false,

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -1209,7 +1209,8 @@ void TestPoolingOp(const OpAttrs& forward_attrs, const OpAttrs& backwards_attrs)
       continue;
     // cannot pool if ndarray and mkldnn memory have different ndim
     if (in_arr.arr.IsView() ||
-        in_arr.arr.GetMKLDNNData()->get_desc().data.ndims != in_arr.arr.shape().ndim())
+        static_cast<const mkldnn::memory*>(in_arr.arr.GetMKLDNNData())->get_desc().data.ndims !=
+            in_arr.arr.shape().ndim())
       continue;
     std::vector<float> scale_vector(in_arr.arr.shape().ndim());
     for (int i = 0; i < in_arr.arr.shape().ndim(); i++) {

--- a/tests/cpp/operator/mkldnn_test.cc
+++ b/tests/cpp/operator/mkldnn_test.cc
@@ -26,25 +26,27 @@
 #if MXNET_USE_MKLDNN == 1
 
 #include <mkldnn_types.h>
-#include <cmath>
+
 #include <climits>
+#include <cmath>
 #include <set>
+
+#include "../../src/operator/nn/mkldnn/mkldnn_base-inl.h"
+#include "../../src/operator/nn/mkldnn/mkldnn_ops-inl.h"
+#include "../include/test_mkldnn.h"
 #include "gtest/gtest.h"
 #include "mxnet/imperative.h"
-#include "../../src/operator/nn/mkldnn/mkldnn_ops-inl.h"
-#include "../../src/operator/nn/mkldnn/mkldnn_base-inl.h"
-#include "../include/test_mkldnn.h"
 
 using namespace mxnet;
 
 #if __GNUC__ >= 5
-bool test_mem_align(void *mem, size_t size, size_t alignment, size_t space) {
+bool test_mem_align(void* mem, size_t size, size_t alignment, size_t space) {
   void *ret1, *ret2;
   size_t space1, space2;
   space1 = space;
   space2 = space;
-  ret1 = mxnet::AlignMem(mem, size, alignment, &space1);
-  ret2 = std::align(alignment, size, mem, space2);
+  ret1   = mxnet::AlignMem(mem, size, alignment, &space1);
+  ret2   = std::align(alignment, size, mem, space2);
   EXPECT_EQ(ret1, ret2);
   EXPECT_EQ(space1, space2);
   return ret1 == ret2;
@@ -54,29 +56,29 @@ bool test_mem_align(void *mem, size_t size, size_t alignment, size_t space) {
 TEST(MKLDNN_UTIL_FUNC, AlignMem) {
 #if __GNUC__ >= 5
   size_t alignment = 4096;
-  void *mem;
+  void* mem;
   size_t size, space;
   // When mem has been aligned.
-  mem = reinterpret_cast<void *>(0x10000);
-  size = 1000;
+  mem   = reinterpret_cast<void*>(0x10000);
+  size  = 1000;
   space = 10000;
   test_mem_align(mem, size, alignment, space);
 
   // When mem isn't aligned and we have enough space for alignment.
-  mem = reinterpret_cast<void *>(0x10010);
-  size = 1000;
+  mem   = reinterpret_cast<void*>(0x10010);
+  size  = 1000;
   space = 10000;
   test_mem_align(mem, size, alignment, space);
 
   // When mem isn't aligned and we don't have enough memory for alignment
-  mem = reinterpret_cast<void *>(0x10010);
-  size = 1000;
+  mem   = reinterpret_cast<void*>(0x10010);
+  size  = 1000;
   space = 1001;
   test_mem_align(mem, size, alignment, space);
 
   for (size_t i = 0; i < 10000; i++) {
-    mem = reinterpret_cast<void *>(random());
-    size = random() % 2000;
+    mem   = reinterpret_cast<void*>(random());
+    size  = random() % 2000;
     space = random() % 2000;
     test_mem_align(mem, size, alignment, space);
   }
@@ -87,12 +89,11 @@ TEST(MKLDNN_UTIL_FUNC, AlignMem) {
 #endif
 }
 
-static void VerifyDefMem(const mkldnn::memory &mem) {
-  mkldnn::memory::desc desc = mem.get_desc();
-  mshadow::default_real_t *data
-      = static_cast<mshadow::default_real_t *>(mem.get_data_handle());
-  size_t size = desc.get_size() / sizeof(mshadow::default_real_t);
-  size_t num_same = 0;
+static void VerifyDefMem(const mkldnn::memory& mem) {
+  mkldnn::memory::desc desc     = mem.get_desc();
+  mshadow::default_real_t* data = static_cast<mshadow::default_real_t*>(mem.get_data_handle());
+  size_t size                   = desc.get_size() / sizeof(mshadow::default_real_t);
+  size_t num_same               = 0;
   for (int i = 0; i < size; i++)
     num_same += data[i] == static_cast<mshadow::default_real_t>(i % 100 - 50);
   EXPECT_EQ(num_same, size);
@@ -105,14 +106,14 @@ TEST(MKLDNN_UTIL_FUNC, MemFormat) {
   CHECK_EQ(mkldnn_oihw, 5);
 }
 
-static void VerifyMem(const mkldnn::memory &mem) {
+static void VerifyMem(const mkldnn::memory& mem) {
   mkldnn::memory::desc desc = mem.get_desc();
   mkldnn::memory::dims dims(desc.data.ndims);
   for (size_t i = 0; i < dims.size(); i++)
     dims[i] = desc.data.dims[i];
   mkldnn::memory::desc new_desc{dims,
-      static_cast<mkldnn::memory::data_type>(desc.data.data_type),
-      static_cast<mkldnn::memory::format_tag>(GetDefaultFormat(desc))};
+                                static_cast<mkldnn::memory::data_type>(desc.data.data_type),
+                                static_cast<mkldnn::memory::format_tag>(GetDefaultFormat(desc))};
 
   if (desc == new_desc) {
     VerifyDefMem(mem);
@@ -121,18 +122,16 @@ static void VerifyMem(const mkldnn::memory &mem) {
     mkldnn::memory new_mem(new_desc, CpuEngine::Get()->get_engine());
 
     mkldnn::stream s(CpuEngine::Get()->get_engine());
-    mkldnn::reorder(*src_mem, new_mem)
-        .execute(s, *src_mem, new_mem);
+    mkldnn::reorder(*src_mem, new_mem).execute(s, *src_mem, new_mem);
 
     VerifyDefMem(new_mem);
   }
 }
 
 TEST(MKLDNN_NDArray, GetDataReorder) {
-  TestArrayShapes tas = GetTestArrayShapes();
-  mxnet::ShapeVector shapes = tas.shapes;
+  TestArrayShapes tas                   = GetTestArrayShapes();
+  mxnet::ShapeVector shapes             = tas.shapes;
   std::vector<mkldnn::memory::desc> mds = tas.mds;
-
 
   // Reorder from the default to any other layout.
   for (auto s : shapes) {
@@ -140,7 +139,8 @@ TEST(MKLDNN_NDArray, GetDataReorder) {
     InitDefaultArray(&arr);
     for (auto md : mds) {
       if (s.Size() == md.get_size() / sizeof(mshadow::default_real_t)) {
-        const mkldnn::memory *mem = arr.GetMKLDNNDataReorder(md);
+        const mkldnn::memory* mem =
+            static_cast<const mkldnn::memory*>(arr.GetMKLDNNDataReorder(&md));
         printf("reorder from (");
         for (size_t i = 0; i < s.ndim(); i++)
           printf("%ld, ", s[i]);
@@ -172,7 +172,8 @@ TEST(MKLDNN_NDArray, GetDataReorder) {
         InitMKLDNNArray(&arr, md);
         for (auto to_md : mds) {
           if (to_md.get_size() / sizeof(mshadow::default_real_t) == s.Size()) {
-            const mkldnn::memory *mem = arr.GetMKLDNNDataReorder(to_md);
+            const mkldnn::memory* mem =
+                static_cast<const mkldnn::memory*>(arr.GetMKLDNNDataReorder(&to_md));
             printf("reorder from (");
             for (size_t i = 0; i < s.ndim(); i++)
               printf("%ld, ", s[i]);
@@ -191,13 +192,13 @@ TEST(MKLDNN_NDArray, GetDataReorder) {
 }
 
 TEST(MKLDNN_BASE, MKLDNNSum) {
-  std::vector<NDArrayAttrs> in_arrs = GetTestInputArrays();
-  std::vector<NDArrayAttrs> in_arrs2 = GetTestInputArrays(ArrayTypes::All, true);
-  TestArrayShapes tas = GetTestArrayShapes();
+  std::vector<NDArrayAttrs> in_arrs     = GetTestInputArrays();
+  std::vector<NDArrayAttrs> in_arrs2    = GetTestInputArrays(ArrayTypes::All, true);
+  TestArrayShapes tas                   = GetTestArrayShapes();
   std::vector<mkldnn::memory::desc> mds = tas.mds;
 
   for (int i = 0; i < in_arrs.size(); i++) {
-    auto in_arr = in_arrs[i];
+    auto in_arr  = in_arrs[i];
     auto in_arr2 = in_arrs2[i];
     if (!SupportMKLDNN(in_arr.arr))
       continue;
@@ -205,12 +206,12 @@ TEST(MKLDNN_BASE, MKLDNNSum) {
       continue;
     }
     std::vector<NDArrayAttrs> out_arrs = GetTestOutputArrays(in_arr.arr.shape(), mds);
-    for (auto &out_arr : out_arrs) {
-      auto in_mem1 = in_arr.arr.GetMKLDNNData();
-      auto in_mem2 = in_arr2.arr.GetMKLDNNData();
+    for (auto& out_arr : out_arrs) {
+      auto in_mem1 = static_cast<const mkldnn::memory*>(in_arr.arr.GetMKLDNNData());
+      auto in_mem2 = static_cast<const mkldnn::memory*>(in_arr2.arr.GetMKLDNNData());
       if (out_arr.arr.IsView())
         continue;
-      auto out_mem = out_arr.arr.GetMKLDNNData();
+      auto out_mem = static_cast<const mkldnn::memory*>(out_arr.arr.GetMKLDNNData());
       PrintVerifyMsg(in_arr, in_arr);
       op::MKLDNNSum(*in_mem1, *in_mem2, *out_mem);
       MKLDNNStream::Get()->Submit();
@@ -220,20 +221,20 @@ TEST(MKLDNN_BASE, MKLDNNSum) {
 
   // in place
   for (int i = 0; i < in_arrs.size(); i++) {
-    auto in_arr = in_arrs[i];
+    auto in_arr  = in_arrs[i];
     auto in_arr2 = in_arrs2[i];
     if (!SupportMKLDNN(in_arr.arr))
       continue;
     if (in_arr.arr.IsMKLDNNData() && in_arr.arr.IsView()) {
       continue;
     }
-    auto input_mem = in_arr.arr.GetMKLDNNData();
-    auto input_mem2 = in_arr2.arr.GetMKLDNNData();
+    auto input_mem  = static_cast<const mkldnn::memory*>(in_arr.arr.GetMKLDNNData());
+    auto input_mem2 = static_cast<const mkldnn::memory*>(in_arr2.arr.GetMKLDNNData());
     NDArrayAttrs orig_arr(in_arr.arr.Copy(in_arr.arr.ctx()), "In Place Copy");
     orig_arr.arr.WaitToRead();
     PrintVerifyMsg(orig_arr, in_arr);
     InitMKLDNNArray(&orig_arr.arr, input_mem->get_desc());
-    orig_arr.arr.CopyFrom(*input_mem);
+    orig_arr.arr.CopyFrom(input_mem);
     op::MKLDNNSum(*input_mem, *input_mem2, *input_mem);
     MKLDNNStream::Get()->Submit();
     VerifySumResult({&orig_arr.arr, &in_arr2.arr}, {&in_arr.arr});
@@ -241,15 +242,15 @@ TEST(MKLDNN_BASE, MKLDNNSum) {
 }
 
 TEST(MKLDNN_BASE, CreateMKLDNNMem) {
-  std::vector<NDArrayAttrs> in_arrs = GetTestInputArrays();
-  std::vector<NDArrayAttrs> in_arrs2 = GetTestInputArrays(ArrayTypes::All, true);
-  TestArrayShapes tas = GetTestArrayShapes();
+  std::vector<NDArrayAttrs> in_arrs     = GetTestInputArrays();
+  std::vector<NDArrayAttrs> in_arrs2    = GetTestInputArrays(ArrayTypes::All, true);
+  TestArrayShapes tas                   = GetTestArrayShapes();
   std::vector<mkldnn::memory::desc> mds = tas.mds;
-  MKLDNNStream *stream = MKLDNNStream::Get();
+  MKLDNNStream* stream                  = MKLDNNStream::Get();
 
   // kWriteTo
   for (int i = 0; i < in_arrs.size(); i++) {
-    auto in_arr = in_arrs[i];
+    auto in_arr  = in_arrs[i];
     auto in_arr2 = in_arrs2[i];
     if (!SupportMKLDNN(in_arr.arr))
       continue;
@@ -257,13 +258,13 @@ TEST(MKLDNN_BASE, CreateMKLDNNMem) {
       continue;
     }
     std::vector<NDArrayAttrs> out_arrs = GetTestOutputArrays(in_arr.arr.shape(), mds);
-    for (auto &out_arr : out_arrs) {
-      auto in_mem = in_arr.arr.GetMKLDNNData();
-      auto in_mem2 = in_arr2.arr.GetMKLDNNData();
+    for (auto& out_arr : out_arrs) {
+      auto in_mem         = static_cast<const mkldnn::memory*>(in_arr.arr.GetMKLDNNData());
+      auto in_mem2        = static_cast<const mkldnn::memory*>(in_arr2.arr.GetMKLDNNData());
       NDArray orig_output = out_arr.arr.Copy(out_arr.arr.ctx());
       orig_output.WaitToRead();
       PrintVerifyMsg(in_arr, out_arr);
-      auto out_mem = out_arr.arr.GetMKLDNNData();
+      auto out_mem      = static_cast<const mkldnn::memory*>(out_arr.arr.GetMKLDNNData());
       auto output_mem_t = CreateMKLDNNMem(out_arr.arr, out_mem->get_desc(), kWriteTo);
       op::MKLDNNSum(*in_mem, *in_mem2, *output_mem_t.second);
       CommitOutput(out_arr.arr, output_mem_t);
@@ -274,22 +275,22 @@ TEST(MKLDNN_BASE, CreateMKLDNNMem) {
 
   // kWriteInPlace
   for (int i = 0; i < in_arrs.size(); i++) {
-    auto in_arr = in_arrs[i];
+    auto in_arr  = in_arrs[i];
     auto in_arr2 = in_arrs2[i];
     if (!SupportMKLDNN(in_arr.arr))
       continue;
     if (in_arr.arr.IsMKLDNNData() && in_arr.arr.IsView()) {
       continue;
     }
-    auto input_mem = in_arr.arr.GetMKLDNNData();
-    auto input_mem2 = in_arr2.arr.GetMKLDNNData();
+    auto input_mem  = static_cast<const mkldnn::memory*>(in_arr.arr.GetMKLDNNData());
+    auto input_mem2 = static_cast<const mkldnn::memory*>(in_arr2.arr.GetMKLDNNData());
     NDArrayAttrs orig_arr(in_arr.arr.Copy(in_arr.arr.ctx()), "In Place Copy");
     orig_arr.arr.WaitToRead();
     PrintVerifyMsg(orig_arr, in_arr);
     InitMKLDNNArray(&orig_arr.arr, input_mem->get_desc());
-    orig_arr.arr.CopyFrom(*input_mem);
-    auto output_mem_t = CreateMKLDNNMem(in_arr.arr,
-        input_mem->get_desc(), kWriteInplace, &in_arr.arr);
+    orig_arr.arr.CopyFrom(input_mem);
+    auto output_mem_t =
+        CreateMKLDNNMem(in_arr.arr, input_mem->get_desc(), kWriteInplace, &in_arr.arr);
     op::MKLDNNSum(*input_mem, *input_mem2, *output_mem_t.second);
     CommitOutput(in_arr.arr, output_mem_t);
     stream->Submit();
@@ -298,7 +299,7 @@ TEST(MKLDNN_BASE, CreateMKLDNNMem) {
 
   // kAddTo
   for (int i = 0; i < in_arrs.size(); i++) {
-    auto in_arr = in_arrs[i];
+    auto in_arr  = in_arrs[i];
     auto in_arr2 = in_arrs2[i];
     if (!SupportMKLDNN(in_arr.arr))
       continue;
@@ -306,13 +307,13 @@ TEST(MKLDNN_BASE, CreateMKLDNNMem) {
       continue;
     }
     std::vector<NDArrayAttrs> out_arrs = GetTestOutputArrays(in_arr.arr.shape(), mds);
-    for (auto &out_arr : out_arrs) {
-      auto in_mem = in_arr.arr.GetMKLDNNData();
-      auto in_mem2 = in_arr2.arr.GetMKLDNNData();
+    for (auto& out_arr : out_arrs) {
+      auto in_mem         = static_cast<const mkldnn::memory*>(in_arr.arr.GetMKLDNNData());
+      auto in_mem2        = static_cast<const mkldnn::memory*>(in_arr2.arr.GetMKLDNNData());
       NDArray orig_output = out_arr.arr.Copy(out_arr.arr.ctx());
       orig_output.WaitToRead();
       PrintVerifyMsg(in_arr, out_arr);
-      auto out_mem = out_arr.arr.GetMKLDNNData();
+      auto out_mem      = static_cast<const mkldnn::memory*>(out_arr.arr.GetMKLDNNData());
       auto output_mem_t = CreateMKLDNNMem(out_arr.arr, out_mem->get_desc(), kAddTo);
       op::MKLDNNSum(*in_mem, *in_mem2, *output_mem_t.second);
       CommitOutput(out_arr.arr, output_mem_t);
@@ -324,20 +325,20 @@ TEST(MKLDNN_BASE, CreateMKLDNNMem) {
 
   // kNullOp
   for (int i = 0; i < in_arrs.size(); i++) {
-    auto in_arr = in_arrs[i];
+    auto in_arr  = in_arrs[i];
     auto in_arr2 = in_arrs2[i];
     if (!SupportMKLDNN(in_arr.arr))
       continue;
     if (in_arr.arr.IsMKLDNNData() && in_arr.arr.IsView()) {
       continue;
     }
-    auto input_mem = in_arr.arr.GetMKLDNNData();
-    auto input_mem2 = in_arr2.arr.GetMKLDNNData();
+    auto input_mem  = static_cast<const mkldnn::memory*>(in_arr.arr.GetMKLDNNData());
+    auto input_mem2 = static_cast<const mkldnn::memory*>(in_arr2.arr.GetMKLDNNData());
     NDArrayAttrs orig_arr(in_arr.arr.Copy(in_arr.arr.ctx()), "In Place Copy");
     orig_arr.arr.WaitToRead();
     PrintVerifyMsg(orig_arr, in_arr);
     InitMKLDNNArray(&orig_arr.arr, input_mem->get_desc());
-    orig_arr.arr.CopyFrom(*input_mem);
+    orig_arr.arr.CopyFrom(input_mem);
     auto output_mem_t = CreateMKLDNNMem(in_arr.arr, input_mem->get_desc(), kNullOp);
     op::MKLDNNSum(*input_mem, *input_mem2, *output_mem_t.second);
     CommitOutput(in_arr.arr, output_mem_t);
@@ -355,10 +356,10 @@ TEST(MKLDNN_NDArray, GetTestInputArraysConcat) {
       for (size_t i = 0; i < dim + 1; ++i)
         scale_vector[i] = 1;
       scale_vector[dim] = num_inputs;
-      std::vector<NDArrayAttrs> expanded_arrs = GetTestInputArrays(
-          ArrayTypes::All, false, scale_vector);
+      std::vector<NDArrayAttrs> expanded_arrs =
+          GetTestInputArrays(ArrayTypes::All, false, scale_vector);
       int i = 0;
-      for (auto &arr : in_arrs) {
+      for (auto& arr : in_arrs) {
         if (dim >= arr.arr.shape().ndim())
           continue;
         auto ex_arr = expanded_arrs[i];
@@ -372,22 +373,22 @@ TEST(MKLDNN_NDArray, GetTestInputArraysConcat) {
 }
 
 TEST(MKLDNN_NDArray, GetTestOutputArraysConcat) {
-  auto shapes_pds = GetTestArrayShapes();
-  std::vector<mxnet::TShape> shapes = shapes_pds.shapes;
+  auto shapes_pds                       = GetTestArrayShapes();
+  std::vector<mxnet::TShape> shapes     = shapes_pds.shapes;
   std::vector<mkldnn::memory::desc> mds = shapes_pds.mds;
-  for (auto &shape : shapes) {
+  for (auto& shape : shapes) {
     for (int dim = 0; dim < 5; dim++) {
       for (int num_inputs = 2; num_inputs < 5; num_inputs++) {
         if (shape.ndim() <= dim)
           continue;
-        std::cout << "Extending " << shape << " dim " <<
-                  dim << " and " << num_inputs << "num_inputs\n";
+        std::cout << "Extending " << shape << " dim " << dim << " and " << num_inputs
+                  << "num_inputs\n";
         std::vector<float> scale_vector(shape.ndim());
         for (int i = 0; i < shape.ndim(); i++)
           scale_vector[i] = 1;
         scale_vector[dim] = num_inputs;
-        auto output_arrs = GetTestOutputArrays(shape, mds, scale_vector);
-        for (auto &out_arr : output_arrs) {
+        auto output_arrs  = GetTestOutputArrays(shape, mds, scale_vector);
+        for (auto& out_arr : output_arrs) {
           auto out_shape = out_arr.arr.shape();
           EXPECT_EQ(shape.Size() * num_inputs, out_arr.arr.shape().Size());
           EXPECT_EQ(shape[dim] * num_inputs, out_arr.arr.shape()[dim]);
@@ -398,19 +399,19 @@ TEST(MKLDNN_NDArray, GetTestOutputArraysConcat) {
 }
 
 TEST(MKLDNN_NDArray, CopyFrom) {
-  TestArrayShapes tas = GetTestArrayShapes();
+  TestArrayShapes tas                   = GetTestArrayShapes();
   std::vector<mkldnn::memory::desc> mds = tas.mds;
 
   std::vector<NDArrayAttrs> in_arrs = GetTestInputArrays();
-  for (auto &in_arr : in_arrs) {
+  for (auto& in_arr : in_arrs) {
     if (in_arr.arr.IsMKLDNNData() && in_arr.arr.IsView())
       continue;
     std::vector<NDArrayAttrs> out_arrs = GetTestOutputArrays(in_arr.arr.shape(), mds);
-    for (auto &out_arr : out_arrs) {
-      const mkldnn::memory *mem = in_arr.arr.GetMKLDNNData();
-      out_arr.arr.CopyFrom(*mem);
+    for (auto& out_arr : out_arrs) {
+      const mkldnn::memory* mem = static_cast<const mkldnn::memory*>(in_arr.arr.GetMKLDNNData());
+      out_arr.arr.CopyFrom(mem);
       MKLDNNStream::Get()->Submit();
-      std::vector<NDArray *> inputs(1);
+      std::vector<NDArray*> inputs(1);
       inputs[0] = &in_arr.arr;
       VerifyCopyResult(inputs, {&out_arr.arr});
     }


### PR DESCRIPTION
## Description ##
NDArry file has been modified, there are a few changes:
1. OneDNN header was moved into *cc file
2. OneDNN object is created on the fly: static_cast is needed

Decouple oneDNN data structures in MXNet C++ API #20196

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
