### PR TITLE
Auto-formatter to keep the same coding style

### DIFF
--- a/include/mxnet/ndarray.h
+++ b/include/mxnet/ndarray.h
@@ -136,8 +136,8 @@ class NDArray {
         entry_(nullptr) {}
 
   /*!
-   * \brief constructing a static NDArray that shares data with TBlob which is with deleter
-   *  Use with caution: allocate ONLY ONE NDArray for each TBlob,
+   * \brief constructing a static NDArray that shares data with TBlob which is
+   * with deleter Use with caution: allocate ONLY ONE NDArray for each TBlob,
    *  make sure the memory region is available through out the life of NDArray
    * \param data the memory content of static data
    * \param dev_id the device id this tensor sits at
@@ -163,8 +163,8 @@ class NDArray {
         entry_(nullptr) {}
 
   /*!
-   * \brief constructing a static NDArray of non-default storage that shares data with TBlob
-   *  Use with caution: allocate ONLY ONE NDArray for each TBlob,
+   * \brief constructing a static NDArray of non-default storage that shares
+   * data with TBlob Use with caution: allocate ONLY ONE NDArray for each TBlob,
    *  make sure the memory region is available through out the life of NDArray
    * \param stype the storage type of NDArray
    * \param shape the shape of NDArray
@@ -183,15 +183,16 @@ class NDArray {
         storage_type_(stype),
         entry_(nullptr) {}
   /*!
-   * \brief initialize the NDArray, assuming it is not assigned a meaningful shape before
-   * \param shape the shape of the NDArray
+   * \brief initialize the NDArray, assuming it is not assigned a meaningful
+   * shape before \param shape the shape of the NDArray
    */
   void Init(const mxnet::TShape& shape) {
     ptr_->Init(shape, this->dtype_);
     this->shape_ = shape;
   }
   /*!
-   * \brief set the correct shape of NDArray directly from the storage_shape of its own chunk.
+   * \brief set the correct shape of NDArray directly from the storage_shape of
+   * its own chunk.
    */
   void SetShapeFromChunk();
   /*
@@ -202,10 +203,12 @@ class NDArray {
    */
   inline bool IsView() const {
     // View only works on the default storage
-    if (storage_type() != kDefaultStorage) return false;
+    if (storage_type() != kDefaultStorage)
+      return false;
     // If the array reuses memory, its shape may be different from the storage
     // shape. However, we shouldn't consider it as a view.
-    if (reuse_) return false;
+    if (reuse_)
+      return false;
     return byte_offset_ > 0 || shape() != ptr_->storage_shape;
   }
 
@@ -218,11 +221,13 @@ class NDArray {
   /*!
    * \return the shape of current NDArray.
    */
-  inline const mxnet::TShape& shape() const { return shape_; }
+  inline const mxnet::TShape& shape() const {
+    return shape_;
+  }
   /*!
    * \return the shape of underlying chunk which stores the NDArray data/value.
-   *  It is only intended for non-default storage. For row-sparse storage, it is the shape of
-   *  the tensor which stores the non-zero values.
+   *  It is only intended for non-default storage. For row-sparse storage, it is
+   * the shape of the tensor which stores the non-zero values.
    */
   inline const mxnet::TShape& storage_shape() const {
     CHECK(ptr_ != nullptr);
@@ -271,7 +276,8 @@ class NDArray {
    * \return the data TBlob
    */
   inline const TBlob& data() const {
-    if (storage_type() == kDefaultStorage) CheckAndAlloc();
+    if (storage_type() == kDefaultStorage)
+      CheckAndAlloc();
     SetTBlob();
     return tblob_;
   }
@@ -297,34 +303,43 @@ class NDArray {
     return res;
   }
   /*!
-   * \return the context of NDArray, this function is only valid when the NDArray is not empty
+   * \return the context of NDArray, this function is only valid when the
+   * NDArray is not empty
    */
   inline Context ctx() const {
     CHECK(!is_none());
     return ptr_->shandle.ctx;
   }
   /*!
-   * \return the data type of NDArray, this function is only valid when the NDArray is not empty
+   * \return the data type of NDArray, this function is only valid when the
+   * NDArray is not empty
    */
-  inline int dtype() const { return dtype_; }
+  inline int dtype() const {
+    return dtype_;
+  }
   inline int aux_type(size_t i) const {
     CHECK(!is_none());
     return ptr_->aux_types[i];
   }
 
-  inline NDArrayStorageType storage_type() const { return storage_type_; }
+  inline NDArrayStorageType storage_type() const {
+    return storage_type_;
+  }
   /*! \return whether this ndarray is not initialized */
-  inline bool is_none() const { return ptr_.get() == nullptr; }
+  inline bool is_none() const {
+    return ptr_.get() == nullptr;
+  }
   /*! \return updated grad state in entry_ */
   bool fresh_out_grad() const;
   /*! \return updated grad state in entry_ */
   void set_fresh_out_grad(bool state) const;
-  /*! \brief Returns true if a sparse ndarray's aux_data and storage are initialized
-   * Throws an exception if the indices array shape is inconsistent
+  /*! \brief Returns true if a sparse ndarray's aux_data and storage are
+   * initialized Throws an exception if the indices array shape is inconsistent
    * Returns false if the indices array is empty(nnz = 0) for csr/row_sparse
    */
   inline bool storage_initialized() const {
-    if (is_none()) return false;
+    if (is_none())
+      return false;
     auto stype = storage_type();
     CHECK_NE(stype, kDefaultStorage)
         << "storage_initialized() is not intended for kDefaultStorage.";
@@ -355,7 +370,8 @@ class NDArray {
    *    to current NDArray are finished, and read can be performed.
    */
   inline void WaitToRead() const {
-    if (is_none()) return;
+    if (is_none())
+      return;
     Engine::Get()->WaitForVar(ptr_->var);
   }
   /*!
@@ -363,22 +379,31 @@ class NDArray {
    *    to current NDArray are finished, and write can be performed.
    */
   inline void WaitToWrite() const {
-    if (is_none()) return;
+    if (is_none())
+      return;
     /*!
      * Push an empty mutable function to flush all preceding reads to the
      * variable.
      */
     Engine::Get()->PushAsync(
-        [](RunContext, Engine::CallbackOnComplete on_complete) { on_complete(); }, Context{}, {},
+        [](RunContext, Engine::CallbackOnComplete on_complete) { on_complete(); },
+        Context{},
+        {},
         {ptr_->var});
     Engine::Get()->WaitForVar(ptr_->var);
   }
   /*! \return the associated variable of the ndarray.*/
-  inline Engine::VarHandle var() const { return ptr_->var; }
+  inline Engine::VarHandle var() const {
+    return ptr_->var;
+  }
   /*! \return byte offset in chunk of the ndarray*/
-  inline size_t byte_offset() const { return byte_offset_; }
+  inline size_t byte_offset() const {
+    return byte_offset_;
+  }
   /*! \brief return var version of the NDArray*/
-  inline size_t version() const { return var()->version(); }
+  inline size_t version() const {
+    return var()->version();
+  }
   /*!
    * \brief save the content into binary stream
    * \param strm the output stream
@@ -489,7 +514,8 @@ class NDArray {
    *  not wrapped by NDArray(thus dependency not being tracked).
    *
    * \param data the data source to copyinto.
-   * \param size the memory size we want to copy into, in sizeof(DType) not raw btyes.
+   * \param size the memory size we want to copy into, in sizeof(DType) not raw
+   * btyes.
    */
   void SyncCopyToCPU(void* data, size_t size) const;
   /*!
@@ -577,11 +603,11 @@ class NDArray {
   static NDArray FromDLPack(const DLManagedTensor* tensor, bool transient_handle);
 
   /*!
-   * \brief Update ndarray chunk storage handles using existing ndarray storage handles
-   * Also update the aux_handle, aux_shapes and aux_types.
-   * This is specifically used for custom op to update the inputs and outputs from
-   * the temporary ndarray which stores intermediate custom op results.
-   * Should be used with caution elsewhere. Supports only CSR and RSP formats.
+   * \brief Update ndarray chunk storage handles using existing ndarray storage
+   * handles Also update the aux_handle, aux_shapes and aux_types. This is
+   * specifically used for custom op to update the inputs and outputs from the
+   * temporary ndarray which stores intermediate custom op results. Should be
+   * used with caution elsewhere. Supports only CSR and RSP formats.
    */
   inline void SparseUpdateChunk(const NDArray& arr) const {
     CHECK(shape_ == arr.shape_) << "ndarray shape is different from the target";
@@ -650,7 +676,8 @@ class NDArray {
    * storage type and effectively changes the ndarray's shape_.
    * Note: This function is named as this to avoid overload conflict
    * with CheckAndAlloc(const mxnet::ShapeVector &aux_shapes), since
-   * mxnet::TShape tmp = some_shape is equivalent to mxnet::TShape tmp = {some_shape}.
+   * mxnet::TShape tmp = some_shape is equivalent to mxnet::TShape tmp =
+   * {some_shape}.
    */
   void ReshapeAndAlloc(const mxnet::TShape& shape) {
     CHECK_EQ(storage_type(), kDefaultStorage);
@@ -693,11 +720,15 @@ class NDArray {
   /*
    * Test if the data is stored in one of special MKLDNN format.
    */
-  bool IsMKLDNNData() const { return ptr_->IsMKLDNN(); }
+  bool IsMKLDNNData() const {
+    return ptr_->IsMKLDNN();
+  }
   /*
    * Test if the data is stored in one of default MXNet formats.
    */
-  bool IsDefaultData() const { return ptr_->IsDefault(); }
+  bool IsDefaultData() const {
+    return ptr_->IsDefault();
+  }
   /*
    * All functions below return a raw pointer to mkldnn memory. Actually there
    * is a shared pointer that hold the memory either in NDArray or in MKLDNN
@@ -711,7 +742,8 @@ class NDArray {
   const mkldnn::memory* GetMKLDNNData() const;
   /*
    * This function returns mkldnn::memory with the given primitive_desc
-   * as long as the array size meets the required size in the given primitive_desc.
+   * as long as the array size meets the required size in the given
+   * primitive_desc.
    */
   const mkldnn::memory* GetMKLDNNData(const mkldnn::memory::desc& md) const;
   /*
@@ -792,7 +824,8 @@ class NDArray {
   friend class Imperative;
   /*! \brief the real data chunk that backs NDArray */
   // shandle is used to store the actual values in the NDArray
-  // aux_handles store the aux data(such as indices) if it's needed by non-default storage.
+  // aux_handles store the aux data(such as indices) if it's needed by
+  // non-default storage.
   struct Chunk {
     /*! \brief storage handle from storage engine.
                for non-default storage, shandle stores the data(value) array.
@@ -817,26 +850,28 @@ class NDArray {
      */
     /*! \brief construct from static data */
     bool static_data;
-    /*! \brief whether data allocation is delayed. This doesn't indicate whether aux data
-               allocation is delayed. */
+    /*! \brief whether data allocation is delayed. This doesn't indicate whether
+       aux data allocation is delayed. */
     bool delay_alloc;
-    // the type of the storage. The storage_type is never kUndefinedStorage once the chunk
-    // is constructed.
+    // the type of the storage. The storage_type is never kUndefinedStorage once
+    // the chunk is constructed.
     NDArrayStorageType storage_type = kDefaultStorage;
     /*! \brief type of aux */
     std::vector<int> aux_types;
     // context of data
     Context ctx;
     // The shape of the chunk data.
-    // This might not be the same shape as the NDArray, since the storage may be sparse.
-    // The default value for storage_shape is {0} when an empty non-default NDArray is created.
+    // This might not be the same shape as the NDArray, since the storage may be
+    // sparse. The default value for storage_shape is {0} when an empty
+    // non-default NDArray is created.
     mxnet::TShape storage_shape;
-    // The shape of aux data. The default value for the shape depends on the type of storage.
-    // If aux_shapes[i].Size() is zero, aux data i is empty.
+    // The shape of aux data. The default value for the shape depends on the
+    // type of storage. If aux_shapes[i].Size() is zero, aux data i is empty.
     mxnet::ShapeVector aux_shapes;
     /*! \brief Reference to the storage to ensure proper destruct order */
     std::shared_ptr<Storage> storage_ref_;
-    /*! \brief Reference to the engine to ensure we cleanup without calling a destructed engine */
+    /*! \brief Reference to the engine to ensure we cleanup without calling a
+     * destructed engine */
     std::weak_ptr<Engine> engine_ref_;
 
     /*! \brief default constructor */
@@ -966,7 +1001,8 @@ class NDArray {
       }
     }
 
-    /*! \brief set the shape for ith aux data, and update storage shape if necessary */
+    /*! \brief set the shape for ith aux data, and update storage shape if
+     * necessary */
     inline void set_aux_shape(const size_t i, const mxnet::TShape& shape) {
       aux_shapes[i] = shape;
       if (storage_shape.ndim() >= 0) {
@@ -1011,7 +1047,8 @@ class NDArray {
 #endif
       }
     }
-    /*! \brief initialize the shape and dtype, assuming it is not initialized before. */
+    /*! \brief initialize the shape and dtype, assuming it is not initialized
+     * before. */
     void Init(const mxnet::TShape& shape, int dtype) {
       auto size     = shape.Size();
       storage_shape = shape;
@@ -1037,10 +1074,9 @@ class NDArray {
         LOG(FATAL) << "Storage type " << storage_type << " not implemented for CheckAndAlloc";
       }
     }
-    // create storage handle for data based on shape and dtype, assuming ctx is set
-    // storage shape is also updated
-    // if data is already allocated, try reuse the storage. Otherwise, free the current one
-    // and allocate new storage
+    // create storage handle for data based on shape and dtype, assuming ctx is
+    // set storage shape is also updated if data is already allocated, try reuse
+    // the storage. Otherwise, free the current one and allocate new storage
     void CheckAndAllocData(const mxnet::TShape& shape, int dtype);
 
 #if MXNET_USE_MKLDNN == 1
@@ -1059,8 +1095,8 @@ class NDArray {
     // create storage handle for aux data based on shape
     // this function assumes ctx, aux shapes and aux types are set
     // aux shape is also updated
-    // if aux data is already allocated, try reuse the storage. Otherwise, free the current one
-    // and allocate new storage
+    // if aux data is already allocated, try reuse the storage. Otherwise, free
+    // the current one and allocate new storage
     inline void CheckAndAllocAuxData(size_t i, const mxnet::TShape& shape) {
       CHECK_EQ(shape.ndim(), 1) << "shape must be 1D in CheckAndAllocAuxData";
       CHECK_NE(storage_type, kUndefinedStorage)
@@ -1136,17 +1172,16 @@ void CopyFromTo(const NDArray& from, const NDArray* to, int priority = 0);
  * \param from the ndarray we want to copy data from
  * \param to the target ndarray
  * \param priority Priority of the action.
- * \param is_opr whether it is invoked by an operator. For example, false if invoked from
-       KVStore, true if invoked from `_copyto` operator.
+ * \param is_opr whether it is invoked by an operator. For example, false if
+ invoked from KVStore, true if invoked from `_copyto` operator.
  * \note The function name explicitly marks the order of from and to
  *     due to different possible convention carried by copy function.
  */
 void CopyFromTo(const NDArray& from, const NDArray& to, int priority = 0, bool is_opr = false);
 
 /*!
- * \brief Perform elementwise sum over each data from source, store result into out.
- * \param source the ndarray we want to sum
- * \param out the target ndarray
+ * \brief Perform elementwise sum over each data from source, store result into
+ * out. \param source the ndarray we want to sum \param out the target ndarray
  * \param priority Priority of the action.
  */
 void ElementwiseSum(const std::vector<NDArray>& source, NDArray* out, int priority = 0);
@@ -1259,10 +1294,9 @@ void SamplePoisson(real_t lambda, NDArray* out);
  */
 void SampleNegBinomial(int32_t k, real_t p, NDArray* out);
 /*!
- * \brief Sample generalized negative binomial distribution for each elements of out.
- * \param mu parameter (mean) of the distribution
- * \param alpha parameter (over dispersion) of the distribution
- * \param out output NDArray.
+ * \brief Sample generalized negative binomial distribution for each elements of
+ * out. \param mu parameter (mean) of the distribution \param alpha parameter
+ * (over dispersion) of the distribution \param out output NDArray.
  */
 void SampleGenNegBinomial(real_t mu, real_t alpha, NDArray* out);
 
@@ -1316,9 +1350,13 @@ struct NDArrayFunctionReg
    * \return ref to the registered entry, used to set properties
    */
   inline NDArrayFunctionReg& set_function(void (*fsetvalue)(const real_t& rhs, NDArray* out)) {
-    body = [fsetvalue](NDArray** used_vars, real_t* s, NDArray** mutate_vars, int num_params,
+    body = [fsetvalue](NDArray** used_vars,
+                       real_t* s,
+                       NDArray** mutate_vars,
+                       int num_params,
                        char** param_keys,
                        char** param_vals) { (*fsetvalue)(s[0], mutate_vars[0]); };
+
     num_mutate_vars = 1;
     num_scalars     = 1;
     this->add_argument("src", "real_t", "Source input to the function.");
@@ -1332,8 +1370,12 @@ struct NDArrayFunctionReg
    */
   inline NDArrayFunctionReg& set_function(
       void (*fternary)(const NDArray& lhs, const NDArray& mhs, const NDArray& rhs, NDArray* out)) {
-    body = [fternary](NDArray** used_vars, real_t* s, NDArray** mutate_vars, int num_params,
-                      char** param_keys, char** param_vals) {
+    body = [fternary](NDArray** used_vars,
+                      real_t* s,
+                      NDArray** mutate_vars,
+                      int num_params,
+                      char** param_keys,
+                      char** param_vals) {
       (*fternary)(*used_vars[0], *used_vars[1], *used_vars[2], mutate_vars[0]);
     };
     num_use_vars    = 3;
@@ -1353,8 +1395,12 @@ struct NDArrayFunctionReg
   inline NDArrayFunctionReg& set_function(void (*fbinary)(const NDArray& lhs,
                                                           const NDArray& rhs,
                                                           NDArray* out)) {
-    body = [fbinary](NDArray** used_vars, real_t* s, NDArray** mutate_vars, int num_params,
-                     char** param_keys, char** param_vals) {
+    body = [fbinary](NDArray** used_vars,
+                     real_t* s,
+                     NDArray** mutate_vars,
+                     int num_params,
+                     char** param_keys,
+                     char** param_vals) {
       (*fbinary)(*used_vars[0], *used_vars[1], mutate_vars[0]);
     };
     num_use_vars    = 2;
@@ -1373,10 +1419,14 @@ struct NDArrayFunctionReg
   inline NDArrayFunctionReg& set_function(void (*fscalar)(const NDArray& lhs,
                                                           const real_t& rhs,
                                                           NDArray* out)) {
-    body         = [fscalar](NDArray** used_vars, real_t* s, NDArray** mutate_vars, int num_params,
+    body = [fscalar](NDArray** used_vars,
+                     real_t* s,
+                     NDArray** mutate_vars,
+                     int num_params,
                      char** param_keys,
                      char** param_vals) { (*fscalar)(*used_vars[0], s[0], mutate_vars[0]); };
-    num_use_vars = 1;
+
+    num_use_vars    = 1;
     num_mutate_vars = 1;
     num_scalars     = 1;
     type_mask       = kNDArrayArgBeforeScalar | kAcceptEmptyMutateTarget;
@@ -1391,10 +1441,14 @@ struct NDArrayFunctionReg
    * \return ref to the registered entry, used to set properties
    */
   inline NDArrayFunctionReg& set_function(void (*funary)(const NDArray& src, NDArray* out)) {
-    body         = [funary](NDArray** used_vars, real_t* s, NDArray** mutate_vars, int num_params,
+    body = [funary](NDArray** used_vars,
+                    real_t* s,
+                    NDArray** mutate_vars,
+                    int num_params,
                     char** param_keys,
                     char** param_vals) { (*funary)(*used_vars[0], mutate_vars[0]); };
-    num_use_vars = 1;
+
+    num_use_vars    = 1;
     num_mutate_vars = 1;
     type_mask       = kNDArrayArgBeforeScalar | kAcceptEmptyMutateTarget;
     this->add_argument("src", "NDArray", "Source input to the function.");
@@ -1411,8 +1465,12 @@ struct NDArrayFunctionReg
                        real_t* s,
                        NDArray** mutate_vars,
                        const std::map<std::string, std::string>& param)) {
-    body = [fgeneric](NDArray** used_vars, real_t* s, NDArray** mutate_vars, int num_params,
-                      char** param_keys, char** param_vals) {
+    body = [fgeneric](NDArray** used_vars,
+                      real_t* s,
+                      NDArray** mutate_vars,
+                      int num_params,
+                      char** param_keys,
+                      char** param_vals) {
       std::map<std::string, std::string> param;
       for (int i = 0; i < num_params; ++i) {
         param[param_keys[i]] = param_vals[i];

--- a/include/mxnet/ndarray.h
+++ b/include/mxnet/ndarray.h
@@ -26,23 +26,23 @@
 #define MXNET_NDARRAY_H_
 
 #include <dmlc/base.h>
-#include <dmlc/logging.h>
 #include <dmlc/io.h>
-#include <dmlc/type_traits.h>
+#include <dmlc/logging.h>
 #include <dmlc/registry.h>
+#include <dmlc/type_traits.h>
 #include <nnvm/node.h>
-#include <vector>
+
+#include <algorithm>
 #include <map>
-#include <string>
-#include <algorithm>
 #include <memory>
-#include <algorithm>
+#include <string>
+#include <vector>
 #if MXNET_USE_MKLDNN == 1
 #include <mkldnn.hpp>
 #endif
 #include "./base.h"
-#include "./storage.h"
 #include "./engine.h"
+#include "./storage.h"
 // check c++11
 #if DMLC_USE_CXX11 == 0
 #error "cxx11 was required for ndarray module"
@@ -90,8 +90,10 @@ class NDArray {
    * \param delay_alloc whether delay the allocation
    * \param dtype data type of this ndarray
    */
-  NDArray(const mxnet::TShape& shape, Context ctx, bool delay_alloc = false,
-          int dtype = mshadow::default_type_flag)
+  NDArray(const mxnet::TShape& shape,
+          Context ctx,
+          bool delay_alloc = false,
+          int dtype        = mshadow::default_type_flag)
       : ptr_(std::make_shared<Chunk>(shape, ctx, delay_alloc, dtype)),
         shape_(shape),
         dtype_(dtype),
@@ -99,10 +101,14 @@ class NDArray {
         entry_(nullptr) {}
   /*! \brief constructor for NDArray with storage type
    */
-  NDArray(const NDArrayStorageType stype, const mxnet::TShape& shape, Context ctx,
-          bool delay_alloc = true, int dtype = mshadow::default_type_flag,
-          std::vector<int> aux_types = {}, mxnet::ShapeVector aux_shapes = {},
-          mxnet::TShape storage_shape = mxnet::TShape(mshadow::Shape1(0)));
+  NDArray(const NDArrayStorageType stype,
+          const mxnet::TShape& shape,
+          Context ctx,
+          bool delay_alloc              = true,
+          int dtype                     = mshadow::default_type_flag,
+          std::vector<int> aux_types    = {},
+          mxnet::ShapeVector aux_shapes = {},
+          mxnet::TShape storage_shape   = mxnet::TShape(mshadow::Shape1(0)));
   /*!
    * \brief constructs a new dynamic NDArray whose shape is unknown,
    *        hence the NDArray is inherently lazily created
@@ -166,8 +172,11 @@ class NDArray {
    * \param aux_data the memory content of static aux data
    * \param dev_id the device id this tensor sits at
    */
-  NDArray(const NDArrayStorageType stype, const mxnet::TShape& shape, const TBlob& data,
-          const std::vector<TBlob>& aux_data, int dev_id)
+  NDArray(const NDArrayStorageType stype,
+          const mxnet::TShape& shape,
+          const TBlob& data,
+          const std::vector<TBlob>& aux_data,
+          int dev_id)
       : ptr_(std::make_shared<Chunk>(stype, data, aux_data, dev_id)),
         shape_(shape),
         dtype_(data.type_flag_),
@@ -768,7 +777,8 @@ class NDArray {
    * \param data the NDArrays to be saved.
    * \param names the name of the NDArray, optional, can be zero length.
    */
-  static void Save(dmlc::Stream* fo, const std::vector<NDArray>& data,
+  static void Save(dmlc::Stream* fo,
+                   const std::vector<NDArray>& data,
                    const std::vector<std::string>& names);
   /*!
    * \brief Load list of ndarray into from the stream.
@@ -889,8 +899,12 @@ class NDArray {
       storage_shape = shape;
     }
     // Constructor for a non-default storage chunk
-    Chunk(NDArrayStorageType storage_type_, const mxnet::TShape& storage_shape_, Context ctx_,
-          bool delay_alloc_, int dtype, const std::vector<int>& aux_types_,
+    Chunk(NDArrayStorageType storage_type_,
+          const mxnet::TShape& storage_shape_,
+          Context ctx_,
+          bool delay_alloc_,
+          int dtype,
+          const std::vector<int>& aux_types_,
           const mxnet::ShapeVector& aux_shapes_)
         : static_data(false),
           delay_alloc(delay_alloc_),
@@ -915,8 +929,10 @@ class NDArray {
       }
     }
 
-    Chunk(const NDArrayStorageType storage_type_, const TBlob& data,
-          const std::vector<TBlob>& aux_data, int dev_id)
+    Chunk(const NDArrayStorageType storage_type_,
+          const TBlob& data,
+          const std::vector<TBlob>& aux_data,
+          int dev_id)
         : static_data(true),
           delay_alloc(false),
           storage_type(storage_type_),
@@ -1002,7 +1018,8 @@ class NDArray {
       shandle.size  = size * mshadow::mshadow_sizeof(dtype);
       this->CheckAndAlloc();
     }
-    inline void CheckAndAlloc(const mxnet::TShape& shape, const mxnet::ShapeVector& aux_shapes,
+    inline void CheckAndAlloc(const mxnet::TShape& shape,
+                              const mxnet::ShapeVector& aux_shapes,
                               int dtype) {
       // calculate size, perform allocation
       if (kRowSparseStorage == storage_type) {
@@ -1254,8 +1271,12 @@ void SampleGenNegBinomial(real_t mu, real_t alpha, NDArray* out);
 //--------------------------------------------------------------
 
 /*! \brief definition of NDArray function */
-typedef std::function<void(NDArray** used_vars, real_t* scalars, NDArray** mutate_vars,
-                           int num_params, char** param_keys, char** param_vals)>
+typedef std::function<void(NDArray** used_vars,
+                           real_t* scalars,
+                           NDArray** mutate_vars,
+                           int num_params,
+                           char** param_keys,
+                           char** param_vals)>
     NDArrayAPIFunction;
 /*! \brief mask information on how functions can be exposed */
 enum NDArrayFunctionTypeMask {
@@ -1309,8 +1330,8 @@ struct NDArrayFunctionReg
    * \param fternary function body to set
    * \return ref to the registered entry, used to set properties
    */
-  inline NDArrayFunctionReg& set_function(void (*fternary)(const NDArray& lhs, const NDArray& mhs,
-                                                           const NDArray& rhs, NDArray* out)) {
+  inline NDArrayFunctionReg& set_function(
+      void (*fternary)(const NDArray& lhs, const NDArray& mhs, const NDArray& rhs, NDArray* out)) {
     body = [fternary](NDArray** used_vars, real_t* s, NDArray** mutate_vars, int num_params,
                       char** param_keys, char** param_vals) {
       (*fternary)(*used_vars[0], *used_vars[1], *used_vars[2], mutate_vars[0]);
@@ -1329,7 +1350,8 @@ struct NDArrayFunctionReg
    * \param fbinary function body to set
    * \return ref to the registered entry, used to set properties
    */
-  inline NDArrayFunctionReg& set_function(void (*fbinary)(const NDArray& lhs, const NDArray& rhs,
+  inline NDArrayFunctionReg& set_function(void (*fbinary)(const NDArray& lhs,
+                                                          const NDArray& rhs,
                                                           NDArray* out)) {
     body = [fbinary](NDArray** used_vars, real_t* s, NDArray** mutate_vars, int num_params,
                      char** param_keys, char** param_vals) {
@@ -1348,7 +1370,8 @@ struct NDArrayFunctionReg
    * \param fscalar function body to set
    * \return ref to the registered entry, used to set properties
    */
-  inline NDArrayFunctionReg& set_function(void (*fscalar)(const NDArray& lhs, const real_t& rhs,
+  inline NDArrayFunctionReg& set_function(void (*fscalar)(const NDArray& lhs,
+                                                          const real_t& rhs,
                                                           NDArray* out)) {
     body         = [fscalar](NDArray** used_vars, real_t* s, NDArray** mutate_vars, int num_params,
                      char** param_keys,
@@ -1384,7 +1407,9 @@ struct NDArrayFunctionReg
    * \return ref to the registered entry, used to set properties
    */
   inline NDArrayFunctionReg& set_function(
-      void (*fgeneric)(NDArray** used_vars, real_t* s, NDArray** mutate_vars,
+      void (*fgeneric)(NDArray** used_vars,
+                       real_t* s,
+                       NDArray** mutate_vars,
                        const std::map<std::string, std::string>& param)) {
     body = [fgeneric](NDArray** used_vars, real_t* s, NDArray** mutate_vars, int num_params,
                       char** param_keys, char** param_vals) {

--- a/include/mxnet/ndarray.h
+++ b/include/mxnet/ndarray.h
@@ -51,11 +51,11 @@
 namespace mxnet {
 // enum for storage types
 namespace csr {
-enum CSRAuxType {kIndPtr, kIdx};
+enum CSRAuxType { kIndPtr, kIdx };
 }
 
 namespace rowsparse {
-enum RowSparseAuxType {kIdx};
+enum RowSparseAuxType { kIdx };
 }
 
 enum NDArrayStorageType {
@@ -82,9 +82,7 @@ class MKLDNNMemory;
 class NDArray {
  public:
   /*! \brief default constructor */
-  NDArray()
-    : entry_(nullptr) {
-  }
+  NDArray() : entry_(nullptr) {}
   /*!
    * \brief constructs a new dynamic NDArray
    * \param shape the shape of array
@@ -92,20 +90,21 @@ class NDArray {
    * \param delay_alloc whether delay the allocation
    * \param dtype data type of this ndarray
    */
-  NDArray(const mxnet::TShape &shape, Context ctx,
-          bool delay_alloc = false, int dtype = mshadow::default_type_flag)
+  NDArray(
+      const mxnet::TShape& shape, Context ctx, bool delay_alloc = false,
+      int dtype = mshadow::default_type_flag)
       : ptr_(std::make_shared<Chunk>(shape, ctx, delay_alloc, dtype)),
         shape_(shape),
         dtype_(dtype),
         storage_type_(kDefaultStorage),
-        entry_(nullptr) {
-  }
+        entry_(nullptr) {}
   /*! \brief constructor for NDArray with storage type
    */
-  NDArray(const NDArrayStorageType stype, const mxnet::TShape &shape, Context ctx,
-          bool delay_alloc = true, int dtype = mshadow::default_type_flag,
-          std::vector<int> aux_types = {}, mxnet::ShapeVector aux_shapes = {},
-          mxnet::TShape storage_shape = mxnet::TShape(mshadow::Shape1(0)));
+  NDArray(
+      const NDArrayStorageType stype, const mxnet::TShape& shape, Context ctx,
+      bool delay_alloc = true, int dtype = mshadow::default_type_flag,
+      std::vector<int> aux_types = {}, mxnet::ShapeVector aux_shapes = {},
+      mxnet::TShape storage_shape = mxnet::TShape(mshadow::Shape1(0)));
   /*!
    * \brief constructs a new dynamic NDArray whose shape is unknown,
    *        hence the NDArray is inherently lazily created
@@ -117,8 +116,7 @@ class NDArray {
         shape_(),
         dtype_(dtype),
         storage_type_(kDefaultStorage),
-        entry_(nullptr) {
-  }
+        entry_(nullptr) {}
   /*!
    * \brief constructing a static NDArray that shares data with TBlob
    *  Use with caution: allocate ONLY ONE NDArray for each TBlob,
@@ -126,13 +124,12 @@ class NDArray {
    * \param data the memory content of static data
    * \param dev_id the device id this tensor sits at
    */
-  NDArray(const TBlob &data, int dev_id)
+  NDArray(const TBlob& data, int dev_id)
       : ptr_(std::make_shared<Chunk>(data, dev_id)),
         shape_(data.shape_),
         dtype_(data.type_flag_),
         storage_type_(kDefaultStorage),
-        entry_(nullptr) {
-  }
+        entry_(nullptr) {}
 
   /*!
    * \brief constructing a static NDArray that shares data with TBlob which is with deleter
@@ -142,15 +139,17 @@ class NDArray {
    * \param dev_id the device id this tensor sits at
    * \param deleter the function pointer of custom deleter
    */
-  NDArray(const TBlob &data, int dev_id, const std::function<void()>& deleter)
-      : ptr_(new Chunk(data, dev_id), [deleter](Chunk *p) {
-            deleter();    // call custom deleter
-            delete p;     // delete Chunk object
-        }),
+  NDArray(const TBlob& data, int dev_id, const std::function<void()>& deleter)
+      : ptr_(
+            new Chunk(data, dev_id),
+            [deleter](Chunk* p) {
+              deleter();  // call custom deleter
+              delete p;   // delete Chunk object
+            }),
         shape_(data.shape_),
-        dtype_(data.type_flag_), storage_type_(kDefaultStorage),
-        entry_(nullptr) {
-  }
+        dtype_(data.type_flag_),
+        storage_type_(kDefaultStorage),
+        entry_(nullptr) {}
 
   /*! \brief create ndarray from shared memory */
   NDArray(int shared_pid, int shared_id, const mxnet::TShape& shape, int dtype)
@@ -158,8 +157,7 @@ class NDArray {
         shape_(shape),
         dtype_(dtype),
         storage_type_(kDefaultStorage),
-        entry_(nullptr) {
-  }
+        entry_(nullptr) {}
 
   /*!
    * \brief constructing a static NDArray of non-default storage that shares data with TBlob
@@ -171,19 +169,19 @@ class NDArray {
    * \param aux_data the memory content of static aux data
    * \param dev_id the device id this tensor sits at
    */
-  NDArray(const NDArrayStorageType stype, const mxnet::TShape &shape,
-          const TBlob &data, const std::vector<TBlob> &aux_data, int dev_id)
+  NDArray(
+      const NDArrayStorageType stype, const mxnet::TShape& shape, const TBlob& data,
+      const std::vector<TBlob>& aux_data, int dev_id)
       : ptr_(std::make_shared<Chunk>(stype, data, aux_data, dev_id)),
         shape_(shape),
         dtype_(data.type_flag_),
         storage_type_(stype),
-        entry_(nullptr) {
-  }
+        entry_(nullptr) {}
   /*!
    * \brief initialize the NDArray, assuming it is not assigned a meaningful shape before
    * \param shape the shape of the NDArray
    */
-  void Init(const mxnet::TShape &shape) {
+  void Init(const mxnet::TShape& shape) {
     ptr_->Init(shape, this->dtype_);
     this->shape_ = shape;
   }
@@ -199,38 +197,32 @@ class NDArray {
    */
   inline bool IsView() const {
     // View only works on the default storage
-    if (storage_type() != kDefaultStorage)
-      return false;
+    if (storage_type() != kDefaultStorage) return false;
     // If the array reuses memory, its shape may be different from the storage
     // shape. However, we shouldn't consider it as a view.
-    if (reuse_)
-      return false;
+    if (reuse_) return false;
     return byte_offset_ > 0 || shape() != ptr_->storage_shape;
   }
 
   /* \brief Check whether the two arrays are the same array */
   inline bool IsSame(const NDArray& other) const {
-    return ptr_ == other.ptr_ &&
-        shape_ == other.shape_ &&
-        byte_offset_ == other.byte_offset_ &&
-        dtype_ == other.dtype_;
+    return ptr_ == other.ptr_ && shape_ == other.shape_ && byte_offset_ == other.byte_offset_ &&
+           dtype_ == other.dtype_;
   }
 
   /*!
    * \return the shape of current NDArray.
    */
-  inline const mxnet::TShape& shape() const {
-    return shape_;
-  }
+  inline const mxnet::TShape& shape() const { return shape_; }
   /*!
    * \return the shape of underlying chunk which stores the NDArray data/value.
    *  It is only intended for non-default storage. For row-sparse storage, it is the shape of
    *  the tensor which stores the non-zero values.
    */
-  inline const mxnet::TShape &storage_shape() const {
+  inline const mxnet::TShape& storage_shape() const {
     CHECK(ptr_ != nullptr);
     CHECK_NE(storage_type(), kDefaultStorage)
-             << "storage_shape() is not intended for kDefaultStorage.";
+        << "storage_shape() is not intended for kDefaultStorage.";
     return ptr_->storage_shape;
   }
 
@@ -240,22 +232,20 @@ class NDArray {
    * \return the shape of aux data at given index
    */
   inline const mxnet::TShape& aux_shape(size_t index) const {
-    CHECK_NE(storage_type(), kDefaultStorage)
-             << "aux_shape() is not intended for kDefaultStorage.";
+    CHECK_NE(storage_type(), kDefaultStorage) << "aux_shape() is not intended for kDefaultStorage.";
     return ptr_->aux_shapes[index];
   }
 
   /* \return the shapes of all aux data */
   const mxnet::ShapeVector& aux_shapes() const {
     CHECK_NE(storage_type(), kDefaultStorage)
-             << "aux_shapes() is not intended for kDefaultStorage.";
+        << "aux_shapes() is not intended for kDefaultStorage.";
     return ptr_->aux_shapes;
   }
 
   /*! returns the dtypes of all aux data */
   const std::vector<int>& aux_types() const {
-    CHECK_NE(storage_type(), kDefaultStorage)
-      << "aux_types() is not intended for kDefaultStorage.";
+    CHECK_NE(storage_type(), kDefaultStorage) << "aux_types() is not intended for kDefaultStorage.";
     return ptr_->aux_types;
   }
 
@@ -268,7 +258,7 @@ class NDArray {
    */
   inline void set_aux_shape(size_t index, const mxnet::TShape& shape) const {
     CHECK_NE(storage_type(), kDefaultStorage)
-      << "set_aux_shape() is not intended for kDefaultStorage.";
+        << "set_aux_shape() is not intended for kDefaultStorage.";
     ptr_->set_aux_shape(index, shape);
   }
 
@@ -292,11 +282,11 @@ class NDArray {
     auto stype = storage_type();
     TBlob res;
     auto shape = aux_shape(i);
-    auto type = aux_type(i);
+    auto type  = aux_type(i);
     MSHADOW_TYPE_SWITCH(type, DType, {
       auto dptr = static_cast<DType*>(ptr_->aux_handles[i].dptr);
       CHECK(stype == kRowSparseStorage || stype == kCSRStorage)
-            << "Unexpected storage type: " << stype;
+          << "Unexpected storage type: " << stype;
       res = TBlob(dptr, shape, ptr_->aux_handles[i].ctx.dev_mask(), type);
     });
     return res;
@@ -311,21 +301,15 @@ class NDArray {
   /*!
    * \return the data type of NDArray, this function is only valid when the NDArray is not empty
    */
-  inline int dtype() const {
-    return dtype_;
-  }
+  inline int dtype() const { return dtype_; }
   inline int aux_type(size_t i) const {
     CHECK(!is_none());
     return ptr_->aux_types[i];
   }
 
-  inline NDArrayStorageType storage_type() const {
-    return storage_type_;
-  }
+  inline NDArrayStorageType storage_type() const { return storage_type_; }
   /*! \return whether this ndarray is not initialized */
-  inline bool is_none() const {
-    return ptr_.get() == nullptr;
-  }
+  inline bool is_none() const { return ptr_.get() == nullptr; }
   /*! \return updated grad state in entry_ */
   bool fresh_out_grad() const;
   /*! \return updated grad state in entry_ */
@@ -338,16 +322,16 @@ class NDArray {
     if (is_none()) return false;
     auto stype = storage_type();
     CHECK_NE(stype, kDefaultStorage)
-             << "storage_initialized() is not intended for kDefaultStorage.";
+        << "storage_initialized() is not intended for kDefaultStorage.";
     if (stype == kRowSparseStorage) {
       CHECK_EQ(aux_shape(rowsparse::kIdx)[0], storage_shape()[0])
-               << "inconsistent storage shape " << storage_shape()
-               << " vs. aux shape " << aux_shape(rowsparse::kIdx);
+          << "inconsistent storage shape " << storage_shape() << " vs. aux shape "
+          << aux_shape(rowsparse::kIdx);
       return aux_shape(rowsparse::kIdx).Size() != 0;
     } else if (stype == kCSRStorage) {
       CHECK_EQ(aux_shape(csr::kIdx)[0], storage_shape()[0])
-               << "inconsistent storage shape " << storage_shape()
-               << " vs. aux shape " << aux_shape(csr::kIdx);
+          << "inconsistent storage shape " << storage_shape() << " vs. aux shape "
+          << aux_shape(csr::kIdx);
       return aux_shape(csr::kIdx).Size() != 0;
     } else {
       LOG(FATAL) << "Unknown storage type";
@@ -380,102 +364,95 @@ class NDArray {
      * variable.
      */
     Engine::Get()->PushAsync(
-      [](RunContext, Engine::CallbackOnComplete on_complete) {
-        on_complete();
-      }, Context{}, {}, {ptr_->var});
+        [](RunContext, Engine::CallbackOnComplete on_complete) { on_complete(); }, Context{}, {},
+        {ptr_->var});
     Engine::Get()->WaitForVar(ptr_->var);
   }
   /*! \return the associated variable of the ndarray.*/
-  inline Engine::VarHandle var() const {
-    return ptr_->var;
-  }
+  inline Engine::VarHandle var() const { return ptr_->var; }
   /*! \return byte offset in chunk of the ndarray*/
-  inline size_t byte_offset() const {
-    return byte_offset_;
-  }
+  inline size_t byte_offset() const { return byte_offset_; }
   /*! \brief return var version of the NDArray*/
-  inline size_t version() const {
-    return var()->version();
-  }
+  inline size_t version() const { return var()->version(); }
   /*!
    * \brief save the content into binary stream
    * \param strm the output stream
    */
-  void Save(dmlc::Stream *strm) const;
+  void Save(dmlc::Stream* strm) const;
   /*!
    * \brief load ndarrays before supporting sparse ndarrays
    * \param strm the output stream
    * \param magic the magic number used for version control
    */
-  bool LegacyLoad(dmlc::Stream *strm, const uint32_t magic);
+  bool LegacyLoad(dmlc::Stream* strm, const uint32_t magic);
   /*!
    * \brief load the content from binary stream
    * \param strm the output stream
    * \return whether the load is successful
    */
-  bool Load(dmlc::Stream *strm);
+  bool Load(dmlc::Stream* strm);
   /*!
    * \brief set all the elements in ndarray to be scalar
    * \param scalar the scalar to set
    * \return reference of self
    */
-  NDArray &operator=(real_t scalar);
+  NDArray& operator=(real_t scalar);
   /*!
    * \brief elementwise add to current space
    *  this mutate the current NDArray
    * \param src the data to add
    * \return reference of self
    */
-  NDArray &operator+=(const NDArray &src);
+  NDArray& operator+=(const NDArray& src);
   /*!
    * \brief elementwise add to current space
    *  this mutate the current NDArray
    * \param src the data to add
    * \return reference of self
    */
-  NDArray &operator+=(const real_t &src);
+  NDArray& operator+=(const real_t& src);
   /*!
    * \brief elementwise subtract from current ndarray
    * this mutate the current NDArray
    * \param src the data to subtract
    * \return reference of self
    */
-  NDArray &operator-=(const NDArray &src);
+  NDArray& operator-=(const NDArray& src);
   /*!
    * \brief elementwise subtract from current ndarray
    * this mutate the current NDArray
    * \param src the data to subtract
    * \return reference of self
    */
-  NDArray &operator-=(const real_t &src);
+  NDArray& operator-=(const real_t& src);
   /*!
    * \brief elementwise multiplication to current ndarray
    *  this mutate the current NDArray
    * \param src the data to subtract
    * \return reference of self
    */
-  NDArray &operator*=(const NDArray &src);
+  NDArray& operator*=(const NDArray& src);
   /*!
    * \brief elementwise multiplication to current ndarray
    *  this mutate the current NDArray
    * \param src the data to subtract
    * \return reference of self
    */
-  NDArray &operator*=(const real_t &src);
+  NDArray& operator*=(const real_t& src);
   /*!
    * \brief elementwise division from current ndarray
    *  this mutate the current NDArray
    * \param src the data to subtract
    * \return reference of self
    */
-  NDArray &operator/=(const NDArray &src);
+  NDArray& operator/=(const NDArray& src);
   /*!
    * \brief elementwise division from current ndarray
    *  this mutate the current NDArray
    * \param src the data to subtract
    * \return reference of self
    */
-  NDArray &operator/=(const real_t &src);
+  NDArray& operator/=(const real_t& src);
   /*!
    * \brief return a new copy this NDArray
    * \param ctx the new context of this NDArray
@@ -492,12 +469,12 @@ class NDArray {
    * \param data the data source to copy from.
    * \param size the size of the source array, in sizeof(DType) not raw btyes.
    */
-  void SyncCopyFromCPU(const void *data, size_t size) const;
+  void SyncCopyFromCPU(const void* data, size_t size) const;
 
   /*!
    * \brief Copy from src.data()/aux_data(i) to this->data()/aux_data(j)
    */
-  void SyncCopyFromNDArray(const NDArray &src, int i = -1, int j = -1);
+  void SyncCopyFromNDArray(const NDArray& src, int i = -1, int j = -1);
 
   /*!
    * \brief Do a synchronize copy to a contiguous CPU memory region.
@@ -509,12 +486,12 @@ class NDArray {
    * \param data the data source to copyinto.
    * \param size the memory size we want to copy into, in sizeof(DType) not raw btyes.
    */
-  void SyncCopyToCPU(void *data, size_t size) const;
+  void SyncCopyToCPU(void* data, size_t size) const;
   /*!
-  * \brief check whether the NDArray format is valid
-  * \param full_check if `True`, rigorous check, O(N) operations
-  *    Otherwise basic check, O(1) operations
-  */
+   * \brief check whether the NDArray format is valid
+   * \param full_check if `True`, rigorous check, O(N) operations
+   *    Otherwise basic check, O(1) operations
+   */
   void SyncCheckFormat(const bool full_check) const;
   /*!
    * \brief Slice a NDArray
@@ -561,18 +538,16 @@ class NDArray {
    * \param dtype The data type.
    * \return NDArray in new shape and type.
    */
-  inline NDArray AsArray(const mxnet::TShape &shape, int dtype) const {
-    CHECK_EQ(storage_type(), kDefaultStorage)
-             << "AsArray is intended only for kDefaultStorage.";
-    CHECK_GE(ptr_->shandle.size,
-             shape.Size() * mshadow::mshadow_sizeof(dtype))
+  inline NDArray AsArray(const mxnet::TShape& shape, int dtype) const {
+    CHECK_EQ(storage_type(), kDefaultStorage) << "AsArray is intended only for kDefaultStorage.";
+    CHECK_GE(ptr_->shandle.size, shape.Size() * mshadow::mshadow_sizeof(dtype))
         << "NDArray.AsArray: target memory size is bigger";
     // We can't reuse memory in a view.
     CHECK(!IsView());
     NDArray ret = *this;
-    ret.shape_ = shape;
-    ret.dtype_ = dtype;
-    ret.reuse_ = true;
+    ret.shape_  = shape;
+    ret.dtype_  = dtype;
+    ret.reuse_  = true;
     return ret;
   }
 
@@ -603,7 +578,7 @@ class NDArray {
    * the temporary ndarray which stores intermediate custom op results.
    * Should be used with caution elsewhere. Supports only CSR and RSP formats.
    */
-  inline void SparseUpdateChunk(const NDArray &arr) const {
+  inline void SparseUpdateChunk(const NDArray& arr) const {
     CHECK(shape_ == arr.shape_) << "ndarray shape is different from the target";
     CHECK(dtype_ == arr.dtype_) << "ndarray dtype is different from the target";
     auto stype = arr.storage_type();
@@ -611,24 +586,24 @@ class NDArray {
         << "Only to be used with CSR and RSP storage types";
     // swap shandles between src and dst
     Storage::Handle shandle_dst = arr.ptr_->shandle;
-    arr.ptr_->shandle = ptr_->shandle;
-    ptr_->shandle = shandle_dst;
+    arr.ptr_->shandle           = ptr_->shandle;
+    ptr_->shandle               = shandle_dst;
 
     ptr_->storage_shape = arr.ptr_->storage_shape;
-    ptr_->storage_type = arr.ptr_->storage_type;
-    ptr_->ctx = arr.ptr_->ctx;
+    ptr_->storage_type  = arr.ptr_->storage_type;
+    ptr_->ctx           = arr.ptr_->ctx;
 
     // swap aux_handles between src and dst
     size_t aux_idx = 0;
     CHECK(ptr_->aux_handles.size() == arr.ptr_->aux_handles.size())
         << "ndarray number of aux_handles is different from target";
-    for (auto &aux_handle : arr.ptr_->aux_handles) {
-      Storage::Handle aux_dst = ptr_->aux_handles[aux_idx];
+    for (auto& aux_handle : arr.ptr_->aux_handles) {
+      Storage::Handle aux_dst    = ptr_->aux_handles[aux_idx];
       ptr_->aux_handles[aux_idx] = aux_handle;
-      aux_handle = aux_dst;
+      aux_handle                 = aux_dst;
       aux_idx++;
     }
-    ptr_->aux_types = arr.ptr_->aux_types;
+    ptr_->aux_types  = arr.ptr_->aux_types;
     ptr_->aux_shapes = arr.ptr_->aux_shapes;
   }
 
@@ -637,13 +612,13 @@ class NDArray {
    * \param shape new shape
    * \return NDArray in new shape
    */
-  NDArray Reshape(const mxnet::TShape &shape) const;
+  NDArray Reshape(const mxnet::TShape& shape) const;
   /*!
    * \brief Get an reshaped NDArray. Supports autograd recording
    * \param shape new shape
    * \return NDArray in new shape
    */
-  NDArray ReshapeWithRecord(const mxnet::TShape &shape);
+  NDArray ReshapeWithRecord(const mxnet::TShape& shape);
   /*!
    * \brief Return a copy of this NDArray without autograd history
    */
@@ -683,19 +658,19 @@ class NDArray {
    * \brief Alloc memory for non-default storage
    * aux_shape is only known at run time
    */
-  inline void CheckAndAlloc(const mxnet::ShapeVector &aux_shapes) const {
+  inline void CheckAndAlloc(const mxnet::ShapeVector& aux_shapes) const {
     CHECK_NE(storage_type(), kDefaultStorage)
-             << "CheckAndAlloc(aux_shapes) is not intended for kDefaultStorage";
+        << "CheckAndAlloc(aux_shapes) is not intended for kDefaultStorage";
     ptr_->CheckAndAlloc(shape_, aux_shapes, dtype_);
   }
-  inline void CheckAndAllocData(const mxnet::TShape &storage_shape) const {
+  inline void CheckAndAllocData(const mxnet::TShape& storage_shape) const {
     CHECK_NE(storage_type(), kDefaultStorage)
-             << "CheckAndAllocData is not intended for kDefaultStorage";
+        << "CheckAndAllocData is not intended for kDefaultStorage";
     ptr_->CheckAndAllocData(storage_shape, dtype_);
   }
-  inline void CheckAndAllocAuxData(size_t i, const mxnet::TShape &aux_shape) const {
+  inline void CheckAndAllocAuxData(size_t i, const mxnet::TShape& aux_shape) const {
     CHECK_NE(storage_type(), kDefaultStorage)
-             << "CheckAndAllocAuxData is not intended for kDefaultStorage";
+        << "CheckAndAllocAuxData is not intended for kDefaultStorage";
     ptr_->CheckAndAllocAuxData(i, aux_shape);
   }
 
@@ -704,24 +679,20 @@ class NDArray {
    * Create NDArray from mkldnn memory.
    * mkldnn_mem The mkldnn memory to be managed.
    */
-  explicit NDArray(const std::shared_ptr<mkldnn::memory> &mkldnn_mem);
+  explicit NDArray(const std::shared_ptr<mkldnn::memory>& mkldnn_mem);
   /*
    * Create NDArray from mkldnn memory descriptor.
    * mem_pd The mkldnn memory descriptor to be created.
    */
-  explicit NDArray(const mkldnn::memory::desc &md);
+  explicit NDArray(const mkldnn::memory::desc& md);
   /*
    * Test if the data is stored in one of special MKLDNN format.
    */
-  bool IsMKLDNNData() const {
-    return ptr_->IsMKLDNN();
-  }
+  bool IsMKLDNNData() const { return ptr_->IsMKLDNN(); }
   /*
    * Test if the data is stored in one of default MXNet formats.
    */
-  bool IsDefaultData() const {
-    return ptr_->IsDefault();
-  }
+  bool IsDefaultData() const { return ptr_->IsDefault(); }
   /*
    * All functions below return a raw pointer to mkldnn memory. Actually there
    * is a shared pointer that hold the memory either in NDArray or in MKLDNN
@@ -732,29 +703,28 @@ class NDArray {
   /*
    * This function returns mkldnn::memory with the default primitive_desc.
    */
-  const mkldnn::memory *GetMKLDNNData() const;
+  const mkldnn::memory* GetMKLDNNData() const;
   /*
    * This function returns mkldnn::memory with the given primitive_desc
    * as long as the array size meets the required size in the given primitive_desc.
    */
-  const mkldnn::memory *GetMKLDNNData(const mkldnn::memory::desc &md) const;
+  const mkldnn::memory* GetMKLDNNData(const mkldnn::memory::desc& md) const;
   /*
    * This function returns mkldnn::memory with the given primitive_desc.
    * The returned mkldnn::memory will have the same physical layout as
    * the given primitive_desc.
    */
-  const mkldnn::memory *GetMKLDNNDataReorder(
-      const mkldnn::memory::desc &md) const;
+  const mkldnn::memory* GetMKLDNNDataReorder(const mkldnn::memory::desc& md) const;
 
   /*
    * This function copies data from mkldnn memory.
    */
-  void CopyFrom(const mkldnn::memory &mem);
+  void CopyFrom(const mkldnn::memory& mem);
   /*
    * This function allocates memory for array and creates mkldnn memory
    * with the specified format.
    */
-  mkldnn::memory *CreateMKLDNNData(const mkldnn::memory::desc &md);
+  mkldnn::memory* CreateMKLDNNData(const mkldnn::memory::desc& md);
 
   /*
    * These are the async version of the methods above.
@@ -762,7 +732,7 @@ class NDArray {
    * the array are complete.
    */
   void Reorder2DefaultAsync() const;
-  void MKLDNNDataReorderAsync(const mkldnn::memory::desc &md) const;
+  void MKLDNNDataReorderAsync(const mkldnn::memory::desc& md) const;
 
   /*
    * This creates a new NDArray with the reordered data.
@@ -770,7 +740,7 @@ class NDArray {
    */
   NDArray Reorder2Default() const;
 
-    /*
+  /*
    * This creates a new NDArray using f32 with the reordered data.
    * It doesn't affect the data of the original NDArray.
    */
@@ -788,12 +758,12 @@ class NDArray {
    * which can be expensive.
    * It's used by FullyConnected right now.
    */
-  NDArray MKLDNNDataReshape(const mxnet::TShape &shape) const;
+  NDArray MKLDNNDataReshape(const mxnet::TShape& shape) const;
 
-   /*!
+  /*!
    * \ Fix mkldnn memory descriptor mismatch from NDArray.
    */
-  void UpdateMKLDNNMemDesc(const mkldnn::memory::desc &desc);
+  void UpdateMKLDNNMemDesc(const mkldnn::memory::desc& desc);
 #endif
 
   /*!
@@ -802,18 +772,15 @@ class NDArray {
    * \param data the NDArrays to be saved.
    * \param names the name of the NDArray, optional, can be zero length.
    */
-  static void Save(dmlc::Stream* fo,
-                   const std::vector<NDArray>& data,
-                   const std::vector<std::string>& names);
+  static void Save(
+      dmlc::Stream* fo, const std::vector<NDArray>& data, const std::vector<std::string>& names);
   /*!
    * \brief Load list of ndarray into from the stream.
    * \param fi The stream of the input file.
    * \param data the NDArrays to be loaded
    * \param keys the name of the NDArray, if saved in the file.
    */
-  static void Load(dmlc::Stream* fi,
-                   std::vector<NDArray>* data,
-                   std::vector<std::string>* keys);
+  static void Load(dmlc::Stream* fi, std::vector<NDArray>* data, std::vector<std::string>* keys);
 
  private:
   friend class Imperative;
@@ -866,30 +833,34 @@ class NDArray {
     /*! \brief Reference to the engine to ensure we cleanup without calling a destructed engine */
     std::weak_ptr<Engine> engine_ref_;
 
-
     /*! \brief default constructor */
-    Chunk() : static_data(true), delay_alloc(false),
-              storage_ref_(Storage::_GetSharedRef()),
-              engine_ref_(Engine::_GetSharedRef()) {}
+    Chunk()
+        : static_data(true),
+          delay_alloc(false),
+          storage_ref_(Storage::_GetSharedRef()),
+          engine_ref_(Engine::_GetSharedRef()) {}
 
     /*! \brief construct a new chunk */
     Chunk(mxnet::TShape shape, Context ctx_, bool delay_alloc_, int dtype)
-        : static_data(false), delay_alloc(true), ctx(ctx_),
+        : static_data(false),
+          delay_alloc(true),
+          ctx(ctx_),
           storage_ref_(Storage::_GetSharedRef()),
           engine_ref_(Engine::_GetSharedRef()) {
       storage_shape = shape;
       if (shape_is_known(storage_shape)) {
         shandle.size = shape.Size() * mshadow::mshadow_sizeof(dtype);
       }
-      var = Engine::Get()->NewVariable();
+      var         = Engine::Get()->NewVariable();
       shandle.ctx = ctx_;
       if (!delay_alloc_) {
         this->CheckAndAlloc();
       }
     }
 
-    Chunk(const TBlob &data, int dev_id)
-        : static_data(true), delay_alloc(false),
+    Chunk(const TBlob& data, int dev_id)
+        : static_data(true),
+          delay_alloc(false),
           storage_ref_(Storage::_GetSharedRef()),
           engine_ref_(Engine::_GetSharedRef()) {
       CHECK(storage_type == kDefaultStorage);
@@ -901,35 +872,42 @@ class NDArray {
         ctx = Context::GPU(dev_id);
       }
       // init shandle
-      shandle.ctx = ctx;
-      shandle.dptr = data.dptr_;
-      shandle.size = data.shape_.Size() * mshadow::mshadow_sizeof(data.type_flag_);
+      shandle.ctx   = ctx;
+      shandle.dptr  = data.dptr_;
+      shandle.size  = data.shape_.Size() * mshadow::mshadow_sizeof(data.type_flag_);
       storage_shape = data.shape_;
     }
 
     Chunk(int shared_pid, int shared_id, const mxnet::TShape& shape, int dtype)
-        : static_data(false), delay_alloc(false),
+        : static_data(false),
+          delay_alloc(false),
           storage_ref_(Storage::_GetSharedRef()),
           engine_ref_(Engine::_GetSharedRef()) {
-      var = Engine::Get()->NewVariable();
-      ctx = Context::CPUShared(0);
-      shandle.size = shape.Size() * mshadow::mshadow_sizeof(dtype);
-      shandle.ctx = ctx;
+      var                = Engine::Get()->NewVariable();
+      ctx                = Context::CPUShared(0);
+      shandle.size       = shape.Size() * mshadow::mshadow_sizeof(dtype);
+      shandle.ctx        = ctx;
       shandle.shared_pid = shared_pid;
-      shandle.shared_id = shared_id;
+      shandle.shared_id  = shared_id;
       Storage::Get()->Alloc(&shandle);
       storage_shape = shape;
     }
     // Constructor for a non-default storage chunk
-    Chunk(NDArrayStorageType storage_type_, const mxnet::TShape &storage_shape_, Context ctx_,
-          bool delay_alloc_, int dtype, const std::vector<int> &aux_types_,
-          const mxnet::ShapeVector &aux_shapes_)
-        : static_data(false), delay_alloc(delay_alloc_), storage_type(storage_type_),
-          aux_types(aux_types_), ctx(ctx_), storage_shape(storage_shape_),
-          aux_shapes(aux_shapes_), storage_ref_(Storage::_GetSharedRef()),
+    Chunk(
+        NDArrayStorageType storage_type_, const mxnet::TShape& storage_shape_, Context ctx_,
+        bool delay_alloc_, int dtype, const std::vector<int>& aux_types_,
+        const mxnet::ShapeVector& aux_shapes_)
+        : static_data(false),
+          delay_alloc(delay_alloc_),
+          storage_type(storage_type_),
+          aux_types(aux_types_),
+          ctx(ctx_),
+          storage_shape(storage_shape_),
+          aux_shapes(aux_shapes_),
+          storage_ref_(Storage::_GetSharedRef()),
           engine_ref_(Engine::_GetSharedRef()) {
       shandle.ctx = ctx;
-      var = Engine::Get()->NewVariable();
+      var         = Engine::Get()->NewVariable();
       // aux_handles always reflect the correct number of aux data
       for (size_t i = 0; i < aux_shapes.size(); i++) {
         CheckAndAllocAuxData(i, aux_shapes[i]);
@@ -942,10 +920,14 @@ class NDArray {
       }
     }
 
-    Chunk(const NDArrayStorageType storage_type_, const TBlob &data,
-          const std::vector<TBlob> &aux_data, int dev_id)
-        : static_data(true), delay_alloc(false), storage_type(storage_type_),
-          storage_ref_(Storage::_GetSharedRef()), engine_ref_(Engine::_GetSharedRef()) {
+    Chunk(
+        const NDArrayStorageType storage_type_, const TBlob& data,
+        const std::vector<TBlob>& aux_data, int dev_id)
+        : static_data(true),
+          delay_alloc(false),
+          storage_type(storage_type_),
+          storage_ref_(Storage::_GetSharedRef()),
+          engine_ref_(Engine::_GetSharedRef()) {
       using namespace mshadow;
       CHECK_NE(storage_type, kDefaultStorage);
       // init var
@@ -958,14 +940,14 @@ class NDArray {
         ctx = Context::GPU(dev_id);
       }
       // init shandle
-      shandle.ctx = ctx;
-      shandle.dptr = data.dptr_;
-      shandle.size = data.shape_.Size() * mshadow_sizeof(data.type_flag_);
+      shandle.ctx   = ctx;
+      shandle.dptr  = data.dptr_;
+      shandle.size  = data.shape_.Size() * mshadow_sizeof(data.type_flag_);
       storage_shape = data.shape_;
       // init aux handles
-      for (const auto &aux : aux_data) {
+      for (const auto& aux : aux_data) {
         Storage::Handle aux_handle;
-        aux_handle.ctx = ctx;
+        aux_handle.ctx  = ctx;
         aux_handle.dptr = aux.dptr_;
         aux_handle.size = aux.shape_.Size() * mshadow_sizeof(aux.type_flag_);
         aux_handles.push_back(aux_handle);
@@ -1020,14 +1002,14 @@ class NDArray {
       }
     }
     /*! \brief initialize the shape and dtype, assuming it is not initialized before. */
-    void Init(const mxnet::TShape &shape, int dtype) {
-      auto size = shape.Size();
+    void Init(const mxnet::TShape& shape, int dtype) {
+      auto size     = shape.Size();
       storage_shape = shape;
-      shandle.size = size * mshadow::mshadow_sizeof(dtype);
+      shandle.size  = size * mshadow::mshadow_sizeof(dtype);
       this->CheckAndAlloc();
     }
-    inline void CheckAndAlloc(const mxnet::TShape &shape, const mxnet::ShapeVector &aux_shapes,
-                              int dtype) {
+    inline void CheckAndAlloc(
+        const mxnet::TShape& shape, const mxnet::ShapeVector& aux_shapes, int dtype) {
       // calculate size, perform allocation
       if (kRowSparseStorage == storage_type) {
         // For row sparse, aux_shape indicates the number of rows to allocate
@@ -1048,17 +1030,17 @@ class NDArray {
     // storage shape is also updated
     // if data is already allocated, try reuse the storage. Otherwise, free the current one
     // and allocate new storage
-    void CheckAndAllocData(const mxnet::TShape &shape, int dtype);
+    void CheckAndAllocData(const mxnet::TShape& shape, int dtype);
 
 #if MXNET_USE_MKLDNN == 1
     // Have MKL memory reference to the data in the default storage
     // or create memory for MKLDNN.
-    void SetMKLMem(const mxnet::TShape &shape, int dtype);
+    void SetMKLMem(const mxnet::TShape& shape, int dtype);
     // If the data is stored in MKLDNN layout, we reorder data in mkl_mem_ and
     // save the result in shandle.
     void Reorder2Default();
     // Reroder data to a specified layout.
-    void MKLDNNDataReorder(const mkldnn::memory::desc &md);
+    void MKLDNNDataReorder(const mkldnn::memory::desc& md);
     bool IsMKLDNN() const;
     bool IsDefault() const;
 #endif
@@ -1068,12 +1050,12 @@ class NDArray {
     // aux shape is also updated
     // if aux data is already allocated, try reuse the storage. Otherwise, free the current one
     // and allocate new storage
-    inline void CheckAndAllocAuxData(size_t i, const mxnet::TShape &shape) {
+    inline void CheckAndAllocAuxData(size_t i, const mxnet::TShape& shape) {
       CHECK_EQ(shape.ndim(), 1) << "shape must be 1D in CheckAndAllocAuxData";
       CHECK_NE(storage_type, kUndefinedStorage)
-        << "storage type cannot be kUndefinedStorage in CheckAndAllocAuxData";
+          << "storage type cannot be kUndefinedStorage in CheckAndAllocAuxData";
       CHECK_NE(storage_type, kDefaultStorage)
-        << "storage type cannot be kDefaultStorage in CheckAndAllocAuxData";
+          << "storage type cannot be kDefaultStorage in CheckAndAllocAuxData";
       if (aux_handles.size() <= i) {
         aux_handles.resize(i + 1);
       }
@@ -1133,7 +1115,7 @@ size_t num_aux_data(NDArrayStorageType stype);
  * \note The function name explicitly marks the order of from and to
  *     due to different possible convention carried by copy function.
  */
-void CopyFromTo(const NDArray &from, const NDArray *to, int priority = 0);
+void CopyFromTo(const NDArray& from, const NDArray* to, int priority = 0);
 
 /*!
  * \brief issue an copy operation from one NDArray to another
@@ -1148,7 +1130,7 @@ void CopyFromTo(const NDArray &from, const NDArray *to, int priority = 0);
  * \note The function name explicitly marks the order of from and to
  *     due to different possible convention carried by copy function.
  */
-void CopyFromTo(const NDArray &from, const NDArray& to, int priority = 0, bool is_opr = false);
+void CopyFromTo(const NDArray& from, const NDArray& to, int priority = 0, bool is_opr = false);
 
 /*!
  * \brief Perform elementwise sum over each data from source, store result into out.
@@ -1156,7 +1138,7 @@ void CopyFromTo(const NDArray &from, const NDArray& to, int priority = 0, bool i
  * \param out the target ndarray
  * \param priority Priority of the action.
  */
-void ElementwiseSum(const std::vector<NDArray> &source, NDArray *out, int priority = 0);
+void ElementwiseSum(const std::vector<NDArray>& source, NDArray* out, int priority = 0);
 
 /*!
  * \brief elementwise add
@@ -1164,56 +1146,55 @@ void ElementwiseSum(const std::vector<NDArray> &source, NDArray *out, int priori
  * \param rhs right operand
  * \return a new result ndarray
  */
-NDArray operator+(const NDArray &lhs, const NDArray &rhs);
+NDArray operator+(const NDArray& lhs, const NDArray& rhs);
 /*!
  * \brief elementwise add
  * \param lhs left operand
  * \param rhs right operand
  * \return a new result ndarray
  */
-NDArray operator+(const NDArray &lhs, const real_t &rhs);
+NDArray operator+(const NDArray& lhs, const real_t& rhs);
 /*!
  * \brief elementwise subtraction
  * \param lhs left operand
  * \param rhs right operand
  * \return a new result ndarray
  */
-NDArray operator-(const NDArray &lhs, const NDArray &rhs);
+NDArray operator-(const NDArray& lhs, const NDArray& rhs);
 /*!
  * \brief elementwise subtraction
  * \param lhs left operand
  * \param rhs right operand
  * \return a new result ndarray
  */
-NDArray operator-(const NDArray &lhs, const real_t &rhs);
+NDArray operator-(const NDArray& lhs, const real_t& rhs);
 /*!
  * \brief elementwise multiplication
  * \param lhs left operand
  * \param rhs right operand
  * \return a new result ndarray
  */
-NDArray operator*(const NDArray &lhs, const NDArray &rhs); \
-/*!
- * \brief elementwise multiplication
- * \param lhs left operand
- * \param rhs right operand
- * \return a new result ndarray
- */
-NDArray operator*(const NDArray &lhs, const real_t &rhs);
-/*!
- * \brief elementwise division
- * \param lhs left operand
- * \param rhs right operand
- * \return a new result ndarray
- */
-NDArray operator/(const NDArray &lhs, const NDArray &rhs);
+NDArray operator*(const NDArray& lhs, const NDArray& rhs); /*!
+                                                            * \brief elementwise multiplication
+                                                            * \param lhs left operand
+                                                            * \param rhs right operand
+                                                            * \return a new result ndarray
+                                                            */
+NDArray operator*(const NDArray& lhs, const real_t& rhs);
 /*!
  * \brief elementwise division
  * \param lhs left operand
  * \param rhs right operand
  * \return a new result ndarray
  */
-NDArray operator/(const NDArray &lhs, const real_t &rhs);
+NDArray operator/(const NDArray& lhs, const NDArray& rhs);
+/*!
+ * \brief elementwise division
+ * \param lhs left operand
+ * \param rhs right operand
+ * \return a new result ndarray
+ */
+NDArray operator/(const NDArray& lhs, const real_t& rhs);
 
 /*!
  * \brief Seed all random number generator in mxnet.
@@ -1231,60 +1212,57 @@ void RandomSeed(Context ctx, uint32_t seed);
  * \param end upper bound of distribution.
  * \param out output NDArray.
  */
-void SampleUniform(real_t begin, real_t end, NDArray *out);
+void SampleUniform(real_t begin, real_t end, NDArray* out);
 /*!
  * \brief Sample gaussian distribution for each elements of out.
  * \param mu mean of gaussian distribution.
  * \param sigma standard deviation of gaussian distribution.
  * \param out output NDArray.
  */
-void SampleGaussian(real_t mu, real_t sigma, NDArray *out);
+void SampleGaussian(real_t mu, real_t sigma, NDArray* out);
 /*!
  * \brief Sample gamma distribution for each elements of out.
  * \param alpha parameter (shape) of the gamma distribution
  * \param beta parameter (scale) of the gamma distribution
  * \param out output NDArray.
  */
-void SampleGamma(real_t alpha, real_t beta, NDArray *out);
+void SampleGamma(real_t alpha, real_t beta, NDArray* out);
 /*!
  * \brief Sample exponential distribution for each elements of out.
  * \param lambda parameter (rate) of the exponential distribution
  * \param out output NDArray.
  */
-void SampleExponential(real_t lambda, NDArray *out);
+void SampleExponential(real_t lambda, NDArray* out);
 /*!
  * \brief Sample Poisson distribution for each elements of out.
  * \param lambda parameter (rate) of the Poisson distribution
  * \param out output NDArray.
  */
-void SamplePoisson(real_t lambda, NDArray *out);
+void SamplePoisson(real_t lambda, NDArray* out);
 /*!
  * \brief Sample negative binomial distribution for each elements of out.
  * \param k failure limit
  * \param p success probability
  * \param out output NDArray.
  */
-void SampleNegBinomial(int32_t k, real_t p, NDArray *out);
+void SampleNegBinomial(int32_t k, real_t p, NDArray* out);
 /*!
  * \brief Sample generalized negative binomial distribution for each elements of out.
  * \param mu parameter (mean) of the distribution
  * \param alpha parameter (over dispersion) of the distribution
  * \param out output NDArray.
  */
-void SampleGenNegBinomial(real_t mu, real_t alpha, NDArray *out);
-
+void SampleGenNegBinomial(real_t mu, real_t alpha, NDArray* out);
 
 //--------------------------------------------------------------
 // The following part are API Registration of NDArray functions.
 //--------------------------------------------------------------
 
 /*! \brief definition of NDArray function */
-typedef std::function<void (NDArray **used_vars,
-                            real_t *scalars,
-                            NDArray **mutate_vars,
-                            int num_params,
-                            char **param_keys,
-                            char **param_vals)> NDArrayAPIFunction;
+typedef std::function<void(
+    NDArray** used_vars, real_t* scalars, NDArray** mutate_vars, int num_params, char** param_keys,
+    char** param_vals)>
+    NDArrayAPIFunction;
 /*! \brief mask information on how functions can be exposed */
 enum NDArrayFunctionTypeMask {
   /*! \brief all the use_vars should go before scalar */
@@ -1303,8 +1281,7 @@ enum NDArrayFunctionTypeMask {
 };
 /*! \brief Registry entry for NDArrayFunction */
 struct NDArrayFunctionReg
-    : public dmlc::FunctionRegEntryBase<NDArrayFunctionReg,
-                                        NDArrayAPIFunction> {
+    : public dmlc::FunctionRegEntryBase<NDArrayFunctionReg, NDArrayAPIFunction> {
   /*! \brief number of variable used by this function */
   unsigned num_use_vars;
   /*! \brief number of variable mutated by this function */
@@ -1316,44 +1293,38 @@ struct NDArrayFunctionReg
   /*!
    * \brief constructor
    */
-  NDArrayFunctionReg()
-      : num_use_vars(0),
-        num_mutate_vars(0),
-        num_scalars(0),
-        type_mask(0) {}
+  NDArrayFunctionReg() : num_use_vars(0), num_mutate_vars(0), num_scalars(0), type_mask(0) {}
   /*!
    * \brief set the function body to a NDArray setvalue function
    *  this will also auto set the parameters correctly
    * \param fsetvalue function body to set
    * \return ref to the registered entry, used to set properties
    */
-  inline NDArrayFunctionReg &set_function(void (*fsetvalue)(const real_t &rhs,
-                                                            NDArray *out)) {
-    body = [fsetvalue] (NDArray **used_vars, real_t *s, NDArray **mutate_vars,
-                        int num_params, char **param_keys, char **param_vals) {
-      (*fsetvalue)(s[0], mutate_vars[0]);
-    };
-    num_mutate_vars = 1; num_scalars = 1;
+  inline NDArrayFunctionReg& set_function(void (*fsetvalue)(const real_t& rhs, NDArray* out)) {
+    body = [fsetvalue](
+               NDArray** used_vars, real_t* s, NDArray** mutate_vars, int num_params,
+               char** param_keys, char** param_vals) { (*fsetvalue)(s[0], mutate_vars[0]); };
+    num_mutate_vars = 1;
+    num_scalars     = 1;
     this->add_argument("src", "real_t", "Source input to the function.");
     return *this;
   }
   /*!
-  * \brief set the function body to a ternary NDArray function
-  *  this will also auto set the parameters correctly
-  * \param fternary function body to set
-  * \return ref to the registered entry, used to set properties
-  */
-  inline NDArrayFunctionReg &set_function(void(*fternary)(const NDArray &lhs,
-                                                          const NDArray &mhs,
-                                                          const NDArray &rhs,
-                                                                NDArray *out)) {
-    body = [fternary](NDArray **used_vars,
-      real_t *s, NDArray **mutate_vars,
-      int num_params, char **param_keys, char **param_vals) {
+   * \brief set the function body to a ternary NDArray function
+   *  this will also auto set the parameters correctly
+   * \param fternary function body to set
+   * \return ref to the registered entry, used to set properties
+   */
+  inline NDArrayFunctionReg& set_function(
+      void (*fternary)(const NDArray& lhs, const NDArray& mhs, const NDArray& rhs, NDArray* out)) {
+    body = [fternary](
+               NDArray** used_vars, real_t* s, NDArray** mutate_vars, int num_params,
+               char** param_keys, char** param_vals) {
       (*fternary)(*used_vars[0], *used_vars[1], *used_vars[2], mutate_vars[0]);
     };
-    num_use_vars = 3; num_mutate_vars = 1;
-    type_mask = kNDArrayArgBeforeScalar | kAcceptEmptyMutateTarget;
+    num_use_vars    = 3;
+    num_mutate_vars = 1;
+    type_mask       = kNDArrayArgBeforeScalar | kAcceptEmptyMutateTarget;
     this->add_argument("lhs", "NDArray", "Left operand to the function.");
     this->add_argument("mhs", "NDArray", "Middle operand to the function.");
     this->add_argument("rhs", "NDArray", "Right operand to the function.");
@@ -1365,15 +1336,15 @@ struct NDArrayFunctionReg
    * \param fbinary function body to set
    * \return ref to the registered entry, used to set properties
    */
-  inline NDArrayFunctionReg &set_function(void (*fbinary)(const NDArray &lhs,
-                                                          const NDArray &rhs,
-                                                          NDArray *out)) {
-    body = [fbinary] (NDArray **used_vars, real_t *s, NDArray **mutate_vars,
-                      int num_params, char **param_keys, char **param_vals) {
-      (*fbinary)(*used_vars[0], *used_vars[1], mutate_vars[0]);
-    };
-    num_use_vars = 2; num_mutate_vars = 1;
-    type_mask = kNDArrayArgBeforeScalar | kAcceptEmptyMutateTarget;
+  inline NDArrayFunctionReg& set_function(
+      void (*fbinary)(const NDArray& lhs, const NDArray& rhs, NDArray* out)) {
+    body = [fbinary](
+               NDArray** used_vars, real_t* s, NDArray** mutate_vars, int num_params,
+               char** param_keys,
+               char** param_vals) { (*fbinary)(*used_vars[0], *used_vars[1], mutate_vars[0]); };
+    num_use_vars    = 2;
+    num_mutate_vars = 1;
+    type_mask       = kNDArrayArgBeforeScalar | kAcceptEmptyMutateTarget;
     this->add_argument("lhs", "NDArray", "Left operand to the function.");
     this->add_argument("rhs", "NDArray", "Right operand to the function.");
     return *this;
@@ -1384,15 +1355,16 @@ struct NDArrayFunctionReg
    * \param fscalar function body to set
    * \return ref to the registered entry, used to set properties
    */
-  inline NDArrayFunctionReg &set_function(void (*fscalar)(const NDArray &lhs,
-                                                          const real_t &rhs,
-                                                          NDArray *out)) {
-    body = [fscalar] (NDArray **used_vars, real_t *s, NDArray **mutate_vars,
-                      int num_params, char **param_keys, char **param_vals) {
-      (*fscalar)(*used_vars[0], s[0], mutate_vars[0]);
-    };
-    num_use_vars = 1; num_mutate_vars = 1; num_scalars = 1;
-    type_mask = kNDArrayArgBeforeScalar | kAcceptEmptyMutateTarget;
+  inline NDArrayFunctionReg& set_function(
+      void (*fscalar)(const NDArray& lhs, const real_t& rhs, NDArray* out)) {
+    body = [fscalar](
+               NDArray** used_vars, real_t* s, NDArray** mutate_vars, int num_params,
+               char** param_keys,
+               char** param_vals) { (*fscalar)(*used_vars[0], s[0], mutate_vars[0]); };
+    num_use_vars    = 1;
+    num_mutate_vars = 1;
+    num_scalars     = 1;
+    type_mask       = kNDArrayArgBeforeScalar | kAcceptEmptyMutateTarget;
     this->add_argument("lhs", "NDArray", "Left operand to the function.");
     this->add_argument("rhs", "real_t", "Right operand to the function.");
     return *this;
@@ -1403,14 +1375,13 @@ struct NDArrayFunctionReg
    * \param funary function body to set
    * \return ref to the registered entry, used to set properties
    */
-  inline NDArrayFunctionReg &set_function(void (*funary)(const NDArray &src,
-                                                         NDArray *out)) {
-    body = [funary] (NDArray **used_vars, real_t *s, NDArray **mutate_vars,
-                     int num_params, char **param_keys, char **param_vals) {
-      (*funary)(*used_vars[0], mutate_vars[0]);
-    };
-    num_use_vars = 1; num_mutate_vars = 1;
-    type_mask = kNDArrayArgBeforeScalar | kAcceptEmptyMutateTarget;
+  inline NDArrayFunctionReg& set_function(void (*funary)(const NDArray& src, NDArray* out)) {
+    body = [funary](
+               NDArray** used_vars, real_t* s, NDArray** mutate_vars, int num_params,
+               char** param_keys, char** param_vals) { (*funary)(*used_vars[0], mutate_vars[0]); };
+    num_use_vars    = 1;
+    num_mutate_vars = 1;
+    type_mask       = kNDArrayArgBeforeScalar | kAcceptEmptyMutateTarget;
     this->add_argument("src", "NDArray", "Source input to the function.");
     return *this;
   }
@@ -1420,13 +1391,12 @@ struct NDArrayFunctionReg
    * \param fgeneric function body to set
    * \return ref to the registered entry, used to set properties
    */
-  inline NDArrayFunctionReg &set_function(
-    void (*fgeneric)(NDArray **used_vars,
-                     real_t *s,
-                     NDArray **mutate_vars,
-                     const std::map<std::string, std::string>& param)) {
-    body = [fgeneric] (NDArray **used_vars, real_t *s, NDArray **mutate_vars,
-                       int num_params, char **param_keys, char **param_vals) {
+  inline NDArrayFunctionReg& set_function(void (*fgeneric)(
+      NDArray** used_vars, real_t* s, NDArray** mutate_vars,
+      const std::map<std::string, std::string>& param)) {
+    body = [fgeneric](
+               NDArray** used_vars, real_t* s, NDArray** mutate_vars, int num_params,
+               char** param_keys, char** param_vals) {
       std::map<std::string, std::string> param;
       for (int i = 0; i < num_params; ++i) {
         param[param_keys[i]] = param_vals[i];
@@ -1440,32 +1410,36 @@ struct NDArrayFunctionReg
    * \param n number of mutate variablesx
    * \return ref to the registered entry, used to set properties
    */
-  inline NDArrayFunctionReg &set_num_use_vars(unsigned n) {
-    num_use_vars = n; return *this;
+  inline NDArrayFunctionReg& set_num_use_vars(unsigned n) {
+    num_use_vars = n;
+    return *this;
   }
   /*!
    * \brief set the number of mutate variables
    * \param n number of mutate variablesx
    * \return ref to the registered entry, used to set properties
    */
-  inline NDArrayFunctionReg &set_num_mutate_vars(unsigned n) {
-    num_mutate_vars = n; return *this;
+  inline NDArrayFunctionReg& set_num_mutate_vars(unsigned n) {
+    num_mutate_vars = n;
+    return *this;
   }
   /*!
    * \brief set the number of scalar arguments
    * \param n number of scalar arguments
    * \return ref to the registered entry, used to set properties
    */
-  inline NDArrayFunctionReg &set_num_scalars(unsigned n) {
-    num_scalars = n; return *this;
+  inline NDArrayFunctionReg& set_num_scalars(unsigned n) {
+    num_scalars = n;
+    return *this;
   }
   /*!
    * \brief set type mask
    * \param tmask typemask
    * \return ref to the registered entry, used to set properties
    */
-  inline NDArrayFunctionReg &set_type_mask(int tmask) {
-    type_mask = tmask; return *this;
+  inline NDArrayFunctionReg& set_type_mask(int tmask) {
+    type_mask = tmask;
+    return *this;
   }
 };  // NDArrayFunctionReg
 
@@ -1480,7 +1454,7 @@ struct NDArrayFunctionReg
  *
  * \endcode
  */
-#define MXNET_REGISTER_NDARRAY_FUN(name)                                 \
+#define MXNET_REGISTER_NDARRAY_FUN(name) \
   DMLC_REGISTRY_REGISTER(::mxnet::NDArrayFunctionReg, NDArrayFunctionReg, name)
 
 }  // namespace mxnet

--- a/include/mxnet/ndarray.h
+++ b/include/mxnet/ndarray.h
@@ -90,9 +90,8 @@ class NDArray {
    * \param delay_alloc whether delay the allocation
    * \param dtype data type of this ndarray
    */
-  NDArray(
-      const mxnet::TShape& shape, Context ctx, bool delay_alloc = false,
-      int dtype = mshadow::default_type_flag)
+  NDArray(const mxnet::TShape& shape, Context ctx, bool delay_alloc = false,
+          int dtype = mshadow::default_type_flag)
       : ptr_(std::make_shared<Chunk>(shape, ctx, delay_alloc, dtype)),
         shape_(shape),
         dtype_(dtype),
@@ -100,11 +99,10 @@ class NDArray {
         entry_(nullptr) {}
   /*! \brief constructor for NDArray with storage type
    */
-  NDArray(
-      const NDArrayStorageType stype, const mxnet::TShape& shape, Context ctx,
-      bool delay_alloc = true, int dtype = mshadow::default_type_flag,
-      std::vector<int> aux_types = {}, mxnet::ShapeVector aux_shapes = {},
-      mxnet::TShape storage_shape = mxnet::TShape(mshadow::Shape1(0)));
+  NDArray(const NDArrayStorageType stype, const mxnet::TShape& shape, Context ctx,
+          bool delay_alloc = true, int dtype = mshadow::default_type_flag,
+          std::vector<int> aux_types = {}, mxnet::ShapeVector aux_shapes = {},
+          mxnet::TShape storage_shape = mxnet::TShape(mshadow::Shape1(0)));
   /*!
    * \brief constructs a new dynamic NDArray whose shape is unknown,
    *        hence the NDArray is inherently lazily created
@@ -140,12 +138,11 @@ class NDArray {
    * \param deleter the function pointer of custom deleter
    */
   NDArray(const TBlob& data, int dev_id, const std::function<void()>& deleter)
-      : ptr_(
-            new Chunk(data, dev_id),
-            [deleter](Chunk* p) {
-              deleter();  // call custom deleter
-              delete p;   // delete Chunk object
-            }),
+      : ptr_(new Chunk(data, dev_id),
+             [deleter](Chunk* p) {
+               deleter();  // call custom deleter
+               delete p;   // delete Chunk object
+             }),
         shape_(data.shape_),
         dtype_(data.type_flag_),
         storage_type_(kDefaultStorage),
@@ -169,9 +166,8 @@ class NDArray {
    * \param aux_data the memory content of static aux data
    * \param dev_id the device id this tensor sits at
    */
-  NDArray(
-      const NDArrayStorageType stype, const mxnet::TShape& shape, const TBlob& data,
-      const std::vector<TBlob>& aux_data, int dev_id)
+  NDArray(const NDArrayStorageType stype, const mxnet::TShape& shape, const TBlob& data,
+          const std::vector<TBlob>& aux_data, int dev_id)
       : ptr_(std::make_shared<Chunk>(stype, data, aux_data, dev_id)),
         shape_(shape),
         dtype_(data.type_flag_),
@@ -772,8 +768,8 @@ class NDArray {
    * \param data the NDArrays to be saved.
    * \param names the name of the NDArray, optional, can be zero length.
    */
-  static void Save(
-      dmlc::Stream* fo, const std::vector<NDArray>& data, const std::vector<std::string>& names);
+  static void Save(dmlc::Stream* fo, const std::vector<NDArray>& data,
+                   const std::vector<std::string>& names);
   /*!
    * \brief Load list of ndarray into from the stream.
    * \param fi The stream of the input file.
@@ -893,10 +889,9 @@ class NDArray {
       storage_shape = shape;
     }
     // Constructor for a non-default storage chunk
-    Chunk(
-        NDArrayStorageType storage_type_, const mxnet::TShape& storage_shape_, Context ctx_,
-        bool delay_alloc_, int dtype, const std::vector<int>& aux_types_,
-        const mxnet::ShapeVector& aux_shapes_)
+    Chunk(NDArrayStorageType storage_type_, const mxnet::TShape& storage_shape_, Context ctx_,
+          bool delay_alloc_, int dtype, const std::vector<int>& aux_types_,
+          const mxnet::ShapeVector& aux_shapes_)
         : static_data(false),
           delay_alloc(delay_alloc_),
           storage_type(storage_type_),
@@ -920,9 +915,8 @@ class NDArray {
       }
     }
 
-    Chunk(
-        const NDArrayStorageType storage_type_, const TBlob& data,
-        const std::vector<TBlob>& aux_data, int dev_id)
+    Chunk(const NDArrayStorageType storage_type_, const TBlob& data,
+          const std::vector<TBlob>& aux_data, int dev_id)
         : static_data(true),
           delay_alloc(false),
           storage_type(storage_type_),
@@ -1008,8 +1002,8 @@ class NDArray {
       shandle.size  = size * mshadow::mshadow_sizeof(dtype);
       this->CheckAndAlloc();
     }
-    inline void CheckAndAlloc(
-        const mxnet::TShape& shape, const mxnet::ShapeVector& aux_shapes, int dtype) {
+    inline void CheckAndAlloc(const mxnet::TShape& shape, const mxnet::ShapeVector& aux_shapes,
+                              int dtype) {
       // calculate size, perform allocation
       if (kRowSparseStorage == storage_type) {
         // For row sparse, aux_shape indicates the number of rows to allocate
@@ -1259,9 +1253,8 @@ void SampleGenNegBinomial(real_t mu, real_t alpha, NDArray* out);
 //--------------------------------------------------------------
 
 /*! \brief definition of NDArray function */
-typedef std::function<void(
-    NDArray** used_vars, real_t* scalars, NDArray** mutate_vars, int num_params, char** param_keys,
-    char** param_vals)>
+typedef std::function<void(NDArray** used_vars, real_t* scalars, NDArray** mutate_vars,
+                           int num_params, char** param_keys, char** param_vals)>
     NDArrayAPIFunction;
 /*! \brief mask information on how functions can be exposed */
 enum NDArrayFunctionTypeMask {
@@ -1301,9 +1294,9 @@ struct NDArrayFunctionReg
    * \return ref to the registered entry, used to set properties
    */
   inline NDArrayFunctionReg& set_function(void (*fsetvalue)(const real_t& rhs, NDArray* out)) {
-    body = [fsetvalue](
-               NDArray** used_vars, real_t* s, NDArray** mutate_vars, int num_params,
-               char** param_keys, char** param_vals) { (*fsetvalue)(s[0], mutate_vars[0]); };
+    body = [fsetvalue](NDArray** used_vars, real_t* s, NDArray** mutate_vars, int num_params,
+                       char** param_keys,
+                       char** param_vals) { (*fsetvalue)(s[0], mutate_vars[0]); };
     num_mutate_vars = 1;
     num_scalars     = 1;
     this->add_argument("src", "real_t", "Source input to the function.");
@@ -1315,11 +1308,10 @@ struct NDArrayFunctionReg
    * \param fternary function body to set
    * \return ref to the registered entry, used to set properties
    */
-  inline NDArrayFunctionReg& set_function(
-      void (*fternary)(const NDArray& lhs, const NDArray& mhs, const NDArray& rhs, NDArray* out)) {
-    body = [fternary](
-               NDArray** used_vars, real_t* s, NDArray** mutate_vars, int num_params,
-               char** param_keys, char** param_vals) {
+  inline NDArrayFunctionReg& set_function(void (*fternary)(const NDArray& lhs, const NDArray& mhs,
+                                                           const NDArray& rhs, NDArray* out)) {
+    body = [fternary](NDArray** used_vars, real_t* s, NDArray** mutate_vars, int num_params,
+                      char** param_keys, char** param_vals) {
       (*fternary)(*used_vars[0], *used_vars[1], *used_vars[2], mutate_vars[0]);
     };
     num_use_vars    = 3;
@@ -1336,12 +1328,12 @@ struct NDArrayFunctionReg
    * \param fbinary function body to set
    * \return ref to the registered entry, used to set properties
    */
-  inline NDArrayFunctionReg& set_function(
-      void (*fbinary)(const NDArray& lhs, const NDArray& rhs, NDArray* out)) {
-    body = [fbinary](
-               NDArray** used_vars, real_t* s, NDArray** mutate_vars, int num_params,
-               char** param_keys,
-               char** param_vals) { (*fbinary)(*used_vars[0], *used_vars[1], mutate_vars[0]); };
+  inline NDArrayFunctionReg& set_function(void (*fbinary)(const NDArray& lhs, const NDArray& rhs,
+                                                          NDArray* out)) {
+    body = [fbinary](NDArray** used_vars, real_t* s, NDArray** mutate_vars, int num_params,
+                     char** param_keys, char** param_vals) {
+      (*fbinary)(*used_vars[0], *used_vars[1], mutate_vars[0]);
+    };
     num_use_vars    = 2;
     num_mutate_vars = 1;
     type_mask       = kNDArrayArgBeforeScalar | kAcceptEmptyMutateTarget;
@@ -1355,13 +1347,12 @@ struct NDArrayFunctionReg
    * \param fscalar function body to set
    * \return ref to the registered entry, used to set properties
    */
-  inline NDArrayFunctionReg& set_function(
-      void (*fscalar)(const NDArray& lhs, const real_t& rhs, NDArray* out)) {
-    body = [fscalar](
-               NDArray** used_vars, real_t* s, NDArray** mutate_vars, int num_params,
-               char** param_keys,
-               char** param_vals) { (*fscalar)(*used_vars[0], s[0], mutate_vars[0]); };
-    num_use_vars    = 1;
+  inline NDArrayFunctionReg& set_function(void (*fscalar)(const NDArray& lhs, const real_t& rhs,
+                                                          NDArray* out)) {
+    body         = [fscalar](NDArray** used_vars, real_t* s, NDArray** mutate_vars, int num_params,
+                     char** param_keys,
+                     char** param_vals) { (*fscalar)(*used_vars[0], s[0], mutate_vars[0]); };
+    num_use_vars = 1;
     num_mutate_vars = 1;
     num_scalars     = 1;
     type_mask       = kNDArrayArgBeforeScalar | kAcceptEmptyMutateTarget;
@@ -1376,10 +1367,10 @@ struct NDArrayFunctionReg
    * \return ref to the registered entry, used to set properties
    */
   inline NDArrayFunctionReg& set_function(void (*funary)(const NDArray& src, NDArray* out)) {
-    body = [funary](
-               NDArray** used_vars, real_t* s, NDArray** mutate_vars, int num_params,
-               char** param_keys, char** param_vals) { (*funary)(*used_vars[0], mutate_vars[0]); };
-    num_use_vars    = 1;
+    body         = [funary](NDArray** used_vars, real_t* s, NDArray** mutate_vars, int num_params,
+                    char** param_keys,
+                    char** param_vals) { (*funary)(*used_vars[0], mutate_vars[0]); };
+    num_use_vars = 1;
     num_mutate_vars = 1;
     type_mask       = kNDArrayArgBeforeScalar | kAcceptEmptyMutateTarget;
     this->add_argument("src", "NDArray", "Source input to the function.");
@@ -1391,12 +1382,11 @@ struct NDArrayFunctionReg
    * \param fgeneric function body to set
    * \return ref to the registered entry, used to set properties
    */
-  inline NDArrayFunctionReg& set_function(void (*fgeneric)(
-      NDArray** used_vars, real_t* s, NDArray** mutate_vars,
-      const std::map<std::string, std::string>& param)) {
-    body = [fgeneric](
-               NDArray** used_vars, real_t* s, NDArray** mutate_vars, int num_params,
-               char** param_keys, char** param_vals) {
+  inline NDArrayFunctionReg& set_function(
+      void (*fgeneric)(NDArray** used_vars, real_t* s, NDArray** mutate_vars,
+                       const std::map<std::string, std::string>& param)) {
+    body = [fgeneric](NDArray** used_vars, real_t* s, NDArray** mutate_vars, int num_params,
+                      char** param_keys, char** param_vals) {
       std::map<std::string, std::string> param;
       for (int i = 0; i < num_params; ++i) {
         param[param_keys[i]] = param_vals[i];

--- a/include/mxnet/ndarray.h
+++ b/include/mxnet/ndarray.h
@@ -1168,12 +1168,13 @@ NDArray operator-(const NDArray& lhs, const real_t& rhs);
  * \param rhs right operand
  * \return a new result ndarray
  */
-NDArray operator*(const NDArray& lhs, const NDArray& rhs); /*!
-                                                            * \brief elementwise multiplication
-                                                            * \param lhs left operand
-                                                            * \param rhs right operand
-                                                            * \return a new result ndarray
-                                                            */
+NDArray operator*(const NDArray& lhs, const NDArray& rhs);
+/*!
+ * \brief elementwise multiplication
+ * \param lhs left operand
+ * \param rhs right operand
+ * \return a new result ndarray
+ */
 NDArray operator*(const NDArray& lhs, const real_t& rhs);
 /*!
  * \brief elementwise division

--- a/src/ndarray/ndarray.cc
+++ b/src/ndarray/ndarray.cc
@@ -47,13 +47,13 @@ DMLC_REGISTRY_ENABLE(::mxnet::NDArrayFunctionReg);
 
 namespace mxnet {
 
-NDArray::NDArray(const NDArrayStorageType stype, const mxnet::TShape &shape, Context ctx,
-    bool delay_alloc, int dtype, std::vector<int> aux_types,
-    mxnet::ShapeVector aux_shapes, mxnet::TShape storage_shape) : shape_(shape),
-  dtype_(dtype), storage_type_(stype), entry_(nullptr) {
+NDArray::NDArray(
+    const NDArrayStorageType stype, const mxnet::TShape& shape, Context ctx, bool delay_alloc,
+    int dtype, std::vector<int> aux_types, mxnet::ShapeVector aux_shapes,
+    mxnet::TShape storage_shape)
+    : shape_(shape), dtype_(dtype), storage_type_(stype), entry_(nullptr) {
   // Assign default aux types if not given
-  if (aux_types.size() == 0
-      && stype != kDefaultStorage) {
+  if (aux_types.size() == 0 && stype != kDefaultStorage) {
     if (stype == kRowSparseStorage) {
       aux_types = {mshadow::kInt64};
     } else if (stype == kCSRStorage) {
@@ -64,8 +64,7 @@ NDArray::NDArray(const NDArrayStorageType stype, const mxnet::TShape &shape, Con
   }
   // Assign default shapes if not given
   // unknown shapes are intialized as {0} such that Size() would return 0
-  if (aux_shapes.size() == 0
-      && stype != kDefaultStorage) {
+  if (aux_shapes.size() == 0 && stype != kDefaultStorage) {
     if (stype == kRowSparseStorage) {
       aux_shapes = {mxnet::TShape(mshadow::Shape1(0))};
     } else if (stype == kCSRStorage) {
@@ -75,10 +74,9 @@ NDArray::NDArray(const NDArrayStorageType stype, const mxnet::TShape &shape, Con
       LOG(FATAL) << "Unknown storage type " << stype;
     }
   }
-  if (storage_shape.Size() == 0
-      && stype != kDefaultStorage) {
+  if (storage_shape.Size() == 0 && stype != kDefaultStorage) {
     if (stype == kRowSparseStorage) {
-      storage_shape = shape;
+      storage_shape    = shape;
       storage_shape[0] = aux_shapes[rowsparse::kIdx][0];
     } else if (stype == kCSRStorage) {
       storage_shape = aux_shapes[csr::kIdx];
@@ -89,8 +87,8 @@ NDArray::NDArray(const NDArrayStorageType stype, const mxnet::TShape &shape, Con
   if (stype == kDefaultStorage)
     ptr_ = std::make_shared<Chunk>(shape, ctx, delay_alloc, dtype);
   else
-    ptr_ = std::make_shared<Chunk>(stype, storage_shape, ctx, delay_alloc,
-        dtype, aux_types, aux_shapes);
+    ptr_ = std::make_shared<Chunk>(
+        stype, storage_shape, ctx, delay_alloc, dtype, aux_types, aux_shapes);
 }
 
 void NDArray::SetShapeFromChunk() {
@@ -111,38 +109,39 @@ struct ChunkMem {
 NDArray::Chunk::~Chunk() {
   bool skip_free = static_data || delay_alloc;
   ChunkMem mem;
-  mem.h = this->shandle;
+  mem.h     = this->shandle;
   mem.aux_h = this->aux_handles;
 #if MXNET_USE_MKLDNN == 1
   // We want to delete mkldnn memory after deleting the variable.
   mem.mem = this->mkl_mem_;
 #endif
   if (auto engine = engine_ref_.lock()) {
-    engine->DeleteVariable([mem, skip_free](RunContext s) {
-      if (skip_free == false) {
+    engine->DeleteVariable(
+        [mem, skip_free](RunContext s) {
+          if (skip_free == false) {
 #if MXNET_USE_MKLDNN == 1
-        if (mem.mem) {
-          CHECK_LE(mem.mem->GetSize(), mem.h.size);
-          CHECK_EQ(mem.mem->GetDataHandle(), mem.h.dptr);
-        }
+            if (mem.mem) {
+              CHECK_LE(mem.mem->GetSize(), mem.h.size);
+              CHECK_EQ(mem.mem->GetDataHandle(), mem.h.dptr);
+            }
 #endif
-        Storage::Get()->Free(mem.h);
-        for (const auto &aux : mem.aux_h) {
-          Storage::Get()->Free(aux);
-        }
-      }
-    }, shandle.ctx, var);
+            Storage::Get()->Free(mem.h);
+            for (const auto& aux : mem.aux_h) {
+              Storage::Get()->Free(aux);
+            }
+          }
+        },
+        shandle.ctx, var);
   }
 }
 
-void NDArray::Chunk::CheckAndAllocData(const mxnet::TShape &shape, int dtype) {
-  CHECK_NE(aux_shapes.size(), 0)
-      << "data is expected to be allocated after aux_data";
+void NDArray::Chunk::CheckAndAllocData(const mxnet::TShape& shape, int dtype) {
+  CHECK_NE(aux_shapes.size(), 0) << "data is expected to be allocated after aux_data";
   auto dbytes = shape.Size() * mshadow::mshadow_sizeof(dtype);
   if (!features::is_enabled(features::INT64_TENSOR_SIZE)) {
-    CHECK_LT(shape.Size(), (int64_t{1} << 31) - 1) <<
-              "[CheckAndAllocData] Size of tensor you are trying to allocate is larger than "
-              "2^31 elements. Please build with flag USE_INT64_TENSOR_SIZE=1";
+    CHECK_LT(shape.Size(), (int64_t{1} << 31) - 1)
+        << "[CheckAndAllocData] Size of tensor you are trying to allocate is larger than "
+           "2^31 elements. Please build with flag USE_INT64_TENSOR_SIZE=1";
   }
   if (shandle.size < dbytes) {
     // free storage
@@ -171,7 +170,7 @@ NDArray NDArray::grad() const {
 
 nnvm::Symbol NDArray::get_autograd_symbol() const {
   CHECK(!Imperative::AGInfo::IsNone(*this))
-    << "NDArray is not part of a computation graph. Did you forget to turn on recording?";
+      << "NDArray is not part of a computation graph. Did you forget to turn on recording?";
   nnvm::Symbol ret;
   ret.outputs.emplace_back(entry_);
   return ret;
@@ -179,36 +178,35 @@ nnvm::Symbol NDArray::get_autograd_symbol() const {
 
 #if MXNET_USE_MKLDNN == 1
 
-NDArray::NDArray(const mkldnn::memory::desc &md)
-    : storage_type_(kDefaultStorage), entry_(nullptr) {
+NDArray::NDArray(const mkldnn::memory::desc& md) : storage_type_(kDefaultStorage), entry_(nullptr) {
   shape_ = mxnet::TShape(md.data.dims, md.data.dims + md.data.ndims);
   dtype_ = get_mxnet_type(md.data.data_type);
-  ptr_ = std::make_shared<Chunk>(shape_, Context::CPU(), true, dtype_);
+  ptr_   = std::make_shared<Chunk>(shape_, Context::CPU(), true, dtype_);
   ptr_->CheckAndAlloc(md.get_size());
   ptr_->mkl_mem_ = std::make_shared<MKLDNNMemory>(md, ptr_->shandle.dptr);
 }
 
-NDArray::NDArray(const std::shared_ptr<mkldnn::memory> &mkldnn_mem)
+NDArray::NDArray(const std::shared_ptr<mkldnn::memory>& mkldnn_mem)
     : storage_type_(kDefaultStorage), entry_(nullptr) {
-  auto mem_desc = mkldnn_mem->get_desc();
-  shape_ = mxnet::TShape(mem_desc.data.dims, mem_desc.data.dims + mem_desc.data.ndims);
-  dtype_ = get_mxnet_type(mem_desc.data.data_type);
-  ptr_ = std::make_shared<Chunk>(shape_, Context::CPU(), true, dtype_);
+  auto mem_desc      = mkldnn_mem->get_desc();
+  shape_             = mxnet::TShape(mem_desc.data.dims, mem_desc.data.dims + mem_desc.data.ndims);
+  dtype_             = get_mxnet_type(mem_desc.data.data_type);
+  ptr_               = std::make_shared<Chunk>(shape_, Context::CPU(), true, dtype_);
   ptr_->shandle.dptr = mkldnn_mem->get_data_handle();
   ptr_->shandle.size = mem_desc.get_size();
-  ptr_->delay_alloc = false;
-  ptr_->mkl_mem_ = std::make_shared<MKLDNNMemory>(mkldnn_mem);
-  ptr_->static_data = true;
+  ptr_->delay_alloc  = false;
+  ptr_->mkl_mem_     = std::make_shared<MKLDNNMemory>(mkldnn_mem);
+  ptr_->static_data  = true;
 }
 
-NDArray NDArray::MKLDNNDataReshape(const mxnet::TShape &shape) const {
+NDArray NDArray::MKLDNNDataReshape(const mxnet::TShape& shape) const {
   CHECK(!is_none()) << "NDArray is not initialized";
   CHECK_GE(shape_.Size(), shape.Size())
-    << "NDArray.Reshape: target shape size is larger current shape";
+      << "NDArray.Reshape: target shape size is larger current shape";
   CHECK_EQ(storage_type(), kDefaultStorage);
   if (!IsMKLDNNData()) {
     NDArray ret = this->Detach();
-    ret.shape_ = shape;
+    ret.shape_  = shape;
     return ret;
   } else {
     NDArray ret(shape, ctx(), true, dtype());
@@ -216,32 +214,32 @@ NDArray NDArray::MKLDNNDataReshape(const mxnet::TShape &shape) const {
     // be called in operators.
     mkldnn_format_tag_t format = ptr_->mkl_mem_->GetDefaultFormat();
     CHECK(ptr_->IsMKLDNN());
-    mkldnn::memory::desc def_desc = ptr_->mkl_mem_->GetDesc(format);
-    mkldnn::memory *def_mem = TmpMemMgr::Get()->Alloc(def_desc);
-    MKLDNNStream *stream = MKLDNNStream::Get();
+    mkldnn::memory::desc def_desc            = ptr_->mkl_mem_->GetDesc(format);
+    mkldnn::memory* def_mem                  = TmpMemMgr::Get()->Alloc(def_desc);
+    MKLDNNStream* stream                     = MKLDNNStream::Get();
     std::shared_ptr<mkldnn::memory> curr_mem = ptr_->mkl_mem_->GetMem();
     stream->RegisterMem(curr_mem);
-    std::unordered_map<int, mkldnn::memory> args({{MKLDNN_ARG_FROM, *curr_mem},
-                                                 {MKLDNN_ARG_TO, *def_mem}});
+    std::unordered_map<int, mkldnn::memory> args(
+        {{MKLDNN_ARG_FROM, *curr_mem}, {MKLDNN_ARG_TO, *def_mem}});
     stream->RegisterPrimArgs(mkldnn::reorder(*curr_mem, *def_mem), args);
     // def_mem points to a memory region in the temp space. It's only valid
     // inside an operator. As such, the returned NDArray can only be valid
     // inside an operator and the shared point doesn't need to do anything
     // when it's destroyed.
-    auto tmp = std::shared_ptr<mkldnn::memory>(def_mem, [](mkldnn::memory *mem) {});
+    auto tmp = std::shared_ptr<mkldnn::memory>(def_mem, [](mkldnn::memory* mem) {});
     ret.ptr_->mkl_mem_.reset(new MKLDNNMemory(tmp));
     ret.ptr_->shandle.dptr = def_mem->get_data_handle();
     ret.ptr_->shandle.size = def_mem->get_desc().get_size();
-    ret.ptr_->delay_alloc = false;
-    ret.ptr_->static_data = true;
-    ret.byte_offset_ = byte_offset_;
-    ret.reuse_ = false;
+    ret.ptr_->delay_alloc  = false;
+    ret.ptr_->static_data  = true;
+    ret.byte_offset_       = byte_offset_;
+    ret.reuse_             = false;
     return ret;
   }
 }
 #endif
 
-NDArray NDArray::Reshape(const mxnet::TShape &shape) const {
+NDArray NDArray::Reshape(const mxnet::TShape& shape) const {
   CHECK(!is_none()) << "NDArray is not initialized";
   if (Imperative::Get()->is_np_shape()) {
     CHECK_EQ(shape_.Size(), shape.Size())
@@ -253,8 +251,7 @@ NDArray NDArray::Reshape(const mxnet::TShape &shape) const {
   }
   NDArray ret = this->Detach();
   // If the shape doesn't change, we can just return it now.
-  if (ret.shape_ == shape)
-    return ret;
+  if (ret.shape_ == shape) return ret;
   // Otherwise, reshape only works on the default layout.
   CHECK_EQ(storage_type(), kDefaultStorage);
   ret.shape_ = shape;
@@ -262,15 +259,16 @@ NDArray NDArray::Reshape(const mxnet::TShape &shape) const {
   return ret;
 }
 
-NDArray NDArray::ReshapeWithRecord(const mxnet::TShape &shape) {
+NDArray NDArray::ReshapeWithRecord(const mxnet::TShape& shape) {
   NDArray ret = this->Reshape(shape);
   if (!Imperative::Get()->is_recording()) return ret;
 
   CHECK_EQ(shape_.Size(), shape.Size())
-    << "NDArray.Reshape: target shape must have the same size as "
-    << "current shape when recording with autograd.";
+      << "NDArray.Reshape: target shape must have the same size as "
+      << "current shape when recording with autograd.";
   nnvm::NodeAttrs attrs;
-  attrs.op = nnvm::Op::Get("Reshape");;
+  attrs.op = nnvm::Op::Get("Reshape");
+  ;
   std::ostringstream os;
   os << shape;
   attrs.dict.insert({"shape", os.str()});
@@ -282,16 +280,14 @@ NDArray NDArray::ReshapeWithRecord(const mxnet::TShape &shape) {
 
 NDArray NDArray::Slice(index_t begin, index_t end) const {
   CHECK(!is_none()) << "NDArray is empty";
-  CHECK_LE(begin, end)
-      << "Invalid slicing range [" << begin << ", " << end << ")";
+  CHECK_LE(begin, end) << "Invalid slicing range [" << begin << ", " << end << ")";
   CHECK_GE(shape_[0], end) << "Slice end index out of range";
   CHECK_EQ(storage_type(), kDefaultStorage);
-  NDArray ret = this->Detach();
+  NDArray ret   = this->Detach();
   size_t length = shape_.ProdShape(1, shape_.ndim());
-  MSHADOW_TYPE_SWITCH_WITH_BOOL(ret.dtype(), DType, {
-    ret.byte_offset_ += begin * length * sizeof(DType);
-  });
-  ret.reuse_ = false;
+  MSHADOW_TYPE_SWITCH_WITH_BOOL(
+      ret.dtype(), DType, { ret.byte_offset_ += begin * length * sizeof(DType); });
+  ret.reuse_    = false;
   ret.shape_[0] = end - begin;
   return ret;
 }
@@ -313,9 +309,9 @@ NDArray NDArray::SliceWithRecord(index_t begin, index_t end) {
 NDArray NDArray::At(index_t idx) const {
   CHECK(storage_type() == kDefaultStorage)
       << "Storage type " << storage_type() << " doesn't support At()";
-  NDArray ret = this->Slice(idx, idx+1);
+  NDArray ret = this->Slice(idx, idx + 1);
   if (shape_.ndim() > 1) {
-    return ret.Reshape(mxnet::TShape(shape_.data()+1, shape_.data()+shape_.ndim()));
+    return ret.Reshape(mxnet::TShape(shape_.data() + 1, shape_.data() + shape_.ndim()));
   } else {
     return ret;
   }
@@ -324,9 +320,9 @@ NDArray NDArray::At(index_t idx) const {
 NDArray NDArray::AtWithRecord(index_t idx) {
   CHECK(storage_type() == kDefaultStorage)
       << "Storage type " << storage_type() << " doesn't support At()";
-  NDArray ret = this->SliceWithRecord(idx, idx+1);
+  NDArray ret = this->SliceWithRecord(idx, idx + 1);
   if (shape_.ndim() > 1 || Imperative::Get()->is_np_shape()) {
-    return ret.ReshapeWithRecord(mxnet::TShape(shape_.data()+1, shape_.data()+shape_.ndim()));
+    return ret.ReshapeWithRecord(mxnet::TShape(shape_.data() + 1, shape_.data() + shape_.ndim()));
   } else {
     return ret;
   }
@@ -359,20 +355,19 @@ struct NDArrayDLManager {
 DLManagedTensor* NDArray::ToDLPack() const {
   CHECK(!is_none()) << "NDArray is not initialized";
   NDArrayDLManager* dlmanager(new NDArrayDLManager);
-  dlmanager->handle = *this;
-  dlmanager->tensor.dl_tensor = dlmanager->handle.data().dltensor();
+  dlmanager->handle             = *this;
+  dlmanager->tensor.dl_tensor   = dlmanager->handle.data().dltensor();
   dlmanager->tensor.manager_ctx = dlmanager;
-  dlmanager->tensor.deleter = [](DLManagedTensor* dlmanager){
+  dlmanager->tensor.deleter     = [](DLManagedTensor* dlmanager) {
     delete static_cast<NDArrayDLManager*>(dlmanager->manager_ctx);
   };
   return &(dlmanager->tensor);
 }
 
 NDArray NDArray::FromDLPack(const DLManagedTensor* tensor, bool transient_handle) {
-  DLManagedTensor *tensor_copy = transient_handle
-                               ? new DLManagedTensor(*tensor)
-                               : const_cast<DLManagedTensor*>(tensor);
-  auto deleter = [tensor_copy, transient_handle](){
+  DLManagedTensor* tensor_copy =
+      transient_handle ? new DLManagedTensor(*tensor) : const_cast<DLManagedTensor*>(tensor);
+  auto deleter = [tensor_copy, transient_handle]() {
     if (tensor_copy->deleter != nullptr) {
       tensor_copy->deleter(tensor_copy);
     }
@@ -389,42 +384,35 @@ bool NDArray::fresh_out_grad() const {
   return info.fresh_out_grad;
 }
 
-
 void NDArray::set_fresh_out_grad(bool state) const {
   CHECK(!Imperative::AGInfo::IsNone(*this))
-    << "NDArray has not been marked as a variable and does not have gradient state";
+      << "NDArray has not been marked as a variable and does not have gradient state";
   Imperative::AGInfo& info = Imperative::AGInfo::Get(entry_.node);
-  info.fresh_out_grad = state;
+  info.fresh_out_grad      = state;
 }
 
 #if MXNET_USE_MKLDNN == 1
 
 bool NDArray::Chunk::IsMKLDNN() const {
-  if (storage_type != kDefaultStorage)
-    return false;
-  if (mkl_mem_ == nullptr)
-    return false;
+  if (storage_type != kDefaultStorage) return false;
+  if (mkl_mem_ == nullptr) return false;
   return mkl_mem_->IsMKLDNN();
 }
 
 bool NDArray::Chunk::IsDefault() const {
-  if (storage_type != kDefaultStorage)
-    return false;
+  if (storage_type != kDefaultStorage) return false;
   // If we don't have mkldnn memory yet, we just assume it's not the default
   // format.
-  if (mkl_mem_ == nullptr)
-    return true;
+  if (mkl_mem_ == nullptr) return true;
   return !mkl_mem_->IsMKLDNN();
 }
 
 void NDArray::Chunk::Reorder2Default() {
-  if (mkl_mem_ == nullptr)
-    return;
+  if (mkl_mem_ == nullptr) return;
 
-  if (IsDefault())
-    return;
+  if (IsDefault()) return;
 
-  mkldnn_format_tag_t format = mkl_mem_->GetDefaultFormat();
+  mkldnn_format_tag_t format    = mkl_mem_->GetDefaultFormat();
   mkldnn::memory::desc def_desc = mkl_mem_->GetDesc(format);
   mkldnn_mem_ptr def_mem(new mkldnn::memory(def_desc, CpuEngine::Get()->get_engine()));
   mkl_mem_->ReorderTo(def_mem.get());
@@ -436,14 +424,12 @@ void NDArray::Chunk::Reorder2Default() {
   mkl_mem_ = nullptr;
 }
 
-void NDArray::Chunk::MKLDNNDataReorder(const mkldnn::memory::desc &md) {
+void NDArray::Chunk::MKLDNNDataReorder(const mkldnn::memory::desc& md) {
   // If the memory already uses the specified layout, don't do anything.
-  if (mkl_mem_ != nullptr && mkl_mem_->SameFormat(md))
-    return;
+  if (mkl_mem_ != nullptr && mkl_mem_->SameFormat(md)) return;
 
   // If the memory is default, don't do anything.
-  if (!mxnet::IsMKLDNN(md) && IsDefault())
-    return;
+  if (!mxnet::IsMKLDNN(md) && IsDefault()) return;
   if (!mxnet::IsMKLDNN(md)) {
     // If the specified layout is default, we should use Reorder2Default.
     Reorder2Default();
@@ -456,7 +442,7 @@ void NDArray::Chunk::MKLDNNDataReorder(const mkldnn::memory::desc &md) {
   std::shared_ptr<mkldnn::memory> old_mem;
   if (IsDefault()) {
     mkldnn_format_tag_t def_format = GetDefaultFormat(md);
-    mkldnn::memory::desc def_desc = GetDesc(md, def_format);
+    mkldnn::memory::desc def_desc  = GetDesc(md, def_format);
     old_mem.reset(new mkldnn::memory(def_desc, engine, shandle.dptr));
   } else {
     old_mem = this->mkl_mem_->GetMem();
@@ -473,12 +459,11 @@ void NDArray::Chunk::MKLDNNDataReorder(const mkldnn::memory::desc &md) {
   mkl_mem_.reset(new MKLDNNMemory(md, shandle.dptr));
 }
 
-void NDArray::Chunk::SetMKLMem(const mxnet::TShape &shape, int dtype) {
+void NDArray::Chunk::SetMKLMem(const mxnet::TShape& shape, int dtype) {
   // The shape of the array and the one of the MKL memory may mismatch.
   // For example, if the array stores parameters, the MKL memory may store data
   // in 5 dimensions while the NDArray stores data in 4 dimensions.
-  if (mkl_mem_ && mkl_mem_->GetDataHandle() == shandle.dptr
-      && mkl_mem_->SameFormat(shape, dtype)) {
+  if (mkl_mem_ && mkl_mem_->GetDataHandle() == shandle.dptr && mkl_mem_->SameFormat(shape, dtype)) {
     return;
   }
 
@@ -486,19 +471,30 @@ void NDArray::Chunk::SetMKLMem(const mxnet::TShape &shape, int dtype) {
   // These are shapes supprted by MKLDNN.
   if (shape.ndim() >= 1 && shape.ndim() <= 6) {
     dims.resize(shape.ndim());
-    for (size_t i = 0; i < dims.size(); i++)
-      dims[i] = shape[i];
+    for (size_t i = 0; i < dims.size(); i++) dims[i] = shape[i];
   } else {
     LOG(FATAL) << "MKLDNN doesn't support " << shape.ndim() << " dimensions";
   }
   mkldnn::memory::format_tag layout = mkldnn::memory::format_tag::undef;
   switch (dims.size()) {
-    case 1: layout = mkldnn::memory::format_tag::a; break;
-    case 2: layout = mkldnn::memory::format_tag::ab; break;
-    case 3: layout = mkldnn::memory::format_tag::abc; break;
-    case 4: layout = mkldnn::memory::format_tag::abcd; break;
-    case 5: layout = mkldnn::memory::format_tag::abcde; break;
-    case 6: layout = mkldnn::memory::format_tag::abcdef; break;
+    case 1:
+      layout = mkldnn::memory::format_tag::a;
+      break;
+    case 2:
+      layout = mkldnn::memory::format_tag::ab;
+      break;
+    case 3:
+      layout = mkldnn::memory::format_tag::abc;
+      break;
+    case 4:
+      layout = mkldnn::memory::format_tag::abcd;
+      break;
+    case 5:
+      layout = mkldnn::memory::format_tag::abcde;
+      break;
+    case 6:
+      layout = mkldnn::memory::format_tag::abcdef;
+      break;
     default:
       LOG(FATAL) << "Not implemented dimension (" << dims.size() << ") for MKLDNN";
   }
@@ -511,12 +507,12 @@ void NDArray::Chunk::SetMKLMem(const mxnet::TShape &shape, int dtype) {
   mkl_mem_.reset(new MKLDNNMemory(data_md, shandle.dptr));
 }
 
-const mkldnn::memory *NDArray::GetMKLDNNData(const mkldnn::memory::desc &desc) const {
+const mkldnn::memory* NDArray::GetMKLDNNData(const mkldnn::memory::desc& desc) const {
   if (desc.get_size() != shape().Size() * GetTypeSize(dtype_)) {
     LOG(FATAL) << "The size of NDArray doesn't match the requested MKLDNN memory desc";
     return nullptr;
   }
-  const mkldnn::memory *mem = GetMKLDNNData();
+  const mkldnn::memory* mem  = GetMKLDNNData();
   mkldnn::memory::desc desc1 = mem->get_desc();
   // The MKL memory has the same format and shape as required,
   // or both use the default format, we can return the MKL memory.
@@ -527,13 +523,12 @@ const mkldnn::memory *NDArray::GetMKLDNNData(const mkldnn::memory::desc &desc) c
   }
 }
 
-const mkldnn::memory *NDArray::GetMKLDNNDataReorder(
-    const mkldnn::memory::desc &new_desc) const {
+const mkldnn::memory* NDArray::GetMKLDNNDataReorder(const mkldnn::memory::desc& new_desc) const {
   CHECK(storage_type() == kDefaultStorage);
 
-  const mkldnn::memory *mem = GetMKLDNNData();
+  const mkldnn::memory* mem = GetMKLDNNData();
   // If the memory descriptor matches, it's easy.
-  MKLDNNStream *stream = MKLDNNStream::Get();
+  MKLDNNStream* stream = MKLDNNStream::Get();
   if (mem->get_desc() == new_desc) {
     return GetMKLDNNExact(mem, new_desc);
   }
@@ -542,13 +537,13 @@ const mkldnn::memory *NDArray::GetMKLDNNDataReorder(
   // Now we need to determine if we should reorder the memory.
   // If both use the default formats, we think we don't need to reorder.
   if ((!mxnet::IsMKLDNN(old_desc)) && (!mxnet::IsMKLDNN(new_desc))) {
-    mkldnn_mem_ptr ret(new mkldnn::memory(new_desc,
-        CpuEngine::Get()->get_engine(), mem->get_data_handle()));
+    mkldnn_mem_ptr ret(
+        new mkldnn::memory(new_desc, CpuEngine::Get()->get_engine(), mem->get_data_handle()));
     stream->RegisterMem(ret);
     return ret.get();
   } else if (same_shape(old_desc, new_desc)) {
     // If they have the same shape, we can reorder data directly.
-    mkldnn::memory *ret = TmpMemMgr::Get()->Alloc(new_desc);
+    mkldnn::memory* ret = TmpMemMgr::Get()->Alloc(new_desc);
     std::unordered_map<int, mkldnn::memory> args({{MKLDNN_ARG_FROM, *mem}, {MKLDNN_ARG_TO, *ret}});
     stream->RegisterPrimArgs(mkldnn::reorder(*mem, *ret), args);
     return ret;
@@ -557,16 +552,15 @@ const mkldnn::memory *NDArray::GetMKLDNNDataReorder(
     // Since this method will only be used inside an operator, we can call
     // MKLDNNDataReshape to reshape an array.
     mxnet::TShape required_shape(new_desc.data.ndims, -1);
-    for (int i = 0; i < new_desc.data.ndims; i++)
-      required_shape[i] = new_desc.data.dims[i];
-    NDArray reshaped = MKLDNNDataReshape(required_shape);
-    const mkldnn::memory *ret = reshaped.GetMKLDNNData();
+    for (int i = 0; i < new_desc.data.ndims; i++) required_shape[i] = new_desc.data.dims[i];
+    NDArray reshaped          = MKLDNNDataReshape(required_shape);
+    const mkldnn::memory* ret = reshaped.GetMKLDNNData();
     if (ret->get_desc() == new_desc) {
       return GetMKLDNNExact(ret, new_desc);
     } else {
-      mkldnn::memory *ret2 = TmpMemMgr::Get()->Alloc(new_desc);
-      std::unordered_map<int, mkldnn::memory> args({{MKLDNN_ARG_FROM, *ret},
-                                                   {MKLDNN_ARG_TO, *ret2}});
+      mkldnn::memory* ret2 = TmpMemMgr::Get()->Alloc(new_desc);
+      std::unordered_map<int, mkldnn::memory> args(
+          {{MKLDNN_ARG_FROM, *ret}, {MKLDNN_ARG_TO, *ret2}});
       stream->RegisterPrimArgs(mkldnn::reorder(*ret, *ret2), args);
       return ret2;
     }
@@ -576,25 +570,23 @@ const mkldnn::memory *NDArray::GetMKLDNNDataReorder(
 NDArray NDArray::Reorder2Default() const {
   CHECK(storage_type() == kDefaultStorage);
 
-  if (ptr_->mkl_mem_ == nullptr)
-    return *this;
-  if (!ptr_->mkl_mem_->IsMKLDNN())
-    return *this;
+  if (ptr_->mkl_mem_ == nullptr) return *this;
+  if (!ptr_->mkl_mem_->IsMKLDNN()) return *this;
 
   // create new ndarray from  mkldnn layout
   mkldnn::memory::desc from_desc = ptr_->mkl_mem_->GetDesc();
   mxnet::TShape tshape(from_desc.data.ndims, -1);
   for (int i = 0; i < from_desc.data.ndims; i++) tshape[i] = from_desc.data.dims[i];
   NDArray ret(tshape, ctx(), false, dtype());
-  mkldnn_format_tag_t format = ptr_->mkl_mem_->GetDefaultFormat();
+  mkldnn_format_tag_t format    = ptr_->mkl_mem_->GetDefaultFormat();
   mkldnn::memory::desc def_desc = ptr_->mkl_mem_->GetDesc(format);
   CHECK(ret.ptr_->shandle.size >= def_desc.get_size());
   mkldnn::memory def_mem(def_desc, CpuEngine::Get()->get_engine(), ret.ptr_->shandle.dptr);
   ptr_->mkl_mem_->ReorderTo(&def_mem);
   // reshape as needed
-  ret.shape_ = shape_;
+  ret.shape_       = shape_;
   ret.byte_offset_ = byte_offset_;
-  ret.reuse_ = false;
+  ret.reuse_       = false;
   return ret;
 }
 
@@ -603,17 +595,17 @@ void NDArray::Reorder2DefaultAsync() const {
   std::vector<Engine::VarHandle> mutable_vars(1, this->var());
   NDArray tmp = *this;
   Engine::Get()->PushAsync(
-    [tmp](RunContext ctx, Engine::CallbackOnComplete on_complete) {
-      tmp.ptr_->Reorder2Default();
-      on_complete();
-    }, ctx(), const_vars, mutable_vars,
-    FnProperty::kNormal, 0, "Reorder2Default");
+      [tmp](RunContext ctx, Engine::CallbackOnComplete on_complete) {
+        tmp.ptr_->Reorder2Default();
+        on_complete();
+      },
+      ctx(), const_vars, mutable_vars, FnProperty::kNormal, 0, "Reorder2Default");
 }
 
 // now just support bf16->fp32
 NDArray NDArray::Reorder2DefaultFloatFormat() const {
   CHECK(storage_type() == kDefaultStorage && IsView() == false);
-  if (dtype() !=  mshadow::kBfloat16) {
+  if (dtype() != mshadow::kBfloat16) {
     return Reorder2Default();
   }
   NDArray ret(shape(), ctx(), false, mshadow::DataType<float>::kFlag);
@@ -624,24 +616,24 @@ NDArray NDArray::Reorder2DefaultFloatFormat() const {
   return ret;
 }
 
-void NDArray::MKLDNNDataReorderAsync(const mkldnn::memory::desc &desc) const {
+void NDArray::MKLDNNDataReorderAsync(const mkldnn::memory::desc& desc) const {
   std::vector<Engine::VarHandle> const_vars;
   std::vector<Engine::VarHandle> mutable_vars(1, this->var());
-  NDArray tmp = *this;
+  NDArray tmp        = *this;
   const auto version = this->version();
   Engine::Get()->PushAsync(
-    [tmp, version, desc](RunContext ctx, Engine::CallbackOnComplete on_complete) {
-      // MXNet will try to reuse NDArray from memory planning, so we need to ensure
-      // the NDArray is still holding the original trunk data.
-      if (tmp.version() == version) {
-        tmp.ptr_->MKLDNNDataReorder(desc);
-      }
-      on_complete();
-    }, ctx(), const_vars, mutable_vars,
-    FnProperty::kNormal, 0, "Reorder");
+      [tmp, version, desc](RunContext ctx, Engine::CallbackOnComplete on_complete) {
+        // MXNet will try to reuse NDArray from memory planning, so we need to ensure
+        // the NDArray is still holding the original trunk data.
+        if (tmp.version() == version) {
+          tmp.ptr_->MKLDNNDataReorder(desc);
+        }
+        on_complete();
+      },
+      ctx(), const_vars, mutable_vars, FnProperty::kNormal, 0, "Reorder");
 }
 
-const mkldnn::memory *NDArray::GetMKLDNNData() const {
+const mkldnn::memory* NDArray::GetMKLDNNData() const {
   CHECK(storage_type() == kDefaultStorage);
   bool is_view = IsView();
   if (IsMKLDNNData()) {
@@ -657,13 +649,12 @@ const mkldnn::memory *NDArray::GetMKLDNNData() const {
     // because we don't have the complete data type and shape information for
     // the chunk.
     CheckAndAlloc();
-    void *off_addr = static_cast<char *>(ptr_->shandle.dptr) + byte_offset_;
+    void* off_addr = static_cast<char*>(ptr_->shandle.dptr) + byte_offset_;
     // Create the primitive desc for the new mkldnn memory.
     mkldnn::memory::dims dims(shape().ndim());
-    for (size_t i = 0; i < dims.size(); i++)
-      dims[i] = shape()[i];
-    mkldnn::memory::format_tag cpp_format = static_cast<mkldnn::memory::format_tag>(
-        GetDefaultFormat(shape().ndim()));
+    for (size_t i = 0; i < dims.size(); i++) dims[i] = shape()[i];
+    mkldnn::memory::format_tag cpp_format =
+        static_cast<mkldnn::memory::format_tag>(GetDefaultFormat(shape().ndim()));
     mkldnn::memory::data_type cpp_type = get_mkldnn_type(dtype_);
     mkldnn::memory::desc data_md(dims, cpp_type, cpp_format);
     std::shared_ptr<mkldnn::memory> ret(
@@ -682,32 +673,29 @@ const mkldnn::memory *NDArray::GetMKLDNNData() const {
 
 void NDArray::InvalidateMKLDNNData() {
   // Removing mkl_mem_ means the NDArray will store data in the default format.
-  if (ptr_->mkl_mem_ && ptr_->mkl_mem_->IsMKLDNN())
-    ptr_->mkl_mem_ = nullptr;
+  if (ptr_->mkl_mem_ && ptr_->mkl_mem_->IsMKLDNN()) ptr_->mkl_mem_ = nullptr;
 }
 
-void NDArray::CopyFrom(const mkldnn::memory &mem) {
+void NDArray::CopyFrom(const mkldnn::memory& mem) {
   CHECK(ptr_ != nullptr) << "The NDArray hasn't been initialized";
-  if (ptr_->mkl_mem_ && ptr_->mkl_mem_->GetRaw() == &mem)
-    return;
+  if (ptr_->mkl_mem_ && ptr_->mkl_mem_->GetRaw() == &mem) return;
 
   CHECK(mem.get_desc().get_size() == shape().Size() * GetTypeSize(dtype_))
       << "The size of NDArray doesn't match the requested MKLDNN memory desc";
   // If this array uses MKLDNN layout, we have to make sure it's not a view.
   // Otherwise, we'll have to change the layout inside the array.
 
-  if (IsMKLDNNData() && IsView())
-    ptr_->Reorder2Default();
+  if (IsMKLDNNData() && IsView()) ptr_->Reorder2Default();
 
-  const mkldnn::memory *this_mem = GetMKLDNNData();
+  const mkldnn::memory* this_mem = GetMKLDNNData();
   MKLDNNMemoryCopy(mem, this_mem);
 }
 
-mkldnn::memory *NDArray::CreateMKLDNNData(const mkldnn::memory::desc &desc) {
+mkldnn::memory* NDArray::CreateMKLDNNData(const mkldnn::memory::desc& desc) {
   if (desc.get_size() != shape().Size() * GetTypeSize(dtype_)) {
     LOG(FATAL) << "The size of NDArray doesn't match the requested MKLDNN memory desc. "
-        << "MKLDNN memory requests for " << desc.get_size() << " bytes, but got "
-        << shape().Size() * GetTypeSize(dtype_) << " bytes from NDArray";
+               << "MKLDNN memory requests for " << desc.get_size() << " bytes, but got "
+               << shape().Size() * GetTypeSize(dtype_) << " bytes from NDArray";
     return nullptr;
   }
   bool isDefaultFormat = IsDefaultFormat(desc);
@@ -720,8 +708,9 @@ mkldnn::memory *NDArray::CreateMKLDNNData(const mkldnn::memory::desc &desc) {
     CHECK(ptr_->shandle.dptr);
     // When this is a view and a user wants the default layout, we can simply
     // create a new mkldnn memory that points to the right memory.
-    std::shared_ptr<mkldnn::memory> mem(new mkldnn::memory(desc,
-        CpuEngine::Get()->get_engine(), static_cast<char *>(ptr_->shandle.dptr) + byte_offset_));
+    std::shared_ptr<mkldnn::memory> mem(new mkldnn::memory(
+        desc, CpuEngine::Get()->get_engine(),
+        static_cast<char*>(ptr_->shandle.dptr) + byte_offset_));
     MKLDNNStream::Get()->RegisterMem(mem);
     return mem.get();
   } else if (IsView()) {
@@ -733,8 +722,7 @@ mkldnn::memory *NDArray::CreateMKLDNNData(const mkldnn::memory::desc &desc) {
     return nullptr;
   }
 
-  if (ptr_->mkl_mem_)
-    CHECK(ptr_->mkl_mem_->GetDataHandle() == ptr_->shandle.dptr);
+  if (ptr_->mkl_mem_) CHECK(ptr_->mkl_mem_->GetDataHandle() == ptr_->shandle.dptr);
   if (ptr_->mkl_mem_ && ptr_->mkl_mem_->GetDesc() == desc) {
     MKLDNNStream::Get()->RegisterMem(ptr_->mkl_mem_->GetMem());
     return GetMKLDNNExact(ptr_->mkl_mem_->GetRaw(), desc);
@@ -747,9 +735,9 @@ mkldnn::memory *NDArray::CreateMKLDNNData(const mkldnn::memory::desc &desc) {
   return ptr_->mkl_mem_->GetRaw();
 }
 
-void NDArray::UpdateMKLDNNMemDesc(const mkldnn::memory::desc &desc) {
-  auto new_desc = desc;
-  auto this_dtype = get_mkldnn_type(dtype());
+void NDArray::UpdateMKLDNNMemDesc(const mkldnn::memory::desc& desc) {
+  auto new_desc           = desc;
+  auto this_dtype         = get_mkldnn_type(dtype());
   new_desc.data.data_type = static_cast<mkldnn_data_type_t>(this_dtype);
   ptr_->mkl_mem_.reset(new MKLDNNMemory(new_desc, ptr_->shandle.dptr));
   MKLDNNStream::Get()->RegisterMem(ptr_->mkl_mem_->GetMem());
@@ -760,12 +748,12 @@ void NDArray::UpdateMKLDNNMemDesc(const mkldnn::memory::desc &desc) {
 void NDArray::SetTBlob() const {
   CHECK(ptr_ != nullptr);
   mxnet::TShape shape = shape_;
-  char *dptr = static_cast<char*>(ptr_->shandle.dptr);
-  auto stype = storage_type();
+  char* dptr          = static_cast<char*>(ptr_->shandle.dptr);
+  auto stype          = storage_type();
   if (stype == kDefaultStorage) {
 #if MXNET_USE_MKLDNN == 1
     CHECK(!IsMKLDNNData()) << "We can't generate TBlob for MKLDNN data. "
-        << "Please use Reorder2Default() to generate a new NDArray first";
+                           << "Please use Reorder2Default() to generate a new NDArray first";
 #endif
     dptr += byte_offset_;
   } else if (stype == kCSRStorage || stype == kRowSparseStorage) {
@@ -774,27 +762,24 @@ void NDArray::SetTBlob() const {
   } else {
     LOG(FATAL) << "unknown storage type " << stype;
   }
-  tblob_.dptr_ = dptr;
-  tblob_.shape_ = shape;
+  tblob_.dptr_      = dptr;
+  tblob_.shape_     = shape;
   tblob_.type_flag_ = dtype_;
   tblob_.SetDLTensor(ptr_->shandle.ctx.dev_mask(), ptr_->shandle.ctx.dev_id);
 }
 
 /*!
-* \brief run a ternary operation
-* \param lhs left operand
-* \param mhs middle operand
-* \param rhs right operand
-* \param out the output ndarray
-*/
-template<typename OP>
-void TernaryOp(const NDArray &lhs,
-  const NDArray &mhs,
-  const NDArray &rhs,
-  NDArray *out) {
+ * \brief run a ternary operation
+ * \param lhs left operand
+ * \param mhs middle operand
+ * \param rhs right operand
+ * \param out the output ndarray
+ */
+template <typename OP>
+void TernaryOp(const NDArray& lhs, const NDArray& mhs, const NDArray& rhs, NDArray* out) {
   // no check if all of them are on cpu
-  if (lhs.ctx().dev_mask() != cpu::kDevMask || mhs.ctx().dev_mask() != cpu::kDevMask
-                                            || rhs.ctx().dev_mask() != cpu::kDevMask) {
+  if (lhs.ctx().dev_mask() != cpu::kDevMask || mhs.ctx().dev_mask() != cpu::kDevMask ||
+      rhs.ctx().dev_mask() != cpu::kDevMask) {
     CHECK((lhs.ctx() == mhs.ctx()) && (mhs.ctx() == rhs.ctx())) << "operands context mismatch";
   }
   // if out is none, allocate space
@@ -802,12 +787,11 @@ void TernaryOp(const NDArray &lhs,
     *out = NDArray(OP::GetShape(lhs.shape(), mhs.shape(), rhs.shape()), lhs.ctx(), true);
   } else {
     // no check if both of them are on cpu
-    if (lhs.ctx().dev_mask() != cpu::kDevMask ||
-      out->ctx().dev_mask() != cpu::kDevMask) {
+    if (lhs.ctx().dev_mask() != cpu::kDevMask || out->ctx().dev_mask() != cpu::kDevMask) {
       CHECK(out->ctx() == lhs.ctx()) << "target context mismatch";
     }
     CHECK(out->shape() == OP::GetShape(lhs.shape(), mhs.shape(), rhs.shape()))
-      << "target shape mismatch";
+        << "target shape mismatch";
   }
   // important: callback must always capture by value
   NDArray ret = *out;
@@ -819,43 +803,45 @@ void TernaryOp(const NDArray &lhs,
 
   // redirect everything to mshadow operations
   switch (lhs.ctx().dev_mask()) {
-  case cpu::kDevMask: {
-    Engine::Get()->PushSync([lhs, mhs, rhs, ret](RunContext ctx) {
-      TBlob tmp = ret.data();
-      ndarray::Eval<cpu, OP>(lhs.data(), mhs.data(), rhs.data(), &tmp, ctx);
-    }, lhs.ctx(), const_vars, { ret.var() },
-    FnProperty::kNormal, 0, PROFILER_MESSAGE_FUNCNAME);
-    break;
-  }
+    case cpu::kDevMask: {
+      Engine::Get()->PushSync(
+          [lhs, mhs, rhs, ret](RunContext ctx) {
+            TBlob tmp = ret.data();
+            ndarray::Eval<cpu, OP>(lhs.data(), mhs.data(), rhs.data(), &tmp, ctx);
+          },
+          lhs.ctx(), const_vars, {ret.var()}, FnProperty::kNormal, 0, PROFILER_MESSAGE_FUNCNAME);
+      break;
+    }
 #if MXNET_USE_CUDA
-  case gpu::kDevMask: {
-    Engine::Get()->PushSync([lhs, mhs, rhs, ret](RunContext ctx) {
-      TBlob tmp = ret.data();
-      ndarray::Eval<gpu, OP>(lhs.data(), mhs.data(), rhs.data(), &tmp, ctx);
-      // Wait GPU kernel to complete
-      ctx.get_stream<gpu>()->Wait();
-    }, lhs.ctx(), const_vars, { ret.var() },
-    FnProperty::kNormal, 0, PROFILER_MESSAGE_FUNCNAME);
-    break;
-  }
+    case gpu::kDevMask: {
+      Engine::Get()->PushSync(
+          [lhs, mhs, rhs, ret](RunContext ctx) {
+            TBlob tmp = ret.data();
+            ndarray::Eval<gpu, OP>(lhs.data(), mhs.data(), rhs.data(), &tmp, ctx);
+            // Wait GPU kernel to complete
+            ctx.get_stream<gpu>()->Wait();
+          },
+          lhs.ctx(), const_vars, {ret.var()}, FnProperty::kNormal, 0, PROFILER_MESSAGE_FUNCNAME);
+      break;
+    }
 #endif
-  default: LOG(FATAL) << MXNET_GPU_NOT_ENABLED_ERROR;
+    default:
+      LOG(FATAL) << MXNET_GPU_NOT_ENABLED_ERROR;
   }
 }
 
 /*!
-* \brief Performs some preparation required to apply binary operators.
-* Checks context and shape of ndarrays, allocates space for output
-* and prepares const variables for engine
-* \param lhs left operand
-* \param rhs right operand
-* \param out the output ndarray
-* \param binary_op the real operation
-*/
-template<typename OP>
-std::vector<Engine::VarHandle> BinaryOpPrepare(const NDArray &lhs,
-                                               const NDArray &rhs,
-                                               NDArray *out) {
+ * \brief Performs some preparation required to apply binary operators.
+ * Checks context and shape of ndarrays, allocates space for output
+ * and prepares const variables for engine
+ * \param lhs left operand
+ * \param rhs right operand
+ * \param out the output ndarray
+ * \param binary_op the real operation
+ */
+template <typename OP>
+std::vector<Engine::VarHandle> BinaryOpPrepare(
+    const NDArray& lhs, const NDArray& rhs, NDArray* out) {
   // no check if both of them are on cpu
   if (lhs.ctx().dev_mask() != cpu::kDevMask || rhs.ctx().dev_mask() != cpu::kDevMask) {
     CHECK(lhs.ctx() == rhs.ctx()) << "operands context mismatch";
@@ -865,12 +851,10 @@ std::vector<Engine::VarHandle> BinaryOpPrepare(const NDArray &lhs,
     *out = NDArray(OP::GetShape(lhs.shape(), rhs.shape()), lhs.ctx(), true, lhs.dtype());
   } else {
     // no check if both of them are on cpu
-    if (lhs.ctx().dev_mask() != cpu::kDevMask ||
-        out->ctx().dev_mask() != cpu::kDevMask) {
+    if (lhs.ctx().dev_mask() != cpu::kDevMask || out->ctx().dev_mask() != cpu::kDevMask) {
       CHECK(out->ctx() == lhs.ctx()) << "target context mismatch";
     }
-    CHECK(out->shape() == OP::GetShape(lhs.shape(), rhs.shape()))
-      << "target shape mismatch";
+    CHECK(out->shape() == OP::GetShape(lhs.shape(), rhs.shape())) << "target shape mismatch";
   }
   std::vector<Engine::VarHandle> const_vars;
   // prepare const variables for engine
@@ -880,44 +864,44 @@ std::vector<Engine::VarHandle> BinaryOpPrepare(const NDArray &lhs,
 }
 
 /*!
-* \brief run a binary operation using the kernel launch method
-* \param lhs left operand
-* \param rhs right operand
-* \param out the output ndarray
-* \param binary_op the real operation
-*/
-template<typename OP>
-void BinaryOpKernel(const NDArray &lhs,
-                    const NDArray &rhs,
-                    NDArray *out) {
+ * \brief run a binary operation using the kernel launch method
+ * \param lhs left operand
+ * \param rhs right operand
+ * \param out the output ndarray
+ * \param binary_op the real operation
+ */
+template <typename OP>
+void BinaryOpKernel(const NDArray& lhs, const NDArray& rhs, NDArray* out) {
   std::vector<Engine::VarHandle> const_vars = BinaryOpPrepare<OP>(lhs, rhs, out);
   // important: callback must always capture by value
   NDArray ret = *out;
   switch (lhs.ctx().dev_mask()) {
     case cpu::kDevMask: {
-      Engine::Get()->PushSync([lhs, rhs, ret](RunContext ctx) {
-        TBlob tmp = ret.data();
-        mshadow::Stream<cpu>* s = ctx.get_stream<cpu>();
-        ndarray::BinaryOpKernelImpl<OP>(s, lhs.data(), rhs.data(), &tmp);
-      },
-      lhs.ctx(), const_vars, {ret.var()},
-      FnProperty::kNormal, 0, PROFILER_MESSAGE_FUNCNAME);
+      Engine::Get()->PushSync(
+          [lhs, rhs, ret](RunContext ctx) {
+            TBlob tmp               = ret.data();
+            mshadow::Stream<cpu>* s = ctx.get_stream<cpu>();
+            ndarray::BinaryOpKernelImpl<OP>(s, lhs.data(), rhs.data(), &tmp);
+          },
+          lhs.ctx(), const_vars, {ret.var()}, FnProperty::kNormal, 0, PROFILER_MESSAGE_FUNCNAME);
       break;
     }
 #if MXNET_USE_CUDA
     case gpu::kDevMask: {
-      Engine::Get()->PushSync([lhs, rhs, ret](RunContext ctx) {
-        TBlob tmp = ret.data();
-        mshadow::Stream<gpu>* s = ctx.get_stream<gpu>();
-        ndarray::BinaryOpKernelImpl<OP>(s, lhs.data(), rhs.data(), &tmp);
-        // Wait GPU kernel to complete
-        ctx.get_stream<gpu>()->Wait();
-      }, lhs.ctx(), const_vars, {ret.var()},
-      FnProperty::kNormal, 0, PROFILER_MESSAGE_FUNCNAME);
+      Engine::Get()->PushSync(
+          [lhs, rhs, ret](RunContext ctx) {
+            TBlob tmp               = ret.data();
+            mshadow::Stream<gpu>* s = ctx.get_stream<gpu>();
+            ndarray::BinaryOpKernelImpl<OP>(s, lhs.data(), rhs.data(), &tmp);
+            // Wait GPU kernel to complete
+            ctx.get_stream<gpu>()->Wait();
+          },
+          lhs.ctx(), const_vars, {ret.var()}, FnProperty::kNormal, 0, PROFILER_MESSAGE_FUNCNAME);
       break;
-}
+    }
 #endif
-    default: LOG(FATAL) << MXNET_GPU_NOT_ENABLED_ERROR;
+    default:
+      LOG(FATAL) << MXNET_GPU_NOT_ENABLED_ERROR;
   }
 }
 
@@ -928,71 +912,74 @@ void BinaryOpKernel(const NDArray &lhs,
  * \param out the output ndarray
  * \param binary_op the real operation
  */
-template<typename OP>
-void BinaryOp(const NDArray &lhs,
-              const NDArray &rhs,
-              NDArray *out) {
+template <typename OP>
+void BinaryOp(const NDArray& lhs, const NDArray& rhs, NDArray* out) {
   std::vector<Engine::VarHandle> const_vars = BinaryOpPrepare<OP>(lhs, rhs, out);
   // important: callback must always capture by value
   NDArray ret = *out;
   // redirect everything to mshadow operations
   switch (lhs.ctx().dev_mask()) {
     case cpu::kDevMask: {
-        Engine::Get()->PushSync([lhs, rhs, ret](RunContext ctx) {
+      Engine::Get()->PushSync(
+          [lhs, rhs, ret](RunContext ctx) {
             TBlob tmp = ret.data();
             ndarray::Eval<cpu, OP>(lhs.data(), rhs.data(), &tmp, ctx);
-          }, lhs.ctx(), const_vars, {ret.var()},
-          FnProperty::kNormal, 0, PROFILER_MESSAGE_FUNCNAME);
+          },
+          lhs.ctx(), const_vars, {ret.var()}, FnProperty::kNormal, 0, PROFILER_MESSAGE_FUNCNAME);
       break;
     }
 #if MXNET_USE_CUDA
     case gpu::kDevMask: {
-      Engine::Get()->PushSync([lhs, rhs, ret](RunContext ctx) {
-          TBlob tmp = ret.data();
-          ndarray::Eval<gpu, OP>(lhs.data(), rhs.data(), &tmp, ctx);
-          // Wait GPU kernel to complete
-          ctx.get_stream<gpu>()->Wait();
-        }, lhs.ctx(), const_vars, {ret.var()},
-        FnProperty::kNormal, 0, PROFILER_MESSAGE_FUNCNAME);
+      Engine::Get()->PushSync(
+          [lhs, rhs, ret](RunContext ctx) {
+            TBlob tmp = ret.data();
+            ndarray::Eval<gpu, OP>(lhs.data(), rhs.data(), &tmp, ctx);
+            // Wait GPU kernel to complete
+            ctx.get_stream<gpu>()->Wait();
+          },
+          lhs.ctx(), const_vars, {ret.var()}, FnProperty::kNormal, 0, PROFILER_MESSAGE_FUNCNAME);
       break;
     }
 #endif
-    default: LOG(FATAL) << MXNET_GPU_NOT_ENABLED_ERROR;
+    default:
+      LOG(FATAL) << MXNET_GPU_NOT_ENABLED_ERROR;
   }
 }
 
-void SetValueOp(const real_t &rhs, NDArray *out) {
+void SetValueOp(const real_t& rhs, NDArray* out) {
   CHECK_NE(out->is_none(), true) << "Set value target must not be empty";
   // important: callback must always capture by value
-  NDArray ret = *out;
+  NDArray ret                    = *out;
   const NDArrayStorageType stype = ret.storage_type();
-  Engine::Get()->PushSync([rhs, ret, stype](RunContext ctx) {
-      TBlob tmp = ret.data();
-      switch (ret.ctx().dev_mask()) {
-        case cpu::kDevMask: {
-          if (stype == kDefaultStorage) {
-            ndarray::Eval<cpu>(rhs, &tmp, ctx);
-          } else {
-            ndarray::Eval(ctx.get_stream<cpu>(), rhs, ret);
+  Engine::Get()->PushSync(
+      [rhs, ret, stype](RunContext ctx) {
+        TBlob tmp = ret.data();
+        switch (ret.ctx().dev_mask()) {
+          case cpu::kDevMask: {
+            if (stype == kDefaultStorage) {
+              ndarray::Eval<cpu>(rhs, &tmp, ctx);
+            } else {
+              ndarray::Eval(ctx.get_stream<cpu>(), rhs, ret);
+            }
+            break;
           }
-          break;
-        }
 #if MXNET_USE_CUDA
-        case gpu::kDevMask: {
-          if (stype == kDefaultStorage) {
-            ndarray::Eval<gpu>(rhs, &tmp, ctx);
-          } else {
-            ndarray::Eval(ctx.get_stream<gpu>(), rhs, ret);
+          case gpu::kDevMask: {
+            if (stype == kDefaultStorage) {
+              ndarray::Eval<gpu>(rhs, &tmp, ctx);
+            } else {
+              ndarray::Eval(ctx.get_stream<gpu>(), rhs, ret);
+            }
+            // Wait GPU kernel to complete
+            ctx.get_stream<gpu>()->Wait();
+            break;
           }
-          // Wait GPU kernel to complete
-          ctx.get_stream<gpu>()->Wait();
-          break;
-        }
 #endif
-        default: LOG(FATAL) << MXNET_GPU_NOT_ENABLED_ERROR;
-      }
-    }, ret.ctx(), {}, {ret.var()},
-  FnProperty::kNormal, 0, PROFILER_MESSAGE_FUNCNAME);
+          default:
+            LOG(FATAL) << MXNET_GPU_NOT_ENABLED_ERROR;
+        }
+      },
+      ret.ctx(), {}, {ret.var()}, FnProperty::kNormal, 0, PROFILER_MESSAGE_FUNCNAME);
 }
 
 /*!
@@ -1002,10 +989,8 @@ void SetValueOp(const real_t &rhs, NDArray *out) {
  * \param out the output ndarray
  * \param binary_op the real
  */
-template<typename OP, bool reverse>
-void ScalarOp(const NDArray &lhs,
-              const real_t &rhs,
-              NDArray *out) {
+template <typename OP, bool reverse>
+void ScalarOp(const NDArray& lhs, const real_t& rhs, NDArray* out) {
   if (out->is_none()) {
     *out = NDArray(lhs.shape(), lhs.ctx(), true, lhs.dtype());
   } else {
@@ -1021,42 +1006,53 @@ void ScalarOp(const NDArray &lhs,
   // redirect everything to mshadow operations
   switch (lhs.ctx().dev_mask()) {
     case cpu::kDevMask: {
-      Engine::Get()->PushSync([lhs, rhs, ret](RunContext ctx) {
-          TBlob tmp = ret.data();
-          ndarray::Eval<cpu, OP, reverse>(lhs.data(), rhs, &tmp, ctx);
-        }, lhs.ctx(), const_vars, {ret.var()},
-        FnProperty::kNormal, 0, PROFILER_MESSAGE_FUNCNAME);
+      Engine::Get()->PushSync(
+          [lhs, rhs, ret](RunContext ctx) {
+            TBlob tmp = ret.data();
+            ndarray::Eval<cpu, OP, reverse>(lhs.data(), rhs, &tmp, ctx);
+          },
+          lhs.ctx(), const_vars, {ret.var()}, FnProperty::kNormal, 0, PROFILER_MESSAGE_FUNCNAME);
       break;
     }
 #if MXNET_USE_CUDA
     case gpu::kDevMask: {
-      Engine::Get()->PushSync([lhs, rhs, ret](RunContext ctx) {
-          TBlob tmp = ret.data();
-          ndarray::Eval<gpu, OP, reverse>(lhs.data(), rhs, &tmp, ctx);
-          // Wait GPU kernel to complete
-          ctx.get_stream<gpu>()->Wait();
-        }, lhs.ctx(), const_vars, {ret.var()},
-        FnProperty::kNormal, 0, PROFILER_MESSAGE_FUNCNAME);
+      Engine::Get()->PushSync(
+          [lhs, rhs, ret](RunContext ctx) {
+            TBlob tmp = ret.data();
+            ndarray::Eval<gpu, OP, reverse>(lhs.data(), rhs, &tmp, ctx);
+            // Wait GPU kernel to complete
+            ctx.get_stream<gpu>()->Wait();
+          },
+          lhs.ctx(), const_vars, {ret.var()}, FnProperty::kNormal, 0, PROFILER_MESSAGE_FUNCNAME);
       break;
     }
 #endif
-    default: LOG(FATAL) << MXNET_GPU_NOT_ENABLED_ERROR;
+    default:
+      LOG(FATAL) << MXNET_GPU_NOT_ENABLED_ERROR;
   }
 }
 
 size_t num_aux_data(NDArrayStorageType stype) {
   size_t num = 0;
   switch (stype) {
-    case kDefaultStorage: num = 0; break;
-    case kCSRStorage: num = 2; break;
-    case kRowSparseStorage: num = 1; break;
-     default: LOG(FATAL) << "Unknown storage type" << stype; break;
+    case kDefaultStorage:
+      num = 0;
+      break;
+    case kCSRStorage:
+      num = 2;
+      break;
+    case kRowSparseStorage:
+      num = 1;
+      break;
+    default:
+      LOG(FATAL) << "Unknown storage type" << stype;
+      break;
   }
   return num;
 }
 
 // Make a copy of a CSR NDArray
-template<typename from_xpu, typename to_xpu>
+template <typename from_xpu, typename to_xpu>
 inline void CopyFromToCsrImpl(const NDArray& from, const NDArray& to, RunContext ctx) {
   using namespace mshadow;
   CHECK_EQ(from.storage_type(), to.storage_type()) << "Copying with different storage type";
@@ -1070,19 +1066,16 @@ inline void CopyFromToCsrImpl(const NDArray& from, const NDArray& to, RunContext
   to.CheckAndAllocAuxData(csr::kIndPtr, from.aux_shape(csr::kIndPtr));
   to.CheckAndAllocAuxData(csr::kIdx, from.aux_shape(csr::kIdx));
   to.CheckAndAllocData(from.aux_shape(csr::kIdx));
-  TBlob val = to.data();
+  TBlob val    = to.data();
   TBlob indptr = to.aux_data(csr::kIndPtr);
-  TBlob idx = to.aux_data(csr::kIdx);
-  ndarray::Copy<from_xpu, to_xpu>(from.data(), &val,
-                                  from.ctx(), to.ctx(), ctx);
-  ndarray::Copy<from_xpu, to_xpu>(from.aux_data(csr::kIndPtr), &indptr,
-                                  from.ctx(), to.ctx(), ctx);
-  ndarray::Copy<from_xpu, to_xpu>(from.aux_data(csr::kIdx), &idx,
-                                  from.ctx(), to.ctx(), ctx);
+  TBlob idx    = to.aux_data(csr::kIdx);
+  ndarray::Copy<from_xpu, to_xpu>(from.data(), &val, from.ctx(), to.ctx(), ctx);
+  ndarray::Copy<from_xpu, to_xpu>(from.aux_data(csr::kIndPtr), &indptr, from.ctx(), to.ctx(), ctx);
+  ndarray::Copy<from_xpu, to_xpu>(from.aux_data(csr::kIdx), &idx, from.ctx(), to.ctx(), ctx);
 }
 
 // Make a copy of a row-sparse NDArray
-template<typename from_xpu, typename to_xpu>
+template <typename from_xpu, typename to_xpu>
 inline void CopyFromToRspImpl(const NDArray& from, const NDArray& to, RunContext ctx) {
   using namespace mshadow;
   CHECK_EQ(from.storage_type(), to.storage_type()) << "Copying with different storage type";
@@ -1096,14 +1089,12 @@ inline void CopyFromToRspImpl(const NDArray& from, const NDArray& to, RunContext
   to.CheckAndAlloc({aux_shape});
   TBlob val = to.data();
   TBlob idx = to.aux_data(rowsparse::kIdx);
-  ndarray::Copy<from_xpu, to_xpu>(from.data(), &val,
-                                  from.ctx(), to.ctx(), ctx);
-  ndarray::Copy<from_xpu, to_xpu>(from.aux_data(rowsparse::kIdx), &idx,
-                                  from.ctx(), to.ctx(), ctx);
+  ndarray::Copy<from_xpu, to_xpu>(from.data(), &val, from.ctx(), to.ctx(), ctx);
+  ndarray::Copy<from_xpu, to_xpu>(from.aux_data(rowsparse::kIdx), &idx, from.ctx(), to.ctx(), ctx);
 }
 
 // Make a copy of a dense NDArray
-template<typename from_xpu, typename to_xpu>
+template <typename from_xpu, typename to_xpu>
 inline void CopyFromToDnsImpl(const NDArray& from, const NDArray& to, RunContext ctx) {
 #if MXNET_USE_MKLDNN == 1
   // If neither is MKLDNN, we can copy data normally.
@@ -1112,23 +1103,20 @@ inline void CopyFromToDnsImpl(const NDArray& from, const NDArray& to, RunContext
     using namespace mshadow;
     CHECK_EQ(from.storage_type(), to.storage_type()) << "Copying with different storage type";
     TBlob tmp = to.data();
-    ndarray::Copy<from_xpu, to_xpu>(from.data(), &tmp,
-                                    from.ctx(), to.ctx(), ctx);
+    ndarray::Copy<from_xpu, to_xpu>(from.data(), &tmp, from.ctx(), to.ctx(), ctx);
 #if MXNET_USE_MKLDNN == 1
-  } else if (SupportMKLDNN(from.dtype(), from.shape())
-             && SupportMKLDNN(to.dtype(), to.shape())
-             && from.ctx().dev_mask() == cpu::kDevMask
-             && to.ctx().dev_mask() == cpu::kDevMask) {
+  } else if (
+      SupportMKLDNN(from.dtype(), from.shape()) && SupportMKLDNN(to.dtype(), to.shape()) &&
+      from.ctx().dev_mask() == cpu::kDevMask && to.ctx().dev_mask() == cpu::kDevMask) {
     // If we copy data directly, we need to make sure both NDArrays are supported
     // by MKLDNN.
     auto from_mem = from.GetMKLDNNData();
-    auto to_mem = to.GetMKLDNNData();
+    auto to_mem   = to.GetMKLDNNData();
     if (from_mem->get_desc() == to_mem->get_desc()) {
-      size_t size = std::min(from_mem->get_desc().get_size(),
-                             to_mem->get_desc().get_size());
+      size_t size = std::min(from_mem->get_desc().get_size(), to_mem->get_desc().get_size());
       memcpy(to_mem->get_data_handle(), from_mem->get_data_handle(), size);
     } else {
-      const_cast<NDArray &>(to).CopyFrom(*from_mem);
+      const_cast<NDArray&>(to).CopyFrom(*from_mem);
       MKLDNNStream::Get()->Submit();
     }
   } else {
@@ -1138,7 +1126,7 @@ inline void CopyFromToDnsImpl(const NDArray& from, const NDArray& to, RunContext
     NDArray tmp_from = from;
     if (tmp_from.IsMKLDNNData()) {
       // TODO(zhengda) tmp_from should be cached.
-      tmp_from = NDArray(from.shape(), from.ctx(), false, from.dtype());
+      tmp_from     = NDArray(from.shape(), from.ctx(), false, from.dtype());
       auto tmp_mem = from.GetMKLDNNData();
       tmp_from.CopyFrom(*tmp_mem);
       MKLDNNStream::Get()->Submit();
@@ -1146,35 +1134,30 @@ inline void CopyFromToDnsImpl(const NDArray& from, const NDArray& to, RunContext
     CHECK(tmp_from.IsDefaultData());
     CHECK(to.IsDefaultData());
     TBlob tmp = to.data();
-    ndarray::Copy<from_xpu, to_xpu>(tmp_from.data(), &tmp,
-                                    from.ctx(), to.ctx(), ctx);
+    ndarray::Copy<from_xpu, to_xpu>(tmp_from.data(), &tmp, from.ctx(), to.ctx(), ctx);
   }
 #endif
 }
 
 // Make a copy of an NDArray based on storage type
-template<typename from_xpu, typename to_xpu>
-void CopyFromToImpl(const NDArray& from, const NDArray& to,
-                    RunContext rctx, const std::vector<Resource>& requested) {
+template <typename from_xpu, typename to_xpu>
+void CopyFromToImpl(
+    const NDArray& from, const NDArray& to, RunContext rctx,
+    const std::vector<Resource>& requested) {
   using namespace std;
   using namespace mshadow;
   // if storage type doesn't match, cast the storage first
   const NDArrayStorageType from_stype = from.storage_type();
-  const NDArrayStorageType to_stype = to.storage_type();
-  CHECK(from_stype == kDefaultStorage
-      || to_stype == kDefaultStorage
-      || from_stype == to_stype)
-    << "Copying ndarray of stype = " << from_stype
-    << " to stype = " << to_stype << " is not supported";
+  const NDArrayStorageType to_stype   = to.storage_type();
+  CHECK(from_stype == kDefaultStorage || to_stype == kDefaultStorage || from_stype == to_stype)
+      << "Copying ndarray of stype = " << from_stype << " to stype = " << to_stype
+      << " is not supported";
   const Context from_ctx = from.ctx();
-  const Context to_ctx = to.ctx();
-  bool is_train = Imperative::Get()->is_training();
+  const Context to_ctx   = to.ctx();
+  bool is_train          = Imperative::Get()->is_training();
 
-  OpContext opctx{Imperative::Get()->is_recording(),
-                  is_train,
-                  rctx,
-                  engine::CallbackOnComplete(),
-                  requested};
+  OpContext opctx{
+      Imperative::Get()->is_recording(), is_train, rctx, engine::CallbackOnComplete(), requested};
   if (from_ctx == to_ctx && from_stype != to_stype) {
     // same ctx, different stypes, use cast op directly without copying
     common::CastStorageDispatch<from_xpu>(opctx, from, to);
@@ -1182,7 +1165,7 @@ void CopyFromToImpl(const NDArray& from, const NDArray& to,
     NDArray casted_nd;  // an intermediate result before copying from to to
     if (from_stype == to_stype) {
       casted_nd = from;  // same stype, no need to cast from
-    } else {  // different stypes on different ctx needs an temporary casted_nd
+    } else {             // different stypes on different ctx needs an temporary casted_nd
       const mxnet::TShape& shape = from.shape();
       if (to_stype == kDefaultStorage) {
         casted_nd = NDArray(shape, from_ctx);
@@ -1213,21 +1196,20 @@ void CopyFromTo(const NDArray& from, const NDArray& to, int priority, bool is_op
   CHECK(from.shape() == to.shape())
       << "operands shape mismatch "
       << "from.shape = " << from.shape() << " to.shape=" << to.shape();
-  CHECK(!mxnet::op::shape_is_none(from.shape()))
-      << "source operands have undefined shape";
+  CHECK(!mxnet::op::shape_is_none(from.shape())) << "source operands have undefined shape";
   // zero-size array, no need to copy
   if (from.shape().Size() == 0U) {
     return;
   }
   // important: callback must always capture by value
   const Context from_ctx = from.ctx();
-  const int a = from_ctx.dev_mask();
-  const int b = to.ctx().dev_mask();
+  const int a            = from_ctx.dev_mask();
+  const int b            = to.ctx().dev_mask();
   std::vector<Engine::VarHandle> const_vars;
   if (from.var() != to.var()) const_vars.push_back(from.var());
 
   const NDArrayStorageType from_stype = from.storage_type();
-  const NDArrayStorageType to_stype = to.storage_type();
+  const NDArrayStorageType to_stype   = to.storage_type();
 
   std::vector<Engine::VarHandle> mutable_vars(1, to.var());
 
@@ -1250,8 +1232,8 @@ void CopyFromTo(const NDArray& from, const NDArray& to, int priority, bool is_op
 
     // request temp resource if cast_storage performs on GPU
     if (a == gpu::kDevMask) {
-      Resource rsc = ResourceManager::Get()->Request(from_ctx,
-          ResourceRequest(ResourceRequest::kTempSpace));
+      Resource rsc =
+          ResourceManager::Get()->Request(from_ctx, ResourceRequest(ResourceRequest::kTempSpace));
       requested.push_back(rsc);
       mutable_vars.push_back(rsc.var);
     }
@@ -1259,38 +1241,39 @@ void CopyFromTo(const NDArray& from, const NDArray& to, int priority, bool is_op
 
   if (a == cpu::kDevMask && b == cpu::kDevMask) {
     Engine::Get()->PushAsync(
-      [from, to, requested](RunContext ctx, Engine::CallbackOnComplete on_complete) {
-        CopyFromToImpl<cpu, cpu>(from, to, ctx, requested);
-        on_complete();
-      }, from.ctx(), const_vars, mutable_vars,
-      FnProperty::kNormal, priority, "CopyCPU2CPU");
+        [from, to, requested](RunContext ctx, Engine::CallbackOnComplete on_complete) {
+          CopyFromToImpl<cpu, cpu>(from, to, ctx, requested);
+          on_complete();
+        },
+        from.ctx(), const_vars, mutable_vars, FnProperty::kNormal, priority, "CopyCPU2CPU");
   } else {
 #if MXNET_USE_CUDA
     if (a == cpu::kDevMask && b == gpu::kDevMask) {
       Engine::Get()->PushAsync(
-        [from, to, requested](RunContext ctx, Engine::CallbackOnComplete on_complete) {
-          CopyFromToImpl<cpu, gpu>(from, to, ctx, requested);
-          ctx.get_stream<gpu>()->Wait();
-          on_complete();
-        }, to.ctx(), const_vars, mutable_vars,
-        FnProperty::kCopyToGPU, priority, "CopyCPU2GPU");
+          [from, to, requested](RunContext ctx, Engine::CallbackOnComplete on_complete) {
+            CopyFromToImpl<cpu, gpu>(from, to, ctx, requested);
+            ctx.get_stream<gpu>()->Wait();
+            on_complete();
+          },
+          to.ctx(), const_vars, mutable_vars, FnProperty::kCopyToGPU, priority, "CopyCPU2GPU");
     } else if (a == gpu::kDevMask && b == cpu::kDevMask) {
       Engine::Get()->PushAsync(
-        [from, to, requested](RunContext ctx, Engine::CallbackOnComplete on_complete) {
-          CopyFromToImpl<gpu, cpu>(from, to, ctx, requested);
-          ctx.get_stream<gpu>()->Wait();
-          on_complete();
-        }, from.ctx(), const_vars, mutable_vars,
-        FnProperty::kCopyFromGPU, priority, "CopyGPU2CPU");
+          [from, to, requested](RunContext ctx, Engine::CallbackOnComplete on_complete) {
+            CopyFromToImpl<gpu, cpu>(from, to, ctx, requested);
+            ctx.get_stream<gpu>()->Wait();
+            on_complete();
+          },
+          from.ctx(), const_vars, mutable_vars, FnProperty::kCopyFromGPU, priority, "CopyGPU2CPU");
     } else if (a == gpu::kDevMask && b == gpu::kDevMask) {
       Engine::Get()->PushAsync(
-        [from, to, requested](RunContext ctx, Engine::CallbackOnComplete on_complete) {
-          CopyFromToImpl<gpu, gpu>(from, to, ctx, requested);
-          ctx.get_stream<gpu>()->Wait();
-          on_complete();
-        }, from.ctx(), const_vars, mutable_vars,
-        from.dtype() != to.dtype() ? FnProperty::kNormal : FnProperty::kCopyFromGPU,
-        priority, is_opr ? "_copyto_GPU2GPU" : "CopyGPU2GPU");
+          [from, to, requested](RunContext ctx, Engine::CallbackOnComplete on_complete) {
+            CopyFromToImpl<gpu, gpu>(from, to, ctx, requested);
+            ctx.get_stream<gpu>()->Wait();
+            on_complete();
+          },
+          from.ctx(), const_vars, mutable_vars,
+          from.dtype() != to.dtype() ? FnProperty::kNormal : FnProperty::kCopyFromGPU, priority,
+          is_opr ? "_copyto_GPU2GPU" : "CopyGPU2GPU");
     } else {
       LOG(FATAL) << "unknown device mask";
     }
@@ -1300,26 +1283,22 @@ void CopyFromTo(const NDArray& from, const NDArray& to, int priority, bool is_op
   }
 }
 
-
-void CopyFromTo(const NDArray& from, const NDArray *to, int priority) {
+void CopyFromTo(const NDArray& from, const NDArray* to, int priority) {
   CopyFromTo(from, *to, priority);
 }
 
-void ElementwiseSum(const std::vector<NDArray> &source, NDArray *out, int priority) {
+void ElementwiseSum(const std::vector<NDArray>& source, NDArray* out, int priority) {
   std::vector<Engine::VarHandle> const_vars;
   const_vars.reserve(source.size());
   for (const auto& source_array : source) {
     if (source_array.var() != out->var()) {
       const_vars.push_back(source_array.var());
     }
-    CHECK_EQ(source_array.shape() , out->shape())
-        << "operands shape mismatch";
+    CHECK_EQ(source_array.shape(), out->shape()) << "operands shape mismatch";
     if (out->ctx().dev_mask() == Context::kCPU) {
-      CHECK_EQ(source_array.ctx().dev_mask(), Context::kCPU)
-          << "operands context mismatch";
+      CHECK_EQ(source_array.ctx().dev_mask(), Context::kCPU) << "operands context mismatch";
     } else {
-      CHECK_EQ(source_array.ctx(), out->ctx())
-          << "operands context mismatch";
+      CHECK_EQ(source_array.ctx(), out->ctx()) << "operands context mismatch";
     }
   }
   // important: callback must always capture by value
@@ -1330,67 +1309,72 @@ void ElementwiseSum(const std::vector<NDArray> &source, NDArray *out, int priori
   if (stype == kDefaultStorage) {
     switch (out->ctx().dev_mask()) {
       case cpu::kDevMask: {
-        Engine::Get()->PushSync([source, ret](RunContext ctx) {
-            std::vector<TBlob> source_tblob(source.size());
-            for (size_t i = 0; i < source.size(); ++i) {
-              source_tblob[i] = source[i].data();
-            }
-            TBlob tmp = ret.data();
-            ndarray::ElementwiseSum<cpu>(source_tblob, &tmp, ctx);
-          }, out->ctx(), const_vars, {ret.var()},
-          FnProperty::kNormal, priority, PROFILER_MESSAGE_FUNCNAME);
+        Engine::Get()->PushSync(
+            [source, ret](RunContext ctx) {
+              std::vector<TBlob> source_tblob(source.size());
+              for (size_t i = 0; i < source.size(); ++i) {
+                source_tblob[i] = source[i].data();
+              }
+              TBlob tmp = ret.data();
+              ndarray::ElementwiseSum<cpu>(source_tblob, &tmp, ctx);
+            },
+            out->ctx(), const_vars, {ret.var()}, FnProperty::kNormal, priority,
+            PROFILER_MESSAGE_FUNCNAME);
         break;
       }
 #if MXNET_USE_CUDA
       case gpu::kDevMask: {
-        Engine::Get()->PushSync([source, ret](RunContext ctx) {
-            std::vector<TBlob> source_tblob(source.size());
-            for (size_t i = 0; i < source.size(); ++i) {
-              source_tblob[i] = source[i].data();
-            }
-            TBlob tmp = ret.data();
-            ndarray::ElementwiseSum<gpu>(source_tblob, &tmp, ctx);
-            // Wait GPU kernel to complete
-            ctx.get_stream<gpu>()->Wait();
-          }, out->ctx(), const_vars, {ret.var()},
-          FnProperty::kNormal, priority, "DenseElementwiseSum");
+        Engine::Get()->PushSync(
+            [source, ret](RunContext ctx) {
+              std::vector<TBlob> source_tblob(source.size());
+              for (size_t i = 0; i < source.size(); ++i) {
+                source_tblob[i] = source[i].data();
+              }
+              TBlob tmp = ret.data();
+              ndarray::ElementwiseSum<gpu>(source_tblob, &tmp, ctx);
+              // Wait GPU kernel to complete
+              ctx.get_stream<gpu>()->Wait();
+            },
+            out->ctx(), const_vars, {ret.var()}, FnProperty::kNormal, priority,
+            "DenseElementwiseSum");
         break;
       }
 #endif
-      default: LOG(FATAL) << MXNET_GPU_NOT_ENABLED_ERROR;
+      default:
+        LOG(FATAL) << MXNET_GPU_NOT_ENABLED_ERROR;
     }
   } else if (stype == kRowSparseStorage) {
-    Resource rsc = ResourceManager::Get()->Request(ret.ctx(),
-      ResourceRequest(ResourceRequest::kTempSpace));
+    Resource rsc =
+        ResourceManager::Get()->Request(ret.ctx(), ResourceRequest(ResourceRequest::kTempSpace));
 
     Engine::Get()->PushSync(
-      [source, ret, rsc](RunContext rctx) {
-        NDArray result = ret;
-        switch (ret.ctx().dev_mask()) {
-          case cpu::kDevMask: {
-            mxnet::ndarray::ElementwiseSum(rctx.get_stream<cpu>(), rsc, source, &result);
-            break;
-          }
+        [source, ret, rsc](RunContext rctx) {
+          NDArray result = ret;
+          switch (ret.ctx().dev_mask()) {
+            case cpu::kDevMask: {
+              mxnet::ndarray::ElementwiseSum(rctx.get_stream<cpu>(), rsc, source, &result);
+              break;
+            }
 #if MXNET_USE_CUDA
-          case gpu::kDevMask: {
-            mxnet::ndarray::ElementwiseSum(rctx.get_stream<gpu>(), rsc, source, &result);
-            // wait for GPU operations to complete
-            rctx.get_stream<gpu>()->Wait();
-            break;
-          }
+            case gpu::kDevMask: {
+              mxnet::ndarray::ElementwiseSum(rctx.get_stream<gpu>(), rsc, source, &result);
+              // wait for GPU operations to complete
+              rctx.get_stream<gpu>()->Wait();
+              break;
+            }
 #endif
-          default: LOG(FATAL) << MXNET_GPU_NOT_ENABLED_ERROR;
-        }
-      }, ret.ctx(), const_vars, {ret.var(), rsc.var},
-    FnProperty::kNormal, priority, "RowSparseElementwiseSum");
+            default:
+              LOG(FATAL) << MXNET_GPU_NOT_ENABLED_ERROR;
+          }
+        },
+        ret.ctx(), const_vars, {ret.var(), rsc.var}, FnProperty::kNormal, priority,
+        "RowSparseElementwiseSum");
   } else {
     LOG(FATAL) << "Not implemented for storage_type " << common::stype_string(stype);
   }
 }
 
-void ClipOp(const NDArray &src,
-            const real_t &a_min, const real_t &a_max,
-            NDArray *out) {
+void ClipOp(const NDArray& src, const real_t& a_min, const real_t& a_max, NDArray* out) {
   if (out->is_none()) {
     *out = NDArray(src.shape(), src.ctx(), true, src.dtype());
   } else {
@@ -1402,196 +1386,179 @@ void ClipOp(const NDArray &src,
   if (src.var() != ret.var()) const_vars.push_back(src.var());
   switch (src.ctx().dev_mask()) {
     case cpu::kDevMask: {
-      Engine::Get()->PushSync([src, a_min, a_max, ret](RunContext ctx) {
-          TBlob tmp = ret.data();
-          ndarray::EvalClip<cpu>(src.data(), a_min, a_max, &tmp, ctx);
-        }, src.ctx(), const_vars, {ret.var()},
-        FnProperty::kNormal, 0, PROFILER_MESSAGE_FUNCNAME);
+      Engine::Get()->PushSync(
+          [src, a_min, a_max, ret](RunContext ctx) {
+            TBlob tmp = ret.data();
+            ndarray::EvalClip<cpu>(src.data(), a_min, a_max, &tmp, ctx);
+          },
+          src.ctx(), const_vars, {ret.var()}, FnProperty::kNormal, 0, PROFILER_MESSAGE_FUNCNAME);
       break;
     }
-    #if MXNET_USE_CUDA
+#if MXNET_USE_CUDA
     case gpu::kDevMask: {
-      Engine::Get()->PushSync([src, a_min, a_max, ret](RunContext ctx) {
-          TBlob tmp = ret.data();
-          ndarray::EvalClip<gpu>(src.data(), a_min, a_max, &tmp, ctx);
-        }, src.ctx(), const_vars, {ret.var()},
-        FnProperty::kNormal, 0, PROFILER_MESSAGE_FUNCNAME);
+      Engine::Get()->PushSync(
+          [src, a_min, a_max, ret](RunContext ctx) {
+            TBlob tmp = ret.data();
+            ndarray::EvalClip<gpu>(src.data(), a_min, a_max, &tmp, ctx);
+          },
+          src.ctx(), const_vars, {ret.var()}, FnProperty::kNormal, 0, PROFILER_MESSAGE_FUNCNAME);
       break;
     }
-    #endif
-    default: LOG(FATAL) << MXNET_GPU_NOT_ENABLED_ERROR;
+#endif
+    default:
+      LOG(FATAL) << MXNET_GPU_NOT_ENABLED_ERROR;
   }
 }
 
-template<typename Distribution>
-void SampleOP(const real_t &a,
-              const real_t &b,
-              NDArray *out) {
+template <typename Distribution>
+void SampleOP(const real_t& a, const real_t& b, NDArray* out) {
   CHECK(!out->is_none());
-  Resource resource = ResourceManager::Get()->Request(
-      out->ctx(), ResourceRequest::kRandom);
+  Resource resource = ResourceManager::Get()->Request(out->ctx(), ResourceRequest::kRandom);
   // important: callback must always capture by value
   NDArray ret = *out;
   // redirect everything to mshadow operations
   switch (out->ctx().dev_mask()) {
     case cpu::kDevMask: {
-      Engine::Get()->PushSync([a, b, resource, ret](RunContext ctx) {
-          TBlob tmp = ret.data();
-          ndarray::EvalRandom<cpu, Distribution>(a, b, resource, &tmp, ctx);
-        }, out->ctx(), {}, {ret.var(), resource.var},
-        FnProperty::kNormal, 0, PROFILER_MESSAGE_FUNCNAME);
+      Engine::Get()->PushSync(
+          [a, b, resource, ret](RunContext ctx) {
+            TBlob tmp = ret.data();
+            ndarray::EvalRandom<cpu, Distribution>(a, b, resource, &tmp, ctx);
+          },
+          out->ctx(), {}, {ret.var(), resource.var}, FnProperty::kNormal, 0,
+          PROFILER_MESSAGE_FUNCNAME);
       break;
     }
 #if MXNET_USE_CUDA
     case gpu::kDevMask: {
-      Engine::Get()->PushSync([a, b, resource, ret](RunContext ctx) {
-          TBlob tmp = ret.data();
-          ndarray::EvalRandom<gpu, Distribution>(a, b, resource, &tmp, ctx);
-          // Wait GPU kernel to complete
-          ctx.get_stream<gpu>()->Wait();
-        }, out->ctx(), {}, {ret.var(), resource.var},
-        FnProperty::kNormal, 0, PROFILER_MESSAGE_FUNCNAME);
+      Engine::Get()->PushSync(
+          [a, b, resource, ret](RunContext ctx) {
+            TBlob tmp = ret.data();
+            ndarray::EvalRandom<gpu, Distribution>(a, b, resource, &tmp, ctx);
+            // Wait GPU kernel to complete
+            ctx.get_stream<gpu>()->Wait();
+          },
+          out->ctx(), {}, {ret.var(), resource.var}, FnProperty::kNormal, 0,
+          PROFILER_MESSAGE_FUNCNAME);
       break;
     }
 #endif
-    default: LOG(FATAL) << MXNET_GPU_NOT_ENABLED_ERROR;
+    default:
+      LOG(FATAL) << MXNET_GPU_NOT_ENABLED_ERROR;
   }
 }
 
-void SampleUniform(real_t begin, real_t end, NDArray *out) {
+void SampleUniform(real_t begin, real_t end, NDArray* out) {
   SampleOP<ndarray::UniformDistribution>(begin, end, out);
 }
 
-void SampleGaussian(real_t mu, real_t sigma, NDArray *out) {
+void SampleGaussian(real_t mu, real_t sigma, NDArray* out) {
   SampleOP<ndarray::GaussianDistribution>(mu, sigma, out);
 }
 
-void SampleExponential(real_t lambda, NDArray *out) {
-  if ( out->ctx().dev_mask() != cpu::kDevMask ) {
-    LOG(FATAL) <<"exponential sampling only valid on cpu";
+void SampleExponential(real_t lambda, NDArray* out) {
+  if (out->ctx().dev_mask() != cpu::kDevMask) {
+    LOG(FATAL) << "exponential sampling only valid on cpu";
   }
   real_t dummy;
   SampleOP<ndarray::ExponentialDistribution>(lambda, dummy, out);
 }
 
-void SamplePoisson(real_t lambda, NDArray *out) {
-  if ( out->ctx().dev_mask() != cpu::kDevMask ) {
-    LOG(FATAL) <<"poisson sampling only valid on cpu";
+void SamplePoisson(real_t lambda, NDArray* out) {
+  if (out->ctx().dev_mask() != cpu::kDevMask) {
+    LOG(FATAL) << "poisson sampling only valid on cpu";
   }
   real_t dummy;
   SampleOP<ndarray::PoissonDistribution>(lambda, dummy, out);
 }
 
-void SampleNegBinomial(int32_t k, real_t p, NDArray *out) {
-  if ( out->ctx().dev_mask() != cpu::kDevMask ) {
-    LOG(FATAL) <<"negative binomial sampling only valid on cpu";
+void SampleNegBinomial(int32_t k, real_t p, NDArray* out) {
+  if (out->ctx().dev_mask() != cpu::kDevMask) {
+    LOG(FATAL) << "negative binomial sampling only valid on cpu";
   }
   SampleOP<ndarray::NegBinomialDistribution>(k, p, out);
 }
 
-void SampleGenNegBinomial(real_t mu, real_t alpha, NDArray *out) {
-  if ( out->ctx().dev_mask() != cpu::kDevMask ) {
-    LOG(FATAL) <<"negative binomial sampling only valid on cpu";
+void SampleGenNegBinomial(real_t mu, real_t alpha, NDArray* out) {
+  if (out->ctx().dev_mask() != cpu::kDevMask) {
+    LOG(FATAL) << "negative binomial sampling only valid on cpu";
   }
   SampleOP<ndarray::GenNegBinomialDistribution>(mu, alpha, out);
 }
 
-void RandomSeed(uint32_t seed) {
-  ResourceManager::Get()->SeedRandom(seed);
-}
+void RandomSeed(uint32_t seed) { ResourceManager::Get()->SeedRandom(seed); }
 
-void RandomSeed(Context ctx, uint32_t seed) {
-  ResourceManager::Get()->SeedRandom(ctx, seed);
-}
+void RandomSeed(Context ctx, uint32_t seed) { ResourceManager::Get()->SeedRandom(ctx, seed); }
 
-template<typename OP>
-inline NDArray BinaryOpRet(const NDArray &lhs,
-                           const NDArray &rhs) {
+template <typename OP>
+inline NDArray BinaryOpRet(const NDArray& lhs, const NDArray& rhs) {
   NDArray ret;
   BinaryOpKernel<OP>(lhs, rhs, &ret);
   return ret;
 }
 
-template<typename OP, bool reverse>
-inline NDArray ScalarOpRet(const NDArray &lhs,
-                           const real_t &rhs) {
+template <typename OP, bool reverse>
+inline NDArray ScalarOpRet(const NDArray& lhs, const real_t& rhs) {
   NDArray ret;
   ScalarOp<OP, reverse>(lhs, rhs, &ret);
   return ret;
 }
 
-template<typename OP>
-inline NDArray &BinaryOpApply(NDArray *dst,
-                              const NDArray &src) {
+template <typename OP>
+inline NDArray& BinaryOpApply(NDArray* dst, const NDArray& src) {
   BinaryOpKernel<OP>(*dst, src, dst);
   return *dst;
 }
 
-template<typename OP>
-inline NDArray &ScalarOpApply(NDArray *dst,
-                             const real_t &src) {
+template <typename OP>
+inline NDArray& ScalarOpApply(NDArray* dst, const real_t& src) {
   ScalarOp<OP, false>(*dst, src, dst);
   return *dst;
 }
 
 // Binary
-NDArray operator+(const NDArray &lhs, const NDArray &rhs) {
+NDArray operator+(const NDArray& lhs, const NDArray& rhs) {
   return BinaryOpRet<ndarray::Plus>(lhs, rhs);
 }
-NDArray operator-(const NDArray &lhs, const NDArray &rhs) {
+NDArray operator-(const NDArray& lhs, const NDArray& rhs) {
   return BinaryOpRet<ndarray::Minus>(lhs, rhs);
 }
-NDArray operator*(const NDArray &lhs, const NDArray &rhs) {
+NDArray operator*(const NDArray& lhs, const NDArray& rhs) {
   return BinaryOpRet<ndarray::Mul>(lhs, rhs);
 }
-NDArray operator/(const NDArray &lhs, const NDArray &rhs) {
+NDArray operator/(const NDArray& lhs, const NDArray& rhs) {
   return BinaryOpRet<ndarray::Div>(lhs, rhs);
 }
 // Scalar
-NDArray operator+(const NDArray &lhs, const real_t &rhs) {
+NDArray operator+(const NDArray& lhs, const real_t& rhs) {
   return ScalarOpRet<ndarray::Plus, false>(lhs, rhs);
 }
-NDArray operator-(const NDArray &lhs, const real_t &rhs) {
+NDArray operator-(const NDArray& lhs, const real_t& rhs) {
   return ScalarOpRet<ndarray::Minus, false>(lhs, rhs);
 }
-NDArray operator*(const NDArray &lhs, const real_t &rhs) {
+NDArray operator*(const NDArray& lhs, const real_t& rhs) {
   return ScalarOpRet<ndarray::Mul, false>(lhs, rhs);
 }
-NDArray operator/(const NDArray &lhs, const real_t &rhs) {
+NDArray operator/(const NDArray& lhs, const real_t& rhs) {
   return ScalarOpRet<ndarray::Div, false>(lhs, rhs);
 }
 
 // Binary
-NDArray &NDArray::operator=(real_t scalar) {
+NDArray& NDArray::operator=(real_t scalar) {
   SetValueOp(scalar, this);
   return *this;
 }
 
-NDArray &NDArray::operator+=(const NDArray &src) {
-  return BinaryOpApply<ndarray::Plus>(this, src);
-}
-NDArray &NDArray::operator-=(const NDArray &src) {
+NDArray& NDArray::operator+=(const NDArray& src) { return BinaryOpApply<ndarray::Plus>(this, src); }
+NDArray& NDArray::operator-=(const NDArray& src) {
   return BinaryOpApply<ndarray::Minus>(this, src);
 }
-NDArray &NDArray::operator*=(const NDArray &src) {
-  return BinaryOpApply<ndarray::Mul>(this, src);
-}
-NDArray &NDArray::operator/=(const NDArray &src) {
-  return BinaryOpApply<ndarray::Div>(this, src);
-}
+NDArray& NDArray::operator*=(const NDArray& src) { return BinaryOpApply<ndarray::Mul>(this, src); }
+NDArray& NDArray::operator/=(const NDArray& src) { return BinaryOpApply<ndarray::Div>(this, src); }
 // Scalar
-NDArray &NDArray::operator+=(const real_t &src) {
-  return ScalarOpApply<ndarray::Plus>(this, src);
-}
-NDArray &NDArray::operator-=(const real_t &src) {
-  return ScalarOpApply<ndarray::Minus>(this, src);
-}
-NDArray &NDArray::operator*=(const real_t &src) {
-  return ScalarOpApply<ndarray::Mul>(this, src);
-}
-NDArray &NDArray::operator/=(const real_t &src) {
-  return ScalarOpApply<ndarray::Div>(this, src);
-}
+NDArray& NDArray::operator+=(const real_t& src) { return ScalarOpApply<ndarray::Plus>(this, src); }
+NDArray& NDArray::operator-=(const real_t& src) { return ScalarOpApply<ndarray::Minus>(this, src); }
+NDArray& NDArray::operator*=(const real_t& src) { return ScalarOpApply<ndarray::Mul>(this, src); }
+NDArray& NDArray::operator/=(const real_t& src) { return ScalarOpApply<ndarray::Div>(this, src); }
 
 /* magic number for ndarray version 1, with int64_t mxnet::TShape */
 static const uint32_t NDARRAY_V1_MAGIC = 0xF993fac8;
@@ -1603,7 +1570,7 @@ static const uint32_t NDARRAY_V2_MAGIC = 0xF993fac9;
 // The ndarray must be saved and loaded within np shape semantics.
 static const uint32_t NDARRAY_V3_MAGIC = 0xF993faca;
 
-void NDArray::Save(dmlc::Stream *strm) const {
+void NDArray::Save(dmlc::Stream* strm) const {
   if (Imperative::Get()->is_np_shape()) {
     CHECK_EQ(storage_type(), kDefaultStorage)
         << "only allow serializing ndarray of default storage type in np shape semantics";
@@ -1641,8 +1608,7 @@ void NDArray::Save(dmlc::Stream *strm) const {
     this->WaitToRead();
     nd_cpu = *this;
 #if MXNET_USE_MKLDNN == 1
-    if (nd_cpu.IsMKLDNNData())
-      nd_cpu = nd_cpu.Reorder2Default();
+    if (nd_cpu.IsMKLDNNData()) nd_cpu = nd_cpu.Reorder2Default();
 #endif
     save_data = nd_cpu.data();
   }
@@ -1679,14 +1645,14 @@ void NDArray::Save(dmlc::Stream *strm) const {
   }
 }
 
-bool LegacyTShapeLoad(dmlc::Stream *strm, mxnet::TShape *shape, const uint32_t magic) {
+bool LegacyTShapeLoad(dmlc::Stream* strm, mxnet::TShape* shape, const uint32_t magic) {
   switch (magic) {
     case NDARRAY_V1_MAGIC:
       return shape->Load(strm);
     default:
       // meet legacy mxnet::TShape, magic is ndim here
       uint32_t ndim = magic;
-      *shape = mxnet::TShape(ndim, -1);
+      *shape        = mxnet::TShape(ndim, -1);
       std::vector<uint32_t> buffer(ndim);
       size_t nread = ndim * sizeof(uint32_t);
       if (strm->Read(buffer.data(), nread) != nread) return false;
@@ -1695,12 +1661,13 @@ bool LegacyTShapeLoad(dmlc::Stream *strm, mxnet::TShape *shape, const uint32_t m
   }
 }
 
-bool NDArray::LegacyLoad(dmlc::Stream *strm, const uint32_t magic) {
+bool NDArray::LegacyLoad(dmlc::Stream* strm, const uint32_t magic) {
   // load shape
   mxnet::TShape shape;
   if (!LegacyTShapeLoad(strm, &shape, magic)) return false;
   if (mxnet::op::shape_is_none(shape)) {
-    *this = NDArray(); return true;
+    *this = NDArray();
+    return true;
   }
   // load context
   Context ctx;
@@ -1710,23 +1677,26 @@ bool NDArray::LegacyLoad(dmlc::Stream *strm, const uint32_t magic) {
   if (strm->Read(&type_flag, sizeof(type_flag)) != sizeof(type_flag)) return false;
   // load data into CPU
   NDArray temp(shape, Context::CPU(), false, type_flag);
-  TBlob load_data = temp.data();
+  TBlob load_data  = temp.data();
   size_t type_size = mshadow::mshadow_sizeof(type_flag);
-  size_t nread = type_size * shape.Size();
+  size_t nread     = type_size * shape.Size();
 
   if (strm->Read(load_data.dptr_, nread) != nread) return false;
   if (ctx.dev_mask() == cpu::kDevMask) {
-    *this = std::move(temp); return true;
+    *this = std::move(temp);
+    return true;
   } else {
 #if MXNET_USE_CUDA
-    *this = temp.Copy(ctx); return true;
+    *this = temp.Copy(ctx);
+    return true;
 #else
-    *this = std::move(temp); return true;
+    *this = std::move(temp);
+    return true;
 #endif
   }
 }
 
-bool NDArray::Load(dmlc::Stream *strm) {
+bool NDArray::Load(dmlc::Stream* strm) {
   uint32_t magic;
   if (strm->Read(&magic, sizeof(uint32_t)) != sizeof(uint32_t)) return false;
   if (magic == NDARRAY_V3_MAGIC) {
@@ -1769,7 +1739,8 @@ bool NDArray::Load(dmlc::Stream *strm) {
       return true;
     }
   } else if (shape.ndim() == 0) {
-    *this = NDArray(); return true;
+    *this = NDArray();
+    return true;
   }
 
   // load context
@@ -1799,14 +1770,14 @@ bool NDArray::Load(dmlc::Stream *strm) {
   if (0 == nad) {
     temp = NDArray(shape, Context::CPU(), false, type_flag);
   } else {
-    temp = NDArray(static_cast<NDArrayStorageType>(stype), shape,
-                   Context::CPU(), false, type_flag,
-                   aux_types, aux_shapes, sshape);
+    temp = NDArray(
+        static_cast<NDArrayStorageType>(stype), shape, Context::CPU(), false, type_flag, aux_types,
+        aux_shapes, sshape);
   }
   // load data
-  TBlob load_data = temp.data();
+  TBlob load_data  = temp.data();
   size_t type_size = mshadow::mshadow_sizeof(type_flag);
-  size_t nread = type_size * load_data.Size();
+  size_t nread     = type_size * load_data.Size();
   if (strm->Read(load_data.dptr_, nread) != nread) return false;
 
   // load aux_data
@@ -1814,33 +1785,36 @@ bool NDArray::Load(dmlc::Stream *strm) {
     for (int i = 0; i < nad; ++i) {
       load_data = temp.aux_data(i);
       type_size = mshadow::mshadow_sizeof(load_data.type_flag_);
-      nread = type_size * load_data.Size();
+      nread     = type_size * load_data.Size();
       if (strm->Read(load_data.dptr_, nread) != nread) return false;
     }
   }
 
   if (ctx.dev_mask() == cpu::kDevMask) {
-    *this = std::move(temp); return true;
+    *this = std::move(temp);
+    return true;
   } else {
 #if MXNET_USE_CUDA
     int device_count = -1;
     cudaGetDeviceCount(&device_count);
     if (device_count > 0) {
-      *this = temp.Copy(ctx); return true;
+      *this = temp.Copy(ctx);
+      return true;
     } else {
-      *this = std::move(temp); return true;
+      *this = std::move(temp);
+      return true;
     }
 #else
-    *this = std::move(temp); return true;
+    *this = std::move(temp);
+    return true;
 #endif
   }
 }
 
 const uint64_t kMXAPINDArrayListMagic = 0x112;
 
-void NDArray::Save(dmlc::Stream* fo,
-                   const std::vector<NDArray>& data,
-                   const std::vector<std::string>& names) {
+void NDArray::Save(
+    dmlc::Stream* fo, const std::vector<NDArray>& data, const std::vector<std::string>& names) {
   uint64_t header = kMXAPINDArrayListMagic, reserved = 0;
   fo->Write(&header, sizeof(header));
   fo->Write(&reserved, sizeof(reserved));
@@ -1848,22 +1822,14 @@ void NDArray::Save(dmlc::Stream* fo,
   fo->Write(names);
 }
 
-void NDArray::Load(dmlc::Stream* fi,
-                   std::vector<NDArray>* data,
-                   std::vector<std::string>* keys) {
+void NDArray::Load(dmlc::Stream* fi, std::vector<NDArray>* data, std::vector<std::string>* keys) {
   uint64_t header, reserved;
-  CHECK(fi->Read(&header))
-      << "Invalid NDArray file format";
-  CHECK(fi->Read(&reserved))
-      << "Invalid NDArray file format";
-  CHECK(header == kMXAPINDArrayListMagic)
-      << "Invalid NDArray file format";
-  CHECK(fi->Read(data))
-      << "Invalid NDArray file format";
-  CHECK(fi->Read(keys))
-      << "Invalid NDArray file format";
-  CHECK(keys->size() == 0 || keys->size() == data->size())
-      << "Invalid NDArray file format";
+  CHECK(fi->Read(&header)) << "Invalid NDArray file format";
+  CHECK(fi->Read(&reserved)) << "Invalid NDArray file format";
+  CHECK(header == kMXAPINDArrayListMagic) << "Invalid NDArray file format";
+  CHECK(fi->Read(data)) << "Invalid NDArray file format";
+  CHECK(fi->Read(keys)) << "Invalid NDArray file format";
+  CHECK(keys->size() == 0 || keys->size() == data->size()) << "Invalid NDArray file format";
 }
 
 NDArray NDArray::Copy(Context ctx) const {
@@ -1871,8 +1837,9 @@ NDArray NDArray::Copy(Context ctx) const {
   if (kDefaultStorage == storage_type()) {
     ret = NDArray(shape(), ctx, true, dtype_);
   } else if (kUndefinedStorage != storage_type()) {
-    ret = NDArray(storage_type(), shape(), ctx, true, dtype_,
-                  ptr_->aux_types, ptr_->aux_shapes, storage_shape());
+    ret = NDArray(
+        storage_type(), shape(), ctx, true, dtype_, ptr_->aux_types, ptr_->aux_shapes,
+        storage_shape());
   } else {
     LOG(FATAL) << "NDArray::Copy cannot copy undefined storage-type ndarray to ctx.dev_type="
                << ctx.dev_type << ", ctx.dev_id=" << ctx.dev_id;
@@ -1881,20 +1848,19 @@ NDArray NDArray::Copy(Context ctx) const {
   return ret;
 }
 
-void NDArray::SyncCopyFromCPU(const void *data, size_t size) const {
+void NDArray::SyncCopyFromCPU(const void* data, size_t size) const {
   mxnet::TShape dshape = this->shape();
   if (!features::is_enabled(features::INT64_TENSOR_SIZE)) {
-    CHECK_LT(size, (int64_t{1} << 31) - 1) <<
-              "[SyncCopyFromCPU] Size of tensor you are trying to allocate is larger than "
-              "2^31 elements. Please build with flag USE_INT64_TENSOR_SIZE=1";
+    CHECK_LT(size, (int64_t{1} << 31) - 1)
+        << "[SyncCopyFromCPU] Size of tensor you are trying to allocate is larger than "
+           "2^31 elements. Please build with flag USE_INT64_TENSOR_SIZE=1";
   }
-  CHECK_EQ(dshape.Size(), size)
-      << "Memory size do not match";
+  CHECK_EQ(dshape.Size(), size) << "Memory size do not match";
   // zero-size array, no need to copy
   if (size == 0U) {
     return;
   }
-  TBlob src((void*)data, dshape, cpu::kDevMask, this->dtype_, 0); // NOLINT(*)
+  TBlob src((void*)data, dshape, cpu::kDevMask, this->dtype_, 0);  // NOLINT(*)
 
   if (this->ctx().dev_mask() == cpu::kDevMask) {
     this->WaitToWrite();
@@ -1904,15 +1870,14 @@ void NDArray::SyncCopyFromCPU(const void *data, size_t size) const {
   } else {
 #if MXNET_USE_CUDA
     Engine::Get()->PushAsync(
-      [&](RunContext rctx, Engine::CallbackOnComplete on_complete) {
-        TBlob dst = this->data();
-        ndarray::Copy<cpu, gpu>(src, &dst,
-                                Context::CPU(), this->ctx(), rctx);
-        // Wait GPU kernel to complete
-        rctx.get_stream<gpu>()->Wait();
-        on_complete();
-      }, this->ctx(), {}, {this->var()},
-      FnProperty::kCopyToGPU, 0, "SyncCopyCPU2GPU");
+        [&](RunContext rctx, Engine::CallbackOnComplete on_complete) {
+          TBlob dst = this->data();
+          ndarray::Copy<cpu, gpu>(src, &dst, Context::CPU(), this->ctx(), rctx);
+          // Wait GPU kernel to complete
+          rctx.get_stream<gpu>()->Wait();
+          on_complete();
+        },
+        this->ctx(), {}, {this->var()}, FnProperty::kCopyToGPU, 0, "SyncCopyCPU2GPU");
     this->WaitToRead();
 #else
     LOG(FATAL) << "GPU is not enabled";
@@ -1958,51 +1923,56 @@ void NDArray::SyncCopyFromNDArray(const NDArray& src, int i, int j) {
         this->CheckAndAllocAuxData(j, src_shape);
       }
     }
-    TBlob dst_data = (j >= 0? this->aux_data(j) : this->data());
+    TBlob dst_data = (j >= 0 ? this->aux_data(j) : this->data());
     CHECK_LE(src_shape.Size(), dst_data.shape_.Size());
     return dst_data;
   };
 
   if (src_dev_mask == cpu::kDevMask && dst_dev_mask == cpu::kDevMask) {
-    Engine::Get()->PushSync([&](RunContext rctx) {
-        const TBlob src_data = (i >= 0? src.aux_data(i) : src.data());
-        TBlob dst_data = get_dst_data(src_data.shape_);
-        ndarray::Copy<cpu, cpu>(src_data, &dst_data, src.ctx(), this->ctx(), rctx);
-      }, this->ctx(), const_vars, {this->var()},
-      FnProperty::kNormal, 0, "SyncCopyFromNDArrayCPU2CPU");
+    Engine::Get()->PushSync(
+        [&](RunContext rctx) {
+          const TBlob src_data = (i >= 0 ? src.aux_data(i) : src.data());
+          TBlob dst_data       = get_dst_data(src_data.shape_);
+          ndarray::Copy<cpu, cpu>(src_data, &dst_data, src.ctx(), this->ctx(), rctx);
+        },
+        this->ctx(), const_vars, {this->var()}, FnProperty::kNormal, 0,
+        "SyncCopyFromNDArrayCPU2CPU");
   } else {
 #if MXNET_USE_CUDA
     if (src_dev_mask == cpu::kDevMask && dst_dev_mask == gpu::kDevMask) {
       Engine::Get()->PushAsync(
-        [&](RunContext rctx, Engine::CallbackOnComplete on_complete) {
-          const TBlob src_data = (i >= 0 ? src.aux_data(i) : src.data());
-          TBlob dst_data = get_dst_data(src_data.shape_);
-          ndarray::Copy<cpu, gpu>(src_data, &dst_data, src.ctx(), this->ctx(), rctx);
-          rctx.get_stream<gpu>()->Wait();
-          on_complete();
-        }, this->ctx(), const_vars, {this->var()},
-        FnProperty::kCopyToGPU, 0, "SyncCopyFromNDArrayCPU2GPU");
+          [&](RunContext rctx, Engine::CallbackOnComplete on_complete) {
+            const TBlob src_data = (i >= 0 ? src.aux_data(i) : src.data());
+            TBlob dst_data       = get_dst_data(src_data.shape_);
+            ndarray::Copy<cpu, gpu>(src_data, &dst_data, src.ctx(), this->ctx(), rctx);
+            rctx.get_stream<gpu>()->Wait();
+            on_complete();
+          },
+          this->ctx(), const_vars, {this->var()}, FnProperty::kCopyToGPU, 0,
+          "SyncCopyFromNDArrayCPU2GPU");
     } else if (src_dev_mask == gpu::kDevMask && dst_dev_mask == cpu::kDevMask) {
       Engine::Get()->PushAsync(
-        [&](RunContext rctx, Engine::CallbackOnComplete on_complete) {
-          const TBlob src_data = (i >= 0 ? src.aux_data(i) : src.data());
-          TBlob dst_data = get_dst_data(src_data.shape_);
-          ndarray::Copy<gpu, cpu>(src_data, &dst_data, src.ctx(), this->ctx(), rctx);
-          rctx.get_stream<gpu>()->Wait();
-          on_complete();
-        }, src.ctx(), const_vars, {this->var()},
-        FnProperty::kCopyFromGPU, 0, "SyncCopyFromNDArrayGPU2CPU");
+          [&](RunContext rctx, Engine::CallbackOnComplete on_complete) {
+            const TBlob src_data = (i >= 0 ? src.aux_data(i) : src.data());
+            TBlob dst_data       = get_dst_data(src_data.shape_);
+            ndarray::Copy<gpu, cpu>(src_data, &dst_data, src.ctx(), this->ctx(), rctx);
+            rctx.get_stream<gpu>()->Wait();
+            on_complete();
+          },
+          src.ctx(), const_vars, {this->var()}, FnProperty::kCopyFromGPU, 0,
+          "SyncCopyFromNDArrayGPU2CPU");
     } else if (src_dev_mask == gpu::kDevMask && dst_dev_mask == gpu::kDevMask) {
       Engine::Get()->PushAsync(
-        [&](RunContext rctx, Engine::CallbackOnComplete on_complete) {
-          const TBlob src_data = (i >= 0 ? src.aux_data(i) : src.data());
-          TBlob dst_data = get_dst_data(src_data.shape_);
-          ndarray::Copy<gpu, gpu>(src_data, &dst_data, src.ctx(), this->ctx(), rctx);
-          rctx.get_stream<gpu>()->Wait();
-          on_complete();
-        }, this->ctx(), const_vars, {this->var()},
-        src.dtype() != this->dtype() ? FnProperty::kNormal : FnProperty::kCopyFromGPU,
-        0, "SyncCopyFromNDArrayGPU2GPU");
+          [&](RunContext rctx, Engine::CallbackOnComplete on_complete) {
+            const TBlob src_data = (i >= 0 ? src.aux_data(i) : src.data());
+            TBlob dst_data       = get_dst_data(src_data.shape_);
+            ndarray::Copy<gpu, gpu>(src_data, &dst_data, src.ctx(), this->ctx(), rctx);
+            rctx.get_stream<gpu>()->Wait();
+            on_complete();
+          },
+          this->ctx(), const_vars, {this->var()},
+          src.dtype() != this->dtype() ? FnProperty::kNormal : FnProperty::kCopyFromGPU, 0,
+          "SyncCopyFromNDArrayGPU2GPU");
     } else {
       LOG(FATAL) << "unknown device mask";
     }
@@ -2021,42 +1991,38 @@ void NDArray::SyncCopyFromNDArray(const NDArray& src, int i, int j) {
   WaitToRead();
 }
 
-void NDArray::SyncCopyToCPU(void *data, size_t size) const {
+void NDArray::SyncCopyToCPU(void* data, size_t size) const {
   mxnet::TShape dshape = this->shape();
   if (!features::is_enabled(features::INT64_TENSOR_SIZE)) {
-    CHECK_LT(size, (int64_t{1} << 31) - 1) <<
-              "[SyncCopyToCPU] Size of tensor you are trying to allocate is larger than "
-              "2^31 elements. Please build with flag USE_INT64_TENSOR_SIZE=1";
+    CHECK_LT(size, (int64_t{1} << 31) - 1)
+        << "[SyncCopyToCPU] Size of tensor you are trying to allocate is larger than "
+           "2^31 elements. Please build with flag USE_INT64_TENSOR_SIZE=1";
   }
-  CHECK_EQ(dshape.Size(), size)
-      << "Memory size do not match";
+  CHECK_EQ(dshape.Size(), size) << "Memory size do not match";
   // zero-size array, no need to copy
   if (size == 0U) {
     return;
   }
-  TBlob dst(data, dshape, cpu::kDevMask, this->dtype_, 0); // NOLINT(*)
+  TBlob dst(data, dshape, cpu::kDevMask, this->dtype_, 0);  // NOLINT(*)
 
   if (this->ctx().dev_mask() == cpu::kDevMask) {
     this->WaitToRead();
     RunContext rctx{this->ctx(), nullptr, nullptr, false};
     NDArray src = *this;
 #if MXNET_USE_MKLDNN == 1
-    if (src.IsMKLDNNData())
-      src = this->Reorder2Default();
+    if (src.IsMKLDNNData()) src = this->Reorder2Default();
 #endif
-    ndarray::Copy<cpu, cpu>(src.data(), &dst,
-                            Context::CPU(), Context::CPU(), rctx);
+    ndarray::Copy<cpu, cpu>(src.data(), &dst, Context::CPU(), Context::CPU(), rctx);
   } else {
 #if MXNET_USE_CUDA
     Engine::Get()->PushAsync(
-      [&](RunContext rctx, Engine::CallbackOnComplete on_complete) {
-        ndarray::Copy<gpu, cpu>(this->data(), &dst,
-                                this->ctx(), Context::CPU(), rctx);
-        // Wait GPU kernel to complete
-        rctx.get_stream<gpu>()->Wait();
-        on_complete();
-      }, this->ctx(), {this->var()}, {},
-      FnProperty::kCopyFromGPU, 0, "SyncCopyGPU2CPU");
+        [&](RunContext rctx, Engine::CallbackOnComplete on_complete) {
+          ndarray::Copy<gpu, cpu>(this->data(), &dst, this->ctx(), Context::CPU(), rctx);
+          // Wait GPU kernel to complete
+          rctx.get_stream<gpu>()->Wait();
+          on_complete();
+        },
+        this->ctx(), {this->var()}, {}, FnProperty::kCopyFromGPU, 0, "SyncCopyGPU2CPU");
     this->WaitToWrite();
 #else
     LOG(FATAL) << "GPU is not enabled";
@@ -2068,17 +2034,17 @@ void NDArray::SyncCheckFormat(const bool full_check) const {
   int32_t err = kNormalErr;
   TBlob err_cpu(&err, mshadow::Shape1(1), cpu::kDevMask, 0);
   if (this->ctx().dev_mask() == cpu::kDevMask) {
-    Engine::Get()->PushSync([&](RunContext rctx) {
-        common::CheckFormatWrapper<cpu>(rctx, *this, err_cpu, full_check);
-      }, this->ctx(), {this->var()}, {},
-      FnProperty::kNormal, 0, "CheckFormat");
+    Engine::Get()->PushSync(
+        [&](RunContext rctx) { common::CheckFormatWrapper<cpu>(rctx, *this, err_cpu, full_check); },
+        this->ctx(), {this->var()}, {}, FnProperty::kNormal, 0, "CheckFormat");
   } else {
 #if MXNET_USE_CUDA
-    Engine::Get()->PushSync([&](RunContext rctx) {
-        common::CheckFormatWrapper<gpu>(rctx, *this, err_cpu, full_check);
-        rctx.get_stream<gpu>()->Wait();
-      }, this->ctx(), {this->var()}, {},
-      FnProperty::kNormal, 0, "CheckFormat");
+    Engine::Get()->PushSync(
+        [&](RunContext rctx) {
+          common::CheckFormatWrapper<gpu>(rctx, *this, err_cpu, full_check);
+          rctx.get_stream<gpu>()->Wait();
+        },
+        this->ctx(), {this->var()}, {}, FnProperty::kNormal, 0, "CheckFormat");
 #else
     LOG(FATAL) << "GPU is not enabled";
 #endif
@@ -2086,83 +2052,73 @@ void NDArray::SyncCheckFormat(const bool full_check) const {
   this->WaitToWrite();
   CHECK_NE(err, kCSRShapeErr) << "Shape mismatch of this csr NDArray";
   CHECK_NE(err, kCSRIndPtrErr)
-           << "IndPtr of csr NDArray should be non-negative, in non-decreasing order, "
-           << "start with 0, and end with value equal with size of indices.";
+      << "IndPtr of csr NDArray should be non-negative, in non-decreasing order, "
+      << "start with 0, and end with value equal with size of indices.";
   CHECK_NE(err, kCSRIdxErr)
-           << "Indices of csr NDArray should be non-negative, in ascending order per row "
-           << " and less than the number of columns.";
+      << "Indices of csr NDArray should be non-negative, in ascending order per row "
+      << " and less than the number of columns.";
   CHECK_NE(err, kRSPShapeErr) << "Shape mismatch of this row_sparse NDArray";
-  CHECK_NE(err, kRSPIdxErr)
-          << "Indices of row_sparse NDArray should be non-negative, "
-          << "less than the size of first dimension and in ascending order";
+  CHECK_NE(err, kRSPIdxErr) << "Indices of row_sparse NDArray should be non-negative, "
+                            << "less than the size of first dimension and in ascending order";
   CHECK_EQ(err, kNormalErr) << "Check the validity of this sparse NDArray";
 }
 
 #if MXNET_PREDICT_ONLY == 0
 // register API function
 // those with underscore will be registered at NDArray
-MXNET_REGISTER_NDARRAY_FUN(_set_value)
-.set_function(SetValueOp);
+MXNET_REGISTER_NDARRAY_FUN(_set_value).set_function(SetValueOp);
 
-
-MXNET_REGISTER_NDARRAY_FUN(_onehot_encode)
-.set_function(BinaryOp<ndarray::OneHotEncode>);
-
+MXNET_REGISTER_NDARRAY_FUN(_onehot_encode).set_function(BinaryOp<ndarray::OneHotEncode>);
 
 MXNET_REGISTER_NDARRAY_FUN(fill_element_0index)
-.set_function(TernaryOp<ndarray::MatFillRowElem>)
-.describe("Fill one element of each line(row for python, column for R/Julia)"
-" in lhs according to index indicated by rhs and values indicated by mhs."
-" This function assume rhs uses 0-based index.");
+    .set_function(TernaryOp<ndarray::MatFillRowElem>)
+    .describe(
+        "Fill one element of each line(row for python, column for R/Julia)"
+        " in lhs according to index indicated by rhs and values indicated by mhs."
+        " This function assume rhs uses 0-based index.");
 
 // register API function
 // those with underscore will be registered at NDArray
 
 void CopyFromToSimple(
-    const nnvm::NodeAttrs& attrs,
-    const OpContext& ctx,
-    const std::vector<NDArray>& inputs,
-    const std::vector<OpReqType>& req,
-    const std::vector<NDArray>& outputs) {
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& inputs,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs) {
   CopyFromTo(inputs[0], outputs[0], 0, true);
 }
 
 // copy function is special
 // that we need to remove kAcceptEmptyMutateTarget from it
 NNVM_REGISTER_OP(_copyto)
-.add_alias("_npi_copyto")
-.set_num_inputs(1)
-.set_num_outputs(1)
-.set_attr<mxnet::FInferShape>("FInferShape", op::ElemwiseShape<1, 1>)
-.set_attr<nnvm::FInferType>("FInferType",
-  [](const NodeAttrs& attrs, std::vector<int> *in_type, std::vector<int> *out_type) {
-    return !op::type_is_none((*in_type)[0]) && !op::type_is_none((*out_type)[0]);
-  })
-.set_attr<FInferStorageType>("FInferStorageType",
-  [](const NodeAttrs& attrs,
-     const int dev_mask,
-     DispatchMode* dispatch_mode,
-     std::vector<int>* in_attrs,
-     std::vector<int>* out_attrs) {
-    op::dispatch_mode_assign(dispatch_mode, DispatchMode::kFComputeEx);
-    if (op::storage_type_is_none((*out_attrs)[0])) {
-      (*out_attrs)[0] = (*in_attrs)[0];
-    }
-    return true;
-  })
-.set_attr<FExecType>("FExecType", [](const NodeAttrs& attrs) {
-    return ExecType::kCrossDeviceCopy;
-  })
-.set_attr<nnvm::FGradient>("FGradient", op::ElemwiseGradUseNone{"_copyto"})
-.set_attr<bool>("TIsBackward", true)
-.set_attr<FComputeEx>("FComputeEx<cpu>", CopyFromToSimple)
-.set_attr<FComputeEx>("FComputeEx<gpu>", CopyFromToSimple)
-.add_argument("data", "NDArray", "input data");
+    .add_alias("_npi_copyto")
+    .set_num_inputs(1)
+    .set_num_outputs(1)
+    .set_attr<mxnet::FInferShape>("FInferShape", op::ElemwiseShape<1, 1>)
+    .set_attr<nnvm::FInferType>(
+        "FInferType",
+        [](const NodeAttrs& attrs, std::vector<int>* in_type, std::vector<int>* out_type) {
+          return !op::type_is_none((*in_type)[0]) && !op::type_is_none((*out_type)[0]);
+        })
+    .set_attr<FInferStorageType>(
+        "FInferStorageType",
+        [](const NodeAttrs& attrs, const int dev_mask, DispatchMode* dispatch_mode,
+           std::vector<int>* in_attrs, std::vector<int>* out_attrs) {
+          op::dispatch_mode_assign(dispatch_mode, DispatchMode::kFComputeEx);
+          if (op::storage_type_is_none((*out_attrs)[0])) {
+            (*out_attrs)[0] = (*in_attrs)[0];
+          }
+          return true;
+        })
+    .set_attr<FExecType>(
+        "FExecType", [](const NodeAttrs& attrs) { return ExecType::kCrossDeviceCopy; })
+    .set_attr<nnvm::FGradient>("FGradient", op::ElemwiseGradUseNone{"_copyto"})
+    .set_attr<bool>("TIsBackward", true)
+    .set_attr<FComputeEx>("FComputeEx<cpu>", CopyFromToSimple)
+    .set_attr<FComputeEx>("FComputeEx<gpu>", CopyFromToSimple)
+    .add_argument("data", "NDArray", "input data");
 
-
-void Imdecode(NDArray *ret, NDArray mean, size_t index,
-              size_t x0, size_t y0, size_t x1, size_t y1, size_t n_channels,
-              size_t size, char *str_img) {
+void Imdecode(
+    NDArray* ret, NDArray mean, size_t index, size_t x0, size_t y0, size_t x1, size_t y1,
+    size_t n_channels, size_t size, char* str_img) {
 #if MXNET_USE_OPENCV
   cv::Mat buf(1, size, CV_8U, str_img);
   cv::Mat res = cv::imdecode(buf, n_channels == 1 ? 0 : -1);
@@ -2174,32 +2130,31 @@ void Imdecode(NDArray *ret, NDArray mean, size_t index,
     y0 = 0;
     y1 = res.rows;
   }
-  CHECK(x1 <= static_cast<size_t>(res.cols) &&
-        y1 <= static_cast<size_t>(res.rows));
+  CHECK(x1 <= static_cast<size_t>(res.cols) && y1 <= static_cast<size_t>(res.rows));
 
   if (ret->is_none()) {
-    *ret = NDArray(mshadow::Shape3(n_channels, y1-y0, x1-x0),
-                   Context::CPU(), false,
-                   mean.is_none() ? mshadow::default_type_flag : mean.dtype());
+    *ret = NDArray(
+        mshadow::Shape3(n_channels, y1 - y0, x1 - x0), Context::CPU(), false,
+        mean.is_none() ? mshadow::default_type_flag : mean.dtype());
   }
   NDArray buff;
   if (ret->shape().ndim() == 3) {
     buff = ret->Reshape(mshadow::Shape4(1, ret->shape()[0], ret->shape()[1], ret->shape()[2]));
   } else {
     CHECK_EQ(ret->shape().ndim(), 4U);
-    buff = ret->Slice(index, index+1);
+    buff = ret->Slice(index, index + 1);
   }
   CHECK_EQ(buff.ctx().dev_mask(), Context::kCPU);
   CHECK_EQ(n_channels, buff.shape()[1]);
-  CHECK_EQ(y1-y0, buff.shape()[2]);
-  CHECK_EQ(x1-x0, buff.shape()[3]);
+  CHECK_EQ(y1 - y0, buff.shape()[2]);
+  CHECK_EQ(x1 - x0, buff.shape()[3]);
   buff.WaitToWrite();
   if (mean.is_none()) {
     MSHADOW_TYPE_SWITCH(buff.dtype(), DType, {
       mshadow::Tensor<cpu, 4, DType> tensor = buff.data().get<cpu, 4, DType>();
-      for (size_t i = 0; i < y1-y0; i++) {
-        uchar* im_data = res.ptr<uchar>(y0+i) + res.channels()*x0;
-        for (size_t j = 0; j < x1-x0; j++) {
+      for (size_t i = 0; i < y1 - y0; i++) {
+        uchar* im_data = res.ptr<uchar>(y0 + i) + res.channels() * x0;
+        for (size_t j = 0; j < x1 - x0; j++) {
           for (size_t k = 0; k < n_channels; k++) {
             tensor[0][k][i][j] = DType(im_data[k]);  // NOLINT(*)
           }
@@ -2216,10 +2171,10 @@ void Imdecode(NDArray *ret, NDArray mean, size_t index,
     mean.WaitToRead();
     MSHADOW_TYPE_SWITCH(buff.dtype(), DType, {
       mshadow::Tensor<cpu, 4, DType> tensor = buff.data().get<cpu, 4, DType>();
-      mshadow::Tensor<cpu, 3, DType> tmean = mean.data().get<cpu, 3, DType>();
-      for (size_t i = 0; i < y1-y0; i++) {
-        uchar* im_data = res.ptr<uchar>(y0+i) + res.channels()*x0;
-        for (size_t j = 0; j < x1-x0; j++) {
+      mshadow::Tensor<cpu, 3, DType> tmean  = mean.data().get<cpu, 3, DType>();
+      for (size_t i = 0; i < y1 - y0; i++) {
+        uchar* im_data = res.ptr<uchar>(y0 + i) + res.channels() * x0;
+        for (size_t j = 0; j < x1 - x0; j++) {
           for (size_t k = 0; k < n_channels; k++) {
             tensor[0][k][i][j] = DType(im_data[k]) - tmean[k][i][j];  // NOLINT(*)
           }
@@ -2234,31 +2189,26 @@ void Imdecode(NDArray *ret, NDArray mean, size_t index,
 }
 
 MXNET_REGISTER_NDARRAY_FUN(_imdecode)
-.set_type_mask(kAcceptEmptyMutateTarget | kNDArrayArgBeforeScalar)
-.set_body([](NDArray **u, real_t *s, NDArray **out,
-             int num_params, char **param_keys, char **param_vals) {
-    CHECK_EQ(num_params, 1);
-    Imdecode(out[0], *u[0],
-             static_cast<size_t>(s[0]),
-             static_cast<size_t>(s[1]),
-             static_cast<size_t>(s[2]),
-             static_cast<size_t>(s[3]),
-             static_cast<size_t>(s[4]),
-             static_cast<size_t>(s[5]),
-             static_cast<size_t>(s[6]),
-             param_vals[0]);
-  })
-.set_num_use_vars(1)
-.set_num_scalars(7)
-.set_num_mutate_vars(1)
-.describe("Decode an image, clip to (x0, y0, x1, y1), subtract mean, and write to buffer")
-.add_argument("mean", "NDArray-or-Symbol", "image mean")
-.add_argument("index", "int", "buffer position for output")
-.add_argument("x0", "int", "x0")
-.add_argument("y0", "int", "y0")
-.add_argument("x1", "int", "x1")
-.add_argument("y1", "int", "y1")
-.add_argument("c", "int", "channel")
-.add_argument("size", "int", "length of str_img");
+    .set_type_mask(kAcceptEmptyMutateTarget | kNDArrayArgBeforeScalar)
+    .set_body([](NDArray** u, real_t* s, NDArray** out, int num_params, char** param_keys,
+                 char** param_vals) {
+      CHECK_EQ(num_params, 1);
+      Imdecode(
+          out[0], *u[0], static_cast<size_t>(s[0]), static_cast<size_t>(s[1]),
+          static_cast<size_t>(s[2]), static_cast<size_t>(s[3]), static_cast<size_t>(s[4]),
+          static_cast<size_t>(s[5]), static_cast<size_t>(s[6]), param_vals[0]);
+    })
+    .set_num_use_vars(1)
+    .set_num_scalars(7)
+    .set_num_mutate_vars(1)
+    .describe("Decode an image, clip to (x0, y0, x1, y1), subtract mean, and write to buffer")
+    .add_argument("mean", "NDArray-or-Symbol", "image mean")
+    .add_argument("index", "int", "buffer position for output")
+    .add_argument("x0", "int", "x0")
+    .add_argument("y0", "int", "y0")
+    .add_argument("x1", "int", "x1")
+    .add_argument("y1", "int", "y1")
+    .add_argument("c", "int", "channel")
+    .add_argument("size", "int", "length of str_img");
 #endif
 }  // namespace mxnet

--- a/src/operator/nn/batch_norm-inl.h
+++ b/src/operator/nn/batch_norm-inl.h
@@ -43,15 +43,24 @@
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #endif
 
+/*! \brief inverse standard deviation <-> variance */
+#define VARIANCE_TO_INVSTD(__var$, __eps$)    (1.0 / std::sqrt((__var$) + DType(__eps$)))
+#define INVSTD_TO_VARIANCE(__invstd$, __eps$) ((1.0 / ((__invstd$) * (__invstd$))) - (__eps$))
+
 namespace mxnet {
 namespace op {
 
 namespace batchnorm {
-enum BatchNormOpInputs {kData, kGamma, kBeta, kInMovingMean,
-  kInMovingVar};  // kGamma: weights, kBeta: biases
-enum BatchNormOpOutputs {kOut, kMean, kVar};  // req, out_data
-enum BatchNormOpResource {kTempSpace};
-enum BatchNormOpAuxiliary {kMovingMean, kMovingVar};  // aux_states
+enum BatchNormOpInputs {
+  kData,
+  kGamma,
+  kBeta,
+  kInMovingMean,
+  kInMovingVar
+};                                              // kGamma: weights, kBeta: biases
+enum BatchNormOpOutputs { kOut, kMean, kVar };  // req, out_data
+enum BatchNormOpResource { kTempSpace };
+enum BatchNormOpAuxiliary { kMovingMean, kMovingVar };  // aux_states
 
 /*! \brief Default channel axis if none specified in the params */
 constexpr int DEFAULT_AXIS = 1;
@@ -59,11 +68,18 @@ constexpr int DEFAULT_AXIS = 1;
 
 /*! \brief Parameters for BatchNorm operator */
 namespace quantized_batchnorm {
-enum QuantizedBatchNormOpInputs {kData, kGamma, kBeta, kInMovingMean,
-  kInMovingVar, kDataMin, kDataMax};
-enum QuantizedBatchNormOutputs {kOut, kOutMin, kOutMax};
-enum QuantizedBatchNormOpAuxiliary {kMovingMean, kMovingVar};
-}  // quantized_batchnorm
+enum QuantizedBatchNormOpInputs {
+  kData,
+  kGamma,
+  kBeta,
+  kInMovingMean,
+  kInMovingVar,
+  kDataMin,
+  kDataMax
+};
+enum QuantizedBatchNormOutputs { kOut, kOutMin, kOutMax };
+enum QuantizedBatchNormOpAuxiliary { kMovingMean, kMovingVar };
+}  // namespace quantized_batchnorm
 
 /*! \brief Parameters for BatchNoram operator */
 struct BatchNormParam : public dmlc::Parameter<BatchNormParam> {
@@ -79,38 +95,42 @@ struct BatchNormParam : public dmlc::Parameter<BatchNormParam> {
   dmlc::optional<float> max_calib_range;  // max float value calculated from calibration dataset
 
   DMLC_DECLARE_PARAMETER(BatchNormParam) {
-    DMLC_DECLARE_FIELD(eps).set_default(1e-3f)
-    .describe("Epsilon to prevent div 0. "
-              "Must be no less than CUDNN_BN_MIN_EPSILON "
-              "defined in cudnn.h when using cudnn (usually 1e-5)");
-    DMLC_DECLARE_FIELD(momentum).set_default(0.9f)
-    .describe("Momentum for moving average");
-    DMLC_DECLARE_FIELD(fix_gamma).set_default(true)
-    .describe("Fix gamma while training");
-    DMLC_DECLARE_FIELD(use_global_stats).set_default(false)
-    .describe("Whether use global moving statistics instead of local batch-norm. "
-              "This will force change batch-norm into a scale shift operator.");
-    DMLC_DECLARE_FIELD(output_mean_var).set_default(false)
-    .describe("Output the mean and inverse std ");
-    DMLC_DECLARE_FIELD(axis).set_default(mxnet::op::batchnorm::DEFAULT_AXIS)
-    .describe("Specify which shape axis the channel is specified");
-    DMLC_DECLARE_FIELD(cudnn_off).set_default(false)
-    .describe("Do not select CUDNN operator, if available");
+    DMLC_DECLARE_FIELD(eps).set_default(1e-3f).describe(
+        "Epsilon to prevent div 0. "
+        "Must be no less than CUDNN_BN_MIN_EPSILON "
+        "defined in cudnn.h when using cudnn (usually 1e-5)");
+    DMLC_DECLARE_FIELD(momentum).set_default(0.9f).describe("Momentum for moving average");
+    DMLC_DECLARE_FIELD(fix_gamma).set_default(true).describe("Fix gamma while training");
+    DMLC_DECLARE_FIELD(use_global_stats)
+        .set_default(false)
+        .describe(
+            "Whether use global moving statistics instead of local batch-norm. "
+            "This will force change batch-norm into a scale shift operator.");
+    DMLC_DECLARE_FIELD(output_mean_var)
+        .set_default(false)
+        .describe("Output the mean and inverse std ");
+    DMLC_DECLARE_FIELD(axis)
+        .set_default(mxnet::op::batchnorm::DEFAULT_AXIS)
+        .describe("Specify which shape axis the channel is specified");
+    DMLC_DECLARE_FIELD(cudnn_off).set_default(false).describe(
+        "Do not select CUDNN operator, if available");
     DMLC_DECLARE_FIELD(min_calib_range)
-    .set_default(dmlc::optional<float>())
-    .describe("The minimum scalar value in the form of float32 obtained "
-              "through calibration. If present, it will be used to by "
-              "quantized batch norm op to calculate primitive scale."
-              "Note: this calib_range is to calib bn output.");
+        .set_default(dmlc::optional<float>())
+        .describe(
+            "The minimum scalar value in the form of float32 obtained "
+            "through calibration. If present, it will be used to by "
+            "quantized batch norm op to calculate primitive scale."
+            "Note: this calib_range is to calib bn output.");
     DMLC_DECLARE_FIELD(max_calib_range)
-    .set_default(dmlc::optional<float>())
-    .describe("The maximum scalar value in the form of float32 obtained "
-              "through calibration. If present, it will be used to by "
-              "quantized batch norm op to calculate primitive scale."
-              "Note: this calib_range is to calib bn output.");
+        .set_default(dmlc::optional<float>())
+        .describe(
+            "The maximum scalar value in the form of float32 obtained "
+            "through calibration. If present, it will be used to by "
+            "quantized batch norm op to calculate primitive scale."
+            "Note: this calib_range is to calib bn output.");
   }
 
-  bool operator==(const BatchNormParam &other) const {
+  bool operator==(const BatchNormParam& other) const {
     bool flag = this->eps == other.eps && this->momentum == other.momentum &&
                 this->fix_gamma == other.fix_gamma &&
                 this->use_global_stats == other.use_global_stats &&
@@ -131,15 +151,15 @@ struct BatchNormParam : public dmlc::Parameter<BatchNormParam> {
 }  // namespace mxnet
 
 namespace std {
-template<>
+template <>
 struct hash<mxnet::op::BatchNormParam> {
   size_t operator()(const mxnet::op::BatchNormParam& val) {
     size_t ret = 0;
-    ret = dmlc::HashCombine(ret, val.momentum);
-    ret = dmlc::HashCombine(ret, val.fix_gamma);
-    ret = dmlc::HashCombine(ret, val.use_global_stats);
-    ret = dmlc::HashCombine(ret, val.output_mean_var);
-    ret = dmlc::HashCombine(ret, val.axis);
+    ret        = dmlc::HashCombine(ret, val.momentum);
+    ret        = dmlc::HashCombine(ret, val.fix_gamma);
+    ret        = dmlc::HashCombine(ret, val.use_global_stats);
+    ret        = dmlc::HashCombine(ret, val.output_mean_var);
+    ret        = dmlc::HashCombine(ret, val.axis);
     return ret;
   }
 };
@@ -153,40 +173,30 @@ static inline bool IsBNWriting(const OpReqType ort) {
 }
 
 template <typename xpu, typename DType, typename AccReal>
-void BatchNormForwardImpl(mshadow::Stream<cpu> *stream,
-                          const OpContext &ctx, const BatchNormParam& param,
-                          const std::vector<TBlob> &in_data,
-                          const std::vector<OpReqType> &req,
-                          const std::vector<TBlob> &out_data,
-                          const std::vector<TBlob> &aux_states);
+void BatchNormForwardImpl(mshadow::Stream<cpu>* stream, const OpContext& ctx,
+                          const BatchNormParam& param, const std::vector<TBlob>& in_data,
+                          const std::vector<OpReqType>& req, const std::vector<TBlob>& out_data,
+                          const std::vector<TBlob>& aux_states);
 
 template <typename xpu, typename DType, typename AccReal>
-void BatchNormBackwardImpl(mshadow::Stream<cpu> *stream,
-                           const OpContext &ctx, const BatchNormParam& param,
-                           const std::vector<TBlob> &out_grad,
-                           const std::vector<TBlob> &in_data,
-                           const std::vector<TBlob> &out_data,
-                           const std::vector<OpReqType> &req,
-                           const std::vector<TBlob> &in_grad,
-                           const std::vector<TBlob> &aux_states);
+void BatchNormBackwardImpl(mshadow::Stream<cpu>* stream, const OpContext& ctx,
+                           const BatchNormParam& param, const std::vector<TBlob>& out_grad,
+                           const std::vector<TBlob>& in_data, const std::vector<TBlob>& out_data,
+                           const std::vector<OpReqType>& req, const std::vector<TBlob>& in_grad,
+                           const std::vector<TBlob>& aux_states);
 
 #if MXNET_USE_CUDA
 template <typename xpu, typename DType, typename AccReal>
-void BatchNormForwardImpl(mshadow::Stream<gpu> *stream,
-                          const OpContext &ctx, const BatchNormParam& param,
-                          const std::vector<TBlob> &in_data,
-                          const std::vector<OpReqType> &req,
-                          const std::vector<TBlob> &out_data,
-                          const std::vector<TBlob> &aux_states);
+void BatchNormForwardImpl(mshadow::Stream<gpu>* stream, const OpContext& ctx,
+                          const BatchNormParam& param, const std::vector<TBlob>& in_data,
+                          const std::vector<OpReqType>& req, const std::vector<TBlob>& out_data,
+                          const std::vector<TBlob>& aux_states);
 template <typename xpu, typename DType, typename AccReal>
-void BatchNormBackwardImpl(mshadow::Stream<gpu> *stream,
-                           const OpContext &ctx, const BatchNormParam& param,
-                           const std::vector<TBlob> &out_grad,
-                           const std::vector<TBlob> &in_data,
-                           const std::vector<TBlob> &out_data,
-                           const std::vector<OpReqType> &req,
-                           const std::vector<TBlob> &in_grad,
-                           const std::vector<TBlob> &aux_states);
+void BatchNormBackwardImpl(mshadow::Stream<gpu>* stream, const OpContext& ctx,
+                           const BatchNormParam& param, const std::vector<TBlob>& out_grad,
+                           const std::vector<TBlob>& in_data, const std::vector<TBlob>& out_data,
+                           const std::vector<OpReqType>& req, const std::vector<TBlob>& in_grad,
+                           const std::vector<TBlob>& aux_states);
 #endif  // MXNET_USE_CUDA
 
 /*!
@@ -201,11 +211,9 @@ void BatchNormBackwardImpl(mshadow::Stream<gpu> *stream,
  * \sa OpReqType, OpContext
  */
 template <typename xpu, typename DType, typename AccReal>
-void BatchNormForward(const OpContext &ctx, const BatchNormParam& param,
-                      const std::vector<TBlob> &in_data,
-                      const std::vector<OpReqType> &req,
-                      const std::vector<TBlob> &out_data,
-                      const std::vector<TBlob> &aux_states) {
+void BatchNormForward(const OpContext& ctx, const BatchNormParam& param,
+                      const std::vector<TBlob>& in_data, const std::vector<OpReqType>& req,
+                      const std::vector<TBlob>& out_data, const std::vector<TBlob>& aux_states) {
   using namespace mshadow;
   using namespace mshadow::expr;
 
@@ -219,9 +227,8 @@ void BatchNormForward(const OpContext &ctx, const BatchNormParam& param,
     CHECK_GE(req.size(), 1U);
     CHECK_EQ(req[batchnorm::kOut], kWriteTo);
   }
-  Stream<xpu> *s = ctx.get_stream<xpu>();
-  BatchNormForwardImpl<xpu, DType, AccReal>(s, ctx, param, in_data, req,
-                                            out_data, aux_states);
+  Stream<xpu>* s = ctx.get_stream<xpu>();
+  BatchNormForwardImpl<xpu, DType, AccReal>(s, ctx, param, in_data, req, out_data, aux_states);
 }
 
 /*!
@@ -253,10 +260,9 @@ void BatchNormForward(const OpContext &ctx, const BatchNormParam& param,
  * \sa OperatorProperty, OpReqType, OpContext
  */
 template <typename xpu, typename DType, typename AccReal>
-void BatchNormBackward(const OpContext &ctx, const BatchNormParam& param,
-                       const std::vector<TBlob> &inputs,
-                       const std::vector<OpReqType> &req,
-                       const std::vector<TBlob> &outputs) {
+void BatchNormBackward(const OpContext& ctx, const BatchNormParam& param,
+                       const std::vector<TBlob>& inputs, const std::vector<OpReqType>& req,
+                       const std::vector<TBlob>& outputs) {
   CHECK_EQ(inputs.size(), 8U);
   CHECK_EQ(outputs.size(), 3U);
 
@@ -265,41 +271,36 @@ void BatchNormBackward(const OpContext &ctx, const BatchNormParam& param,
   std::vector<TBlob> in_data(3);
   std::vector<TBlob> aux_states(2);
 
-  out_grad[0] = inputs[0];
-  out_data[batchnorm::kMean] = inputs[1];
-  out_data[batchnorm::kVar] = inputs[2];
-  in_data[batchnorm::kData] = inputs[3];
-  in_data[batchnorm::kGamma] = inputs[4];
-  in_data[batchnorm::kBeta] = inputs[5];
+  out_grad[0]                        = inputs[0];
+  out_data[batchnorm::kMean]         = inputs[1];
+  out_data[batchnorm::kVar]          = inputs[2];
+  in_data[batchnorm::kData]          = inputs[3];
+  in_data[batchnorm::kGamma]         = inputs[4];
+  in_data[batchnorm::kBeta]          = inputs[5];
   aux_states[batchnorm::kMovingMean] = inputs[6];
-  aux_states[batchnorm::kMovingVar] = inputs[7];
-  const std::vector<TBlob> &in_grad = outputs;
-  mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
-  BatchNormBackwardImpl<xpu, DType, AccReal>(s, ctx, param, out_grad, in_data,
-                                             out_data, req, in_grad, aux_states);
+  aux_states[batchnorm::kMovingVar]  = inputs[7];
+  const std::vector<TBlob>& in_grad  = outputs;
+  mshadow::Stream<xpu>* s            = ctx.get_stream<xpu>();
+  BatchNormBackwardImpl<xpu, DType, AccReal>(s, ctx, param, out_grad, in_data, out_data, req,
+                                             in_grad, aux_states);
 }
 
-template<typename xpu>
-void BatchNormCompute(const nnvm::NodeAttrs& attrs,
-                      const OpContext& ctx, const std::vector<TBlob>& inputs,
-                      const std::vector<OpReqType>& req,
+template <typename xpu>
+void BatchNormCompute(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+                      const std::vector<TBlob>& inputs, const std::vector<OpReqType>& req,
                       const std::vector<TBlob>& outputs) {
   const BatchNormParam& param = nnvm::get<BatchNormParam>(attrs.parsed);
   CHECK_EQ(inputs.size(), 5U);
-  std::vector<TBlob> in_data(inputs.begin(),
-                             inputs.begin() + batchnorm::kInMovingMean);
-  std::vector<TBlob> aux_states(inputs.begin() + batchnorm::kInMovingMean,
-                                inputs.end());
+  std::vector<TBlob> in_data(inputs.begin(), inputs.begin() + batchnorm::kInMovingMean);
+  std::vector<TBlob> aux_states(inputs.begin() + batchnorm::kInMovingMean, inputs.end());
   MSHADOW_REAL_TYPE_SWITCH_EX(inputs[0].type_flag_, DType, AccReal, {
-    BatchNormForward<xpu, DType, AccReal>(ctx, param, in_data, req, outputs,
-                                          aux_states);
+    BatchNormForward<xpu, DType, AccReal>(ctx, param, in_data, req, outputs, aux_states);
   });
 }
 
-template<typename xpu>
-void BatchNormGradCompute(const nnvm::NodeAttrs& attrs,
-                          const OpContext& ctx, const std::vector<TBlob>& inputs,
-                          const std::vector<OpReqType>& req,
+template <typename xpu>
+void BatchNormGradCompute(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+                          const std::vector<TBlob>& inputs, const std::vector<OpReqType>& req,
                           const std::vector<TBlob>& outputs) {
   CHECK_EQ(inputs.size(), 8U);
   const BatchNormParam& param = nnvm::get<BatchNormParam>(attrs.parsed);
@@ -313,15 +314,15 @@ void BatchNormGradCompute(const nnvm::NodeAttrs& attrs,
 
 namespace batchnorm {
 
-template<typename DType>
+template <typename DType>
 class BNTensor3 {
   enum { OUTER, CHANNEL, INNER, COUNT };
 
  public:
   inline BNTensor3(const TBlob& blob, const int indexOfChannel)
-    : dptr_(blob.dptr<DType>())
-      , indexOfChannel_(static_cast<size_t>(indexOfChannel < 0
-                               ? (static_cast<int>(blob.shape_.ndim()) + indexOfChannel)
+      : dptr_(blob.dptr<DType>()),
+        indexOfChannel_(static_cast<size_t>(
+            indexOfChannel < 0 ? (static_cast<int>(blob.shape_.ndim()) + indexOfChannel)
                                : indexOfChannel)) {
     CHECK_EQ(blob.type_flag_, mshadow::DataType<DType>::kFlag);
     shape_[OUTER] = 1;
@@ -329,31 +330,29 @@ class BNTensor3 {
       shape_[OUTER] *= blob.shape_[i];
     }
     shape_[CHANNEL] = blob.shape_[indexOfChannel_];
-    shape_[INNER] = 1;
+    shape_[INNER]   = 1;
     for (size_t i = indexOfChannel_ + 1, n = blob.shape_.ndim(); i < n; ++i) {
       shape_[INNER] *= blob.shape_[i];
     }
   }
 
-  inline BNTensor3(DType *p, const mxnet::TShape& shape, const int indexOfChannel)
-    : dptr_(p)
-      , indexOfChannel_(static_cast<size_t>(indexOfChannel < 0
-                               ? (static_cast<int>(shape.ndim()) + indexOfChannel)
-                               : indexOfChannel)) {
+  inline BNTensor3(DType* p, const mxnet::TShape& shape, const int indexOfChannel)
+      : dptr_(p),
+        indexOfChannel_(static_cast<size_t>(indexOfChannel < 0
+                                                ? (static_cast<int>(shape.ndim()) + indexOfChannel)
+                                                : indexOfChannel)) {
     shape_[OUTER] = 1;
     for (size_t i = 0; i < indexOfChannel_; ++i) {
       shape_[OUTER] *= shape[i];
     }
     shape_[CHANNEL] = shape[indexOfChannel_];
-    shape_[INNER] = 1;
+    shape_[INNER]   = 1;
     for (size_t i = indexOfChannel_ + 1, n = shape.ndim(); i < n; ++i) {
       shape_[INNER] *= shape[i];
     }
   }
 
-  MSHADOW_FORCE_INLINE bool IsEmpty() const {
-    return dptr_ == nullptr;
-  }
+  MSHADOW_FORCE_INLINE bool IsEmpty() const { return dptr_ == nullptr; }
 
   MSHADOW_XINLINE size_t Size() const {
     size_t n = 1;
@@ -363,22 +362,14 @@ class BNTensor3 {
     return n;
   }
 
-  MSHADOW_XINLINE size_t ChannelCount() const {
-    return shape_[CHANNEL];
-  }
+  MSHADOW_XINLINE size_t ChannelCount() const { return shape_[CHANNEL]; }
 
-  MSHADOW_XINLINE size_t OuterSize() const {
-    return shape_[OUTER];
-  }
+  MSHADOW_XINLINE size_t OuterSize() const { return shape_[OUTER]; }
 
-  MSHADOW_XINLINE size_t InnerSize() const {
-    return shape_[INNER];
-  }
+  MSHADOW_XINLINE size_t InnerSize() const { return shape_[INNER]; }
 
   /*! \brief start of a given channel's spatial data */
-  MSHADOW_XINLINE size_t StartOffset(const size_t channel) const {
-    return channel * InnerSize();
-  }
+  MSHADOW_XINLINE size_t StartOffset(const size_t channel) const { return channel * InnerSize(); }
 
   /*! \brief This is the amount to skip to next same-channel data
    * This is the number of bytes to skip from one past the end of the current spatial data
@@ -392,12 +383,10 @@ class BNTensor3 {
     return (ChannelCount() - 1) * InnerSize();
   }
 
-  MSHADOW_XINLINE size_t offset(const size_t outer,
-                                const size_t channel,
-                                const size_t i) const {
+  MSHADOW_XINLINE size_t offset(const size_t outer, const size_t channel, const size_t i) const {
     const size_t spatial_size = InnerSize();
-    const size_t skip_length = SkipLengthToNextSameChannelData();
-    size_t off = StartOffset(channel);
+    const size_t skip_length  = SkipLengthToNextSameChannelData();
+    size_t off                = StartOffset(channel);
     off += outer * shape_[CHANNEL] * shape_[INNER];
     const size_t skips = i / spatial_size;
     off += (1 + skip_length) * skips;
@@ -405,21 +394,18 @@ class BNTensor3 {
     return off;
   }
 
-  MSHADOW_XINLINE DType& get_ref(const size_t batch,
-                                 const size_t channel,
-                                 const size_t i) {
+  MSHADOW_XINLINE DType& get_ref(const size_t batch, const size_t channel, const size_t i) {
     const size_t off = offset(batch, channel, i);
     return dptr_[off];
   }
 
-  MSHADOW_XINLINE const DType& get_ref(const size_t batch,
-                                       const size_t channel,
+  MSHADOW_XINLINE const DType& get_ref(const size_t batch, const size_t channel,
                                        const size_t i) const {
     const size_t off = offset(batch, channel, i);
     return dptr_[off];
   }
 
-  DType *dptr_;
+  DType* dptr_;
   size_t indexOfChannel_;
   size_t shape_[COUNT];
 };

--- a/src/operator/nn/batch_norm.cc
+++ b/src/operator/nn/batch_norm.cc
@@ -24,10 +24,11 @@
  * \author Bing Xu, Chris Olivier, Da Zheng
  */
 
-#include "batch_norm-inl.h"
 #include <nnvm/op_attr_types.h>
+
 #include "../elemwise_op_common.h"
 #include "../operator_common.h"
+#include "batch_norm-inl.h"
 #if MXNET_USE_MKLDNN == 1
 #include "./mkldnn/mkldnn_batch_norm-inl.h"
 #endif

--- a/src/operator/nn/batch_norm.cu
+++ b/src/operator/nn/batch_norm.cu
@@ -47,10 +47,6 @@
 
 using namespace mxnet;
 
-/*! \brief inverse standard deviation <-> variance */
-#define VARIANCE_TO_INVSTD(__var$,    __eps$)   (1.0/sqrt((__var$) + DType(__eps$)))
-#define INVSTD_TO_VARIANCE(__invstd$, __eps$)   ((1.0 / ((__invstd$) * (__invstd$))) - (__eps$))
-
 namespace mxnet {
 namespace op {
 namespace batchnorm {

--- a/src/operator/nn/mkldnn/mkldnn_act-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_act-inl.h
@@ -28,10 +28,11 @@
 #define MXNET_OPERATOR_NN_MKLDNN_MKLDNN_ACT_INL_H_
 
 #if MXNET_USE_MKLDNN == 1
-#include <vector>
 #include <utility>
-#include "../activation-inl.h"
+#include <vector>
+
 #include "../../leaky_relu-inl.h"
+#include "../activation-inl.h"
 
 namespace mxnet {
 namespace op {
@@ -56,7 +57,9 @@ class MKLDNNActForward {
  public:
   const mkldnn::eltwise_forward::primitive_desc fwd_pd;
 
-  MKLDNNActForward(const MKLDNNActParam& param, bool is_train, const NDArray& data,
+  MKLDNNActForward(const MKLDNNActParam& param,
+                   bool is_train,
+                   const NDArray& data,
                    const mkldnn::memory& mem)
       : fwd_pd(GetActFwdDescImpl(param, is_train, mem)) {
     fwd_ = std::make_shared<mkldnn::eltwise_forward>(fwd_pd);
@@ -68,8 +71,10 @@ class MKLDNNActForward {
 };
 
 typedef ParamOpSign<MKLDNNActParam> MKLDNNActSignature;
-MKLDNNActForward& GetActForward(const MKLDNNActParam& param, const OpContext& ctx,
-                                const NDArray& in_data, const mkldnn::memory& in_mem);
+MKLDNNActForward& GetActForward(const MKLDNNActParam& param,
+                                const OpContext& ctx,
+                                const NDArray& in_data,
+                                const mkldnn::memory& in_mem);
 
 mkldnn::eltwise_backward::primitive_desc GetActBwdDescImpl(const MKLDNNActParam& param,
                                                            const mkldnn::memory& input_mem,
@@ -79,8 +84,10 @@ class MKLDNNActBackward {
  public:
   const mkldnn::eltwise_backward::primitive_desc bwd_pd;
 
-  explicit MKLDNNActBackward(const MKLDNNActParam& param, const NDArray& data,
-                             const mkldnn::memory& mem, const mkldnn::memory& diff_dst_memory)
+  explicit MKLDNNActBackward(const MKLDNNActParam& param,
+                             const NDArray& data,
+                             const mkldnn::memory& mem,
+                             const mkldnn::memory& diff_dst_memory)
       : bwd_pd(GetActBwdDescImpl(param, mem, diff_dst_memory)) {
     bwd_prim_ = std::make_shared<mkldnn::eltwise_backward>(bwd_pd);
   }

--- a/src/operator/nn/mkldnn/mkldnn_act-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_act-inl.h
@@ -22,11 +22,10 @@
  * \file mkldnn_act-inl.h
  * \brief MKLDNN Activation operator
  * /author Zhiyuan Huang
-*/
+ */
 
 #ifndef MXNET_OPERATOR_NN_MKLDNN_MKLDNN_ACT_INL_H_
 #define MXNET_OPERATOR_NN_MKLDNN_MKLDNN_ACT_INL_H_
-
 
 #if MXNET_USE_MKLDNN == 1
 #include <vector>
@@ -42,8 +41,7 @@ struct MKLDNNActParam {
   float slope = 0.f;
 
   bool operator==(const MKLDNNActParam& other) const {
-    return this->alg == other.alg &&
-           this->slope == other.slope;
+    return this->alg == other.alg && this->slope == other.slope;
   }
 };
 
@@ -51,44 +49,43 @@ mkldnn::algorithm GetMKLDNNActAlgo(const ActivationParam& param);
 mkldnn::algorithm GetMKLDNNActAlgo(const LeakyReLUParam& param);
 
 mkldnn::eltwise_forward::primitive_desc GetActFwdDescImpl(
-    const MKLDNNActParam& param, bool is_train,
-    const mkldnn::memory &input_mem);
+    const MKLDNNActParam& param, bool is_train, const mkldnn::memory& input_mem);
 
 class MKLDNNActForward {
  public:
   const mkldnn::eltwise_forward::primitive_desc fwd_pd;
 
-  MKLDNNActForward(const MKLDNNActParam& param, bool is_train,
-                   const NDArray &data, const mkldnn::memory &mem): fwd_pd(
-                       GetActFwdDescImpl(param, is_train, mem)) {
+  MKLDNNActForward(
+      const MKLDNNActParam& param, bool is_train, const NDArray& data, const mkldnn::memory& mem)
+      : fwd_pd(GetActFwdDescImpl(param, is_train, mem)) {
     fwd_ = std::make_shared<mkldnn::eltwise_forward>(fwd_pd);
   }
-  const inline mkldnn::eltwise_forward &GetFwd() const;
+  const inline mkldnn::eltwise_forward& GetFwd() const;
 
  private:
   std::shared_ptr<mkldnn::eltwise_forward> fwd_;
 };
 
 typedef ParamOpSign<MKLDNNActParam> MKLDNNActSignature;
-MKLDNNActForward &GetActForward(const MKLDNNActParam& param,
-                                const OpContext &ctx, const NDArray &in_data,
-                                const mkldnn::memory &in_mem);
+MKLDNNActForward& GetActForward(
+    const MKLDNNActParam& param, const OpContext& ctx, const NDArray& in_data,
+    const mkldnn::memory& in_mem);
 
 mkldnn::eltwise_backward::primitive_desc GetActBwdDescImpl(
-    const MKLDNNActParam &param, const mkldnn::memory &input_mem,
-    const mkldnn::memory &diff_dst_memory);
+    const MKLDNNActParam& param, const mkldnn::memory& input_mem,
+    const mkldnn::memory& diff_dst_memory);
 
 class MKLDNNActBackward {
  public:
   const mkldnn::eltwise_backward::primitive_desc bwd_pd;
 
-  explicit MKLDNNActBackward(const MKLDNNActParam &param, const NDArray &data,
-                             const mkldnn::memory &mem,
-                             const mkldnn::memory &diff_dst_memory): bwd_pd(
-                                 GetActBwdDescImpl(param, mem, diff_dst_memory)) {
+  explicit MKLDNNActBackward(
+      const MKLDNNActParam& param, const NDArray& data, const mkldnn::memory& mem,
+      const mkldnn::memory& diff_dst_memory)
+      : bwd_pd(GetActBwdDescImpl(param, mem, diff_dst_memory)) {
     bwd_prim_ = std::make_shared<mkldnn::eltwise_backward>(bwd_pd);
   }
-  const inline mkldnn::eltwise_backward &GetBwd() const;
+  const inline mkldnn::eltwise_backward& GetBwd() const;
 
  private:
   std::shared_ptr<mkldnn::eltwise_backward> bwd_prim_;
@@ -97,12 +94,12 @@ class MKLDNNActBackward {
 }  // namespace mxnet
 
 namespace std {
-template<>
+template <>
 struct hash<mxnet::op::MKLDNNActParam> {
   size_t operator()(const mxnet::op::MKLDNNActParam& val) {
     size_t ret = 0;
-    ret = dmlc::HashCombine(ret, static_cast<size_t>(val.alg));
-    ret = dmlc::HashCombine(ret, val.slope);
+    ret        = dmlc::HashCombine(ret, static_cast<size_t>(val.alg));
+    ret        = dmlc::HashCombine(ret, val.slope);
     return ret;
   }
 };

--- a/src/operator/nn/mkldnn/mkldnn_act-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_act-inl.h
@@ -48,15 +48,16 @@ struct MKLDNNActParam {
 mkldnn::algorithm GetMKLDNNActAlgo(const ActivationParam& param);
 mkldnn::algorithm GetMKLDNNActAlgo(const LeakyReLUParam& param);
 
-mkldnn::eltwise_forward::primitive_desc GetActFwdDescImpl(
-    const MKLDNNActParam& param, bool is_train, const mkldnn::memory& input_mem);
+mkldnn::eltwise_forward::primitive_desc GetActFwdDescImpl(const MKLDNNActParam& param,
+                                                          bool is_train,
+                                                          const mkldnn::memory& input_mem);
 
 class MKLDNNActForward {
  public:
   const mkldnn::eltwise_forward::primitive_desc fwd_pd;
 
-  MKLDNNActForward(
-      const MKLDNNActParam& param, bool is_train, const NDArray& data, const mkldnn::memory& mem)
+  MKLDNNActForward(const MKLDNNActParam& param, bool is_train, const NDArray& data,
+                   const mkldnn::memory& mem)
       : fwd_pd(GetActFwdDescImpl(param, is_train, mem)) {
     fwd_ = std::make_shared<mkldnn::eltwise_forward>(fwd_pd);
   }
@@ -67,21 +68,19 @@ class MKLDNNActForward {
 };
 
 typedef ParamOpSign<MKLDNNActParam> MKLDNNActSignature;
-MKLDNNActForward& GetActForward(
-    const MKLDNNActParam& param, const OpContext& ctx, const NDArray& in_data,
-    const mkldnn::memory& in_mem);
+MKLDNNActForward& GetActForward(const MKLDNNActParam& param, const OpContext& ctx,
+                                const NDArray& in_data, const mkldnn::memory& in_mem);
 
-mkldnn::eltwise_backward::primitive_desc GetActBwdDescImpl(
-    const MKLDNNActParam& param, const mkldnn::memory& input_mem,
-    const mkldnn::memory& diff_dst_memory);
+mkldnn::eltwise_backward::primitive_desc GetActBwdDescImpl(const MKLDNNActParam& param,
+                                                           const mkldnn::memory& input_mem,
+                                                           const mkldnn::memory& diff_dst_memory);
 
 class MKLDNNActBackward {
  public:
   const mkldnn::eltwise_backward::primitive_desc bwd_pd;
 
-  explicit MKLDNNActBackward(
-      const MKLDNNActParam& param, const NDArray& data, const mkldnn::memory& mem,
-      const mkldnn::memory& diff_dst_memory)
+  explicit MKLDNNActBackward(const MKLDNNActParam& param, const NDArray& data,
+                             const mkldnn::memory& mem, const mkldnn::memory& diff_dst_memory)
       : bwd_pd(GetActBwdDescImpl(param, mem, diff_dst_memory)) {
     bwd_prim_ = std::make_shared<mkldnn::eltwise_backward>(bwd_pd);
   }

--- a/src/operator/nn/mkldnn/mkldnn_act.cc
+++ b/src/operator/nn/mkldnn/mkldnn_act.cc
@@ -116,7 +116,9 @@ mkldnn::eltwise_forward::primitive_desc GetActFwdDescImpl(const MKLDNNActParam& 
   return mkldnn::eltwise_forward::primitive_desc(desc, cpu_engine);
 }
 
-const inline mkldnn::eltwise_forward& MKLDNNActForward::GetFwd() const { return *fwd_; }
+const inline mkldnn::eltwise_forward& MKLDNNActForward::GetFwd() const {
+  return *fwd_;
+}
 
 MKLDNNActForward& GetActForward(const MKLDNNActParam& param,
                                 const OpContext& ctx,
@@ -172,7 +174,8 @@ void MKLDNNLeakyReluForward(const nnvm::NodeAttrs& attrs,
   NDArray in_buffer    = in_data;
   MKLDNNStream* stream = MKLDNNStream::Get();
 
-  if (in_data.IsView() && in_data.IsMKLDNNData()) in_buffer = in_data.Reorder2Default();
+  if (in_data.IsView() && in_data.IsMKLDNNData())
+    in_buffer = in_data.Reorder2Default();
 
   auto input_mem        = in_buffer.GetMKLDNNData();
   MKLDNNActForward& fwd = GetActForward(param_, ctx, in_buffer, *input_mem);
@@ -191,15 +194,17 @@ mkldnn::eltwise_backward::primitive_desc GetActBwdDescImpl(const MKLDNNActParam&
   auto cpu_engine              = CpuEngine::Get()->get_engine();
   auto alg                     = param.alg;
 
-  mkldnn::eltwise_forward::desc fw_desc(mkldnn::prop_kind::forward_training, alg, data_md,
-                                        param.slope);
+  mkldnn::eltwise_forward::desc fw_desc(
+      mkldnn::prop_kind::forward_training, alg, data_md, param.slope);
   mkldnn::eltwise_forward::primitive_desc fw_pdesc(fw_desc, cpu_engine);
   mkldnn::eltwise_backward::desc bw_desc(alg, diff_md, data_md, param.slope);
   mkldnn::eltwise_backward::primitive_desc bw_pdesc(bw_desc, cpu_engine, fw_pdesc);
   return bw_pdesc;
 }
 
-const inline mkldnn::eltwise_backward& MKLDNNActBackward::GetBwd() const { return *bwd_prim_; }
+const inline mkldnn::eltwise_backward& MKLDNNActBackward::GetBwd() const {
+  return *bwd_prim_;
+}
 
 static inline MKLDNNActBackward& GetActBackward(const MKLDNNActParam& param,
                                                 const OpContext& ctx,
@@ -223,8 +228,8 @@ static inline MKLDNNActBackward& GetActBackward(const MKLDNNActParam& param,
   return it->second;
 }
 
-// For backward relu activation, it's okay to pass "out_data" as "in_data" to this
-// function, since the computation only involes non-zeros.
+// For backward relu activation, it's okay to pass "out_data" as "in_data" to
+// this function, since the computation only involes non-zeros.
 void MKLDNNActivationBackward(const nnvm::NodeAttrs& attrs,
                               const OpContext& ctx,
                               const std::vector<NDArray>& inputs,

--- a/src/operator/nn/mkldnn/mkldnn_act.cc
+++ b/src/operator/nn/mkldnn/mkldnn_act.cc
@@ -21,7 +21,7 @@
  * \file mkldnn_act.cc
  * \brief
  * \author Da Zheng
-*/
+ */
 
 #if MXNET_USE_MKLDNN == 1
 
@@ -41,37 +41,32 @@ namespace mxnet {
 namespace op {
 
 bool SupportMKLDNNAct(const ActivationParam& param) {
-  return param.act_type == activation::kReLU
-      || param.act_type == activation::kSigmoid
-      || param.act_type == activation::kSoftReLU
-      || param.act_type == activation::kTanh;
+  return param.act_type == activation::kReLU || param.act_type == activation::kSigmoid ||
+         param.act_type == activation::kSoftReLU || param.act_type == activation::kTanh;
 }
 
-bool SupportMKLDNNAct(const ActivationParam& param, const NDArray &input) {
+bool SupportMKLDNNAct(const ActivationParam& param, const NDArray& input) {
   // MKL-DNN Activation supports 1d, 2d, 3d, 4d and 5d data layout
-  if ((input.shape().ndim() < 1) ||
-      (input.shape().ndim() > 5) ||
+  if ((input.shape().ndim() < 1) || (input.shape().ndim() > 5) ||
       !(input.dtype() == mshadow::kFloat32 || input.dtype() == mshadow::kBfloat16))
     return false;
   return SupportMKLDNNAct(param);
 }
 
 bool SupportMKLDNNLeakyRelu(const LeakyReLUParam& param) {
-  return param.act_type == leakyrelu::kLeakyReLU
-      || param.act_type == leakyrelu::kELU
-      || param.act_type == leakyrelu::kGELU;
+  return param.act_type == leakyrelu::kLeakyReLU || param.act_type == leakyrelu::kELU ||
+         param.act_type == leakyrelu::kGELU;
 }
 
-bool SupportMKLDNNLeakyRelu(const LeakyReLUParam& param, const NDArray &input) {
+bool SupportMKLDNNLeakyRelu(const LeakyReLUParam& param, const NDArray& input) {
   // MKL-DNN Activation supports 1d, 2d, 3d, 4d and 5d data layout
-  if ((input.shape().ndim() < 1) ||
-      (input.shape().ndim() > 5) ||
+  if ((input.shape().ndim() < 1) || (input.shape().ndim() > 5) ||
       !(input.dtype() == mshadow::kFloat32 || input.dtype() == mshadow::kBfloat16))
     return false;
   return SupportMKLDNNLeakyRelu(param);
 }
 
-bool SupportQuantizedMKLDNNAct(const ActivationParam &param) {
+bool SupportQuantizedMKLDNNAct(const ActivationParam& param) {
   // TODO(zhennan): Add more activation type when mkldnn supports.
   //                Remove this when it's identity to SupportMKLDNNAct.
   return param.act_type == activation::kReLU;
@@ -108,25 +103,21 @@ mkldnn::algorithm GetMKLDNNActAlgo(const LeakyReLUParam& param) {
 }
 
 mkldnn::eltwise_forward::primitive_desc GetActFwdDescImpl(
-    const MKLDNNActParam& param, bool is_train,
-    const mkldnn::memory &input_mem) {
+    const MKLDNNActParam& param, bool is_train, const mkldnn::memory& input_mem) {
   mkldnn::memory::desc data_md = input_mem.get_desc();
-  auto cpu_engine = CpuEngine::Get()->get_engine();
-  auto alg = param.alg;
+  auto cpu_engine              = CpuEngine::Get()->get_engine();
+  auto alg                     = param.alg;
 
-  auto prop = is_train ? mkldnn::prop_kind::forward_training :
-                         mkldnn::prop_kind::forward_scoring;
+  auto prop = is_train ? mkldnn::prop_kind::forward_training : mkldnn::prop_kind::forward_scoring;
   auto desc = mkldnn::eltwise_forward::desc(prop, alg, data_md, param.slope);
   return mkldnn::eltwise_forward::primitive_desc(desc, cpu_engine);
 }
 
-const inline mkldnn::eltwise_forward &MKLDNNActForward::GetFwd() const {
-  return *fwd_;
-}
+const inline mkldnn::eltwise_forward& MKLDNNActForward::GetFwd() const { return *fwd_; }
 
-MKLDNNActForward &GetActForward(const MKLDNNActParam& param,
-                                const OpContext &ctx, const NDArray &in_data,
-                                const mkldnn::memory &in_mem) {
+MKLDNNActForward& GetActForward(
+    const MKLDNNActParam& param, const OpContext& ctx, const NDArray& in_data,
+    const mkldnn::memory& in_mem) {
 #if DMLC_CXX11_THREAD_LOCAL
   static thread_local std::unordered_map<MKLDNNActSignature, MKLDNNActForward, OpHash> fwds;
 #else
@@ -145,72 +136,66 @@ MKLDNNActForward &GetActForward(const MKLDNNActParam& param,
   return it->second;
 }
 
-void MKLDNNActivationForward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
-                             const NDArray &in_data, const OpReqType &req,
-                             const NDArray &out_data) {
+void MKLDNNActivationForward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const NDArray& in_data,
+    const OpReqType& req, const NDArray& out_data) {
   const ActivationParam& param = nnvm::get<ActivationParam>(attrs.parsed);
   MKLDNNActParam param_;
-  param_.alg = GetMKLDNNActAlgo(param);
+  param_.alg               = GetMKLDNNActAlgo(param);
   const NDArray& in_buffer = in_data;
-  MKLDNNStream *stream = MKLDNNStream::Get();
-  auto input_mem = in_buffer.GetMKLDNNData();
-  MKLDNNActForward &fwd = GetActForward(param_, ctx, in_buffer, *input_mem);
-  auto out_mem_t = CreateMKLDNNMem(out_data, fwd.fwd_pd.dst_desc(), req, &in_buffer);
-  stream->RegisterPrimArgs(fwd.GetFwd(),
-                           {{ MKLDNN_ARG_SRC, *input_mem}, { MKLDNN_ARG_DST, *out_mem_t.second}});
+  MKLDNNStream* stream     = MKLDNNStream::Get();
+  auto input_mem           = in_buffer.GetMKLDNNData();
+  MKLDNNActForward& fwd    = GetActForward(param_, ctx, in_buffer, *input_mem);
+  auto out_mem_t           = CreateMKLDNNMem(out_data, fwd.fwd_pd.dst_desc(), req, &in_buffer);
+  stream->RegisterPrimArgs(
+      fwd.GetFwd(), {{MKLDNN_ARG_SRC, *input_mem}, {MKLDNN_ARG_DST, *out_mem_t.second}});
   CommitOutput(out_data, out_mem_t);
   stream->Submit();
 }
 
-void MKLDNNLeakyReluForward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
-                             const NDArray &in_data, const OpReqType &req,
-                             const NDArray &out_data) {
+void MKLDNNLeakyReluForward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const NDArray& in_data,
+    const OpReqType& req, const NDArray& out_data) {
   const LeakyReLUParam& param = nnvm::get<LeakyReLUParam>(attrs.parsed);
   MKLDNNActParam param_;
-  param_.alg = GetMKLDNNActAlgo(param);
+  param_.alg   = GetMKLDNNActAlgo(param);
   param_.slope = param.slope;
 
-  NDArray in_buffer = in_data;
-  MKLDNNStream *stream = MKLDNNStream::Get();
+  NDArray in_buffer    = in_data;
+  MKLDNNStream* stream = MKLDNNStream::Get();
 
-  if (in_data.IsView() && in_data.IsMKLDNNData())
-    in_buffer = in_data.Reorder2Default();
+  if (in_data.IsView() && in_data.IsMKLDNNData()) in_buffer = in_data.Reorder2Default();
 
-  auto input_mem = in_buffer.GetMKLDNNData();
-  MKLDNNActForward &fwd = GetActForward(param_, ctx, in_buffer, *input_mem);
-  auto out_mem_t = CreateMKLDNNMem(out_data, fwd.fwd_pd.dst_desc(), req, &in_buffer);
-  stream->RegisterPrimArgs(fwd.GetFwd(),
-                           {{ MKLDNN_ARG_SRC, *input_mem}, { MKLDNN_ARG_DST, *out_mem_t.second}});
+  auto input_mem        = in_buffer.GetMKLDNNData();
+  MKLDNNActForward& fwd = GetActForward(param_, ctx, in_buffer, *input_mem);
+  auto out_mem_t        = CreateMKLDNNMem(out_data, fwd.fwd_pd.dst_desc(), req, &in_buffer);
+  stream->RegisterPrimArgs(
+      fwd.GetFwd(), {{MKLDNN_ARG_SRC, *input_mem}, {MKLDNN_ARG_DST, *out_mem_t.second}});
   CommitOutput(out_data, out_mem_t);
   stream->Submit();
 }
 
 mkldnn::eltwise_backward::primitive_desc GetActBwdDescImpl(
-    const MKLDNNActParam &param, const mkldnn::memory &input_mem,
-    const mkldnn::memory &diff_dst_memory) {
+    const MKLDNNActParam& param, const mkldnn::memory& input_mem,
+    const mkldnn::memory& diff_dst_memory) {
   mkldnn::memory::desc data_md = input_mem.get_desc();
   mkldnn::memory::desc diff_md = diff_dst_memory.get_desc();
-  auto cpu_engine = CpuEngine::Get()->get_engine();
-  auto alg = param.alg;
+  auto cpu_engine              = CpuEngine::Get()->get_engine();
+  auto alg                     = param.alg;
 
-  mkldnn::eltwise_forward::desc fw_desc(mkldnn::prop_kind::forward_training,
-                                        alg, data_md, param.slope);
+  mkldnn::eltwise_forward::desc fw_desc(
+      mkldnn::prop_kind::forward_training, alg, data_md, param.slope);
   mkldnn::eltwise_forward::primitive_desc fw_pdesc(fw_desc, cpu_engine);
   mkldnn::eltwise_backward::desc bw_desc(alg, diff_md, data_md, param.slope);
-  mkldnn::eltwise_backward::primitive_desc bw_pdesc(bw_desc, cpu_engine,
-                                                    fw_pdesc);
+  mkldnn::eltwise_backward::primitive_desc bw_pdesc(bw_desc, cpu_engine, fw_pdesc);
   return bw_pdesc;
 }
 
-const inline mkldnn::eltwise_backward &MKLDNNActBackward::GetBwd() const {
-  return *bwd_prim_;
-}
+const inline mkldnn::eltwise_backward& MKLDNNActBackward::GetBwd() const { return *bwd_prim_; }
 
-static inline MKLDNNActBackward &GetActBackward(const MKLDNNActParam &param,
-                                                const OpContext &ctx,
-                                                const NDArray &in_data,
-                                                const NDArray &out_grad,
-                                                const mkldnn::memory &in_mem) {
+static inline MKLDNNActBackward& GetActBackward(
+    const MKLDNNActParam& param, const OpContext& ctx, const NDArray& in_data,
+    const NDArray& out_grad, const mkldnn::memory& in_mem) {
 #if DMLC_CXX11_THREAD_LOCAL
   static thread_local std::unordered_map<MKLDNNActSignature, MKLDNNActBackward, OpHash> bwds;
 #else
@@ -230,77 +215,71 @@ static inline MKLDNNActBackward &GetActBackward(const MKLDNNActParam &param,
 
 // For backward relu activation, it's okay to pass "out_data" as "in_data" to this
 // function, since the computation only involes non-zeros.
-void MKLDNNActivationBackward(const nnvm::NodeAttrs &attrs, const OpContext &ctx,
-                              const std::vector<NDArray> &inputs, const std::vector<OpReqType> &req,
-                              const std::vector<NDArray> &outputs) {
+void MKLDNNActivationBackward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& inputs,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs) {
   if (req[0] == kNullOp) {
     return;
   }
   const ActivationParam& param = nnvm::get<ActivationParam>(attrs.parsed);
   // XXX: for y = relu(x), y is passed as "in_data" to Backward()
-  const bool relu = param.act_type == activation::kReLU;
-  const NDArray &out_buffer = inputs[0];
-  const NDArray &in_buffer = relu ? inputs[1] : inputs[2];
-  const NDArray &in_grad = outputs[0];
+  const bool relu           = param.act_type == activation::kReLU;
+  const NDArray& out_buffer = inputs[0];
+  const NDArray& in_buffer  = relu ? inputs[1] : inputs[2];
+  const NDArray& in_grad    = outputs[0];
   MKLDNNActParam param_;
   param_.alg = GetMKLDNNActAlgo(param);
   TmpMemMgr::Get()->Init(ctx.requested[activation::kTempSpace]);
   auto diff_dst_memory = out_buffer.GetMKLDNNData();
-  auto input_mem = in_buffer.GetMKLDNNData();
+  auto input_mem       = in_buffer.GetMKLDNNData();
   // We need to make sure the two inputs to eltwise_backward has the same memory
   // descriptor. Otherwise, the perf will suffer.
   if (input_mem->get_desc() != diff_dst_memory->get_desc())
     input_mem = in_buffer.GetMKLDNNDataReorder(diff_dst_memory->get_desc());
-  MKLDNNActBackward &bwd =
-      GetActBackward(param_, ctx, in_buffer, out_buffer, *input_mem);
-  MKLDNNStream *stream = MKLDNNStream::Get();
-  mkldnn_output_t diff_src_memory =
-      CreateMKLDNNMem(in_grad, bwd.bwd_pd.diff_src_desc(), req[0]);
-  mkldnn_args_map_t args = {
-    { MKLDNN_ARG_SRC, *input_mem },
-    { MKLDNN_ARG_DIFF_DST, *diff_dst_memory },
-    { MKLDNN_ARG_DIFF_SRC, *diff_src_memory.second },
+  MKLDNNActBackward& bwd          = GetActBackward(param_, ctx, in_buffer, out_buffer, *input_mem);
+  MKLDNNStream* stream            = MKLDNNStream::Get();
+  mkldnn_output_t diff_src_memory = CreateMKLDNNMem(in_grad, bwd.bwd_pd.diff_src_desc(), req[0]);
+  mkldnn_args_map_t args          = {
+      {MKLDNN_ARG_SRC, *input_mem},
+      {MKLDNN_ARG_DIFF_DST, *diff_dst_memory},
+      {MKLDNN_ARG_DIFF_SRC, *diff_src_memory.second},
   };
   stream->RegisterPrimArgs(bwd.GetBwd(), args);
   CommitOutput(in_grad, diff_src_memory);
   stream->Submit();
 }
 
-void MKLDNNLeakyReluBackward(const nnvm::NodeAttrs& attrs,
-                             const OpContext &ctx,
-                             const std::vector<NDArray>& inputs,
-                             const std::vector<OpReqType> &req,
-                             const std::vector<NDArray> &outputs) {
+void MKLDNNLeakyReluBackward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& inputs,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs) {
   if (req[0] == kNullOp) {
     return;
   }
   CHECK_EQ(inputs.size(), 2U);
   CHECK_EQ(outputs.size(), 1U);
   const NDArray& out_buffer = inputs[0];
-  const NDArray& in_buffer = inputs[1];
-  const NDArray &output = outputs[0];
+  const NDArray& in_buffer  = inputs[1];
+  const NDArray& output     = outputs[0];
 
   const LeakyReLUParam& param = nnvm::get<LeakyReLUParam>(attrs.parsed);
   MKLDNNActParam param_;
-  param_.alg = GetMKLDNNActAlgo(param);
+  param_.alg   = GetMKLDNNActAlgo(param);
   param_.slope = param.slope;
 
   TmpMemMgr::Get()->Init(ctx.requested[leakyrelu::kRandom]);
   auto diff_dst_memory = out_buffer.GetMKLDNNData();
-  auto input_mem = in_buffer.GetMKLDNNData();
+  auto input_mem       = in_buffer.GetMKLDNNData();
   // We need to make sure the two inputs to eltwise_backward has the same memory
   // descriptor. Otherwise, the perf will suffer.
   if (input_mem->get_desc() != diff_dst_memory->get_desc())
     input_mem = in_buffer.GetMKLDNNDataReorder(diff_dst_memory->get_desc());
-  MKLDNNActBackward &bwd =
-      GetActBackward(param_, ctx, in_buffer, out_buffer, *input_mem);
-  MKLDNNStream *stream = MKLDNNStream::Get();
-  mkldnn_output_t diff_src_memory =
-      CreateMKLDNNMem(output, bwd.bwd_pd.diff_src_desc(), req[0]);
-  mkldnn_args_map_t args = {
-    { MKLDNN_ARG_SRC, *input_mem },
-    { MKLDNN_ARG_DIFF_DST, *diff_dst_memory },
-    { MKLDNN_ARG_DIFF_SRC, *diff_src_memory.second },
+  MKLDNNActBackward& bwd          = GetActBackward(param_, ctx, in_buffer, out_buffer, *input_mem);
+  MKLDNNStream* stream            = MKLDNNStream::Get();
+  mkldnn_output_t diff_src_memory = CreateMKLDNNMem(output, bwd.bwd_pd.diff_src_desc(), req[0]);
+  mkldnn_args_map_t args          = {
+      {MKLDNN_ARG_SRC, *input_mem},
+      {MKLDNN_ARG_DIFF_DST, *diff_dst_memory},
+      {MKLDNN_ARG_DIFF_SRC, *diff_src_memory.second},
   };
   stream->RegisterPrimArgs(bwd.GetBwd(), args);
   CommitOutput(output, diff_src_memory);

--- a/src/operator/nn/mkldnn/mkldnn_act.cc
+++ b/src/operator/nn/mkldnn/mkldnn_act.cc
@@ -28,14 +28,16 @@
 #include <dmlc/logging.h>
 #include <dmlc/parameter.h>
 #include <mxnet/operator.h>
+
 #include <algorithm>
 #include <map>
-#include <vector>
 #include <string>
 #include <utility>
+#include <vector>
+
 #include "../../operator_common.h"
-#include "mkldnn_act-inl.h"
 #include "./mkldnn_base-inl.h"
+#include "mkldnn_act-inl.h"
 
 namespace mxnet {
 namespace op {
@@ -116,8 +118,10 @@ mkldnn::eltwise_forward::primitive_desc GetActFwdDescImpl(const MKLDNNActParam& 
 
 const inline mkldnn::eltwise_forward& MKLDNNActForward::GetFwd() const { return *fwd_; }
 
-MKLDNNActForward& GetActForward(const MKLDNNActParam& param, const OpContext& ctx,
-                                const NDArray& in_data, const mkldnn::memory& in_mem) {
+MKLDNNActForward& GetActForward(const MKLDNNActParam& param,
+                                const OpContext& ctx,
+                                const NDArray& in_data,
+                                const mkldnn::memory& in_mem) {
 #if DMLC_CXX11_THREAD_LOCAL
   static thread_local std::unordered_map<MKLDNNActSignature, MKLDNNActForward, OpHash> fwds;
 #else
@@ -136,8 +140,10 @@ MKLDNNActForward& GetActForward(const MKLDNNActParam& param, const OpContext& ct
   return it->second;
 }
 
-void MKLDNNActivationForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
-                             const NDArray& in_data, const OpReqType& req,
+void MKLDNNActivationForward(const nnvm::NodeAttrs& attrs,
+                             const OpContext& ctx,
+                             const NDArray& in_data,
+                             const OpReqType& req,
                              const NDArray& out_data) {
   const ActivationParam& param = nnvm::get<ActivationParam>(attrs.parsed);
   MKLDNNActParam param_;
@@ -153,8 +159,11 @@ void MKLDNNActivationForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
   stream->Submit();
 }
 
-void MKLDNNLeakyReluForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
-                            const NDArray& in_data, const OpReqType& req, const NDArray& out_data) {
+void MKLDNNLeakyReluForward(const nnvm::NodeAttrs& attrs,
+                            const OpContext& ctx,
+                            const NDArray& in_data,
+                            const OpReqType& req,
+                            const NDArray& out_data) {
   const LeakyReLUParam& param = nnvm::get<LeakyReLUParam>(attrs.parsed);
   MKLDNNActParam param_;
   param_.alg   = GetMKLDNNActAlgo(param);
@@ -192,8 +201,10 @@ mkldnn::eltwise_backward::primitive_desc GetActBwdDescImpl(const MKLDNNActParam&
 
 const inline mkldnn::eltwise_backward& MKLDNNActBackward::GetBwd() const { return *bwd_prim_; }
 
-static inline MKLDNNActBackward& GetActBackward(const MKLDNNActParam& param, const OpContext& ctx,
-                                                const NDArray& in_data, const NDArray& out_grad,
+static inline MKLDNNActBackward& GetActBackward(const MKLDNNActParam& param,
+                                                const OpContext& ctx,
+                                                const NDArray& in_data,
+                                                const NDArray& out_grad,
                                                 const mkldnn::memory& in_mem) {
 #if DMLC_CXX11_THREAD_LOCAL
   static thread_local std::unordered_map<MKLDNNActSignature, MKLDNNActBackward, OpHash> bwds;
@@ -214,8 +225,10 @@ static inline MKLDNNActBackward& GetActBackward(const MKLDNNActParam& param, con
 
 // For backward relu activation, it's okay to pass "out_data" as "in_data" to this
 // function, since the computation only involes non-zeros.
-void MKLDNNActivationBackward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
-                              const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+void MKLDNNActivationBackward(const nnvm::NodeAttrs& attrs,
+                              const OpContext& ctx,
+                              const std::vector<NDArray>& inputs,
+                              const std::vector<OpReqType>& req,
                               const std::vector<NDArray>& outputs) {
   if (req[0] == kNullOp) {
     return;
@@ -248,8 +261,10 @@ void MKLDNNActivationBackward(const nnvm::NodeAttrs& attrs, const OpContext& ctx
   stream->Submit();
 }
 
-void MKLDNNLeakyReluBackward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
-                             const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+void MKLDNNLeakyReluBackward(const nnvm::NodeAttrs& attrs,
+                             const OpContext& ctx,
+                             const std::vector<NDArray>& inputs,
+                             const std::vector<OpReqType>& req,
                              const std::vector<NDArray>& outputs) {
   if (req[0] == kNullOp) {
     return;

--- a/src/operator/nn/mkldnn/mkldnn_base-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_base-inl.h
@@ -172,8 +172,8 @@ static inline int GetMKLDNNCacheSize() {
 
 // TODO(alex): (MXNET-1075) Will remove env variable and calculate cache size during runtime
 template <typename S, typename I, typename H>
-static typename std::unordered_map<S, I, H>::iterator AddToCache(
-    std::unordered_map<S, I, H>* cache, const S& key, const I& item) {
+static typename std::unordered_map<S, I, H>::iterator AddToCache(std::unordered_map<S, I, H>* cache,
+                                                                 const S& key, const I& item) {
   int mkldnn_cache_size = GetMKLDNNCacheSize();
   if (mkldnn_cache_size != -1 && static_cast<int>(cache->size()) > mkldnn_cache_size)
     cache->erase(cache->begin());
@@ -309,8 +309,8 @@ inline static mkldnn::memory::desc GetFCWeightDesc(const NDArray& arr, int dtype
   return mkldnn::memory::desc{dims, get_mkldnn_type(dtype), format};
 }
 
-inline static mkldnn::memory::desc GetWeightDesc(
-    const NDArray& arr, int num_groups, bool quantized = false) {
+inline static mkldnn::memory::desc GetWeightDesc(const NDArray& arr, int num_groups,
+                                                 bool quantized = false) {
   int dtype = quantized ? mshadow::kInt8 : arr.dtype();
   if (num_groups == 1) {
     return GetMemDesc(arr, dtype);
@@ -328,13 +328,12 @@ inline static mkldnn::memory::desc GetWeightDesc(
     }
     switch (ndim) {
       case 3:
-        tz = mkldnn::memory::dims{
-            num_groups, arr.shape()[N] / num_groups, arr.shape()[C], arr.shape()[H]};
+        tz = mkldnn::memory::dims{num_groups, arr.shape()[N] / num_groups, arr.shape()[C],
+                                  arr.shape()[H]};
         break;
       case 4:
-        tz = mkldnn::memory::dims{
-            num_groups, arr.shape()[N] / num_groups, arr.shape()[C], arr.shape()[H],
-            arr.shape()[W]};
+        tz = mkldnn::memory::dims{num_groups, arr.shape()[N] / num_groups, arr.shape()[C],
+                                  arr.shape()[H], arr.shape()[W]};
         break;
       case 5:
         tz = mkldnn::memory::dims{num_groups,     arr.shape()[N] / num_groups,
@@ -474,8 +473,8 @@ void MKLDNNMemoryCopy(const mkldnn::memory& mem, const mkldnn::memory* this_mem)
  * the given one. operator== can't guarantee that. == can return true even if
  * the formats are different. I need to double check its format.
  */
-static inline mkldnn::memory* GetMKLDNNExact(
-    const mkldnn::memory* mem, const mkldnn::memory::desc& desc) {
+static inline mkldnn::memory* GetMKLDNNExact(const mkldnn::memory* mem,
+                                             const mkldnn::memory::desc& desc) {
   mkldnn::memory::desc src_desc = mem->get_desc();
   if (desc == src_desc) {
     return const_cast<mkldnn::memory*>(mem);
@@ -498,16 +497,15 @@ static inline mkldnn::memory* GetMKLDNNExact(
  * If these two functions are used, we have to call CommitOutput to write
  * the output back to the output NDArray.
  */
-mkldnn_output_t CreateMKLDNNMem(
-    const NDArray& out_arr, const mkldnn::memory::desc& desc, OpReqType req,
-    const NDArray* in_arr = nullptr);
-mkldnn_output_t CreateMKLDNNWeightGrad(
-    const NDArray& out_arr, const mkldnn::memory::desc& desc, OpReqType req);
+mkldnn_output_t CreateMKLDNNMem(const NDArray& out_arr, const mkldnn::memory::desc& desc,
+                                OpReqType req, const NDArray* in_arr = nullptr);
+mkldnn_output_t CreateMKLDNNWeightGrad(const NDArray& out_arr, const mkldnn::memory::desc& desc,
+                                       OpReqType req);
 /* This function has to be used with one of the functions above. */
 void CommitOutput(const NDArray& arr, const mkldnn_output_t& res);
 
-static inline void InvalidateOutputs(
-    const std::vector<NDArray>& arrs, const std::vector<OpReqType>& reqs) {
+static inline void InvalidateOutputs(const std::vector<NDArray>& arrs,
+                                     const std::vector<OpReqType>& reqs) {
   for (size_t i = 0; i < arrs.size(); i++) {
     if (reqs[i] == kWriteTo || reqs[i] == kNullOp) {
       const_cast<NDArray&>(arrs[i]).InvalidateMKLDNNData();
@@ -516,8 +514,8 @@ static inline void InvalidateOutputs(
 }
 
 // TODO(alexzai): (MXNET-856) Remove helper function after subgraph feature added
-static inline void CreateDefaultInputs(
-    const std::vector<NDArray>& arrs, std::vector<NDArray>* out_arrs) {
+static inline void CreateDefaultInputs(const std::vector<NDArray>& arrs,
+                                       std::vector<NDArray>* out_arrs) {
   out_arrs->clear();
   for (size_t i = 0; i < arrs.size(); ++i) {
     if (arrs[i].IsMKLDNNData())
@@ -529,8 +527,8 @@ static inline void CreateDefaultInputs(
 
 const mkldnn::memory* GetWeights(const NDArray& arr, int num_groups);
 
-const mkldnn::memory* GetWeights(
-    const NDArray& arr, const mkldnn::memory::desc& target_md, int num_groups);
+const mkldnn::memory* GetWeights(const NDArray& arr, const mkldnn::memory::desc& target_md,
+                                 int num_groups);
 
 bool IsDefaultFormat(const mkldnn::memory::desc& desc);
 bool IsMKLDNN(const mkldnn::memory::desc& desc);
@@ -623,9 +621,9 @@ class MKLDNNMemory {
 void ReorderTo(const mkldnn::memory* src, const mkldnn::memory* dst);
 
 template <typename Compute, typename AttrState>
-void FallBackCompute(
-    Compute fn, const AttrState& attrs, const OpContext& ctx, const std::vector<NDArray>& inputs,
-    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs);
+void FallBackCompute(Compute fn, const AttrState& attrs, const OpContext& ctx,
+                     const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+                     const std::vector<NDArray>& outputs);
 
 /*
  * This class is used to check the correctness of MKLDNN operators.
@@ -642,20 +640,19 @@ class OpCheck {
     this->num_checks = num_checks;
   }
 
-  void Init(
-      const std::vector<mxnet::NDArray>& inputs_, const std::vector<mxnet::NDArray>& outputs_);
+  void Init(const std::vector<mxnet::NDArray>& inputs_,
+            const std::vector<mxnet::NDArray>& outputs_);
 
-  void Run(
-      mxnet::FCompute fn, const nnvm::NodeAttrs& attrs, const mxnet::OpContext& ctx,
-      const std::vector<mxnet::NDArray>& inputs_, const std::vector<mxnet::OpReqType>& req,
-      const std::vector<mxnet::NDArray>& outputs_);
+  void Run(mxnet::FCompute fn, const nnvm::NodeAttrs& attrs, const mxnet::OpContext& ctx,
+           const std::vector<mxnet::NDArray>& inputs_, const std::vector<mxnet::OpReqType>& req,
+           const std::vector<mxnet::NDArray>& outputs_);
 
   void CopyResult(const std::vector<mxnet::NDArray>& outputs_, const std::vector<size_t>& indice);
 };
 
-bool MKLDNNStorageType(
-    const nnvm::NodeAttrs& attrs, const int dev_mask, bool support_mkldnn,
-    DispatchMode* dispatch_mode, std::vector<int>* in_attrs, std::vector<int>* out_attrs);
+bool MKLDNNStorageType(const nnvm::NodeAttrs& attrs, const int dev_mask, bool support_mkldnn,
+                       DispatchMode* dispatch_mode, std::vector<int>* in_attrs,
+                       std::vector<int>* out_attrs);
 
 #define MKLDNN_OPCHECK_INIT(backward, num_checks, inputs, outputs) \
   static bool debug = dmlc::GetEnv("MXNET_MKLDNN_DEBUG", false);   \
@@ -674,18 +671,17 @@ struct MKLDNNPostEltwiseParam {
   float beta            = 1.f;
 };
 
-void MKLDNNRun(
-    mxnet::FComputeEx fn, const nnvm::NodeAttrs& attrs, const mxnet::OpContext& ctx,
-    const std::vector<mxnet::NDArray>& inputs_, const std::vector<mxnet::OpReqType>& req,
-    const std::vector<mxnet::NDArray>& outputs_);
+void MKLDNNRun(mxnet::FComputeEx fn, const nnvm::NodeAttrs& attrs, const mxnet::OpContext& ctx,
+               const std::vector<mxnet::NDArray>& inputs_, const std::vector<mxnet::OpReqType>& req,
+               const std::vector<mxnet::NDArray>& outputs_);
 
-using FComputeExUnary = std::function<void(
-    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const NDArray& input, const OpReqType& req,
-    const NDArray& output)>;
+using FComputeExUnary =
+    std::function<void(const nnvm::NodeAttrs& attrs, const OpContext& ctx, const NDArray& input,
+                       const OpReqType& req, const NDArray& output)>;
 
-void MKLDNNRun(
-    FComputeExUnary fn, const nnvm::NodeAttrs& attrs, const mxnet::OpContext& ctx,
-    const mxnet::NDArray& inputs_, const mxnet::OpReqType& req, const mxnet::NDArray& outputs_);
+void MKLDNNRun(FComputeExUnary fn, const nnvm::NodeAttrs& attrs, const mxnet::OpContext& ctx,
+               const mxnet::NDArray& inputs_, const mxnet::OpReqType& req,
+               const mxnet::NDArray& outputs_);
 
 }  // namespace mxnet
 #endif

--- a/src/operator/nn/mkldnn/mkldnn_base-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_base-inl.h
@@ -92,7 +92,9 @@ class CpuEngine {
   CpuEngine& operator=(CpuEngine const&) = delete;  // Copy assign
   CpuEngine& operator=(CpuEngine&&) = delete;       // Move assign
 
-  mkldnn::engine& get_engine() { return _cpu_engine; }
+  mkldnn::engine& get_engine() {
+    return _cpu_engine;
+  }
 
  protected:
   CpuEngine() : _cpu_engine(mkldnn::engine::kind::cpu, 0) {}
@@ -140,7 +142,9 @@ static inline bool SupportMKLDNNArray(int dtype, const mxnet::TShape& shape) {
   return support;
 }
 
-static inline bool SupportStorageMKLDNN(int stype) { return stype == kDefaultStorage; }
+static inline bool SupportStorageMKLDNN(int stype) {
+  return stype == kDefaultStorage;
+}
 
 static inline bool SupportMKLDNN(int dtype, const mxnet::TShape& shape) {
   int ndim = shape.ndim();
@@ -171,7 +175,8 @@ static inline int GetMKLDNNCacheSize() {
   return mkldnn_cache_size;
 }
 
-// TODO(alex): (MXNET-1075) Will remove env variable and calculate cache size during runtime
+// TODO(alex): (MXNET-1075) Will remove env variable and calculate cache size
+// during runtime
 template <typename S, typename I, typename H>
 static typename std::unordered_map<S, I, H>::iterator AddToCache(std::unordered_map<S, I, H>* cache,
                                                                  const S& key,
@@ -278,7 +283,8 @@ static inline int get_mxnet_type(mkldnn_data_type_t dtype) {
 }
 
 static inline size_t GetMemDescSize(const mkldnn::memory::desc& md) {
-  if (md.data.ndims == 0) return 0;
+  if (md.data.ndims == 0)
+    return 0;
 
   size_t ret = 1;
   for (int i = 0; i < md.data.ndims; i++) {
@@ -293,7 +299,8 @@ inline static mkldnn::memory::desc GetMemDesc(const NDArray& arr, int dtype = -1
   int ndim = arr.shape().ndim();
   mkldnn::memory::dims dims(ndim);
   dtype = (dtype == -1) ? arr.dtype() : dtype;
-  for (size_t i = 0; i < dims.size(); i++) dims[i] = arr.shape()[i];
+  for (size_t i = 0; i < dims.size(); i++)
+    dims[i] = arr.shape()[i];
   return mkldnn::memory::desc{dims, get_mkldnn_type(dtype), mkldnn::memory::format_tag::any};
 }
 
@@ -301,7 +308,8 @@ inline static mkldnn::memory::desc GetFCWeightDesc(const NDArray& arr, int dtype
   int ndim = arr.shape().ndim();
   mkldnn::memory::dims dims(ndim);
   dtype = (dtype == -1) ? arr.dtype() : dtype;
-  for (size_t i = 0; i < dims.size(); i++) dims[i] = arr.shape()[i];
+  for (size_t i = 0; i < dims.size(); i++)
+    dims[i] = arr.shape()[i];
   auto format = mkldnn::memory::format_tag::any;
   // for batch 256 alexnet benchmark test
   if (dims.size() == 2) {
@@ -331,17 +339,23 @@ inline static mkldnn::memory::desc GetWeightDesc(const NDArray& arr,
     }
     switch (ndim) {
       case 3:
-        tz = mkldnn::memory::dims{num_groups, arr.shape()[N] / num_groups, arr.shape()[C],
-                                  arr.shape()[H]};
+        tz = mkldnn::memory::dims{
+            num_groups, arr.shape()[N] / num_groups, arr.shape()[C], arr.shape()[H]};
         break;
       case 4:
-        tz = mkldnn::memory::dims{num_groups, arr.shape()[N] / num_groups, arr.shape()[C],
-                                  arr.shape()[H], arr.shape()[W]};
+        tz = mkldnn::memory::dims{num_groups,
+                                  arr.shape()[N] / num_groups,
+                                  arr.shape()[C],
+                                  arr.shape()[H],
+                                  arr.shape()[W]};
         break;
       case 5:
-        tz = mkldnn::memory::dims{num_groups,     arr.shape()[N] / num_groups,
-                                  arr.shape()[C], arr.shape()[D],
-                                  arr.shape()[H], arr.shape()[W]};
+        tz = mkldnn::memory::dims{num_groups,
+                                  arr.shape()[N] / num_groups,
+                                  arr.shape()[C],
+                                  arr.shape()[D],
+                                  arr.shape()[H],
+                                  arr.shape()[W]};
     }
     return mkldnn::memory::desc{tz, get_mkldnn_type(dtype), mkldnn::memory::format_tag::any};
   }
@@ -409,8 +423,8 @@ class TmpMemMgr {
     // larger memory size.
     mem_size = std::max(mem_size, est_size);
     if (mem_size > 0) {
-      // Let's allocate some extra memory. If we don't use some of them all the time,
-      // the OS won't physically allocate pages for them any way.
+      // Let's allocate some extra memory. If we don't use some of them all the
+      // time, the OS won't physically allocate pages for them any way.
       this->curr_size = mem_size * 2;
       this->curr_mem  = static_cast<char*>(r.get_host_space_internal(this->curr_size));
     }
@@ -437,9 +451,13 @@ class MKLDNNStream {
     net_prim_args.emplace_back(prim, args);
   }
 
-  void RegisterMem(std::shared_ptr<const mkldnn::memory> mem) { mem_holder.push_back(mem); }
+  void RegisterMem(std::shared_ptr<const mkldnn::memory> mem) {
+    mem_holder.push_back(mem);
+  }
 
-  bool HasOps() const { return !net_prim_args.empty(); }
+  bool HasOps() const {
+    return !net_prim_args.empty();
+  }
 
   /*
    * After submitting mkldnn operations for execution, we need to
@@ -453,7 +471,8 @@ class MKLDNNStream {
       }
       net_prim_args.clear();
     }
-    if (cleanup) Cleanup();
+    if (cleanup)
+      Cleanup();
   }
 
   void Cleanup() {
@@ -519,7 +538,8 @@ static inline void InvalidateOutputs(const std::vector<NDArray>& arrs,
   }
 }
 
-// TODO(alexzai): (MXNET-856) Remove helper function after subgraph feature added
+// TODO(alexzai): (MXNET-856) Remove helper function after subgraph feature
+// added
 static inline void CreateDefaultInputs(const std::vector<NDArray>& arrs,
                                        std::vector<NDArray>* out_arrs) {
   out_arrs->clear();
@@ -545,16 +565,20 @@ mkldnn_format_tag_t GetDefaultFormat(int num_dims);
 mkldnn::memory::desc GetDesc(const mkldnn::memory::desc& md, const mkldnn_format_tag_t& format);
 
 inline bool same_shape(const mxnet::TShape& shape, const mkldnn_dims_t dims, int ndims) {
-  if (shape.ndim() != ndims) return false;
+  if (shape.ndim() != ndims)
+    return false;
   for (int i = 0; i < ndims; i++)
-    if (shape[i] != dims[i]) return false;
+    if (shape[i] != dims[i])
+      return false;
   return true;
 }
 
 inline bool same_shape(const mkldnn::memory::desc& desc1, const mkldnn::memory::desc& desc2) {
-  if (desc1.data.ndims != desc2.data.ndims) return false;
+  if (desc1.data.ndims != desc2.data.ndims)
+    return false;
   for (int i = 0; i < desc1.data.ndims; i++)
-    if (desc1.data.dims[i] != desc2.data.dims[i]) return false;
+    if (desc1.data.dims[i] != desc2.data.dims[i])
+      return false;
   return true;
 }
 
@@ -584,17 +608,29 @@ class MKLDNNMemory {
     size      = desc.get_size();
   }
 
-  void SetDataHandle(void* handle) { mem->set_data_handle(handle); }
+  void SetDataHandle(void* handle) {
+    mem->set_data_handle(handle);
+  }
 
-  void* GetDataHandle() const { return mem->get_data_handle(); }
+  void* GetDataHandle() const {
+    return mem->get_data_handle();
+  }
 
-  std::shared_ptr<mkldnn::memory> GetMem() const { return mem; }
+  std::shared_ptr<mkldnn::memory> GetMem() const {
+    return mem;
+  }
 
-  mkldnn::memory* GetRaw() const { return mem.get(); }
+  mkldnn::memory* GetRaw() const {
+    return mem.get();
+  }
 
-  size_t GetSize() const { return size; }
+  size_t GetSize() const {
+    return size;
+  }
 
-  mkldnn::memory::desc GetDesc() const { return mem->get_desc(); }
+  mkldnn::memory::desc GetDesc() const {
+    return mem->get_desc();
+  }
 
   mkldnn::memory::desc GetDesc(
       mkldnn_format_tag_t format,
@@ -608,11 +644,17 @@ class MKLDNNMemory {
     return data_md;
   }
 
-  mkldnn_format_tag_t GetDefaultFormat() const { return mxnet::GetDefaultFormat(desc); }
+  mkldnn_format_tag_t GetDefaultFormat() const {
+    return mxnet::GetDefaultFormat(desc);
+  }
 
-  bool IsMKLDNN() const { return mxnet::IsMKLDNN(desc); }
+  bool IsMKLDNN() const {
+    return mxnet::IsMKLDNN(desc);
+  }
 
-  bool SameFormat(mkldnn::memory::desc md) const { return mem->get_desc() == md; }
+  bool SameFormat(mkldnn::memory::desc md) const {
+    return mem->get_desc() == md;
+  }
 
   bool SameFormat(const mxnet::TShape& shape, int dtype) const {
     return same_shape(shape, dtype, desc);
@@ -673,12 +715,15 @@ bool MKLDNNStorageType(const nnvm::NodeAttrs& attrs,
 #define MKLDNN_OPCHECK_INIT(backward, num_checks, inputs, outputs) \
   static bool debug = dmlc::GetEnv("MXNET_MKLDNN_DEBUG", false);   \
   OpCheck check(backward, num_checks);                             \
-  if (debug) check.Init(inputs, outputs);
+  if (debug)                                                       \
+    check.Init(inputs, outputs);
 
 #define MKLDNN_OPCHECK_RUN(fn, attrs, ctx, inputs, req, outputs) \
-  if (debug) check.Run(fn, attrs, ctx, inputs, req, outputs);
+  if (debug)                                                     \
+    check.Run(fn, attrs, ctx, inputs, req, outputs);
 #define MKLDNN_OPCHECK_COPY_RESULT(outputs, indice) \
-  if (debug) check.CopyResult(outputs, indice);
+  if (debug)                                        \
+    check.CopyResult(outputs, indice);
 
 struct MKLDNNPostEltwiseParam {
   mkldnn::algorithm alg = mkldnn::algorithm::undef;

--- a/src/operator/nn/mkldnn/mkldnn_base-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_base-inl.h
@@ -206,16 +206,17 @@ struct ReshapeParam;
 bool SupportMKLDNNAct(const ActivationParam& param);
 bool SupportMKLDNNAct(const ActivationParam& param, const NDArray& input);
 bool SupportMKLDNNLeakyRelu(const LeakyReLUParam& param);
-bool SupportMKLDNNLeakyRelu(const LeakyReLUParam& param, const NDArray &input);
-bool SupportQuantizedMKLDNNAct(const ActivationParam &param);
-bool SupportMKLDNNConv(const ConvolutionParam &params, const NDArray &input);
-bool SupportMKLDNNDeconv(const DeconvolutionParam& params, const NDArray &input);
-bool SupportMKLDNNSoftmax(const SoftmaxParam& param, const NDArray &input, const NDArray &output);
-bool SupportMKLDNNLogSoftmax(const SoftmaxParam& param, const NDArray &input,
-                             const NDArray &output);
-bool SupportMKLDNNSoftmaxOutput(const SoftmaxOutputParam &param);
-bool SupportMKLDNNTranspose(const TransposeParam& param, const NDArray &data);
-bool SupportMKLDNNBatchDot(const std::vector<NDArray> &inputs, const NDArray &output);
+bool SupportMKLDNNLeakyRelu(const LeakyReLUParam& param, const NDArray& input);
+bool SupportQuantizedMKLDNNAct(const ActivationParam& param);
+bool SupportMKLDNNConv(const ConvolutionParam& params, const NDArray& input);
+bool SupportMKLDNNDeconv(const DeconvolutionParam& params, const NDArray& input);
+bool SupportMKLDNNSoftmax(const SoftmaxParam& param, const NDArray& input, const NDArray& output);
+bool SupportMKLDNNLogSoftmax(const SoftmaxParam& param,
+                             const NDArray& input,
+                             const NDArray& output);
+bool SupportMKLDNNSoftmaxOutput(const SoftmaxOutputParam& param);
+bool SupportMKLDNNTranspose(const TransposeParam& param, const NDArray& data);
+bool SupportMKLDNNBatchDot(const std::vector<NDArray>& inputs, const NDArray& output);
 }  // namespace op
 
 static int GetTypeSize(int dtype) {

--- a/src/operator/nn/mkldnn/mkldnn_base-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_base-inl.h
@@ -18,30 +18,30 @@
  */
 
 /*******************************************************************************
-* Copyright 2016-2017 Intel Corporation
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-* \file mkldnn_base-inl.h
-* \brief
-* \author young.jin.kim@intel.com
-*         ashok.emani@intel.com
-*         deepthi.karkada@intel.com
-*         louis.feng@intel.com
-*         adam.d.straw@intel.com
-*         zhengda1936@gmail.com
-*
-*******************************************************************************/
+ * Copyright 2016-2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \file mkldnn_base-inl.h
+ * \brief
+ * \author young.jin.kim@intel.com
+ *         ashok.emani@intel.com
+ *         deepthi.karkada@intel.com
+ *         louis.feng@intel.com
+ *         adam.d.straw@intel.com
+ *         zhengda1936@gmail.com
+ *
+ *******************************************************************************/
 
 #ifndef MXNET_OPERATOR_NN_MKLDNN_MKLDNN_BASE_INL_H_
 #define MXNET_OPERATOR_NN_MKLDNN_MKLDNN_BASE_INL_H_
@@ -60,22 +60,18 @@
 #include "mxnet/op_attr_types.h"
 #include "mxnet/resource.h"
 
-#define MKLDNN_REAL_TYPE_SWITCH(type, DType, ...)   \
-  switch (type) {                                   \
-  case mshadow::kFloat32:                           \
-    {                                               \
-      typedef float DType;                          \
-      {__VA_ARGS__}                                 \
-    }                                               \
-    break;                                          \
-  case mshadow::kBfloat16:                          \
-    {                                               \
-      typedef mshadow::bfloat::bf16_t DType;        \
-      {__VA_ARGS__}                                 \
-    }                                               \
-    break;                                          \
-  default:                                          \
-    LOG(FATAL) << "Unknown type enum " << type;     \
+#define MKLDNN_REAL_TYPE_SWITCH(type, DType, ...) \
+  switch (type) {                                 \
+    case mshadow::kFloat32: {                     \
+      typedef float DType;                        \
+      { __VA_ARGS__ }                             \
+    } break;                                      \
+    case mshadow::kBfloat16: {                    \
+      typedef mshadow::bfloat::bf16_t DType;      \
+      { __VA_ARGS__ }                             \
+    } break;                                      \
+    default:                                      \
+      LOG(FATAL) << "Unknown type enum " << type; \
   }
 
 namespace mxnet {
@@ -84,18 +80,18 @@ namespace mxnet {
 // cpu_engine singleton
 class CpuEngine {
  public:
-  static CpuEngine *Get() {
+  static CpuEngine* Get() {
     // I's thread-safe in C++11.
     // ensure same mkldnn engine is used across threads
     static CpuEngine myInstance;
     return &myInstance;
   }
-  CpuEngine(CpuEngine const &) = delete;             // Copy construct
-  CpuEngine(CpuEngine &&) = delete;                  // Move construct
-  CpuEngine &operator=(CpuEngine const &) = delete;  // Copy assign
-  CpuEngine &operator=(CpuEngine &&) = delete;       // Move assign
+  CpuEngine(CpuEngine const&) = delete;             // Copy construct
+  CpuEngine(CpuEngine&&)      = delete;             // Move construct
+  CpuEngine& operator=(CpuEngine const&) = delete;  // Copy assign
+  CpuEngine& operator=(CpuEngine&&) = delete;       // Move assign
 
-  mkldnn::engine &get_engine() { return _cpu_engine; }
+  mkldnn::engine& get_engine() { return _cpu_engine; }
 
  protected:
   CpuEngine() : _cpu_engine(mkldnn::engine::kind::cpu, 0) {}
@@ -134,37 +130,34 @@ struct data_type_enum<uint8_t> {
   enum { type = static_cast<unsigned int>(mkldnn::memory::data_type::u8) };
 };
 
-static inline bool SupportMKLDNNArray(int dtype, const mxnet::TShape &shape) {
-  int ndim = shape.ndim();
+static inline bool SupportMKLDNNArray(int dtype, const mxnet::TShape& shape) {
+  int ndim     = shape.ndim();
   bool support = ndim == 1 || ndim == 2 || ndim == 4;
-  support = support &&
+  support      = support &&
             (dtype == mshadow::kFloat32 || dtype == mshadow::kInt32 || dtype == mshadow::kInt8 ||
              dtype == mshadow::kUint8 || dtype == mshadow::kBfloat16);
   return support;
 }
 
-static inline bool SupportStorageMKLDNN(int stype) {
-  return stype == kDefaultStorage;
-}
+static inline bool SupportStorageMKLDNN(int stype) { return stype == kDefaultStorage; }
 
-static inline bool SupportMKLDNN(int dtype, const mxnet::TShape &shape) {
+static inline bool SupportMKLDNN(int dtype, const mxnet::TShape& shape) {
   int ndim = shape.ndim();
   if (ndim == 0 || shape.Size() == 0) {
     // MKLDNN currently does not support 0-dim Tensor and 0-size Tensor
     return false;
   }
   return (dtype == mshadow::kFloat32 || dtype == mshadow::kBfloat16) &&
-                    (ndim == 1 || ndim == 2 || ndim == 4);
+         (ndim == 1 || ndim == 2 || ndim == 4);
 }
 
 static inline bool SupportMKLDNNQuantize(int dtype) {
-  return dtype == mshadow::kFloat32 || dtype == mshadow::kInt8 ||
-         dtype == mshadow::kUint8 || dtype == mshadow::kBfloat16;
+  return dtype == mshadow::kFloat32 || dtype == mshadow::kInt8 || dtype == mshadow::kUint8 ||
+         dtype == mshadow::kBfloat16;
 }
 
-static inline bool SupportMKLDNN(const NDArray &input) {
-  return SupportMKLDNN(input.dtype(), input.shape())
-      && SupportStorageMKLDNN(input.storage_type());
+static inline bool SupportMKLDNN(const NDArray& input) {
+  return SupportMKLDNN(input.dtype(), input.shape()) && SupportStorageMKLDNN(input.storage_type());
 }
 
 static inline bool MKLDNNEnvSet() {
@@ -178,9 +171,9 @@ static inline int GetMKLDNNCacheSize() {
 }
 
 // TODO(alex): (MXNET-1075) Will remove env variable and calculate cache size during runtime
-template<typename S, typename I, typename H>
+template <typename S, typename I, typename H>
 static typename std::unordered_map<S, I, H>::iterator AddToCache(
-    std::unordered_map<S, I, H>* cache, const S &key, const I &item) {
+    std::unordered_map<S, I, H>* cache, const S& key, const I& item) {
   int mkldnn_cache_size = GetMKLDNNCacheSize();
   if (mkldnn_cache_size != -1 && static_cast<int>(cache->size()) > mkldnn_cache_size)
     cache->erase(cache->begin());
@@ -192,7 +185,7 @@ static typename std::unordered_map<S, I, H>::iterator AddToCache(
 /*
  * This is to align address to a certain alignment.
  */
-void *AlignMem(void *mem, size_t size, size_t alignment, size_t *space);
+void* AlignMem(void* mem, size_t size, size_t alignment, size_t* space);
 
 namespace op {
 struct ActivationParam;
@@ -204,7 +197,7 @@ struct SoftmaxOutputParam;
 struct TransposeParam;
 struct ReshapeParam;
 bool SupportMKLDNNAct(const ActivationParam& param);
-bool SupportMKLDNNAct(const ActivationParam& param, const NDArray &input);
+bool SupportMKLDNNAct(const ActivationParam& param, const NDArray& input);
 bool SupportMKLDNNLeakyRelu(const LeakyReLUParam& param);
 bool SupportMKLDNNLeakyRelu(const LeakyReLUParam& param, const NDArray &input);
 bool SupportQuantizedMKLDNNAct(const ActivationParam &param);
@@ -220,13 +213,11 @@ bool SupportMKLDNNBatchDot(const std::vector<NDArray> &inputs, const NDArray &ou
 
 static int GetTypeSize(int dtype) {
   int size = -1;
-  MSHADOW_TYPE_SWITCH(dtype, DType, {
-    size = sizeof(DType);
-  });
+  MSHADOW_TYPE_SWITCH(dtype, DType, { size = sizeof(DType); });
   return size;
 }
 
-static inline size_t GetArraySize(const NDArray &arr) {
+static inline size_t GetArraySize(const NDArray& arr) {
   if (arr.IsMKLDNNData()) {
     return arr.GetMKLDNNData()->get_desc().get_size();
   }
@@ -251,7 +242,7 @@ static inline mkldnn::memory::data_type get_mkldnn_type(int dtype) {
   }
 }
 
-template<typename T>
+template <typename T>
 static inline mkldnn::memory::data_type get_mkldnn_type() {
   return static_cast<mkldnn::memory::data_type>(data_type_enum<T>::type);
 }
@@ -260,11 +251,10 @@ static inline mkldnn_data_type_t get_mkldnn_type_t(int dtype) {
   return static_cast<mkldnn_data_type_t>(get_mkldnn_type(dtype));
 }
 
-template<typename T>
+template <typename T>
 static inline mkldnn_data_type_t get_mkldnn_type_t() {
   return static_cast<mkldnn_data_type_t>(data_type_enum<T>::type);
 }
-
 
 static inline int get_mxnet_type(mkldnn_data_type_t dtype) {
   auto mkldnn_dtype = static_cast<mkldnn::memory::data_type>(dtype);
@@ -285,7 +275,7 @@ static inline int get_mxnet_type(mkldnn_data_type_t dtype) {
   }
 }
 
-static inline size_t GetMemDescSize(const mkldnn::memory::desc &md) {
+static inline size_t GetMemDescSize(const mkldnn::memory::desc& md) {
   if (md.data.ndims == 0) return 0;
 
   size_t ret = 1;
@@ -297,7 +287,7 @@ static inline size_t GetMemDescSize(const mkldnn::memory::desc &md) {
   return ret;
 }
 
-inline static mkldnn::memory::desc GetMemDesc(const NDArray &arr, int dtype = -1) {
+inline static mkldnn::memory::desc GetMemDesc(const NDArray& arr, int dtype = -1) {
   int ndim = arr.shape().ndim();
   mkldnn::memory::dims dims(ndim);
   dtype = (dtype == -1) ? arr.dtype() : dtype;
@@ -305,7 +295,7 @@ inline static mkldnn::memory::desc GetMemDesc(const NDArray &arr, int dtype = -1
   return mkldnn::memory::desc{dims, get_mkldnn_type(dtype), mkldnn::memory::format_tag::any};
 }
 
-inline static mkldnn::memory::desc GetFCWeightDesc(const NDArray &arr, int dtype = -1) {
+inline static mkldnn::memory::desc GetFCWeightDesc(const NDArray& arr, int dtype = -1) {
   int ndim = arr.shape().ndim();
   mkldnn::memory::dims dims(ndim);
   dtype = (dtype == -1) ? arr.dtype() : dtype;
@@ -319,9 +309,8 @@ inline static mkldnn::memory::desc GetFCWeightDesc(const NDArray &arr, int dtype
   return mkldnn::memory::desc{dims, get_mkldnn_type(dtype), format};
 }
 
-inline static mkldnn::memory::desc GetWeightDesc(const NDArray &arr,
-                                                 int num_groups,
-                                                 bool quantized = false) {
+inline static mkldnn::memory::desc GetWeightDesc(
+    const NDArray& arr, int num_groups, bool quantized = false) {
   int dtype = quantized ? mshadow::kInt8 : arr.dtype();
   if (num_groups == 1) {
     return GetMemDesc(arr, dtype);
@@ -340,25 +329,24 @@ inline static mkldnn::memory::desc GetWeightDesc(const NDArray &arr,
     switch (ndim) {
       case 3:
         tz = mkldnn::memory::dims{
-                num_groups, arr.shape()[N] / num_groups,
-                arr.shape()[C], arr.shape()[H]};
+            num_groups, arr.shape()[N] / num_groups, arr.shape()[C], arr.shape()[H]};
         break;
       case 4:
         tz = mkldnn::memory::dims{
-                num_groups, arr.shape()[N] / num_groups,
-                arr.shape()[C], arr.shape()[H], arr.shape()[W]};
+            num_groups, arr.shape()[N] / num_groups, arr.shape()[C], arr.shape()[H],
+            arr.shape()[W]};
         break;
       case 5:
-        tz = mkldnn::memory::dims{
-                num_groups, arr.shape()[N] / num_groups,
-                arr.shape()[C], arr.shape()[D], arr.shape()[H], arr.shape()[W]};
+        tz = mkldnn::memory::dims{num_groups,     arr.shape()[N] / num_groups,
+                                  arr.shape()[C], arr.shape()[D],
+                                  arr.shape()[H], arr.shape()[W]};
     }
     return mkldnn::memory::desc{tz, get_mkldnn_type(dtype), mkldnn::memory::format_tag::any};
   }
 }
 
-inline static bool CheckMKLDNNInputArrayIsView(const std::vector<NDArray> &inputs) {
-  for (const auto &in : inputs) {
+inline static bool CheckMKLDNNInputArrayIsView(const std::vector<NDArray>& inputs) {
+  for (const auto& in : inputs) {
     if (in.IsView() && in.IsMKLDNNData()) {
       return true;
     }
@@ -381,7 +369,7 @@ typedef std::shared_ptr<const mkldnn::memory> mkldnn_mem_const_ptr;
  */
 class TmpMemMgr {
   // This points to the memory buffer where we can allocate temp memory.
-  char *curr_mem;
+  char* curr_mem;
   // The total size of the temp memory.
   size_t mem_size;
   // This contains the current available memory size.
@@ -391,7 +379,7 @@ class TmpMemMgr {
   const size_t alignment = kMKLDNNAlign;
 
  public:
-  static TmpMemMgr *Get() {
+  static TmpMemMgr* Get() {
 #if DMLC_CXX11_THREAD_LOCAL
     static thread_local TmpMemMgr mgr;
 #else
@@ -407,14 +395,14 @@ class TmpMemMgr {
   }
 
   void Reset() {
-    curr_mem = nullptr;
+    curr_mem  = nullptr;
     curr_size = 0;
     // We don't reset est_size and mem_size because est_size contains the
     // estimated temp memory size from the last run and mem_size contains the
     // memroy size allocated in the last run.
   }
 
-  void Init(const Resource &r) {
+  void Init(const Resource& r) {
     // If the last time, if we estimate that we need more memory, we should the
     // larger memory size.
     mem_size = std::max(mem_size, est_size);
@@ -422,39 +410,34 @@ class TmpMemMgr {
       // Let's allocate some extra memory. If we don't use some of them all the time,
       // the OS won't physically allocate pages for them any way.
       this->curr_size = mem_size * 2;
-      this->curr_mem = static_cast<char *>(r.get_host_space_internal(this->curr_size));
+      this->curr_mem  = static_cast<char*>(r.get_host_space_internal(this->curr_size));
     }
     // reset est_size, so we can start to estimate the temp memory size.
     this->est_size = 0;
   }
 
-  mkldnn::memory *Alloc(const mkldnn::memory::desc &md);
+  mkldnn::memory* Alloc(const mkldnn::memory::desc& md);
 };
 
 typedef std::unordered_map<int, mkldnn::memory> mkldnn_args_map_t;
 class MKLDNNStream {
-  std::vector<std::pair<mkldnn::primitive, mkldnn_args_map_t> > net_prim_args;
+  std::vector<std::pair<mkldnn::primitive, mkldnn_args_map_t>> net_prim_args;
   // Here we hold all memory related to the operators in the stream.
-  std::vector<std::shared_ptr<const mkldnn::memory> > mem_holder;
+  std::vector<std::shared_ptr<const mkldnn::memory>> mem_holder;
   mkldnn::stream s;
 
  public:
-  static MKLDNNStream *Get();
+  static MKLDNNStream* Get();
 
-  MKLDNNStream(): s(CpuEngine::Get()->get_engine()) {}
+  MKLDNNStream() : s(CpuEngine::Get()->get_engine()) {}
 
-  void RegisterPrimArgs(const mkldnn::primitive &prim,
-                        const mkldnn_args_map_t &args) {
+  void RegisterPrimArgs(const mkldnn::primitive& prim, const mkldnn_args_map_t& args) {
     net_prim_args.emplace_back(prim, args);
   }
 
-  void RegisterMem(std::shared_ptr<const mkldnn::memory> mem) {
-    mem_holder.push_back(mem);
-  }
+  void RegisterMem(std::shared_ptr<const mkldnn::memory> mem) { mem_holder.push_back(mem); }
 
-  bool HasOps() const {
-    return !net_prim_args.empty();
-  }
+  bool HasOps() const { return !net_prim_args.empty(); }
 
   /*
    * After submitting mkldnn operations for execution, we need to
@@ -463,13 +446,12 @@ class MKLDNNStream {
    */
   void Submit(bool cleanup = true) {
     if (!net_prim_args.empty()) {
-      for (auto &v : net_prim_args) {
+      for (auto& v : net_prim_args) {
         v.first.execute(s, v.second);
       }
       net_prim_args.clear();
     }
-    if (cleanup)
-      Cleanup();
+    if (cleanup) Cleanup();
   }
 
   void Cleanup() {
@@ -484,22 +466,22 @@ enum OutDataOp {
   AddBack,
 };
 
-typedef std::pair<OutDataOp, mkldnn::memory *> mkldnn_output_t;
-void MKLDNNMemoryCopy(const mkldnn::memory &mem, const mkldnn::memory* this_mem);
+typedef std::pair<OutDataOp, mkldnn::memory*> mkldnn_output_t;
+void MKLDNNMemoryCopy(const mkldnn::memory& mem, const mkldnn::memory* this_mem);
 
 /*
  * Here we want to get MKLDNN memory whose desc is exactly the same as
  * the given one. operator== can't guarantee that. == can return true even if
  * the formats are different. I need to double check its format.
  */
-static inline mkldnn::memory *GetMKLDNNExact(
-    const mkldnn::memory *mem, const mkldnn::memory::desc &desc) {
+static inline mkldnn::memory* GetMKLDNNExact(
+    const mkldnn::memory* mem, const mkldnn::memory::desc& desc) {
   mkldnn::memory::desc src_desc = mem->get_desc();
   if (desc == src_desc) {
-    return const_cast<mkldnn::memory *>(mem);
+    return const_cast<mkldnn::memory*>(mem);
   } else {
-    std::shared_ptr<mkldnn::memory> ret(new mkldnn::memory(
-            desc, CpuEngine::Get()->get_engine(), mem->get_data_handle()));
+    std::shared_ptr<mkldnn::memory> ret(
+        new mkldnn::memory(desc, CpuEngine::Get()->get_engine(), mem->get_data_handle()));
     MKLDNNStream::Get()->RegisterMem(ret);
     return ret.get();
   }
@@ -516,27 +498,26 @@ static inline mkldnn::memory *GetMKLDNNExact(
  * If these two functions are used, we have to call CommitOutput to write
  * the output back to the output NDArray.
  */
-mkldnn_output_t CreateMKLDNNMem(const NDArray &out_arr,
-                                const mkldnn::memory::desc &desc,
-                                OpReqType req, const NDArray* in_arr = nullptr);
-mkldnn_output_t CreateMKLDNNWeightGrad(const NDArray &out_arr,
-                                       const mkldnn::memory::desc &desc,
-                                       OpReqType req);
+mkldnn_output_t CreateMKLDNNMem(
+    const NDArray& out_arr, const mkldnn::memory::desc& desc, OpReqType req,
+    const NDArray* in_arr = nullptr);
+mkldnn_output_t CreateMKLDNNWeightGrad(
+    const NDArray& out_arr, const mkldnn::memory::desc& desc, OpReqType req);
 /* This function has to be used with one of the functions above. */
-void CommitOutput(const NDArray &arr, const mkldnn_output_t &res);
+void CommitOutput(const NDArray& arr, const mkldnn_output_t& res);
 
-static inline void InvalidateOutputs(const std::vector<NDArray> &arrs,
-                                     const std::vector<OpReqType> &reqs) {
+static inline void InvalidateOutputs(
+    const std::vector<NDArray>& arrs, const std::vector<OpReqType>& reqs) {
   for (size_t i = 0; i < arrs.size(); i++) {
     if (reqs[i] == kWriteTo || reqs[i] == kNullOp) {
-      const_cast<NDArray &>(arrs[i]).InvalidateMKLDNNData();
+      const_cast<NDArray&>(arrs[i]).InvalidateMKLDNNData();
     }
   }
 }
 
 // TODO(alexzai): (MXNET-856) Remove helper function after subgraph feature added
-static inline void CreateDefaultInputs(const std::vector<NDArray> &arrs,
-                                       std::vector<NDArray> *out_arrs) {
+static inline void CreateDefaultInputs(
+    const std::vector<NDArray>& arrs, std::vector<NDArray>* out_arrs) {
   out_arrs->clear();
   for (size_t i = 0; i < arrs.size(); ++i) {
     if (arrs[i].IsMKLDNNData())
@@ -546,42 +527,35 @@ static inline void CreateDefaultInputs(const std::vector<NDArray> &arrs,
   }
 }
 
-const mkldnn::memory *GetWeights(const NDArray &arr, int num_groups);
+const mkldnn::memory* GetWeights(const NDArray& arr, int num_groups);
 
-const mkldnn::memory *GetWeights(const NDArray &arr,
-                                 const mkldnn::memory::desc &target_md,
-                                 int num_groups);
+const mkldnn::memory* GetWeights(
+    const NDArray& arr, const mkldnn::memory::desc& target_md, int num_groups);
 
-bool IsDefaultFormat(const mkldnn::memory::desc &desc);
-bool IsMKLDNN(const mkldnn::memory::desc &desc);
+bool IsDefaultFormat(const mkldnn::memory::desc& desc);
+bool IsMKLDNN(const mkldnn::memory::desc& desc);
 
-mkldnn_format_tag_t GetDefaultFormat(const mkldnn::memory::desc &md);
+mkldnn_format_tag_t GetDefaultFormat(const mkldnn::memory::desc& md);
 mkldnn_format_tag_t GetDefaultFormat(int num_dims);
-mkldnn::memory::desc GetDesc(const mkldnn::memory::desc &md, const mkldnn_format_tag_t &format);
+mkldnn::memory::desc GetDesc(const mkldnn::memory::desc& md, const mkldnn_format_tag_t& format);
 
-inline bool same_shape(const mxnet::TShape &shape, const mkldnn_dims_t dims, int ndims) {
-  if (shape.ndim() != ndims)
-    return false;
+inline bool same_shape(const mxnet::TShape& shape, const mkldnn_dims_t dims, int ndims) {
+  if (shape.ndim() != ndims) return false;
   for (int i = 0; i < ndims; i++)
-    if (shape[i] != dims[i])
-      return false;
+    if (shape[i] != dims[i]) return false;
   return true;
 }
 
-inline bool same_shape(const mkldnn::memory::desc &desc1,
-                       const mkldnn::memory::desc &desc2) {
-  if (desc1.data.ndims != desc2.data.ndims)
-    return false;
+inline bool same_shape(const mkldnn::memory::desc& desc1, const mkldnn::memory::desc& desc2) {
+  if (desc1.data.ndims != desc2.data.ndims) return false;
   for (int i = 0; i < desc1.data.ndims; i++)
-    if (desc1.data.dims[i] != desc2.data.dims[i])
-      return false;
+    if (desc1.data.dims[i] != desc2.data.dims[i]) return false;
   return true;
 }
 
-inline bool same_shape(const mxnet::TShape &shape, int dtype,
-                       const mkldnn::memory::desc &desc) {
-  return same_shape(shape, desc.data.dims, desc.data.ndims)
-      && get_mkldnn_type(dtype) == desc.data.data_type;
+inline bool same_shape(const mxnet::TShape& shape, int dtype, const mkldnn::memory::desc& desc) {
+  return same_shape(shape, desc.data.dims, desc.data.ndims) &&
+         get_mkldnn_type(dtype) == desc.data.data_type;
 }
 
 /*
@@ -592,85 +566,66 @@ inline bool same_shape(const mxnet::TShape &shape, int dtype,
 class MKLDNNMemory {
   std::shared_ptr<mkldnn::memory> mem;
   mkldnn::memory::desc desc;
-  size_t size;      // The number of bytes.
+  size_t size;  // The number of bytes.
 
  public:
-  MKLDNNMemory(mkldnn::memory::desc md, void *addr): desc(md) {
+  MKLDNNMemory(mkldnn::memory::desc md, void* addr) : desc(md) {
     mem.reset(new mkldnn::memory(md, CpuEngine::Get()->get_engine(), addr));
     size = desc.get_size();
   }
 
-  explicit MKLDNNMemory(std::shared_ptr<mkldnn::memory> mem): desc(
-      mem->get_desc()) {
+  explicit MKLDNNMemory(std::shared_ptr<mkldnn::memory> mem) : desc(mem->get_desc()) {
     this->mem = mem;
-    size = desc.get_size();
+    size      = desc.get_size();
   }
 
-  void SetDataHandle(void *handle) {
-    mem->set_data_handle(handle);
-  }
+  void SetDataHandle(void* handle) { mem->set_data_handle(handle); }
 
-  void *GetDataHandle() const {
-    return mem->get_data_handle();
-  }
+  void* GetDataHandle() const { return mem->get_data_handle(); }
 
-  std::shared_ptr<mkldnn::memory> GetMem() const {
-    return mem;
-  }
+  std::shared_ptr<mkldnn::memory> GetMem() const { return mem; }
 
-  mkldnn::memory *GetRaw() const {
-    return mem.get();
-  }
+  mkldnn::memory* GetRaw() const { return mem.get(); }
 
-  size_t GetSize() const {
-    return size;
-  }
+  size_t GetSize() const { return size; }
 
-  mkldnn::memory::desc GetDesc() const {
-    return mem->get_desc();
-  }
+  mkldnn::memory::desc GetDesc() const { return mem->get_desc(); }
 
-  mkldnn::memory::desc GetDesc(mkldnn_format_tag_t format,
-          mkldnn::memory::data_type data_type = mkldnn::memory::data_type::undef) const {
+  mkldnn::memory::desc GetDesc(
+      mkldnn_format_tag_t format,
+      mkldnn::memory::data_type data_type = mkldnn::memory::data_type::undef) const {
     mkldnn::memory::dims dims(desc.data.dims, desc.data.dims + desc.data.ndims);
-    mkldnn::memory::data_type cpp_type = (data_type == mkldnn::memory::data_type::undef)
-                        ? static_cast<mkldnn::memory::data_type>(desc.data.data_type) : data_type;
-    mkldnn::memory::desc data_md(dims, cpp_type,
-        static_cast<mkldnn::memory::format_tag>(format));
+    mkldnn::memory::data_type cpp_type =
+        (data_type == mkldnn::memory::data_type::undef)
+            ? static_cast<mkldnn::memory::data_type>(desc.data.data_type)
+            : data_type;
+    mkldnn::memory::desc data_md(dims, cpp_type, static_cast<mkldnn::memory::format_tag>(format));
     return data_md;
   }
 
-  mkldnn_format_tag_t GetDefaultFormat() const {
-    return mxnet::GetDefaultFormat(desc);
-  }
+  mkldnn_format_tag_t GetDefaultFormat() const { return mxnet::GetDefaultFormat(desc); }
 
-  bool IsMKLDNN() const {
-    return mxnet::IsMKLDNN(desc);
-  }
+  bool IsMKLDNN() const { return mxnet::IsMKLDNN(desc); }
 
-  bool SameFormat(mkldnn::memory::desc md) const {
-    return mem->get_desc() == md;
-  }
+  bool SameFormat(mkldnn::memory::desc md) const { return mem->get_desc() == md; }
 
-  bool SameFormat(const mxnet::TShape &shape, int dtype) const {
+  bool SameFormat(const mxnet::TShape& shape, int dtype) const {
     return same_shape(shape, dtype, desc);
   }
 
-  void ReorderTo(mkldnn::memory *other) const {
+  void ReorderTo(mkldnn::memory* other) const {
     mkldnn::stream s(CpuEngine::Get()->get_engine());
     mkldnn::reorder(*mem, *other).execute(s, *mem, *other);
   }
 };
 
 // reorder mkldnn src to dst format dtype
-void ReorderTo(const mkldnn::memory *src, const mkldnn::memory *dst);
+void ReorderTo(const mkldnn::memory* src, const mkldnn::memory* dst);
 
 template <typename Compute, typename AttrState>
-void FallBackCompute(Compute fn, const AttrState &attrs,
-                     const OpContext &ctx,
-                     const std::vector<NDArray> &inputs,
-                     const std::vector<OpReqType> &req,
-                     const std::vector<NDArray> &outputs);
+void FallBackCompute(
+    Compute fn, const AttrState& attrs, const OpContext& ctx, const std::vector<NDArray>& inputs,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs);
 
 /*
  * This class is used to check the correctness of MKLDNN operators.
@@ -683,66 +638,54 @@ class OpCheck {
 
  public:
   OpCheck(bool backward, size_t num_checks) {
-    this->backward = backward;
+    this->backward   = backward;
     this->num_checks = num_checks;
   }
 
-  void Init(const std::vector<mxnet::NDArray> &inputs_,
-          const std::vector<mxnet::NDArray> &outputs_);
+  void Init(
+      const std::vector<mxnet::NDArray>& inputs_, const std::vector<mxnet::NDArray>& outputs_);
 
-  void Run(mxnet::FCompute fn, const nnvm::NodeAttrs &attrs,
-           const mxnet::OpContext &ctx,
-           const std::vector<mxnet::NDArray> &inputs_,
-           const std::vector<mxnet::OpReqType> &req,
-           const std::vector<mxnet::NDArray> &outputs_);
+  void Run(
+      mxnet::FCompute fn, const nnvm::NodeAttrs& attrs, const mxnet::OpContext& ctx,
+      const std::vector<mxnet::NDArray>& inputs_, const std::vector<mxnet::OpReqType>& req,
+      const std::vector<mxnet::NDArray>& outputs_);
 
-  void CopyResult(const std::vector<mxnet::NDArray> &outputs_,
-                  const std::vector<size_t>& indice);
+  void CopyResult(const std::vector<mxnet::NDArray>& outputs_, const std::vector<size_t>& indice);
 };
 
-bool MKLDNNStorageType(const nnvm::NodeAttrs &attrs,
-                       const int dev_mask,
-                       bool support_mkldnn,
-                       DispatchMode *dispatch_mode,
-                       std::vector<int> *in_attrs,
-                       std::vector<int> *out_attrs);
+bool MKLDNNStorageType(
+    const nnvm::NodeAttrs& attrs, const int dev_mask, bool support_mkldnn,
+    DispatchMode* dispatch_mode, std::vector<int>* in_attrs, std::vector<int>* out_attrs);
 
-#define MKLDNN_OPCHECK_INIT(backward, num_checks, inputs, outputs)  \
-    static bool debug = dmlc::GetEnv("MXNET_MKLDNN_DEBUG", false);  \
-    OpCheck check(backward, num_checks);                            \
-    if (debug) check.Init(inputs, outputs);
+#define MKLDNN_OPCHECK_INIT(backward, num_checks, inputs, outputs) \
+  static bool debug = dmlc::GetEnv("MXNET_MKLDNN_DEBUG", false);   \
+  OpCheck check(backward, num_checks);                             \
+  if (debug) check.Init(inputs, outputs);
 
-#define MKLDNN_OPCHECK_RUN(fn, attrs, ctx, inputs, req, outputs)    \
-    if (debug) check.Run(fn, attrs, ctx, inputs, req, outputs);
+#define MKLDNN_OPCHECK_RUN(fn, attrs, ctx, inputs, req, outputs) \
+  if (debug) check.Run(fn, attrs, ctx, inputs, req, outputs);
 #define MKLDNN_OPCHECK_COPY_RESULT(outputs, indice) \
-    if (debug) check.CopyResult(outputs, indice);
+  if (debug) check.CopyResult(outputs, indice);
 
 struct MKLDNNPostEltwiseParam {
   mkldnn::algorithm alg = mkldnn::algorithm::undef;
-  float scale = 1.f;
-  float alpha = 0.f;
-  float beta = 1.f;
+  float scale           = 1.f;
+  float alpha           = 0.f;
+  float beta            = 1.f;
 };
 
-void MKLDNNRun(mxnet::FComputeEx fn,
-               const nnvm::NodeAttrs &attrs,
-               const mxnet::OpContext &ctx,
-               const std::vector<mxnet::NDArray> &inputs_,
-               const std::vector<mxnet::OpReqType> &req,
-               const std::vector<mxnet::NDArray> &outputs_);
+void MKLDNNRun(
+    mxnet::FComputeEx fn, const nnvm::NodeAttrs& attrs, const mxnet::OpContext& ctx,
+    const std::vector<mxnet::NDArray>& inputs_, const std::vector<mxnet::OpReqType>& req,
+    const std::vector<mxnet::NDArray>& outputs_);
 
-using FComputeExUnary = std::function<void (const nnvm::NodeAttrs& attrs,
-                                       const OpContext& ctx,
-                                       const NDArray& input,
-                                       const OpReqType& req,
-                                       const NDArray& output)>;
+using FComputeExUnary = std::function<void(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const NDArray& input, const OpReqType& req,
+    const NDArray& output)>;
 
-void MKLDNNRun(FComputeExUnary fn,
-               const nnvm::NodeAttrs &attrs,
-               const mxnet::OpContext &ctx,
-               const mxnet::NDArray &inputs_,
-               const mxnet::OpReqType &req,
-               const mxnet::NDArray &outputs_);
+void MKLDNNRun(
+    FComputeExUnary fn, const nnvm::NodeAttrs& attrs, const mxnet::OpContext& ctx,
+    const mxnet::NDArray& inputs_, const mxnet::OpReqType& req, const mxnet::NDArray& outputs_);
 
 }  // namespace mxnet
 #endif

--- a/src/operator/nn/mkldnn/mkldnn_base.cc
+++ b/src/operator/nn/mkldnn/mkldnn_base.cc
@@ -94,8 +94,8 @@ void MKLDNNMemoryCopy(const mkldnn::memory& mem, const mkldnn::memory* this_mem)
     // shape.
     mkldnn::memory::dims dims(this_desc.data.dims, this_desc.data.dims + this_desc.data.ndims);
     auto this_dtype = static_cast<mkldnn::memory::data_type>(this_desc.data.data_type);
-    mkldnn::memory::desc data_md(
-        dims, this_dtype, static_cast<mkldnn::memory::format_tag>(this_def_format));
+    mkldnn::memory::desc data_md(dims, this_dtype,
+                                 static_cast<mkldnn::memory::format_tag>(this_def_format));
 
     mkldnn_mem_ptr tmp_mem(new mkldnn::memory(data_md, mem.get_engine(), mem.get_data_handle()));
     stream->RegisterMem(tmp_mem);
@@ -160,9 +160,8 @@ bool CanWriteTo(const NDArray& out_arr, const NDArray& in_arr, const mkldnn::mem
   return add_same && pdesc_same;
 }
 
-mkldnn_output_t CreateMKLDNNMem(
-    const NDArray& out_arr, const mkldnn::memory::desc& desc, OpReqType req,
-    const NDArray* in_arr) {
+mkldnn_output_t CreateMKLDNNMem(const NDArray& out_arr, const mkldnn::memory::desc& desc,
+                                OpReqType req, const NDArray* in_arr) {
   if (kAddTo == req) {
     auto tmp = TmpMemMgr::Get()->Alloc(desc);
     return mkldnn_output_t(OutDataOp::AddBack, tmp);
@@ -187,8 +186,8 @@ mkldnn_output_t CreateMKLDNNMem(
   return mkldnn_output_t(OutDataOp::Noop, tmp);
 }
 
-mkldnn_output_t CreateMKLDNNWeightGrad(
-    const NDArray& out_arr, const mkldnn::memory::desc& desc, OpReqType req) {
+mkldnn_output_t CreateMKLDNNWeightGrad(const NDArray& out_arr, const mkldnn::memory::desc& desc,
+                                       OpReqType req) {
   if (kAddTo == req) {
     auto tmp = TmpMemMgr::Get()->Alloc(desc);
     return mkldnn_output_t(OutDataOp::AddBack, tmp);
@@ -243,27 +242,24 @@ const mkldnn::memory* GetWeights(const NDArray& arr, int num_groups) {
     tz         = mkldnn::memory::dims{arr.shape()[O], arr.shape()[I]};
     format_tag = mkldnn::memory::format_tag::oi;
   } else if (ndim == 3) {
-    tz = num_groups > 1
-             ? mkldnn::memory::
-                   dims{num_groups, arr.shape()[O] / num_groups, arr.shape()[I], arr.shape()[H]}
-             : mkldnn::memory::dims{arr.shape()[O], arr.shape()[I], arr.shape()[H]};
+    tz = num_groups > 1 ? mkldnn::memory::dims{num_groups, arr.shape()[O] / num_groups,
+                                               arr.shape()[I], arr.shape()[H]}
+                        : mkldnn::memory::dims{arr.shape()[O], arr.shape()[I], arr.shape()[H]};
     format_tag =
         num_groups > 1 ? mkldnn::memory::format_tag::goiw : mkldnn::memory::format_tag::oiw;
   } else if (ndim == 4) {
-    tz =
-        num_groups > 1
-            ? mkldnn::memory::
-                  dims{num_groups, arr.shape()[O] / num_groups, arr.shape()[I], arr.shape()[H], arr.shape()[W]}
-            : mkldnn::memory::dims{arr.shape()[O], arr.shape()[I], arr.shape()[H], arr.shape()[W]};
+    tz = num_groups > 1
+             ? mkldnn::memory::dims{num_groups, arr.shape()[O] / num_groups, arr.shape()[I],
+                                    arr.shape()[H], arr.shape()[W]}
+             : mkldnn::memory::dims{arr.shape()[O], arr.shape()[I], arr.shape()[H], arr.shape()[W]};
     format_tag =
         num_groups > 1 ? mkldnn::memory::format_tag::goihw : mkldnn::memory::format_tag::oihw;
   } else if (ndim == 5) {
-    tz = num_groups > 1
-             ? mkldnn::memory::dims{num_groups,     arr.shape()[O] / num_groups,
-                                    arr.shape()[I], arr.shape()[D],
-                                    arr.shape()[H], arr.shape()[W]}
-             : mkldnn::memory::dims{
-                   arr.shape()[O], arr.shape()[I], arr.shape()[D], arr.shape()[H], arr.shape()[W]};
+    tz = num_groups > 1 ? mkldnn::memory::dims{num_groups,     arr.shape()[O] / num_groups,
+                                               arr.shape()[I], arr.shape()[D],
+                                               arr.shape()[H], arr.shape()[W]}
+                        : mkldnn::memory::dims{arr.shape()[O], arr.shape()[I], arr.shape()[D],
+                                               arr.shape()[H], arr.shape()[W]};
     format_tag =
         num_groups > 1 ? mkldnn::memory::format_tag::goidhw : mkldnn::memory::format_tag::oidhw;
   } else {
@@ -273,8 +269,8 @@ const mkldnn::memory* GetWeights(const NDArray& arr, int num_groups) {
   return arr.GetMKLDNNData(md);
 }
 
-const mkldnn::memory* GetWeights(
-    const NDArray& arr, const mkldnn::memory::desc& target_desc, int num_groups) {
+const mkldnn::memory* GetWeights(const NDArray& arr, const mkldnn::memory::desc& target_desc,
+                                 int num_groups) {
   const mkldnn::memory* mem = arr.GetMKLDNNData(target_desc);
   // If the weight array already uses the target layout, simply return it directly.
   if (mem) return mem;
@@ -370,10 +366,9 @@ void ReorderTo(const mkldnn::memory* src, const mkldnn::memory* dst) {
 }
 
 template <typename Compute, typename AttrState>
-void FallBackCompute(
-    Compute fn, const AttrState& attrs_states, const OpContext& ctx,
-    const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
-    const std::vector<NDArray>& outputs) {
+void FallBackCompute(Compute fn, const AttrState& attrs_states, const OpContext& ctx,
+                     const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+                     const std::vector<NDArray>& outputs) {
   std::vector<TBlob> in_blobs(inputs.size());
   std::vector<NDArray> in_bufs;
   std::vector<OpReqType> new_req = req;
@@ -450,8 +445,8 @@ void print_diff(const mxnet::NDArray& arr1, const mxnet::NDArray& arr2) {
 }
 
 template <typename DType>
-static bool SimilarArray(
-    const mxnet::NDArray& arr1, const mxnet::NDArray& arr2, DType rtol, DType atol) {
+static bool SimilarArray(const mxnet::NDArray& arr1, const mxnet::NDArray& arr2, DType rtol,
+                         DType atol) {
   if (arr1.shape().Size() != arr2.shape().Size()) return false;
 
   // This function should be used outside an MKLDNN operator.
@@ -489,26 +484,26 @@ static bool SimilarArray(
   return success.load();
 }
 
-template void FallBackCompute(
-    void (*)(
-        nnvm::NodeAttrs const&, OpContext const&, std::vector<TBlob, std::allocator<TBlob>> const&,
-        std::vector<OpReqType, std::allocator<OpReqType>> const&,
-        std::vector<TBlob, std::allocator<TBlob>> const&),
-    nnvm::NodeAttrs const&, OpContext const&, std::vector<NDArray, std::allocator<NDArray>> const&,
-    std::vector<OpReqType, std::allocator<OpReqType>> const&,
-    std::vector<NDArray, std::allocator<NDArray>> const&);
+template void FallBackCompute(void (*)(nnvm::NodeAttrs const&, OpContext const&,
+                                       std::vector<TBlob, std::allocator<TBlob>> const&,
+                                       std::vector<OpReqType, std::allocator<OpReqType>> const&,
+                                       std::vector<TBlob, std::allocator<TBlob>> const&),
+                              nnvm::NodeAttrs const&, OpContext const&,
+                              std::vector<NDArray, std::allocator<NDArray>> const&,
+                              std::vector<OpReqType, std::allocator<OpReqType>> const&,
+                              std::vector<NDArray, std::allocator<NDArray>> const&);
 
-template void FallBackCompute(
-    void (*)(
-        OpStatePtr const&, OpContext const&, std::vector<TBlob, std::allocator<TBlob>> const&,
-        std::vector<OpReqType, std::allocator<OpReqType>> const&,
-        std::vector<TBlob, std::allocator<TBlob>> const&),
-    OpStatePtr const&, OpContext const&, std::vector<NDArray, std::allocator<NDArray>> const&,
-    std::vector<OpReqType, std::allocator<OpReqType>> const&,
-    std::vector<NDArray, std::allocator<NDArray>> const&);
+template void FallBackCompute(void (*)(OpStatePtr const&, OpContext const&,
+                                       std::vector<TBlob, std::allocator<TBlob>> const&,
+                                       std::vector<OpReqType, std::allocator<OpReqType>> const&,
+                                       std::vector<TBlob, std::allocator<TBlob>> const&),
+                              OpStatePtr const&, OpContext const&,
+                              std::vector<NDArray, std::allocator<NDArray>> const&,
+                              std::vector<OpReqType, std::allocator<OpReqType>> const&,
+                              std::vector<NDArray, std::allocator<NDArray>> const&);
 
-void OpCheck::Init(
-    const std::vector<mxnet::NDArray>& inputs_, const std::vector<mxnet::NDArray>& outputs_) {
+void OpCheck::Init(const std::vector<mxnet::NDArray>& inputs_,
+                   const std::vector<mxnet::NDArray>& outputs_) {
   auto ctx = inputs_[0].ctx();
   CHECK(!MKLDNNStream::Get()->HasOps());
   for (size_t i = 0; i < inputs_.size(); i++) {
@@ -528,10 +523,10 @@ void OpCheck::Init(
   MKLDNNStream::Get()->Submit();
 }
 
-void OpCheck::Run(
-    mxnet::FCompute fn, const nnvm::NodeAttrs& attrs, const mxnet::OpContext& ctx,
-    const std::vector<mxnet::NDArray>& inputs_, const std::vector<mxnet::OpReqType>& req,
-    const std::vector<mxnet::NDArray>& outputs_) {
+void OpCheck::Run(mxnet::FCompute fn, const nnvm::NodeAttrs& attrs, const mxnet::OpContext& ctx,
+                  const std::vector<mxnet::NDArray>& inputs_,
+                  const std::vector<mxnet::OpReqType>& req,
+                  const std::vector<mxnet::NDArray>& outputs_) {
   static auto& is_excluded = Op::GetAttr<bool>("TExcludeMKLDNNDebug");
   if (is_excluded.get(attrs.op, false)) {
     LOG(WARNING) << attrs.op->name << " not checked. TExcludeMKLDNNDebug flag present";
@@ -558,8 +553,8 @@ void OpCheck::Run(
   }
 }
 
-void OpCheck::CopyResult(
-    const std::vector<mxnet::NDArray>& outputs_, const std::vector<size_t>& indice) {
+void OpCheck::CopyResult(const std::vector<mxnet::NDArray>& outputs_,
+                         const std::vector<size_t>& indice) {
   CHECK(!MKLDNNStream::Get()->HasOps());
   auto non_const_outputs_ = const_cast<std::vector<mxnet::NDArray>&>(outputs_);
   for (auto i = indice.begin(); i != indice.end(); ++i) {
@@ -569,9 +564,9 @@ void OpCheck::CopyResult(
   MKLDNNStream::Get()->Submit();
 }
 
-bool MKLDNNStorageType(
-    const nnvm::NodeAttrs& attrs, const int dev_mask, bool support_mkldnn,
-    DispatchMode* dispatch_mode, std::vector<int>* in_attrs, std::vector<int>* out_attrs) {
+bool MKLDNNStorageType(const nnvm::NodeAttrs& attrs, const int dev_mask, bool support_mkldnn,
+                       DispatchMode* dispatch_mode, std::vector<int>* in_attrs,
+                       std::vector<int>* out_attrs) {
   for (int& v : *in_attrs)
     if (v == -1) v = kDefaultStorage;
 
@@ -609,10 +604,9 @@ inline static const std::vector<NDArray> GetMKLDNNInputArray(const std::vector<N
   return ret;
 }
 
-void MKLDNNRun(
-    mxnet::FComputeEx fn, const nnvm::NodeAttrs& attrs, const mxnet::OpContext& ctx,
-    const std::vector<mxnet::NDArray>& inputs, const std::vector<mxnet::OpReqType>& req,
-    const std::vector<mxnet::NDArray>& outputs) {
+void MKLDNNRun(mxnet::FComputeEx fn, const nnvm::NodeAttrs& attrs, const mxnet::OpContext& ctx,
+               const std::vector<mxnet::NDArray>& inputs, const std::vector<mxnet::OpReqType>& req,
+               const std::vector<mxnet::NDArray>& outputs) {
   if (CheckMKLDNNInputArrayIsView(inputs)) {
     const auto mkldnn_inputs = GetMKLDNNInputArray(inputs);
     fn(attrs, ctx, mkldnn_inputs, req, outputs);
@@ -621,9 +615,9 @@ void MKLDNNRun(
   }
 }
 
-void MKLDNNRun(
-    FComputeExUnary fn, const nnvm::NodeAttrs& attrs, const mxnet::OpContext& ctx,
-    const mxnet::NDArray& input, const mxnet::OpReqType& req, const mxnet::NDArray& output) {
+void MKLDNNRun(FComputeExUnary fn, const nnvm::NodeAttrs& attrs, const mxnet::OpContext& ctx,
+               const mxnet::NDArray& input, const mxnet::OpReqType& req,
+               const mxnet::NDArray& output) {
   auto mkldnn_input = input;
   if (input.IsView() && input.IsMKLDNNData()) {
     mkldnn_input = input.Reorder2Default();

--- a/src/operator/nn/mkldnn/mkldnn_base.cc
+++ b/src/operator/nn/mkldnn/mkldnn_base.cc
@@ -27,7 +27,7 @@
 
 namespace mxnet {
 
-MKLDNNStream *MKLDNNStream::Get() {
+MKLDNNStream* MKLDNNStream::Get() {
 #if DMLC_CXX11_THREAD_LOCAL
   static thread_local MKLDNNStream stream;
 #else
@@ -36,28 +36,25 @@ MKLDNNStream *MKLDNNStream::Get() {
   return &stream;
 }
 
-void *AlignMem(void *mem, size_t size, size_t alignment, size_t *space) {
-  if (size > *space)
-    return nullptr;
+void* AlignMem(void* mem, size_t size, size_t alignment, size_t* space) {
+  if (size > *space) return nullptr;
   intptr_t addr = reinterpret_cast<intptr_t>(mem);
   // If the address has been aligned, don't do anything.
   intptr_t last_chunk = addr % alignment;
-  if (last_chunk == 0)
-    return mem;
+  if (last_chunk == 0) return mem;
   intptr_t padding = alignment - last_chunk;
   // If the buffer doesn't have enough space, we should return null here.
-  if (padding + size > *space)
-    return nullptr;
+  if (padding + size > *space) return nullptr;
   addr += padding;
   *space -= padding;
   CHECK_EQ(addr % alignment, 0);
-  return reinterpret_cast<void *>(addr);
+  return reinterpret_cast<void*>(addr);
 }
 
-mkldnn::memory *TmpMemMgr::Alloc(const mkldnn::memory::desc &md) {
+mkldnn::memory* TmpMemMgr::Alloc(const mkldnn::memory::desc& md) {
   // We need to include the size of the memory used for alignment.
   this->est_size += md.get_size() + alignment;
-  void *mem = AlignMem(this->curr_mem, md.get_size(), alignment, &this->curr_size);
+  void* mem = AlignMem(this->curr_mem, md.get_size(), alignment, &this->curr_size);
   if (mem) {
     // The memory is allocated from the temporary memory space in the
     // operator. It'll only become invalid after we exit from the operator.
@@ -65,7 +62,7 @@ mkldnn::memory *TmpMemMgr::Alloc(const mkldnn::memory::desc &md) {
     MKLDNNStream::Get()->RegisterMem(ret);
     CHECK_EQ(mem, mem);
     this->curr_size -= md.get_size();
-    this->curr_mem = static_cast<char *>(mem) + md.get_size();
+    this->curr_mem = static_cast<char*>(mem) + md.get_size();
     return ret.get();
   } else {
     // If curr_mem has been initialized and we still reach here, it means the current
@@ -76,8 +73,8 @@ mkldnn::memory *TmpMemMgr::Alloc(const mkldnn::memory::desc &md) {
     // required space size. It will be allocated at next call.
     if (this->curr_mem && dmlc::GetEnv("MXNET_MKLDNN_DEBUG", false)) {
       LOG(WARNING) << "mkl-dnn debug message: The rest of the temporary space is not "
-          << "adequate for allocating " << md.get_size() << " bytes. Thus, mkl-dnn "
-          << "allocate the space by itself.";
+                   << "adequate for allocating " << md.get_size() << " bytes. Thus, mkl-dnn "
+                   << "allocate the space by itself.";
     }
     mkldnn_mem_ptr ret(new mkldnn::memory(md, CpuEngine::Get()->get_engine()));
     MKLDNNStream::Get()->RegisterMem(ret);
@@ -85,97 +82,92 @@ mkldnn::memory *TmpMemMgr::Alloc(const mkldnn::memory::desc &md) {
   }
 }
 
-void MKLDNNMemoryCopy(const mkldnn::memory &mem, const mkldnn::memory* this_mem) {
-  MKLDNNStream *stream = MKLDNNStream::Get();
-  mkldnn::memory::desc from_desc = mem.get_desc();
-  mkldnn::memory::desc this_desc = this_mem->get_desc();
+void MKLDNNMemoryCopy(const mkldnn::memory& mem, const mkldnn::memory* this_mem) {
+  MKLDNNStream* stream                = MKLDNNStream::Get();
+  mkldnn::memory::desc from_desc      = mem.get_desc();
+  mkldnn::memory::desc this_desc      = this_mem->get_desc();
   mkldnn_format_tag_t from_def_format = GetDefaultFormat(from_desc);
   mkldnn_format_tag_t this_def_format = GetDefaultFormat(this_desc);
 
   if (!same_shape(this_desc, from_desc) && IsDefaultFormat(from_desc)) {
     // In this case, we can simply create a new MKLDNN memory for the required
     // shape.
-    mkldnn::memory::dims dims(this_desc.data.dims,
-                              this_desc.data.dims + this_desc.data.ndims);
+    mkldnn::memory::dims dims(this_desc.data.dims, this_desc.data.dims + this_desc.data.ndims);
     auto this_dtype = static_cast<mkldnn::memory::data_type>(this_desc.data.data_type);
-    mkldnn::memory::desc data_md(dims, this_dtype,
-                                 static_cast<mkldnn::memory::format_tag>(this_def_format));
+    mkldnn::memory::desc data_md(
+        dims, this_dtype, static_cast<mkldnn::memory::format_tag>(this_def_format));
 
     mkldnn_mem_ptr tmp_mem(new mkldnn::memory(data_md, mem.get_engine(), mem.get_data_handle()));
     stream->RegisterMem(tmp_mem);
-    std::unordered_map<int, mkldnn::memory> args({{MKLDNN_ARG_FROM, *tmp_mem},
-                                                 {MKLDNN_ARG_TO, *this_mem}});
+    std::unordered_map<int, mkldnn::memory> args(
+        {{MKLDNN_ARG_FROM, *tmp_mem}, {MKLDNN_ARG_TO, *this_mem}});
     stream->RegisterPrimArgs(mkldnn::reorder(*tmp_mem, *this_mem), args);
   } else if (!same_shape(this_desc, from_desc)) {
     // In this case, the source memory stores data in a customized layout. We
     // need to reorganize the data in memory before we can reshape.
     mkldnn::memory::desc def_desc = GetDesc(from_desc, from_def_format);
-    mkldnn::memory *def_mem = TmpMemMgr::Get()->Alloc(def_desc);
-    std::unordered_map<int, mkldnn::memory> args({{MKLDNN_ARG_FROM, mem},
-                                                 {MKLDNN_ARG_TO, *def_mem}});
+    mkldnn::memory* def_mem       = TmpMemMgr::Get()->Alloc(def_desc);
+    std::unordered_map<int, mkldnn::memory> args(
+        {{MKLDNN_ARG_FROM, mem}, {MKLDNN_ARG_TO, *def_mem}});
     stream->RegisterPrimArgs(mkldnn::reorder(mem, *def_mem), args);
 
     // Now we can reshape it
-    mkldnn_mem_ptr tmp_mem(new mkldnn::memory(this_desc,
-        mem.get_engine(), def_mem->get_data_handle()));
+    mkldnn_mem_ptr tmp_mem(
+        new mkldnn::memory(this_desc, mem.get_engine(), def_mem->get_data_handle()));
     stream->RegisterMem(tmp_mem);
     args = {{MKLDNN_ARG_FROM, *tmp_mem}, {MKLDNN_ARG_TO, *this_mem}};
     stream->RegisterPrimArgs(mkldnn::reorder(*tmp_mem, *this_mem), args);
-} else if (this_desc == from_desc) {
-    std::unordered_map<int, mkldnn::memory> args({{MKLDNN_ARG_FROM, mem},
-                                                 {MKLDNN_ARG_TO, *this_mem}});
+  } else if (this_desc == from_desc) {
+    std::unordered_map<int, mkldnn::memory> args(
+        {{MKLDNN_ARG_FROM, mem}, {MKLDNN_ARG_TO, *this_mem}});
     // If the layout is the same, we can just copy data.
     stream->RegisterPrimArgs(mkldnn::reorder(mem, *this_mem), args);
-} else {
+  } else {
     // If both are not using the default layouts. There isn't much we can do,
     // other than reorder data layout directly.
     if (!IsDefaultFormat(this_desc) && !IsDefaultFormat(from_desc)) {
-      std::unordered_map<int, mkldnn::memory> args({{MKLDNN_ARG_FROM, mem},
-                                                   {MKLDNN_ARG_TO, *this_mem}});
+      std::unordered_map<int, mkldnn::memory> args(
+          {{MKLDNN_ARG_FROM, mem}, {MKLDNN_ARG_TO, *this_mem}});
       stream->RegisterPrimArgs(mkldnn::reorder(mem, *this_mem), args);
     } else if (IsDefaultFormat(this_desc)) {
       // If the dest mem uses the default memory layout, we can simply use
       // the default format of the source memory to improve perf of reorder.
       mkldnn::memory::desc desc = GetDesc(from_desc, from_def_format);
-      mkldnn_mem_ptr tmp_mem(new mkldnn::memory(desc,
-          mem.get_engine(), this_mem->get_data_handle()));
+      mkldnn_mem_ptr tmp_mem(
+          new mkldnn::memory(desc, mem.get_engine(), this_mem->get_data_handle()));
       stream->RegisterMem(tmp_mem);
-      std::unordered_map<int, mkldnn::memory> args({{MKLDNN_ARG_FROM, mem},
-                                                   {MKLDNN_ARG_TO, *tmp_mem}});
+      std::unordered_map<int, mkldnn::memory> args(
+          {{MKLDNN_ARG_FROM, mem}, {MKLDNN_ARG_TO, *tmp_mem}});
       stream->RegisterPrimArgs(mkldnn::reorder(mem, *tmp_mem), args);
     } else {
       // If the src mem uses the default memory layout, we can use
       // the default format of the source memory to improve perf.
       mkldnn::memory::desc desc = GetDesc(this_desc, this_def_format);
-      mkldnn_mem_ptr tmp_mem(new mkldnn::memory(desc,
-          this_mem->get_engine(), mem.get_data_handle()));
+      mkldnn_mem_ptr tmp_mem(
+          new mkldnn::memory(desc, this_mem->get_engine(), mem.get_data_handle()));
       stream->RegisterMem(tmp_mem);
-      std::unordered_map<int, mkldnn::memory> args({{MKLDNN_ARG_FROM, *tmp_mem},
-                                                   {MKLDNN_ARG_TO, *this_mem}});
+      std::unordered_map<int, mkldnn::memory> args(
+          {{MKLDNN_ARG_FROM, *tmp_mem}, {MKLDNN_ARG_TO, *this_mem}});
       stream->RegisterPrimArgs(mkldnn::reorder(*tmp_mem, *this_mem), args);
     }
   }
 }
 
-bool CanWriteTo(const NDArray &out_arr,
-                const NDArray &in_arr,
-                const mkldnn::memory::desc &desc) {
-  auto in_mem = in_arr.GetMKLDNNData();
-  bool add_same = in_mem->get_data_handle() == out_arr.GetMKLDNNData()->get_data_handle();
-  bool pdesc_same = out_arr.GetMKLDNNData()->get_desc() == desc &&
-      in_mem->get_desc() == desc;
+bool CanWriteTo(const NDArray& out_arr, const NDArray& in_arr, const mkldnn::memory::desc& desc) {
+  auto in_mem     = in_arr.GetMKLDNNData();
+  bool add_same   = in_mem->get_data_handle() == out_arr.GetMKLDNNData()->get_data_handle();
+  bool pdesc_same = out_arr.GetMKLDNNData()->get_desc() == desc && in_mem->get_desc() == desc;
   return add_same && pdesc_same;
 }
 
-mkldnn_output_t CreateMKLDNNMem(const NDArray &out_arr,
-                                const mkldnn::memory::desc &desc,
-                                OpReqType req,
-                                const NDArray* in_arr) {
+mkldnn_output_t CreateMKLDNNMem(
+    const NDArray& out_arr, const mkldnn::memory::desc& desc, OpReqType req,
+    const NDArray* in_arr) {
   if (kAddTo == req) {
     auto tmp = TmpMemMgr::Get()->Alloc(desc);
     return mkldnn_output_t(OutDataOp::AddBack, tmp);
   } else if (kWriteInplace == req && in_arr != nullptr && CanWriteTo(out_arr, *in_arr, desc)) {
-    mkldnn::memory *mem = const_cast<NDArray &>(out_arr).CreateMKLDNNData(desc);
+    mkldnn::memory* mem = const_cast<NDArray&>(out_arr).CreateMKLDNNData(desc);
     // mem is nullptr if out_arr is view and desc is MKLDNN format.
     // need to Reorder2Default before calling CreateMKLDNNMem
     CHECK(mem != nullptr);
@@ -184,7 +176,7 @@ mkldnn_output_t CreateMKLDNNMem(const NDArray &out_arr,
     auto tmp = TmpMemMgr::Get()->Alloc(desc);
     return mkldnn_output_t(OutDataOp::CopyBack, tmp);
   } else if (kWriteTo == req) {
-    mkldnn::memory *mem = const_cast<NDArray &>(out_arr).CreateMKLDNNData(desc);
+    mkldnn::memory* mem = const_cast<NDArray&>(out_arr).CreateMKLDNNData(desc);
     if (nullptr == mem) {
       auto tmp = TmpMemMgr::Get()->Alloc(desc);
       return mkldnn_output_t(OutDataOp::CopyBack, tmp);
@@ -195,9 +187,8 @@ mkldnn_output_t CreateMKLDNNMem(const NDArray &out_arr,
   return mkldnn_output_t(OutDataOp::Noop, tmp);
 }
 
-mkldnn_output_t CreateMKLDNNWeightGrad(const NDArray &out_arr,
-                                       const mkldnn::memory::desc &desc,
-                                       OpReqType req) {
+mkldnn_output_t CreateMKLDNNWeightGrad(
+    const NDArray& out_arr, const mkldnn::memory::desc& desc, OpReqType req) {
   if (kAddTo == req) {
     auto tmp = TmpMemMgr::Get()->Alloc(desc);
     return mkldnn_output_t(OutDataOp::AddBack, tmp);
@@ -205,9 +196,9 @@ mkldnn_output_t CreateMKLDNNWeightGrad(const NDArray &out_arr,
     auto tmp = TmpMemMgr::Get()->Alloc(desc);
     return mkldnn_output_t(OutDataOp::CopyBack, tmp);
   } else {
-    mkldnn::memory *mem = nullptr;
+    mkldnn::memory* mem = nullptr;
     if (IsDefaultFormat(desc)) {
-      mem = const_cast<NDArray &>(out_arr).CreateMKLDNNData(desc);
+      mem = const_cast<NDArray&>(out_arr).CreateMKLDNNData(desc);
     }
     if (mem == nullptr) {
       auto tmp = TmpMemMgr::Get()->Alloc(desc);
@@ -218,29 +209,29 @@ mkldnn_output_t CreateMKLDNNWeightGrad(const NDArray &out_arr,
   }
 }
 
-void CommitOutput(const NDArray &arr, const mkldnn_output_t &res) {
+void CommitOutput(const NDArray& arr, const mkldnn_output_t& res) {
   if (res.first == CopyBack) {
-    const_cast<NDArray &>(arr).CopyFrom(*res.second);
+    const_cast<NDArray&>(arr).CopyFrom(*res.second);
   } else if (res.first == AddBack) {
     auto res_memory = res.second;
-    auto target_pd = arr.GetMKLDNNData()->get_desc();
-    auto mem = arr.GetMKLDNNData(res.second->get_desc());
+    auto target_pd  = arr.GetMKLDNNData()->get_desc();
+    auto mem        = arr.GetMKLDNNData(res.second->get_desc());
     if (mem == nullptr) {
       auto tmp_memory = TmpMemMgr::Get()->Alloc(target_pd);
       MKLDNNMemoryCopy(*res_memory, tmp_memory);
       res_memory = tmp_memory;
-      mem = arr.GetMKLDNNData();
+      mem        = arr.GetMKLDNNData();
     }
     op::MKLDNNSum(*mem, *res_memory, *mem);
   }
 }
 
-const mkldnn::memory *GetWeights(const NDArray &arr, int num_groups) {
+const mkldnn::memory* GetWeights(const NDArray& arr, int num_groups) {
   const auto type = get_mkldnn_type(arr.dtype());
-  auto tz = mkldnn::memory::dims{0};
+  auto tz         = mkldnn::memory::dims{0};
   auto format_tag = mkldnn::memory::format_tag::undef;
-  auto engine = CpuEngine::Get()->get_engine();
-  const int ndim = arr.shape().ndim();
+  auto engine     = CpuEngine::Get()->get_engine();
+  const int ndim  = arr.shape().ndim();
   int O = 0, I = 1, H = 2, W = 3;
   int D = -1;
   if (ndim == 5) {
@@ -249,35 +240,32 @@ const mkldnn::memory *GetWeights(const NDArray &arr, int num_groups) {
     W = 4;
   }
   if (ndim == 2) {
-    tz = mkldnn::memory::dims{arr.shape()[O], arr.shape()[I]};
+    tz         = mkldnn::memory::dims{arr.shape()[O], arr.shape()[I]};
     format_tag = mkldnn::memory::format_tag::oi;
   } else if (ndim == 3) {
     tz = num_groups > 1
-             ? mkldnn::memory::dims{num_groups, arr.shape()[O] / num_groups,
-                                    arr.shape()[I], arr.shape()[H]}
-             : mkldnn::memory::dims{arr.shape()[O],
-                                    arr.shape()[I], arr.shape()[H]};
-    format_tag = num_groups > 1 ? mkldnn::memory::format_tag::goiw
-                                : mkldnn::memory::format_tag::oiw;
+             ? mkldnn::memory::
+                   dims{num_groups, arr.shape()[O] / num_groups, arr.shape()[I], arr.shape()[H]}
+             : mkldnn::memory::dims{arr.shape()[O], arr.shape()[I], arr.shape()[H]};
+    format_tag =
+        num_groups > 1 ? mkldnn::memory::format_tag::goiw : mkldnn::memory::format_tag::oiw;
   } else if (ndim == 4) {
-    tz = num_groups > 1
-             ? mkldnn::memory::dims{num_groups, arr.shape()[O] / num_groups,
-                                    arr.shape()[I], arr.shape()[H],
-                                    arr.shape()[W]}
-             : mkldnn::memory::dims{
-                   arr.shape()[O], arr.shape()[I],  arr.shape()[H], arr.shape()[W]};
-    format_tag = num_groups > 1 ? mkldnn::memory::format_tag::goihw
-                                : mkldnn::memory::format_tag::oihw;
+    tz =
+        num_groups > 1
+            ? mkldnn::memory::
+                  dims{num_groups, arr.shape()[O] / num_groups, arr.shape()[I], arr.shape()[H], arr.shape()[W]}
+            : mkldnn::memory::dims{arr.shape()[O], arr.shape()[I], arr.shape()[H], arr.shape()[W]};
+    format_tag =
+        num_groups > 1 ? mkldnn::memory::format_tag::goihw : mkldnn::memory::format_tag::oihw;
   } else if (ndim == 5) {
     tz = num_groups > 1
-             ? mkldnn::memory::dims{num_groups, arr.shape()[O] / num_groups,
+             ? mkldnn::memory::dims{num_groups,     arr.shape()[O] / num_groups,
                                     arr.shape()[I], arr.shape()[D],
                                     arr.shape()[H], arr.shape()[W]}
              : mkldnn::memory::dims{
-                   arr.shape()[O], arr.shape()[I], arr.shape()[D],
-                   arr.shape()[H], arr.shape()[W]};
-    format_tag = num_groups > 1 ? mkldnn::memory::format_tag::goidhw
-                                : mkldnn::memory::format_tag::oidhw;
+                   arr.shape()[O], arr.shape()[I], arr.shape()[D], arr.shape()[H], arr.shape()[W]};
+    format_tag =
+        num_groups > 1 ? mkldnn::memory::format_tag::goidhw : mkldnn::memory::format_tag::oidhw;
   } else {
     LOG(FATAL) << "The weight array has an unsupported number of dimensions";
   }
@@ -285,9 +273,9 @@ const mkldnn::memory *GetWeights(const NDArray &arr, int num_groups) {
   return arr.GetMKLDNNData(md);
 }
 
-const mkldnn::memory *GetWeights(const NDArray &arr,
-                                 const mkldnn::memory::desc &target_desc, int num_groups) {
-  const mkldnn::memory *mem = arr.GetMKLDNNData(target_desc);
+const mkldnn::memory* GetWeights(
+    const NDArray& arr, const mkldnn::memory::desc& target_desc, int num_groups) {
+  const mkldnn::memory* mem = arr.GetMKLDNNData(target_desc);
   // If the weight array already uses the target layout, simply return it directly.
   if (mem) return mem;
   mem = GetWeights(arr, num_groups);
@@ -295,27 +283,25 @@ const mkldnn::memory *GetWeights(const NDArray &arr,
   if (mem->get_desc() == target_desc) return mem;
 
   auto ret = TmpMemMgr::Get()->Alloc(target_desc);
-  std::unordered_map<int, mkldnn::memory> args({{MKLDNN_ARG_FROM, *mem},
-                                               {MKLDNN_ARG_TO, *ret}});
+  std::unordered_map<int, mkldnn::memory> args({{MKLDNN_ARG_FROM, *mem}, {MKLDNN_ARG_TO, *ret}});
   MKLDNNStream::Get()->RegisterPrimArgs(mkldnn::reorder(*mem, *ret), args);
   return ret;
 }
 
-
 // default: block and dims' stride increase monotonically
 // mkldnn: 1.winograd 2.rnn packed 3. block and dims'stride is not increase monotonically
-bool IsMKLDNN(const mkldnn::memory::desc &desc) {
+bool IsMKLDNN(const mkldnn::memory::desc& desc) {
   bool rslt = true;
   if (desc.data.format_kind == mkldnn_blocked) {
     if (desc.data.format_desc.blocking.inner_nblks == 0) {
       int i = 0;
-      for (i = 0; i < desc.data.ndims-1; i++) {
-        if (desc.data.format_desc.blocking.strides[i]
-            < desc.data.format_desc.blocking.strides[i + 1]) {
+      for (i = 0; i < desc.data.ndims - 1; i++) {
+        if (desc.data.format_desc.blocking.strides[i] <
+            desc.data.format_desc.blocking.strides[i + 1]) {
           break;
         }
       }
-      if (i == desc.data.ndims-1) {
+      if (i == desc.data.ndims - 1) {
         rslt = false;
       }
     }
@@ -325,34 +311,40 @@ bool IsMKLDNN(const mkldnn::memory::desc &desc) {
 
 mkldnn_format_tag_t GetDefaultFormat(int num_dims) {
   switch (num_dims) {
-    case 1: return mkldnn_a;
-    case 2: return mkldnn_ab;
-    case 3: return mkldnn_abc;
-    case 4: return mkldnn_abcd;
-    case 5: return mkldnn_abcde;
-    case 6: return mkldnn_abcdef;
+    case 1:
+      return mkldnn_a;
+    case 2:
+      return mkldnn_ab;
+    case 3:
+      return mkldnn_abc;
+    case 4:
+      return mkldnn_abcd;
+    case 5:
+      return mkldnn_abcde;
+    case 6:
+      return mkldnn_abcdef;
     default:
       LOG(FATAL) << "Not implemented dimension (" << num_dims << ") for MKLDNN";
       return mkldnn_format_tag_undef;
   }
 }
 
-mkldnn_format_tag_t GetDefaultFormat(const mkldnn::memory::desc &desc) {
+mkldnn_format_tag_t GetDefaultFormat(const mkldnn::memory::desc& desc) {
   return GetDefaultFormat(desc.data.ndims);
 }
 
-bool IsDefaultFormat(const mkldnn::memory::desc &desc) {
+bool IsDefaultFormat(const mkldnn::memory::desc& desc) {
   bool rslt = false;
   if (desc.data.format_kind == mkldnn_blocked) {
     if (desc.data.format_desc.blocking.inner_nblks == 0) {
       int i = 0;
-      for (i = 0; i < desc.data.ndims-1; i++) {
-        if (desc.data.format_desc.blocking.strides[i]
-            < desc.data.format_desc.blocking.strides[i + 1]) {
+      for (i = 0; i < desc.data.ndims - 1; i++) {
+        if (desc.data.format_desc.blocking.strides[i] <
+            desc.data.format_desc.blocking.strides[i + 1]) {
           break;
         }
       }
-      if (i == desc.data.ndims-1) {
+      if (i == desc.data.ndims - 1) {
         rslt = true;
       }
     }
@@ -360,20 +352,17 @@ bool IsDefaultFormat(const mkldnn::memory::desc &desc) {
   return rslt;
 }
 
-mkldnn::memory::desc GetDesc(const mkldnn::memory::desc &desc,
-                             const mkldnn_format_tag_t &format) {
+mkldnn::memory::desc GetDesc(const mkldnn::memory::desc& desc, const mkldnn_format_tag_t& format) {
   mkldnn::memory::dims dims(desc.data.ndims);
-  for (size_t i = 0; i < dims.size(); i++)
-    dims[i] = desc.data.dims[i];
+  for (size_t i = 0; i < dims.size(); i++) dims[i] = desc.data.dims[i];
   mkldnn::memory::format_tag cpp_format = static_cast<mkldnn::memory::format_tag>(format);
-  mkldnn::memory::data_type cpp_type = static_cast<mkldnn::memory::data_type>(
-      desc.data.data_type);
+  mkldnn::memory::data_type cpp_type = static_cast<mkldnn::memory::data_type>(desc.data.data_type);
   mkldnn::memory::desc data_md(dims, cpp_type, cpp_format);
   return mkldnn::memory::desc(dims, cpp_type, cpp_format);
 }
 
 // reorder mkldnn src to dst format dtype
-void ReorderTo(const mkldnn::memory *src, const mkldnn::memory *dst) {
+void ReorderTo(const mkldnn::memory* src, const mkldnn::memory* dst) {
   mkldnn::stream s(CpuEngine::Get()->get_engine());
   auto new_src = *src;
   auto new_dst = *dst;
@@ -381,11 +370,10 @@ void ReorderTo(const mkldnn::memory *src, const mkldnn::memory *dst) {
 }
 
 template <typename Compute, typename AttrState>
-void FallBackCompute(Compute fn, const AttrState &attrs_states,
-                     const OpContext &ctx,
-                     const std::vector<NDArray> &inputs,
-                     const std::vector<OpReqType> &req,
-                     const std::vector<NDArray> &outputs) {
+void FallBackCompute(
+    Compute fn, const AttrState& attrs_states, const OpContext& ctx,
+    const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+    const std::vector<NDArray>& outputs) {
   std::vector<TBlob> in_blobs(inputs.size());
   std::vector<NDArray> in_bufs;
   std::vector<OpReqType> new_req = req;
@@ -397,8 +385,7 @@ void FallBackCompute(Compute fn, const AttrState &attrs_states,
     if (inputs[i].IsDefaultData() && inputs[i].dtype() != mshadow::kBfloat16) {
       in_blobs[i] = inputs[i].data();
     } else {
-      if (in_bufs.empty())
-        in_bufs.reserve(inputs.size());
+      if (in_bufs.empty()) in_bufs.reserve(inputs.size());
       if (inputs[i].dtype() != mshadow::kBfloat16) {
         in_bufs.push_back(inputs[i].Reorder2Default());
       } else {
@@ -427,7 +414,7 @@ void FallBackCompute(Compute fn, const AttrState &attrs_states,
       // ensure output does not use mkldnn mem.
       // for inplace, we already converted & copied input above.
       if ((req[i] == kWriteTo) || (req[i] == kWriteInplace)) {
-        const_cast<NDArray &>(output).InvalidateMKLDNNData();
+        const_cast<NDArray&>(output).InvalidateMKLDNNData();
         if (req[i] == kWriteInplace) {
           new_req[i] = kWriteTo;
         }
@@ -454,20 +441,18 @@ void FallBackCompute(Compute fn, const AttrState &attrs_states,
   }
 }
 
-template<typename DType>
-void print_diff(const mxnet::NDArray &arr1, const mxnet::NDArray &arr2) {
-  DType *data1 = reinterpret_cast<DType *>(arr1.data().dptr_);
-  DType *data2 = reinterpret_cast<DType *>(arr2.data().dptr_);
-  for (size_t i = 0; i < arr1.shape().Size(); i++)
-    std::cout << data1[i] - data2[i] << ", ";
+template <typename DType>
+void print_diff(const mxnet::NDArray& arr1, const mxnet::NDArray& arr2) {
+  DType* data1 = reinterpret_cast<DType*>(arr1.data().dptr_);
+  DType* data2 = reinterpret_cast<DType*>(arr2.data().dptr_);
+  for (size_t i = 0; i < arr1.shape().Size(); i++) std::cout << data1[i] - data2[i] << ", ";
   std::cout << std::endl;
 }
 
-template<typename DType>
-static bool SimilarArray(const mxnet::NDArray &arr1, const mxnet::NDArray &arr2,
-                         DType rtol, DType atol) {
-  if (arr1.shape().Size() != arr2.shape().Size())
-    return false;
+template <typename DType>
+static bool SimilarArray(
+    const mxnet::NDArray& arr1, const mxnet::NDArray& arr2, DType rtol, DType atol) {
+  if (arr1.shape().Size() != arr2.shape().Size()) return false;
 
   // This function should be used outside an MKLDNN operator.
   // There shouldn't be any operators in the stream.
@@ -476,21 +461,21 @@ static bool SimilarArray(const mxnet::NDArray &arr1, const mxnet::NDArray &arr2,
   // But we shouldn't reorder data in the original array.
   NDArray buf1, buf2;
   if (arr1.IsMKLDNNData()) {
-    buf1 = NDArray(arr1.shape(), arr1.ctx(), false, arr1.dtype());
+    buf1     = NDArray(arr1.shape(), arr1.ctx(), false, arr1.dtype());
     auto mem = arr1.GetMKLDNNData();
     buf1.CopyFrom(*mem);
   }
   if (arr2.IsMKLDNNData()) {
-    buf2 = NDArray(arr2.shape(), arr2.ctx(), false, arr2.dtype());
+    buf2     = NDArray(arr2.shape(), arr2.ctx(), false, arr2.dtype());
     auto mem = arr2.GetMKLDNNData();
     buf2.CopyFrom(*mem);
   }
   MKLDNNStream::Get()->Submit();
 
-  DType *data1 = reinterpret_cast<DType *>(
-      arr1.IsMKLDNNData() ? buf1.data().dptr_: arr1.data().dptr_);
-  DType *data2 = reinterpret_cast<DType *>(
-      arr2.IsMKLDNNData() ? buf2.data().dptr_: arr2.data().dptr_);
+  DType* data1 =
+      reinterpret_cast<DType*>(arr1.IsMKLDNNData() ? buf1.data().dptr_ : arr1.data().dptr_);
+  DType* data2 =
+      reinterpret_cast<DType*>(arr2.IsMKLDNNData() ? buf2.data().dptr_ : arr2.data().dptr_);
   std::atomic<bool> success(true);
 #pragma omp parallel for
 #ifdef _MSC_VER
@@ -499,45 +484,42 @@ static bool SimilarArray(const mxnet::NDArray &arr1, const mxnet::NDArray &arr2,
   for (size_t i = 0; i < arr1.shape().Size(); i++)
 #endif
   {
-    if (std::abs(data1[i] - data2[i]) > atol + rtol * std::abs(data2[i]))
-      success.store(false);
+    if (std::abs(data1[i] - data2[i]) > atol + rtol * std::abs(data2[i])) success.store(false);
   }
   return success.load();
 }
 
-template void FallBackCompute(void (*)(nnvm::NodeAttrs const &, OpContext const &,
-                                       std::vector<TBlob, std::allocator<TBlob> > const &,
-                                       std::vector<OpReqType, std::allocator<OpReqType> > const &,
-                                       std::vector<TBlob, std::allocator<TBlob> > const &),
-                              nnvm::NodeAttrs const &, OpContext const &,
-                              std::vector<NDArray, std::allocator<NDArray> > const &,
-                              std::vector<OpReqType, std::allocator<OpReqType> > const &,
-                              std::vector<NDArray, std::allocator<NDArray> > const &);
+template void FallBackCompute(
+    void (*)(
+        nnvm::NodeAttrs const&, OpContext const&, std::vector<TBlob, std::allocator<TBlob>> const&,
+        std::vector<OpReqType, std::allocator<OpReqType>> const&,
+        std::vector<TBlob, std::allocator<TBlob>> const&),
+    nnvm::NodeAttrs const&, OpContext const&, std::vector<NDArray, std::allocator<NDArray>> const&,
+    std::vector<OpReqType, std::allocator<OpReqType>> const&,
+    std::vector<NDArray, std::allocator<NDArray>> const&);
 
-template void FallBackCompute(void (*)(OpStatePtr const &, OpContext const &,
-                                       std::vector<TBlob, std::allocator<TBlob> > const &,
-                                       std::vector<OpReqType, std::allocator<OpReqType> > const &,
-                                       std::vector<TBlob, std::allocator<TBlob> > const &),
-                              OpStatePtr const &, OpContext const &,
-                              std::vector<NDArray, std::allocator<NDArray> > const &,
-                              std::vector<OpReqType, std::allocator<OpReqType> > const &,
-                              std::vector<NDArray, std::allocator<NDArray> > const &);
+template void FallBackCompute(
+    void (*)(
+        OpStatePtr const&, OpContext const&, std::vector<TBlob, std::allocator<TBlob>> const&,
+        std::vector<OpReqType, std::allocator<OpReqType>> const&,
+        std::vector<TBlob, std::allocator<TBlob>> const&),
+    OpStatePtr const&, OpContext const&, std::vector<NDArray, std::allocator<NDArray>> const&,
+    std::vector<OpReqType, std::allocator<OpReqType>> const&,
+    std::vector<NDArray, std::allocator<NDArray>> const&);
 
-void OpCheck::Init(const std::vector<mxnet::NDArray> &inputs_,
-                   const std::vector<mxnet::NDArray> &outputs_) {
+void OpCheck::Init(
+    const std::vector<mxnet::NDArray>& inputs_, const std::vector<mxnet::NDArray>& outputs_) {
   auto ctx = inputs_[0].ctx();
   CHECK(!MKLDNNStream::Get()->HasOps());
   for (size_t i = 0; i < inputs_.size(); i++) {
     NDArray data = inputs_[i];
     inputs.emplace_back(data.shape(), ctx, false, data.dtype());
-    if (data.IsMKLDNNData() && data.IsView())
-        data = data.Reorder2Default();
+    if (data.IsMKLDNNData() && data.IsView()) data = data.Reorder2Default();
     auto mem = data.GetMKLDNNData();
     inputs[i].CopyFrom(*mem);
   }
   for (size_t i = 0; i < outputs_.size(); i++) {
-    outputs.emplace_back(outputs_[i].shape(), ctx,
-                         false, outputs_[i].dtype());
+    outputs.emplace_back(outputs_[i].shape(), ctx, false, outputs_[i].dtype());
     if (backward) {
       auto mem = outputs_[i].GetMKLDNNData();
       outputs[i].CopyFrom(*mem);
@@ -546,11 +528,10 @@ void OpCheck::Init(const std::vector<mxnet::NDArray> &inputs_,
   MKLDNNStream::Get()->Submit();
 }
 
-void OpCheck::Run(mxnet::FCompute fn, const nnvm::NodeAttrs &attrs,
-                  const mxnet::OpContext &ctx,
-                  const std::vector<mxnet::NDArray> &inputs_,
-                  const std::vector<mxnet::OpReqType> &req,
-                  const std::vector<mxnet::NDArray> &outputs_) {
+void OpCheck::Run(
+    mxnet::FCompute fn, const nnvm::NodeAttrs& attrs, const mxnet::OpContext& ctx,
+    const std::vector<mxnet::NDArray>& inputs_, const std::vector<mxnet::OpReqType>& req,
+    const std::vector<mxnet::NDArray>& outputs_) {
   static auto& is_excluded = Op::GetAttr<bool>("TExcludeMKLDNNDebug");
   if (is_excluded.get(attrs.op, false)) {
     LOG(WARNING) << attrs.op->name << " not checked. TExcludeMKLDNNDebug flag present";
@@ -559,17 +540,14 @@ void OpCheck::Run(mxnet::FCompute fn, const nnvm::NodeAttrs &attrs,
   std::vector<mxnet::TBlob> in_blobs(inputs.size());
   for (size_t i = 0; i < in_blobs.size(); i++) in_blobs[i] = inputs[i].data();
   std::vector<mxnet::TBlob> out_blobs(outputs.size());
-  for (size_t i = 0; i < out_blobs.size(); i++)
-    out_blobs[i] = outputs[i].data();
+  for (size_t i = 0; i < out_blobs.size(); i++) out_blobs[i] = outputs[i].data();
   fn(attrs, ctx, in_blobs, req, out_blobs);
-  if (dmlc::GetEnv("MXNET_MKLDNN_DEBUG", false))
-    LOG(INFO) << "test " << attrs.op->name;
+  if (dmlc::GetEnv("MXNET_MKLDNN_DEBUG", false)) LOG(INFO) << "test " << attrs.op->name;
   size_t num = std::min(outputs.size(), outputs_.size());
-  num = std::min(num_checks, num);
+  num        = std::min(num_checks, num);
   for (size_t i = 0; i < num; i++) {
     // We don't need to compare if it doesn't need to output data.
-    if (req[i] == kNullOp)
-      continue;
+    if (req[i] == kNullOp) continue;
     MSHADOW_TYPE_SWITCH(outputs[i].dtype(), DType, {
       bool similar = SimilarArray<DType>(outputs[i], outputs_[i], 1e-2, 1e-2);
       if (!similar) {
@@ -580,10 +558,10 @@ void OpCheck::Run(mxnet::FCompute fn, const nnvm::NodeAttrs &attrs,
   }
 }
 
-void OpCheck::CopyResult(const std::vector<mxnet::NDArray> &outputs_,
-                         const std::vector<size_t> &indice) {
+void OpCheck::CopyResult(
+    const std::vector<mxnet::NDArray>& outputs_, const std::vector<size_t>& indice) {
   CHECK(!MKLDNNStream::Get()->HasOps());
-  auto non_const_outputs_ = const_cast<std::vector<mxnet::NDArray> &>(outputs_);
+  auto non_const_outputs_ = const_cast<std::vector<mxnet::NDArray>&>(outputs_);
   for (auto i = indice.begin(); i != indice.end(); ++i) {
     auto mem = outputs[*i].GetMKLDNNData();
     non_const_outputs_[*i].CopyFrom(*mem);
@@ -591,14 +569,11 @@ void OpCheck::CopyResult(const std::vector<mxnet::NDArray> &outputs_,
   MKLDNNStream::Get()->Submit();
 }
 
-bool MKLDNNStorageType(const nnvm::NodeAttrs &attrs,
-                       const int dev_mask,
-                       bool support_mkldnn,
-                       DispatchMode *dispatch_mode,
-                       std::vector<int> *in_attrs,
-                       std::vector<int> *out_attrs) {
+bool MKLDNNStorageType(
+    const nnvm::NodeAttrs& attrs, const int dev_mask, bool support_mkldnn,
+    DispatchMode* dispatch_mode, std::vector<int>* in_attrs, std::vector<int>* out_attrs) {
   for (int& v : *in_attrs)
-    if (v == - 1) v = kDefaultStorage;
+    if (v == -1) v = kDefaultStorage;
 
   DispatchMode wanted_mode;
 #if MXNET_USE_MKLDNN == 1
@@ -612,8 +587,8 @@ bool MKLDNNStorageType(const nnvm::NodeAttrs &attrs,
 
   bool dispatched = false;
   if (!dispatched && common::ContainsOnlyStorage(*in_attrs, kDefaultStorage)) {
-    dispatched = op::storage_type_assign(out_attrs, mxnet::kDefaultStorage,
-                                         dispatch_mode, wanted_mode);
+    dispatched =
+        op::storage_type_assign(out_attrs, mxnet::kDefaultStorage, dispatch_mode, wanted_mode);
   }
   if (!dispatched) {
     dispatched = op::dispatch_fallback(out_attrs, dispatch_mode);
@@ -621,10 +596,10 @@ bool MKLDNNStorageType(const nnvm::NodeAttrs &attrs,
   return dispatched;
 }
 
-inline static const std::vector<NDArray> GetMKLDNNInputArray(const std::vector<NDArray> &inputs) {
+inline static const std::vector<NDArray> GetMKLDNNInputArray(const std::vector<NDArray>& inputs) {
   std::vector<NDArray> ret;
   ret.reserve(inputs.size());
-  for (const auto &in : inputs) {
+  for (const auto& in : inputs) {
     if (in.IsView() && in.IsMKLDNNData()) {
       ret.push_back(in.Reorder2Default());
     } else {
@@ -634,12 +609,10 @@ inline static const std::vector<NDArray> GetMKLDNNInputArray(const std::vector<N
   return ret;
 }
 
-void MKLDNNRun(mxnet::FComputeEx fn,
-               const nnvm::NodeAttrs &attrs,
-               const mxnet::OpContext &ctx,
-               const std::vector<mxnet::NDArray> &inputs,
-               const std::vector<mxnet::OpReqType> &req,
-               const std::vector<mxnet::NDArray> &outputs) {
+void MKLDNNRun(
+    mxnet::FComputeEx fn, const nnvm::NodeAttrs& attrs, const mxnet::OpContext& ctx,
+    const std::vector<mxnet::NDArray>& inputs, const std::vector<mxnet::OpReqType>& req,
+    const std::vector<mxnet::NDArray>& outputs) {
   if (CheckMKLDNNInputArrayIsView(inputs)) {
     const auto mkldnn_inputs = GetMKLDNNInputArray(inputs);
     fn(attrs, ctx, mkldnn_inputs, req, outputs);
@@ -648,12 +621,9 @@ void MKLDNNRun(mxnet::FComputeEx fn,
   }
 }
 
-void MKLDNNRun(FComputeExUnary fn,
-               const nnvm::NodeAttrs &attrs,
-               const mxnet::OpContext &ctx,
-               const mxnet::NDArray &input,
-               const mxnet::OpReqType &req,
-               const mxnet::NDArray &output) {
+void MKLDNNRun(
+    FComputeExUnary fn, const nnvm::NodeAttrs& attrs, const mxnet::OpContext& ctx,
+    const mxnet::NDArray& input, const mxnet::OpReqType& req, const mxnet::NDArray& output) {
   auto mkldnn_input = input;
   if (input.IsView() && input.IsMKLDNNData()) {
     mkldnn_input = input.Reorder2Default();

--- a/src/operator/nn/mkldnn/mkldnn_base.cc
+++ b/src/operator/nn/mkldnn/mkldnn_base.cc
@@ -20,10 +20,11 @@
 #if MXNET_USE_MKLDNN == 1
 
 #include <atomic>
-#include "./mkldnn_base-inl.h"
-#include "./mkldnn_ops-inl.h"
+
 #include "../../../common/exec_utils.h"
 #include "../../operator_common.h"
+#include "./mkldnn_base-inl.h"
+#include "./mkldnn_ops-inl.h"
 
 namespace mxnet {
 
@@ -160,8 +161,10 @@ bool CanWriteTo(const NDArray& out_arr, const NDArray& in_arr, const mkldnn::mem
   return add_same && pdesc_same;
 }
 
-mkldnn_output_t CreateMKLDNNMem(const NDArray& out_arr, const mkldnn::memory::desc& desc,
-                                OpReqType req, const NDArray* in_arr) {
+mkldnn_output_t CreateMKLDNNMem(const NDArray& out_arr,
+                                const mkldnn::memory::desc& desc,
+                                OpReqType req,
+                                const NDArray* in_arr) {
   if (kAddTo == req) {
     auto tmp = TmpMemMgr::Get()->Alloc(desc);
     return mkldnn_output_t(OutDataOp::AddBack, tmp);
@@ -186,7 +189,8 @@ mkldnn_output_t CreateMKLDNNMem(const NDArray& out_arr, const mkldnn::memory::de
   return mkldnn_output_t(OutDataOp::Noop, tmp);
 }
 
-mkldnn_output_t CreateMKLDNNWeightGrad(const NDArray& out_arr, const mkldnn::memory::desc& desc,
+mkldnn_output_t CreateMKLDNNWeightGrad(const NDArray& out_arr,
+                                       const mkldnn::memory::desc& desc,
                                        OpReqType req) {
   if (kAddTo == req) {
     auto tmp = TmpMemMgr::Get()->Alloc(desc);
@@ -269,7 +273,8 @@ const mkldnn::memory* GetWeights(const NDArray& arr, int num_groups) {
   return arr.GetMKLDNNData(md);
 }
 
-const mkldnn::memory* GetWeights(const NDArray& arr, const mkldnn::memory::desc& target_desc,
+const mkldnn::memory* GetWeights(const NDArray& arr,
+                                 const mkldnn::memory::desc& target_desc,
                                  int num_groups) {
   const mkldnn::memory* mem = arr.GetMKLDNNData(target_desc);
   // If the weight array already uses the target layout, simply return it directly.
@@ -366,8 +371,11 @@ void ReorderTo(const mkldnn::memory* src, const mkldnn::memory* dst) {
 }
 
 template <typename Compute, typename AttrState>
-void FallBackCompute(Compute fn, const AttrState& attrs_states, const OpContext& ctx,
-                     const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+void FallBackCompute(Compute fn,
+                     const AttrState& attrs_states,
+                     const OpContext& ctx,
+                     const std::vector<NDArray>& inputs,
+                     const std::vector<OpReqType>& req,
                      const std::vector<NDArray>& outputs) {
   std::vector<TBlob> in_blobs(inputs.size());
   std::vector<NDArray> in_bufs;
@@ -445,7 +453,9 @@ void print_diff(const mxnet::NDArray& arr1, const mxnet::NDArray& arr2) {
 }
 
 template <typename DType>
-static bool SimilarArray(const mxnet::NDArray& arr1, const mxnet::NDArray& arr2, DType rtol,
+static bool SimilarArray(const mxnet::NDArray& arr1,
+                         const mxnet::NDArray& arr2,
+                         DType rtol,
                          DType atol) {
   if (arr1.shape().Size() != arr2.shape().Size()) return false;
 
@@ -484,20 +494,24 @@ static bool SimilarArray(const mxnet::NDArray& arr1, const mxnet::NDArray& arr2,
   return success.load();
 }
 
-template void FallBackCompute(void (*)(nnvm::NodeAttrs const&, OpContext const&,
+template void FallBackCompute(void (*)(nnvm::NodeAttrs const&,
+                                       OpContext const&,
                                        std::vector<TBlob, std::allocator<TBlob>> const&,
                                        std::vector<OpReqType, std::allocator<OpReqType>> const&,
                                        std::vector<TBlob, std::allocator<TBlob>> const&),
-                              nnvm::NodeAttrs const&, OpContext const&,
+                              nnvm::NodeAttrs const&,
+                              OpContext const&,
                               std::vector<NDArray, std::allocator<NDArray>> const&,
                               std::vector<OpReqType, std::allocator<OpReqType>> const&,
                               std::vector<NDArray, std::allocator<NDArray>> const&);
 
-template void FallBackCompute(void (*)(OpStatePtr const&, OpContext const&,
+template void FallBackCompute(void (*)(OpStatePtr const&,
+                                       OpContext const&,
                                        std::vector<TBlob, std::allocator<TBlob>> const&,
                                        std::vector<OpReqType, std::allocator<OpReqType>> const&,
                                        std::vector<TBlob, std::allocator<TBlob>> const&),
-                              OpStatePtr const&, OpContext const&,
+                              OpStatePtr const&,
+                              OpContext const&,
                               std::vector<NDArray, std::allocator<NDArray>> const&,
                               std::vector<OpReqType, std::allocator<OpReqType>> const&,
                               std::vector<NDArray, std::allocator<NDArray>> const&);
@@ -523,7 +537,9 @@ void OpCheck::Init(const std::vector<mxnet::NDArray>& inputs_,
   MKLDNNStream::Get()->Submit();
 }
 
-void OpCheck::Run(mxnet::FCompute fn, const nnvm::NodeAttrs& attrs, const mxnet::OpContext& ctx,
+void OpCheck::Run(mxnet::FCompute fn,
+                  const nnvm::NodeAttrs& attrs,
+                  const mxnet::OpContext& ctx,
                   const std::vector<mxnet::NDArray>& inputs_,
                   const std::vector<mxnet::OpReqType>& req,
                   const std::vector<mxnet::NDArray>& outputs_) {
@@ -564,8 +580,11 @@ void OpCheck::CopyResult(const std::vector<mxnet::NDArray>& outputs_,
   MKLDNNStream::Get()->Submit();
 }
 
-bool MKLDNNStorageType(const nnvm::NodeAttrs& attrs, const int dev_mask, bool support_mkldnn,
-                       DispatchMode* dispatch_mode, std::vector<int>* in_attrs,
+bool MKLDNNStorageType(const nnvm::NodeAttrs& attrs,
+                       const int dev_mask,
+                       bool support_mkldnn,
+                       DispatchMode* dispatch_mode,
+                       std::vector<int>* in_attrs,
                        std::vector<int>* out_attrs) {
   for (int& v : *in_attrs)
     if (v == -1) v = kDefaultStorage;
@@ -604,8 +623,11 @@ inline static const std::vector<NDArray> GetMKLDNNInputArray(const std::vector<N
   return ret;
 }
 
-void MKLDNNRun(mxnet::FComputeEx fn, const nnvm::NodeAttrs& attrs, const mxnet::OpContext& ctx,
-               const std::vector<mxnet::NDArray>& inputs, const std::vector<mxnet::OpReqType>& req,
+void MKLDNNRun(mxnet::FComputeEx fn,
+               const nnvm::NodeAttrs& attrs,
+               const mxnet::OpContext& ctx,
+               const std::vector<mxnet::NDArray>& inputs,
+               const std::vector<mxnet::OpReqType>& req,
                const std::vector<mxnet::NDArray>& outputs) {
   if (CheckMKLDNNInputArrayIsView(inputs)) {
     const auto mkldnn_inputs = GetMKLDNNInputArray(inputs);
@@ -615,8 +637,11 @@ void MKLDNNRun(mxnet::FComputeEx fn, const nnvm::NodeAttrs& attrs, const mxnet::
   }
 }
 
-void MKLDNNRun(FComputeExUnary fn, const nnvm::NodeAttrs& attrs, const mxnet::OpContext& ctx,
-               const mxnet::NDArray& input, const mxnet::OpReqType& req,
+void MKLDNNRun(FComputeExUnary fn,
+               const nnvm::NodeAttrs& attrs,
+               const mxnet::OpContext& ctx,
+               const mxnet::NDArray& input,
+               const mxnet::OpReqType& req,
                const mxnet::NDArray& output) {
   auto mkldnn_input = input;
   if (input.IsView() && input.IsMKLDNNData()) {

--- a/src/operator/nn/mkldnn/mkldnn_batch_norm-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_batch_norm-inl.h
@@ -44,9 +44,10 @@ typedef mkldnn::batch_normalization_forward::desc t_bn_f_desc;
 typedef mkldnn::batch_normalization_backward::primitive_desc t_bn_b_pdesc;
 typedef mkldnn::batch_normalization_backward::desc t_bn_b_desc;
 
-inline static mkldnn::normalization_flags _GetFlags(
-    const std::vector<NDArray>& in_data, const std::vector<NDArray>& aux_states,
-    bool is_train_and_not_global_stats, bool fuse_relu) {
+inline static mkldnn::normalization_flags _GetFlags(const std::vector<NDArray>& in_data,
+                                                    const std::vector<NDArray>& aux_states,
+                                                    bool is_train_and_not_global_stats,
+                                                    bool fuse_relu) {
   mkldnn::normalization_flags flags = static_cast<mkldnn::normalization_flags>(0U);
   if (in_data.size() == 3U) {
     flags |= mkldnn::normalization_flags::use_scale_shift;
@@ -64,8 +65,8 @@ inline static mkldnn::normalization_flags _GetFlags(
   return flags;
 }
 
-inline static t_bn_f_pdesc _GetFwd(
-    const mkldnn::memory& data_mem, bool is_train, float eps, mkldnn::normalization_flags flags) {
+inline static t_bn_f_pdesc _GetFwd(const mkldnn::memory& data_mem, bool is_train, float eps,
+                                   mkldnn::normalization_flags flags) {
   auto data_md = data_mem.get_desc();
   auto engine  = CpuEngine::Get()->get_engine();
 
@@ -78,9 +79,8 @@ inline static t_bn_f_pdesc _GetFwd(
   }
 }
 
-inline static t_bn_b_pdesc _GetBwd(
-    const mkldnn::memory& data_mem, const mkldnn::memory& diff_mem, float eps,
-    mkldnn::normalization_flags flags) {
+inline static t_bn_b_pdesc _GetBwd(const mkldnn::memory& data_mem, const mkldnn::memory& diff_mem,
+                                   float eps, mkldnn::normalization_flags flags) {
   auto data_md = data_mem.get_desc();
   auto diff_md = diff_mem.get_desc();
   auto engine  = CpuEngine::Get()->get_engine();
@@ -112,9 +112,9 @@ class MKLDNNBNForward {
 };
 
 template <typename DType>
-static MKLDNNBNForward& GetBNForward(
-    const BatchNormParam& param, const OpContext& ctx, const mkldnn::memory* data_mem,
-    mkldnn::normalization_flags flags) {
+static MKLDNNBNForward& GetBNForward(const BatchNormParam& param, const OpContext& ctx,
+                                     const mkldnn::memory* data_mem,
+                                     mkldnn::normalization_flags flags) {
 #if DMLC_CXX11_THREAD_LOCAL
   static thread_local std::unordered_map<MKLDNNBNSignature, MKLDNNBNForward, OpHash> fwds;
 #else
@@ -135,9 +135,9 @@ static MKLDNNBNForward& GetBNForward(
 }
 
 template <typename DType>
-void MKLDNNBatchNormForward(
-    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& inputs,
-    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs, bool fuse_relu) {
+void MKLDNNBatchNormForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+                            const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+                            const std::vector<NDArray>& outputs, bool fuse_relu) {
   const BatchNormParam& param = nnvm::get<BatchNormParam>(attrs.parsed);
   std::vector<NDArray> in_data(inputs.begin(), inputs.begin() + batchnorm::kInMovingMean);
 
@@ -209,8 +209,8 @@ void MKLDNNBatchNormForward(
       if (workspace == nullptr) {
         LOG(FATAL) << "MKLDNN BatchNorm: incorrect workspace input";
       }
-      auto ws = std::make_shared<mkldnn::memory>(
-          fwd.GetPd().workspace_desc(), engine, workspace->GetMKLDNNData()->get_data_handle());
+      auto ws = std::make_shared<mkldnn::memory>(fwd.GetPd().workspace_desc(), engine,
+                                                 workspace->GetMKLDNNData()->get_data_handle());
       net_args[MKLDNN_ARG_WORKSPACE] = *ws;
     }
     if (!ctx.is_train || param.use_global_stats) {
@@ -268,10 +268,10 @@ class MKLDNNBNBackward {
 };
 
 template <typename DType>
-static MKLDNNBNBackward& GetBNBackward(
-    const BatchNormParam& param, const OpContext& ctx, const NDArray& in_data,
-    const mkldnn::memory& in_mem, const NDArray& diff_data, const mkldnn::memory& diff_mem,
-    mkldnn::normalization_flags flags) {
+static MKLDNNBNBackward& GetBNBackward(const BatchNormParam& param, const OpContext& ctx,
+                                       const NDArray& in_data, const mkldnn::memory& in_mem,
+                                       const NDArray& diff_data, const mkldnn::memory& diff_mem,
+                                       mkldnn::normalization_flags flags) {
 #if DMLC_CXX11_THREAD_LOCAL
   static thread_local std::unordered_map<MKLDNNBNSignature, MKLDNNBNBackward, OpHash> bwds;
 #else
@@ -292,9 +292,9 @@ static MKLDNNBNBackward& GetBNBackward(
 }
 
 template <typename DType>
-void MKLDNNBatchNormBackward(
-    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& inputs,
-    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs, bool fuse_relu) {
+void MKLDNNBatchNormBackward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+                             const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+                             const std::vector<NDArray>& outputs, bool fuse_relu) {
   if (fuse_relu) {
     CHECK_EQ(inputs.size(), 9U);
   } else {

--- a/src/operator/nn/mkldnn/mkldnn_batch_norm-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_batch_norm-inl.h
@@ -27,12 +27,13 @@
 #define MXNET_OPERATOR_NN_MKLDNN_MKLDNN_BATCH_NORM_INL_H_
 
 #if MXNET_USE_MKLDNN == 1
-#include <vector>
-#include <utility>
 #include <mkldnn.hpp>
+#include <utility>
+#include <vector>
+
 #include "../batch_norm-inl.h"
-#include "./mkldnn_ops-inl.h"
 #include "./mkldnn_base-inl.h"
+#include "./mkldnn_ops-inl.h"
 
 namespace mxnet {
 namespace op {
@@ -63,7 +64,9 @@ inline static mkldnn::normalization_flags _GetFlags(const std::vector<NDArray>& 
   return flags;
 }
 
-inline static t_bn_f_pdesc _GetFwd(const mkldnn::memory& data_mem, bool is_train, float eps,
+inline static t_bn_f_pdesc _GetFwd(const mkldnn::memory& data_mem,
+                                   bool is_train,
+                                   float eps,
                                    mkldnn::normalization_flags flags) {
   auto data_md = data_mem.get_desc();
   auto engine  = CpuEngine::Get()->get_engine();
@@ -77,8 +80,10 @@ inline static t_bn_f_pdesc _GetFwd(const mkldnn::memory& data_mem, bool is_train
   }
 }
 
-inline static t_bn_b_pdesc _GetBwd(const mkldnn::memory& data_mem, const mkldnn::memory& diff_mem,
-                                   float eps, mkldnn::normalization_flags flags) {
+inline static t_bn_b_pdesc _GetBwd(const mkldnn::memory& data_mem,
+                                   const mkldnn::memory& diff_mem,
+                                   float eps,
+                                   mkldnn::normalization_flags flags) {
   auto data_md = data_mem.get_desc();
   auto diff_md = diff_mem.get_desc();
   auto engine  = CpuEngine::Get()->get_engine();
@@ -110,7 +115,8 @@ class MKLDNNBNForward {
 };
 
 template <typename DType>
-static MKLDNNBNForward& GetBNForward(const BatchNormParam& param, const OpContext& ctx,
+static MKLDNNBNForward& GetBNForward(const BatchNormParam& param,
+                                     const OpContext& ctx,
                                      const mkldnn::memory* data_mem,
                                      mkldnn::normalization_flags flags) {
 #if DMLC_CXX11_THREAD_LOCAL
@@ -133,9 +139,12 @@ static MKLDNNBNForward& GetBNForward(const BatchNormParam& param, const OpContex
 }
 
 template <typename DType>
-void MKLDNNBatchNormForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
-                            const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
-                            const std::vector<NDArray>& outputs, bool fuse_relu) {
+void MKLDNNBatchNormForward(const nnvm::NodeAttrs& attrs,
+                            const OpContext& ctx,
+                            const std::vector<NDArray>& inputs,
+                            const std::vector<OpReqType>& req,
+                            const std::vector<NDArray>& outputs,
+                            bool fuse_relu) {
   const BatchNormParam& param = nnvm::get<BatchNormParam>(attrs.parsed);
   std::vector<NDArray> in_data(inputs.begin(), inputs.begin() + batchnorm::kInMovingMean);
 
@@ -266,9 +275,12 @@ class MKLDNNBNBackward {
 };
 
 template <typename DType>
-static MKLDNNBNBackward& GetBNBackward(const BatchNormParam& param, const OpContext& ctx,
-                                       const NDArray& in_data, const mkldnn::memory& in_mem,
-                                       const NDArray& diff_data, const mkldnn::memory& diff_mem,
+static MKLDNNBNBackward& GetBNBackward(const BatchNormParam& param,
+                                       const OpContext& ctx,
+                                       const NDArray& in_data,
+                                       const mkldnn::memory& in_mem,
+                                       const NDArray& diff_data,
+                                       const mkldnn::memory& diff_mem,
                                        mkldnn::normalization_flags flags) {
 #if DMLC_CXX11_THREAD_LOCAL
   static thread_local std::unordered_map<MKLDNNBNSignature, MKLDNNBNBackward, OpHash> bwds;
@@ -290,9 +302,12 @@ static MKLDNNBNBackward& GetBNBackward(const BatchNormParam& param, const OpCont
 }
 
 template <typename DType>
-void MKLDNNBatchNormBackward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
-                             const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
-                             const std::vector<NDArray>& outputs, bool fuse_relu) {
+void MKLDNNBatchNormBackward(const nnvm::NodeAttrs& attrs,
+                             const OpContext& ctx,
+                             const std::vector<NDArray>& inputs,
+                             const std::vector<OpReqType>& req,
+                             const std::vector<NDArray>& outputs,
+                             bool fuse_relu) {
   if (fuse_relu) {
     CHECK_EQ(inputs.size(), 9U);
   } else {

--- a/src/operator/nn/mkldnn/mkldnn_batch_norm-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_batch_norm-inl.h
@@ -11,7 +11,7 @@
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY92
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
@@ -107,11 +107,17 @@ class MKLDNNBNForward {
     this->is_train_and_not_global_stats = is_train_and_not_global_stats;
   }
 
-  const mkldnn::memory& GetWeight() const { return *weight_m; }
+  const mkldnn::memory& GetWeight() const {
+    return *weight_m;
+  }
 
-  const t_bn_f_pdesc& GetPd() const { return pd; }
+  const t_bn_f_pdesc& GetPd() const {
+    return pd;
+  }
 
-  const mkldnn::batch_normalization_forward& GetFwd() const { return *fwd; }
+  const mkldnn::batch_normalization_forward& GetFwd() const {
+    return *fwd;
+  }
 };
 
 template <typename DType>
@@ -155,7 +161,9 @@ void MKLDNNBatchNormForward(const nnvm::NodeAttrs& attrs,
   if (param.axis != 1 || shape.ndim() != 4) {
     // reshape to (N, C, 1, D)
     mxnet::TShape new_shape{
-        static_cast<dim_t>(shape.ProdShape(0, real_axis)), shape[real_axis], 1,
+        static_cast<dim_t>(shape.ProdShape(0, real_axis)),
+        shape[real_axis],
+        1,
         static_cast<dim_t>(shape.ProdShape(real_axis + 1, static_cast<int>(shape.ndim())))};
     in_data[batchnorm::kData] = in_data[batchnorm::kData].Reshape(new_shape);
     out                       = out.Reshape(new_shape);
@@ -166,7 +174,8 @@ void MKLDNNBatchNormForward(const nnvm::NodeAttrs& attrs,
   mkldnn::normalization_flags flags =
       _GetFlags(in_data, aux_states, ctx.is_train && !param.use_global_stats, fuse_relu);
   NDArray& data = in_data[batchnorm::kData];
-  if (data.IsMKLDNNData() && data.IsView()) data = data.Reorder2Default();
+  if (data.IsMKLDNNData() && data.IsView())
+    data = data.Reorder2Default();
   auto data_mem = data.GetMKLDNNData();
   auto& fwd     = GetBNForward<DType>(param, ctx, data_mem, flags);
 
@@ -216,8 +225,8 @@ void MKLDNNBatchNormForward(const nnvm::NodeAttrs& attrs,
       if (workspace == nullptr) {
         LOG(FATAL) << "MKLDNN BatchNorm: incorrect workspace input";
       }
-      auto ws = std::make_shared<mkldnn::memory>(fwd.GetPd().workspace_desc(), engine,
-                                                 workspace->GetMKLDNNData()->get_data_handle());
+      auto ws = std::make_shared<mkldnn::memory>(
+          fwd.GetPd().workspace_desc(), engine, workspace->GetMKLDNNData()->get_data_handle());
       net_args[MKLDNN_ARG_WORKSPACE] = *ws;
     }
     if (!ctx.is_train || param.use_global_stats) {
@@ -267,11 +276,17 @@ class MKLDNNBNBackward {
     bwd.reset(new mkldnn::batch_normalization_backward(pd));
   }
 
-  const mkldnn::memory& GetWeight() const { return *weight_m; }
+  const mkldnn::memory& GetWeight() const {
+    return *weight_m;
+  }
 
-  const mkldnn::memory& GetGradw() const { return *gradw_m; }
+  const mkldnn::memory& GetGradw() const {
+    return *gradw_m;
+  }
 
-  const mkldnn::batch_normalization_backward& GetBwd() const { return *bwd; }
+  const mkldnn::batch_normalization_backward& GetBwd() const {
+    return *bwd;
+  }
 };
 
 template <typename DType>
@@ -350,7 +365,9 @@ void MKLDNNBatchNormBackward(const nnvm::NodeAttrs& attrs,
   if (param.axis != 1 || shape.ndim() != 4) {
     // reshape to (N, C, 1, D)
     mxnet::TShape new_shape{
-        static_cast<dim_t>(shape.ProdShape(0, real_axis)), shape[real_axis], 1,
+        static_cast<dim_t>(shape.ProdShape(0, real_axis)),
+        shape[real_axis],
+        1,
         static_cast<dim_t>(shape.ProdShape(real_axis + 1, static_cast<int>(shape.ndim())))};
     data   = data.Reshape(new_shape);
     diff   = diff.Reshape(new_shape);

--- a/src/operator/nn/mkldnn/mkldnn_batch_norm-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_batch_norm-inl.h
@@ -34,8 +34,6 @@
 #include "./mkldnn_ops-inl.h"
 #include "./mkldnn_base-inl.h"
 
-#define VARIANCE_TO_INVSTD(__var$, __eps$)    (1.0 / std::sqrt((__var$) + DType(__eps$)))
-#define INVSTD_TO_VARIANCE(__invstd$, __eps$) ((1.0 / ((__invstd$) * (__invstd$))) - (__eps$))
 namespace mxnet {
 namespace op {
 

--- a/src/operator/nn/mkldnn/mkldnn_batch_norm-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_batch_norm-inl.h
@@ -21,7 +21,7 @@
  * \file mkldnn_batch_norm.cc
  * \brief
  * \author Tao Lv
-*/
+ */
 
 #ifndef MXNET_OPERATOR_NN_MKLDNN_MKLDNN_BATCH_NORM_INL_H_
 #define MXNET_OPERATOR_NN_MKLDNN_MKLDNN_BATCH_NORM_INL_H_
@@ -34,43 +34,40 @@
 #include "./mkldnn_ops-inl.h"
 #include "./mkldnn_base-inl.h"
 
-#define VARIANCE_TO_INVSTD(__var$,    __eps$)   (1.0/std::sqrt((__var$) + DType(__eps$)))
-#define INVSTD_TO_VARIANCE(__invstd$, __eps$)   ((1.0 / ((__invstd$) * (__invstd$))) - (__eps$))
+#define VARIANCE_TO_INVSTD(__var$, __eps$)    (1.0 / std::sqrt((__var$) + DType(__eps$)))
+#define INVSTD_TO_VARIANCE(__invstd$, __eps$) ((1.0 / ((__invstd$) * (__invstd$))) - (__eps$))
 namespace mxnet {
 namespace op {
 
-typedef mkldnn::batch_normalization_forward::primitive_desc     t_bn_f_pdesc;
-typedef mkldnn::batch_normalization_forward::desc               t_bn_f_desc;
-typedef mkldnn::batch_normalization_backward::primitive_desc    t_bn_b_pdesc;
-typedef mkldnn::batch_normalization_backward::desc              t_bn_b_desc;
+typedef mkldnn::batch_normalization_forward::primitive_desc t_bn_f_pdesc;
+typedef mkldnn::batch_normalization_forward::desc t_bn_f_desc;
+typedef mkldnn::batch_normalization_backward::primitive_desc t_bn_b_pdesc;
+typedef mkldnn::batch_normalization_backward::desc t_bn_b_desc;
 
-inline static mkldnn::normalization_flags _GetFlags(const std::vector<NDArray> &in_data,
-                                                    const std::vector<NDArray> &aux_states,
-                                                    bool is_train_and_not_global_stats,
-                                                    bool fuse_relu) {
+inline static mkldnn::normalization_flags _GetFlags(
+    const std::vector<NDArray>& in_data, const std::vector<NDArray>& aux_states,
+    bool is_train_and_not_global_stats, bool fuse_relu) {
   mkldnn::normalization_flags flags = static_cast<mkldnn::normalization_flags>(0U);
   if (in_data.size() == 3U) {
-    flags |=  mkldnn::normalization_flags::use_scale_shift;
+    flags |= mkldnn::normalization_flags::use_scale_shift;
   }
 
   // aux_states[0]: inMean
   // aux_states[1]: inVariance
   if (aux_states.size() == 2U && !is_train_and_not_global_stats) {
-    flags |=  mkldnn::normalization_flags::use_global_stats;
+    flags |= mkldnn::normalization_flags::use_global_stats;
   }
 
   if (fuse_relu) {
-    flags |=  mkldnn::normalization_flags::fuse_norm_relu;
+    flags |= mkldnn::normalization_flags::fuse_norm_relu;
   }
   return flags;
 }
 
-inline static t_bn_f_pdesc _GetFwd(const mkldnn::memory &data_mem,
-                                   bool is_train,
-                                   float eps,
-                                   mkldnn::normalization_flags flags) {
-  auto data_md   = data_mem.get_desc();
-  auto engine    = CpuEngine::Get()->get_engine();
+inline static t_bn_f_pdesc _GetFwd(
+    const mkldnn::memory& data_mem, bool is_train, float eps, mkldnn::normalization_flags flags) {
+  auto data_md = data_mem.get_desc();
+  auto engine  = CpuEngine::Get()->get_engine();
 
   if (is_train) {
     t_bn_f_desc bnFwd_desc(mkldnn::prop_kind::forward_training, data_md, eps, flags);
@@ -81,15 +78,14 @@ inline static t_bn_f_pdesc _GetFwd(const mkldnn::memory &data_mem,
   }
 }
 
-inline static t_bn_b_pdesc _GetBwd(const mkldnn::memory &data_mem,
-                                   const mkldnn::memory &diff_mem,
-                                   float eps,
-                                   mkldnn::normalization_flags flags) {
-  auto data_md    = data_mem.get_desc();
-  auto diff_md    = diff_mem.get_desc();
-  auto engine     = CpuEngine::Get()->get_engine();
+inline static t_bn_b_pdesc _GetBwd(
+    const mkldnn::memory& data_mem, const mkldnn::memory& diff_mem, float eps,
+    mkldnn::normalization_flags flags) {
+  auto data_md = data_mem.get_desc();
+  auto diff_md = diff_mem.get_desc();
+  auto engine  = CpuEngine::Get()->get_engine();
 
-  t_bn_b_desc  bnBwd_desc(mkldnn::prop_kind::backward, diff_md, data_md, eps, flags);
+  t_bn_b_desc bnBwd_desc(mkldnn::prop_kind::backward, diff_md, data_md, eps, flags);
   return t_bn_b_pdesc(bnBwd_desc, engine, _GetFwd(data_mem, true, eps, flags));
 }
 
@@ -102,29 +98,23 @@ class MKLDNNBNForward {
   t_bn_f_pdesc pd;
 
  public:
-  MKLDNNBNForward(const t_bn_f_pdesc &_pd, bool is_train_and_not_global_stats): pd(_pd) {
+  MKLDNNBNForward(const t_bn_f_pdesc& _pd, bool is_train_and_not_global_stats) : pd(_pd) {
     weight_m.reset(new mkldnn::memory(pd.weights_desc(), CpuEngine::Get()->get_engine()));
     fwd.reset(new mkldnn::batch_normalization_forward(pd));
     this->is_train_and_not_global_stats = is_train_and_not_global_stats;
   }
 
-  const mkldnn::memory &GetWeight() const {
-    return *weight_m;
-  }
+  const mkldnn::memory& GetWeight() const { return *weight_m; }
 
-  const t_bn_f_pdesc &GetPd() const {
-    return pd;
-  }
+  const t_bn_f_pdesc& GetPd() const { return pd; }
 
-  const mkldnn::batch_normalization_forward &GetFwd() const {
-    return *fwd;
-  }
+  const mkldnn::batch_normalization_forward& GetFwd() const { return *fwd; }
 };
 
-template<typename DType>
-static MKLDNNBNForward &GetBNForward(const BatchNormParam& param,
-                                     const OpContext &ctx, const mkldnn::memory *data_mem,
-                                     mkldnn::normalization_flags flags) {
+template <typename DType>
+static MKLDNNBNForward& GetBNForward(
+    const BatchNormParam& param, const OpContext& ctx, const mkldnn::memory* data_mem,
+    mkldnn::normalization_flags flags) {
 #if DMLC_CXX11_THREAD_LOCAL
   static thread_local std::unordered_map<MKLDNNBNSignature, MKLDNNBNForward, OpHash> fwds;
 #else
@@ -137,8 +127,7 @@ static MKLDNNBNForward &GetBNForward(const BatchNormParam& param,
 
   auto it = fwds.find(key);
   if (it == fwds.end()) {
-    auto fwd_pd = _GetFwd(*data_mem, ctx.is_train,
-                          param.eps, flags);
+    auto fwd_pd = _GetFwd(*data_mem, ctx.is_train, param.eps, flags);
     MKLDNNBNForward fwd(fwd_pd, ctx.is_train && !param.use_global_stats);
     it = AddToCache(&fwds, key, fwd);
   }
@@ -146,10 +135,10 @@ static MKLDNNBNForward &GetBNForward(const BatchNormParam& param,
 }
 
 template <typename DType>
-void MKLDNNBatchNormForward(const nnvm::NodeAttrs &attrs, const OpContext &ctx,
-                            const std::vector<NDArray> &inputs, const std::vector<OpReqType> &req,
-                            const std::vector<NDArray> &outputs, bool fuse_relu) {
-  const BatchNormParam &param = nnvm::get<BatchNormParam>(attrs.parsed);
+void MKLDNNBatchNormForward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& inputs,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs, bool fuse_relu) {
+  const BatchNormParam& param = nnvm::get<BatchNormParam>(attrs.parsed);
   std::vector<NDArray> in_data(inputs.begin(), inputs.begin() + batchnorm::kInMovingMean);
 
   mxnet::TShape shape = inputs[batchnorm::kData].shape();
@@ -159,96 +148,89 @@ void MKLDNNBatchNormForward(const nnvm::NodeAttrs &attrs, const OpContext &ctx,
   if (param.axis != 1 || shape.ndim() != 4) {
     // reshape to (N, C, 1, D)
     mxnet::TShape new_shape{
-      static_cast<dim_t>(shape.ProdShape(0, real_axis)),
-      shape[real_axis],
-      1,
-      static_cast<dim_t>(shape.ProdShape(real_axis + 1,
-            static_cast<int>(shape.ndim())))
-    };
+        static_cast<dim_t>(shape.ProdShape(0, real_axis)), shape[real_axis], 1,
+        static_cast<dim_t>(shape.ProdShape(real_axis + 1, static_cast<int>(shape.ndim())))};
     in_data[batchnorm::kData] = in_data[batchnorm::kData].Reshape(new_shape);
-    out = out.Reshape(new_shape);
+    out                       = out.Reshape(new_shape);
   }
 
   const std::vector<NDArray> aux_states(inputs.begin() + batchnorm::kInMovingMean, inputs.end());
   TmpMemMgr::Get()->Init(ctx.requested[batchnorm::kTempSpace]);
-  mkldnn::normalization_flags flags = _GetFlags(in_data,
-                                                aux_states,
-                                                ctx.is_train && !param.use_global_stats,
-                                                fuse_relu);
-  NDArray &data = in_data[batchnorm::kData];
-  if (data.IsMKLDNNData() && data.IsView())
-    data = data.Reorder2Default();
+  mkldnn::normalization_flags flags =
+      _GetFlags(in_data, aux_states, ctx.is_train && !param.use_global_stats, fuse_relu);
+  NDArray& data = in_data[batchnorm::kData];
+  if (data.IsMKLDNNData() && data.IsView()) data = data.Reorder2Default();
   auto data_mem = data.GetMKLDNNData();
-  auto &fwd = GetBNForward<DType>(param, ctx, data_mem, flags);
+  auto& fwd     = GetBNForward<DType>(param, ctx, data_mem, flags);
 
   // for output memory
-  auto out_mem = const_cast<NDArray &>(out).CreateMKLDNNData(fwd.GetPd().dst_desc());
+  auto out_mem = const_cast<NDArray&>(out).CreateMKLDNNData(fwd.GetPd().dst_desc());
 
   // mxnet will always use scale shift.
   // But if fix_gamma is true, then all scale elements will be set to 1.0f
   if (static_cast<int>(flags) & static_cast<int>(mkldnn::normalization_flags::use_scale_shift)) {
-    const NDArray &gamma    = in_data[batchnorm::kGamma];
-    const NDArray &beta     = in_data[batchnorm::kBeta];
+    const NDArray& gamma = in_data[batchnorm::kGamma];
+    const NDArray& beta  = in_data[batchnorm::kBeta];
     CHECK_EQ(gamma.storage_type(), mxnet::kDefaultStorage);
     CHECK_EQ(beta.storage_type(), mxnet::kDefaultStorage);
 
-    const mkldnn::memory &weight_mem = fwd.GetWeight();
-    float* weight_buf = reinterpret_cast<float *>(weight_mem.get_data_handle());
+    const mkldnn::memory& weight_mem = fwd.GetWeight();
+    float* weight_buf                = reinterpret_cast<float*>(weight_mem.get_data_handle());
 
     nnvm::dim_t channels_ = data.shape()[1];
     CHECK(weight_mem.get_desc().get_size() == channels_ * sizeof(float) * 2);
-    float* weight_ptr = gamma.data().dptr<float>();
-    float* bias_ptr = beta.data().dptr<float>();
+    float* weight_ptr      = gamma.data().dptr<float>();
+    float* bias_ptr        = beta.data().dptr<float>();
     const size_t copy_size = sizeof(weight_buf[0]) * channels_;
     if (!param.fix_gamma) {
       memcpy(weight_buf, weight_ptr, copy_size);
       memcpy(&weight_buf[channels_], bias_ptr, copy_size);
     } else if (IsBNWriting(req[batchnorm::kGamma])) {
       for (int i = 0; i < channels_; i++) {
-        weight_buf[i] = 1.0f;
-        weight_ptr[i] = 1.0f;
+        weight_buf[i]             = 1.0f;
+        weight_ptr[i]             = 1.0f;
         weight_buf[channels_ + i] = bias_ptr[i];  // bias
       }
     } else {
       for (int i = 0; i < channels_; i++) {
-        weight_buf[i] = 1.0f;
+        weight_buf[i]             = 1.0f;
         weight_buf[channels_ + i] = bias_ptr[i];  // bias
       }
     }
 
     mkldnn_args_map_t net_args;
-    net_args[MKLDNN_ARG_SRC] = *data_mem;
+    net_args[MKLDNN_ARG_SRC]         = *data_mem;
     net_args[MKLDNN_ARG_SCALE_SHIFT] = weight_mem;
-    net_args[MKLDNN_ARG_DST] = *out_mem;
+    net_args[MKLDNN_ARG_DST]         = *out_mem;
     if (fuse_relu) {
-      const NDArray *workspace = nullptr;
-      workspace = &outputs[3];
-      auto engine = CpuEngine::Get()->get_engine();
+      const NDArray* workspace = nullptr;
+      workspace                = &outputs[3];
+      auto engine              = CpuEngine::Get()->get_engine();
       if (workspace == nullptr) {
-          LOG(FATAL) << "MKLDNN BatchNorm: incorrect workspace input";
+        LOG(FATAL) << "MKLDNN BatchNorm: incorrect workspace input";
       }
-      auto ws = std::make_shared<mkldnn::memory>(fwd.GetPd().workspace_desc(),
-                        engine, workspace->GetMKLDNNData()->get_data_handle());
+      auto ws = std::make_shared<mkldnn::memory>(
+          fwd.GetPd().workspace_desc(), engine, workspace->GetMKLDNNData()->get_data_handle());
       net_args[MKLDNN_ARG_WORKSPACE] = *ws;
     }
     if (!ctx.is_train || param.use_global_stats) {
-      float* omean    = outputs[batchnorm::kMean].data().dptr<float>();
-      float* ovar     = outputs[batchnorm::kVar].data().dptr<float>();
-      float* inmean   = aux_states[batchnorm::kMovingMean].data().dptr<float>();
-      float* invar    = aux_states[batchnorm::kMovingVar].data().dptr<float>();
+      float* omean  = outputs[batchnorm::kMean].data().dptr<float>();
+      float* ovar   = outputs[batchnorm::kVar].data().dptr<float>();
+      float* inmean = aux_states[batchnorm::kMovingMean].data().dptr<float>();
+      float* invar  = aux_states[batchnorm::kMovingVar].data().dptr<float>();
       // to align with origin implmentation: batch_norm.cc: L164
       for (int i = 0; i < channels_; i++) {
         omean[i] = inmean[i];
-        ovar[i] = VARIANCE_TO_INVSTD(invar[i], param.eps);
+        ovar[i]  = VARIANCE_TO_INVSTD(invar[i], param.eps);
       }
-      net_args[MKLDNN_ARG_MEAN] = *(aux_states[batchnorm::kMovingMean].GetMKLDNNData());
+      net_args[MKLDNN_ARG_MEAN]     = *(aux_states[batchnorm::kMovingMean].GetMKLDNNData());
       net_args[MKLDNN_ARG_VARIANCE] = *(aux_states[batchnorm::kMovingVar].GetMKLDNNData());
       MKLDNNStream::Get()->RegisterPrimArgs(fwd.GetFwd(), net_args);
       MKLDNNStream::Get()->Submit();
     } else {  // training
-      const NDArray &outMean  = outputs[batchnorm::kMean];
-      const NDArray &outVar   = outputs[batchnorm::kVar];
-      net_args[MKLDNN_ARG_MEAN] = *(outMean.GetMKLDNNData());
+      const NDArray& outMean        = outputs[batchnorm::kMean];
+      const NDArray& outVar         = outputs[batchnorm::kVar];
+      net_args[MKLDNN_ARG_MEAN]     = *(outMean.GetMKLDNNData());
       net_args[MKLDNN_ARG_VARIANCE] = *(outVar.GetMKLDNNData());
       MKLDNNStream::Get()->RegisterPrimArgs(fwd.GetFwd(), net_args);
       MKLDNNStream::Get()->Submit();
@@ -271,25 +253,25 @@ class MKLDNNBNBackward {
  public:
   const t_bn_b_pdesc pd;
 
-  explicit MKLDNNBNBackward(const t_bn_b_pdesc &_pd)
+  explicit MKLDNNBNBackward(const t_bn_b_pdesc& _pd)
       : weight_m(new mkldnn::memory(_pd.weights_desc(), CpuEngine::Get()->get_engine())),
         gradw_m(new mkldnn::memory(_pd.diff_weights_desc(), CpuEngine::Get()->get_engine())),
         pd(_pd) {
     bwd.reset(new mkldnn::batch_normalization_backward(pd));
   }
 
-  const mkldnn::memory &GetWeight() const { return *weight_m; }
+  const mkldnn::memory& GetWeight() const { return *weight_m; }
 
-  const mkldnn::memory &GetGradw() const { return *gradw_m; }
+  const mkldnn::memory& GetGradw() const { return *gradw_m; }
 
-  const mkldnn::batch_normalization_backward &GetBwd() const { return *bwd; }
+  const mkldnn::batch_normalization_backward& GetBwd() const { return *bwd; }
 };
 
 template <typename DType>
-static MKLDNNBNBackward &GetBNBackward(
-    const BatchNormParam &param, const OpContext &ctx, const NDArray &in_data,
-    const mkldnn::memory &in_mem, const NDArray &diff_data,
-    const mkldnn::memory &diff_mem, mkldnn::normalization_flags flags) {
+static MKLDNNBNBackward& GetBNBackward(
+    const BatchNormParam& param, const OpContext& ctx, const NDArray& in_data,
+    const mkldnn::memory& in_mem, const NDArray& diff_data, const mkldnn::memory& diff_mem,
+    mkldnn::normalization_flags flags) {
 #if DMLC_CXX11_THREAD_LOCAL
   static thread_local std::unordered_map<MKLDNNBNSignature, MKLDNNBNBackward, OpHash> bwds;
 #else
@@ -310,41 +292,39 @@ static MKLDNNBNBackward &GetBNBackward(
 }
 
 template <typename DType>
-void MKLDNNBatchNormBackward(const nnvm::NodeAttrs &attrs, const OpContext &ctx,
-                             const std::vector<NDArray> &inputs, const std::vector<OpReqType> &req,
-                             const std::vector<NDArray> &outputs, bool fuse_relu) {
+void MKLDNNBatchNormBackward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& inputs,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs, bool fuse_relu) {
   if (fuse_relu) {
     CHECK_EQ(inputs.size(), 9U);
   } else {
     CHECK_EQ(inputs.size(), 8U);
   }
-  const BatchNormParam &param = nnvm::get<BatchNormParam>(attrs.parsed);
+  const BatchNormParam& param = nnvm::get<BatchNormParam>(attrs.parsed);
   std::vector<NDArray> out_grad(1);
   std::vector<NDArray> out_data(3);
   std::vector<NDArray> in_data(3);
   std::vector<NDArray> aux_states(2);
-  out_grad[0] = inputs[0];
-  out_data[batchnorm::kMean] = inputs[1];
-  out_data[batchnorm::kVar] = inputs[2];
-  in_data[batchnorm::kData] = inputs[3];
-  in_data[batchnorm::kGamma] = inputs[4];
-  in_data[batchnorm::kBeta] = inputs[5];
-  aux_states[batchnorm::kMovingMean] = inputs[6];
-  aux_states[batchnorm::kMovingVar] = inputs[7];
-  const std::vector<NDArray> &in_grad = outputs;
+  out_grad[0]                         = inputs[0];
+  out_data[batchnorm::kMean]          = inputs[1];
+  out_data[batchnorm::kVar]           = inputs[2];
+  in_data[batchnorm::kData]           = inputs[3];
+  in_data[batchnorm::kGamma]          = inputs[4];
+  in_data[batchnorm::kBeta]           = inputs[5];
+  aux_states[batchnorm::kMovingMean]  = inputs[6];
+  aux_states[batchnorm::kMovingVar]   = inputs[7];
+  const std::vector<NDArray>& in_grad = outputs;
   TmpMemMgr::Get()->Init(ctx.requested[batchnorm::kTempSpace]);
-  mkldnn::normalization_flags flags = _GetFlags(in_data,
-                                                aux_states,
-                                                ctx.is_train && !param.use_global_stats,
-                                                fuse_relu);
+  mkldnn::normalization_flags flags =
+      _GetFlags(in_data, aux_states, ctx.is_train && !param.use_global_stats, fuse_relu);
 
-  NDArray data         = in_data[batchnorm::kData];
-  NDArray diff         = out_grad[batchnorm::kOut];
-  NDArray gradIn       = in_grad[batchnorm::kData];
-  const NDArray &moving_mean  = aux_states[batchnorm::kMovingMean];
-  const NDArray &moving_var   = aux_states[batchnorm::kMovingVar];
-  const NDArray &out_mean     = out_data[batchnorm::kMean];
-  const NDArray &out_var      = out_data[batchnorm::kVar];
+  NDArray data               = in_data[batchnorm::kData];
+  NDArray diff               = out_grad[batchnorm::kOut];
+  NDArray gradIn             = in_grad[batchnorm::kData];
+  const NDArray& moving_mean = aux_states[batchnorm::kMovingMean];
+  const NDArray& moving_var  = aux_states[batchnorm::kMovingVar];
+  const NDArray& out_mean    = out_data[batchnorm::kMean];
+  const NDArray& out_var     = out_data[batchnorm::kVar];
 
   CHECK(out_mean.IsDefaultData());
   CHECK(out_var.IsDefaultData());
@@ -357,36 +337,32 @@ void MKLDNNBatchNormBackward(const nnvm::NodeAttrs &attrs, const OpContext &ctx,
   if (param.axis != 1 || shape.ndim() != 4) {
     // reshape to (N, C, 1, D)
     mxnet::TShape new_shape{
-      static_cast<dim_t>(shape.ProdShape(0, real_axis)),
-      shape[real_axis],
-      1,
-      static_cast<dim_t>(shape.ProdShape(real_axis + 1,
-            static_cast<int>(shape.ndim())))
-    };
-    data = data.Reshape(new_shape);
-    diff = diff.Reshape(new_shape);
+        static_cast<dim_t>(shape.ProdShape(0, real_axis)), shape[real_axis], 1,
+        static_cast<dim_t>(shape.ProdShape(real_axis + 1, static_cast<int>(shape.ndim())))};
+    data   = data.Reshape(new_shape);
+    diff   = diff.Reshape(new_shape);
     gradIn = gradIn.Reshape(new_shape);
   }
 
-  auto data_mem  = data.GetMKLDNNData();
-  auto diff_mem  = diff.GetMKLDNNData();
+  auto data_mem = data.GetMKLDNNData();
+  auto diff_mem = diff.GetMKLDNNData();
   // MKLDNN batchnorm should run on special layouts. If one of them isn't, we
   // should reorder them.
   if (data.IsDefaultData())
     data_mem = data.GetMKLDNNDataReorder(diff_mem->get_desc());
   else if (diff.IsDefaultData())
     diff_mem = diff.GetMKLDNNDataReorder(data_mem->get_desc());
-  auto &bwd = GetBNBackward<DType>(param, ctx, data, *data_mem, diff, *diff_mem, flags);
-  auto gradi_mem = CreateMKLDNNMem(const_cast<NDArray &>(gradIn),
-      bwd.pd.diff_src_desc(), req[batchnorm::kData]);
+  auto& bwd = GetBNBackward<DType>(param, ctx, data, *data_mem, diff, *diff_mem, flags);
+  auto gradi_mem =
+      CreateMKLDNNMem(const_cast<NDArray&>(gradIn), bwd.pd.diff_src_desc(), req[batchnorm::kData]);
 
   if (static_cast<int>(flags) & static_cast<int>(mkldnn::normalization_flags::use_scale_shift)) {
-    const NDArray &gamma    = in_data[batchnorm::kGamma];
-    const NDArray &beta     = in_data[batchnorm::kBeta];
-    DType *weight_buf = reinterpret_cast<DType *>(bwd.GetWeight().get_data_handle());
-    nnvm::dim_t channels_ = data.shape()[1];
-    DType *weight_ptr = gamma.data().dptr<DType>();
-    DType* bias_ptr = beta.data().dptr<DType>();
+    const NDArray& gamma   = in_data[batchnorm::kGamma];
+    const NDArray& beta    = in_data[batchnorm::kBeta];
+    DType* weight_buf      = reinterpret_cast<DType*>(bwd.GetWeight().get_data_handle());
+    nnvm::dim_t channels_  = data.shape()[1];
+    DType* weight_ptr      = gamma.data().dptr<DType>();
+    DType* bias_ptr        = beta.data().dptr<DType>();
     const size_t copy_size = sizeof(DType) * channels_;
     if (!param.fix_gamma) {
       memcpy(weight_buf, weight_ptr, copy_size);
@@ -398,15 +374,15 @@ void MKLDNNBatchNormBackward(const nnvm::NodeAttrs &attrs, const OpContext &ctx,
       memcpy(&weight_buf[channels_], bias_ptr, copy_size);
     }
     mkldnn_args_map_t net_args;
-    net_args[MKLDNN_ARG_SRC] = *data_mem;
-    net_args[MKLDNN_ARG_DIFF_SRC] = *gradi_mem.second;
-    net_args[MKLDNN_ARG_SCALE_SHIFT] = bwd.GetWeight();
+    net_args[MKLDNN_ARG_SRC]              = *data_mem;
+    net_args[MKLDNN_ARG_DIFF_SRC]         = *gradi_mem.second;
+    net_args[MKLDNN_ARG_SCALE_SHIFT]      = bwd.GetWeight();
     net_args[MKLDNN_ARG_DIFF_SCALE_SHIFT] = bwd.GetGradw();
-    net_args[MKLDNN_ARG_DIFF_DST] = *diff_mem;
+    net_args[MKLDNN_ARG_DIFF_DST]         = *diff_mem;
 
     if (fuse_relu) {
-      const NDArray *workspace = nullptr;
-      workspace = &inputs[8];
+      const NDArray* workspace = nullptr;
+      workspace                = &inputs[8];
       if (workspace != nullptr) {
         net_args[MKLDNN_ARG_WORKSPACE] = *(workspace->GetMKLDNNData());
       }
@@ -414,26 +390,24 @@ void MKLDNNBatchNormBackward(const nnvm::NodeAttrs &attrs, const OpContext &ctx,
 
     // training but no input mean and variance
     if (ctx.is_train && !param.use_global_stats) {
-      DType* moving_mean_ptr  = moving_mean.data().dptr<DType>();
-      DType* moving_var_ptr   = moving_var.data().dptr<DType>();
-      DType* out_mean_ptr     = out_mean.data().dptr<DType>();
-      DType* out_var_ptr      = out_var.data().dptr<DType>();
+      DType* moving_mean_ptr = moving_mean.data().dptr<DType>();
+      DType* moving_var_ptr  = moving_var.data().dptr<DType>();
+      DType* out_mean_ptr    = out_mean.data().dptr<DType>();
+      DType* out_var_ptr     = out_var.data().dptr<DType>();
       mkldnn::memory var_mem(bwd.pd.variance_desc(), CpuEngine::Get()->get_engine());
-      DType *tmp_var_ptr = reinterpret_cast<DType *>(var_mem.get_data_handle());
+      DType* tmp_var_ptr = reinterpret_cast<DType*>(var_mem.get_data_handle());
 
       DType minus_mom = (1.0f - param.momentum);
       for (int i = 0; i < channels_; i++) {
-        moving_mean_ptr[i] = moving_mean_ptr[i] * param.momentum +
-                             out_mean_ptr[i] * minus_mom;
-        float variance = INVSTD_TO_VARIANCE(out_var_ptr[i], param.eps);
-        tmp_var_ptr[i] = variance;
-        moving_var_ptr[i] = moving_var_ptr[i] * param.momentum +
-                            variance * minus_mom;
+        moving_mean_ptr[i] = moving_mean_ptr[i] * param.momentum + out_mean_ptr[i] * minus_mom;
+        float variance     = INVSTD_TO_VARIANCE(out_var_ptr[i], param.eps);
+        tmp_var_ptr[i]     = variance;
+        moving_var_ptr[i]  = moving_var_ptr[i] * param.momentum + variance * minus_mom;
       }
-      net_args[MKLDNN_ARG_MEAN] = *(out_mean.GetMKLDNNData());
+      net_args[MKLDNN_ARG_MEAN]     = *(out_mean.GetMKLDNNData());
       net_args[MKLDNN_ARG_VARIANCE] = var_mem;
     } else {
-      net_args[MKLDNN_ARG_MEAN] =  *(moving_mean.GetMKLDNNData());
+      net_args[MKLDNN_ARG_MEAN]     = *(moving_mean.GetMKLDNNData());
       net_args[MKLDNN_ARG_VARIANCE] = *(moving_var.GetMKLDNNData());
     }
     MKLDNNStream::Get()->RegisterPrimArgs(bwd.GetBwd(), net_args);
@@ -441,9 +415,9 @@ void MKLDNNBatchNormBackward(const nnvm::NodeAttrs &attrs, const OpContext &ctx,
     MKLDNNStream::Get()->Submit();
 
     // copy data from gradw_mem to in_grad[1] and in_grad[2]
-    DType *gw_buf = reinterpret_cast<DType *>(bwd.GetGradw().get_data_handle());
-    DType *w_grad_1 = in_grad[batchnorm::kGamma].data().dptr<DType>();
-    DType *w_grad_2 = in_grad[batchnorm::kBeta].data().dptr<DType>();
+    DType* gw_buf   = reinterpret_cast<DType*>(bwd.GetGradw().get_data_handle());
+    DType* w_grad_1 = in_grad[batchnorm::kGamma].data().dptr<DType>();
+    DType* w_grad_2 = in_grad[batchnorm::kBeta].data().dptr<DType>();
 
     // the gradient of gamma
     if (!param.fix_gamma) {
@@ -467,7 +441,7 @@ void MKLDNNBatchNormBackward(const nnvm::NodeAttrs &attrs, const OpContext &ctx,
       if (req[batchnorm::kBeta] != kAddTo) {
         memcpy(w_grad_2, &gw_buf[channels_], copy_size);
       } else {
-        DType *grad_beta = &gw_buf[channels_];
+        DType* grad_beta = &gw_buf[channels_];
         for (int i = 0; i < channels_; i++) {
           w_grad_2[i] += grad_beta[i];
         }

--- a/src/operator/nn/mkldnn/mkldnn_concat-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_concat-inl.h
@@ -21,10 +21,9 @@
  * \file mkldnn_concat-inl.h
  * \brief
  * \author
-*/
+ */
 #ifndef MXNET_OPERATOR_NN_MKLDNN_MKLDNN_CONCAT_INL_H_
 #define MXNET_OPERATOR_NN_MKLDNN_MKLDNN_CONCAT_INL_H_
-
 
 #if MXNET_USE_MKLDNN == 1
 #include <vector>
@@ -40,17 +39,17 @@ class MKLDNNConcatFwd {
  public:
   mkldnn::concat::primitive_desc fwd_pd;
 
-  MKLDNNConcatFwd(int concat_dim, const std::vector<mkldnn::memory::desc> &data_md);
+  MKLDNNConcatFwd(int concat_dim, const std::vector<mkldnn::memory::desc>& data_md);
 
-  const mkldnn::concat &GetFwd() const { return *fwd_; }
+  const mkldnn::concat& GetFwd() const { return *fwd_; }
 
  private:
   std::shared_ptr<mkldnn::concat> fwd_;
 };
 
-static MKLDNNConcatFwd &GetConcatForward(
-    int concat_dim, const std::vector<NDArray> &in_data,
-    const std::vector<mkldnn::memory::desc> &data_md) {
+static MKLDNNConcatFwd& GetConcatForward(
+    int concat_dim, const std::vector<NDArray>& in_data,
+    const std::vector<mkldnn::memory::desc>& data_md) {
 #if DMLC_CXX11_THREAD_LOCAL
   static thread_local std::unordered_map<OpSignature, MKLDNNConcatFwd, OpHash> fwds;
 #else

--- a/src/operator/nn/mkldnn/mkldnn_concat-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_concat-inl.h
@@ -26,11 +26,12 @@
 #define MXNET_OPERATOR_NN_MKLDNN_MKLDNN_CONCAT_INL_H_
 
 #if MXNET_USE_MKLDNN == 1
-#include <vector>
 #include <utility>
+#include <vector>
+
 #include "../concat-inl.h"
-#include "./mkldnn_ops-inl.h"
 #include "./mkldnn_base-inl.h"
+#include "./mkldnn_ops-inl.h"
 
 namespace mxnet {
 namespace op {
@@ -47,7 +48,8 @@ class MKLDNNConcatFwd {
   std::shared_ptr<mkldnn::concat> fwd_;
 };
 
-static MKLDNNConcatFwd& GetConcatForward(int concat_dim, const std::vector<NDArray>& in_data,
+static MKLDNNConcatFwd& GetConcatForward(int concat_dim,
+                                         const std::vector<NDArray>& in_data,
                                          const std::vector<mkldnn::memory::desc>& data_md) {
 #if DMLC_CXX11_THREAD_LOCAL
   static thread_local std::unordered_map<OpSignature, MKLDNNConcatFwd, OpHash> fwds;

--- a/src/operator/nn/mkldnn/mkldnn_concat-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_concat-inl.h
@@ -42,7 +42,9 @@ class MKLDNNConcatFwd {
 
   MKLDNNConcatFwd(int concat_dim, const std::vector<mkldnn::memory::desc>& data_md);
 
-  const mkldnn::concat& GetFwd() const { return *fwd_; }
+  const mkldnn::concat& GetFwd() const {
+    return *fwd_;
+  }
 
  private:
   std::shared_ptr<mkldnn::concat> fwd_;

--- a/src/operator/nn/mkldnn/mkldnn_concat-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_concat-inl.h
@@ -47,9 +47,8 @@ class MKLDNNConcatFwd {
   std::shared_ptr<mkldnn::concat> fwd_;
 };
 
-static MKLDNNConcatFwd& GetConcatForward(
-    int concat_dim, const std::vector<NDArray>& in_data,
-    const std::vector<mkldnn::memory::desc>& data_md) {
+static MKLDNNConcatFwd& GetConcatForward(int concat_dim, const std::vector<NDArray>& in_data,
+                                         const std::vector<mkldnn::memory::desc>& data_md) {
 #if DMLC_CXX11_THREAD_LOCAL
   static thread_local std::unordered_map<OpSignature, MKLDNNConcatFwd, OpHash> fwds;
 #else

--- a/src/operator/nn/mkldnn/mkldnn_concat.cc
+++ b/src/operator/nn/mkldnn/mkldnn_concat.cc
@@ -56,8 +56,10 @@ MKLDNNConcatFwd::MKLDNNConcatFwd(int concat_dim, const std::vector<mkldnn::memor
   fwd_ = std::make_shared<mkldnn::concat>(fwd_pd);
 }
 
-void MKLDNNConcatForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
-                         const std::vector<NDArray>& in_data, const std::vector<OpReqType>& req,
+void MKLDNNConcatForward(const nnvm::NodeAttrs& attrs,
+                         const OpContext& ctx,
+                         const std::vector<NDArray>& in_data,
+                         const std::vector<OpReqType>& req,
                          const std::vector<NDArray>& out_data) {
   TmpMemMgr::Get()->Init(ctx.requested[concat_enum::kTempSpace]);
   const ConcatParam& param = nnvm::get<ConcatParam>(attrs.parsed);
@@ -86,8 +88,10 @@ void MKLDNNConcatForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
   MKLDNNStream::Get()->Submit();
 }
 
-void MKLDNNConcatBackward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
-                          const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+void MKLDNNConcatBackward(const nnvm::NodeAttrs& attrs,
+                          const OpContext& ctx,
+                          const std::vector<NDArray>& inputs,
+                          const std::vector<OpReqType>& req,
                           const std::vector<NDArray>& outputs) {
   TmpMemMgr::Get()->Init(ctx.requested[concat_enum::kTempSpace]);
   const ConcatParam& param = nnvm::get<ConcatParam>(attrs.parsed);

--- a/src/operator/nn/mkldnn/mkldnn_concat.cc
+++ b/src/operator/nn/mkldnn/mkldnn_concat.cc
@@ -21,7 +21,7 @@
  * \file mkldnn_concat.cc
  * \brief
  * \author
-*/
+ */
 
 #if MXNET_USE_MKLDNN == 1
 #include "mkldnn_concat-inl.h"
@@ -29,15 +29,16 @@
 namespace mxnet {
 namespace op {
 
-static inline bool IsUsingPadding(const mkldnn::memory::desc &dst_md) {
+static inline bool IsUsingPadding(const mkldnn::memory::desc& dst_md) {
   // make sure a blocked format is used (at least one dimension is blocked)
-  bool is_blocked_format = dst_md.data.format_kind == mkldnn_blocked &&
-                           dst_md.data.format_desc.blocking.inner_nblks > 0;
-  return is_blocked_format && !std::equal(dst_md.data.dims, dst_md.data.dims + dst_md.data.ndims,
-                                          dst_md.data.padded_dims);
+  bool is_blocked_format =
+      dst_md.data.format_kind == mkldnn_blocked && dst_md.data.format_desc.blocking.inner_nblks > 0;
+  return is_blocked_format &&
+         !std::equal(
+             dst_md.data.dims, dst_md.data.dims + dst_md.data.ndims, dst_md.data.padded_dims);
 }
 
-MKLDNNConcatFwd::MKLDNNConcatFwd(int concat_dim, const std::vector<mkldnn::memory::desc> &data_md)
+MKLDNNConcatFwd::MKLDNNConcatFwd(int concat_dim, const std::vector<mkldnn::memory::desc>& data_md)
     : fwd_pd(concat_dim, data_md, CpuEngine::Get()->get_engine()) {
   // MKL-DNN introduced padded formats since 0.15 which require more memory
   // compared to the actual size of the tensor. Currently, MKL-DNN operators
@@ -45,39 +46,37 @@ MKLDNNConcatFwd::MKLDNNConcatFwd(int concat_dim, const std::vector<mkldnn::memor
   // format that has the expected memory size requirements (a plain format)
 
   // When fwd_pd uses padding, impose a plain format
-  const auto &dst_md = fwd_pd.dst_desc();
+  const auto& dst_md = fwd_pd.dst_desc();
   if (IsUsingPadding(dst_md)) {
-    auto plain_dst_tag = static_cast<mkldnn::memory::format_tag>(
-        GetDefaultFormat(dst_md.data.ndims));
+    auto plain_dst_tag =
+        static_cast<mkldnn::memory::format_tag>(GetDefaultFormat(dst_md.data.ndims));
     auto plain_dst_md = mkldnn::memory::desc(dst_md.dims(), dst_md.data_type(), plain_dst_tag);
-    fwd_pd = mkldnn::concat::primitive_desc(plain_dst_md, concat_dim, data_md,
-                                            CpuEngine::Get()->get_engine());
+    fwd_pd            = mkldnn::concat::primitive_desc(
+        plain_dst_md, concat_dim, data_md, CpuEngine::Get()->get_engine());
   }
   fwd_ = std::make_shared<mkldnn::concat>(fwd_pd);
 }
 
-void MKLDNNConcatForward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
-                         const std::vector<NDArray> &in_data,
-                         const std::vector<OpReqType> &req,
-                         const std::vector<NDArray> &out_data) {
+void MKLDNNConcatForward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& in_data,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& out_data) {
   TmpMemMgr::Get()->Init(ctx.requested[concat_enum::kTempSpace]);
   const ConcatParam& param = nnvm::get<ConcatParam>(attrs.parsed);
-  const int num_in_data = param.num_args;
-  const int concat_dim = param.dim;
+  const int num_in_data    = param.num_args;
+  const int concat_dim     = param.dim;
   std::vector<mkldnn::memory::desc> data_md;
-  std::vector<const mkldnn::memory *> data_mem;
+  std::vector<const mkldnn::memory*> data_mem;
   data_md.reserve(num_in_data);
   data_mem.reserve(num_in_data);
   for (int i = 0; i < num_in_data; i++) {
-    const mkldnn::memory *tmp_mem = in_data[i].GetMKLDNNData();
-    mkldnn::memory::desc tmp_md = tmp_mem->get_desc();
+    const mkldnn::memory* tmp_mem = in_data[i].GetMKLDNNData();
+    mkldnn::memory::desc tmp_md   = tmp_mem->get_desc();
     data_md.push_back(tmp_md);
     data_mem.push_back(tmp_mem);
   }
-  MKLDNNConcatFwd &fwd = GetConcatForward(concat_dim, in_data, data_md);
-  mxnet::mkldnn_output_t out_mem = CreateMKLDNNMem(out_data[concat_enum::kOut],
-                                                   fwd.fwd_pd.dst_desc(),
-                                                   req[concat_enum::kOut]);
+  MKLDNNConcatFwd& fwd = GetConcatForward(concat_dim, in_data, data_md);
+  mxnet::mkldnn_output_t out_mem =
+      CreateMKLDNNMem(out_data[concat_enum::kOut], fwd.fwd_pd.dst_desc(), req[concat_enum::kOut]);
   std::unordered_map<int, mkldnn::memory> net_args;
   net_args.insert({MKLDNN_ARG_DST, *out_mem.second});
   for (int i = 0; i < num_in_data; i++) {
@@ -88,35 +87,32 @@ void MKLDNNConcatForward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
   MKLDNNStream::Get()->Submit();
 }
 
-void MKLDNNConcatBackward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
-                          const std::vector<NDArray>& inputs,
-                          const std::vector<OpReqType>& req,
-                          const std::vector<NDArray>& outputs) {
+void MKLDNNConcatBackward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& inputs,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs) {
   TmpMemMgr::Get()->Init(ctx.requested[concat_enum::kTempSpace]);
   const ConcatParam& param = nnvm::get<ConcatParam>(attrs.parsed);
-  const int num_in_data = param.num_args;
-  const int axis = param.dim;
-  const auto gradz_mem = inputs[0].GetMKLDNNData();
+  const int num_in_data    = param.num_args;
+  const int axis           = param.dim;
+  const auto gradz_mem     = inputs[0].GetMKLDNNData();
   /* init the offset */
   mkldnn::memory::dims offsets(outputs[0].shape().ndim());
-  for (auto &v : offsets) {
+  for (auto& v : offsets) {
     v = 0;
   }
 
   for (int i = 0; i < num_in_data; i++) {
     mkldnn::memory::dims diff_src_tz(outputs[i].shape().begin(), outputs[i].shape().end());
     auto diff_src_md = outputs[i].GetMKLDNNData()->get_desc();
-    auto gradi_mem = CreateMKLDNNMem(outputs[i], diff_src_md, req[i]);
+    auto gradi_mem   = CreateMKLDNNMem(outputs[i], diff_src_md, req[i]);
 
     auto from_md = gradz_mem->get_desc().submemory_desc(diff_src_tz, offsets);
-    auto from_mem = new mkldnn::memory(from_md, gradz_mem->get_engine(),
-                                       gradz_mem->get_data_handle());
+    auto from_mem =
+        new mkldnn::memory(from_md, gradz_mem->get_engine(), gradz_mem->get_data_handle());
     offsets[axis] += diff_src_tz[axis];
 
-    std::unordered_map<int, mkldnn::memory> net_args({
-        {MKLDNN_ARG_FROM, *gradz_mem},
-        {MKLDNN_ARG_TO, *gradi_mem.second}
-    });
+    std::unordered_map<int, mkldnn::memory> net_args(
+        {{MKLDNN_ARG_FROM, *gradz_mem}, {MKLDNN_ARG_TO, *gradi_mem.second}});
     MKLDNNStream::Get()->RegisterPrimArgs(mkldnn::reorder(*from_mem, *gradi_mem.second), net_args);
     CommitOutput(outputs[i], gradi_mem);
   }

--- a/src/operator/nn/mkldnn/mkldnn_concat.cc
+++ b/src/operator/nn/mkldnn/mkldnn_concat.cc
@@ -33,9 +33,8 @@ static inline bool IsUsingPadding(const mkldnn::memory::desc& dst_md) {
   // make sure a blocked format is used (at least one dimension is blocked)
   bool is_blocked_format =
       dst_md.data.format_kind == mkldnn_blocked && dst_md.data.format_desc.blocking.inner_nblks > 0;
-  return is_blocked_format &&
-         !std::equal(
-             dst_md.data.dims, dst_md.data.dims + dst_md.data.ndims, dst_md.data.padded_dims);
+  return is_blocked_format && !std::equal(dst_md.data.dims, dst_md.data.dims + dst_md.data.ndims,
+                                          dst_md.data.padded_dims);
 }
 
 MKLDNNConcatFwd::MKLDNNConcatFwd(int concat_dim, const std::vector<mkldnn::memory::desc>& data_md)
@@ -51,15 +50,15 @@ MKLDNNConcatFwd::MKLDNNConcatFwd(int concat_dim, const std::vector<mkldnn::memor
     auto plain_dst_tag =
         static_cast<mkldnn::memory::format_tag>(GetDefaultFormat(dst_md.data.ndims));
     auto plain_dst_md = mkldnn::memory::desc(dst_md.dims(), dst_md.data_type(), plain_dst_tag);
-    fwd_pd            = mkldnn::concat::primitive_desc(
-        plain_dst_md, concat_dim, data_md, CpuEngine::Get()->get_engine());
+    fwd_pd            = mkldnn::concat::primitive_desc(plain_dst_md, concat_dim, data_md,
+                                            CpuEngine::Get()->get_engine());
   }
   fwd_ = std::make_shared<mkldnn::concat>(fwd_pd);
 }
 
-void MKLDNNConcatForward(
-    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& in_data,
-    const std::vector<OpReqType>& req, const std::vector<NDArray>& out_data) {
+void MKLDNNConcatForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+                         const std::vector<NDArray>& in_data, const std::vector<OpReqType>& req,
+                         const std::vector<NDArray>& out_data) {
   TmpMemMgr::Get()->Init(ctx.requested[concat_enum::kTempSpace]);
   const ConcatParam& param = nnvm::get<ConcatParam>(attrs.parsed);
   const int num_in_data    = param.num_args;
@@ -87,9 +86,9 @@ void MKLDNNConcatForward(
   MKLDNNStream::Get()->Submit();
 }
 
-void MKLDNNConcatBackward(
-    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& inputs,
-    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs) {
+void MKLDNNConcatBackward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+                          const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+                          const std::vector<NDArray>& outputs) {
   TmpMemMgr::Get()->Init(ctx.requested[concat_enum::kTempSpace]);
   const ConcatParam& param = nnvm::get<ConcatParam>(attrs.parsed);
   const int num_in_data    = param.num_args;

--- a/src/operator/nn/mkldnn/mkldnn_concat.cc
+++ b/src/operator/nn/mkldnn/mkldnn_concat.cc
@@ -33,8 +33,9 @@ static inline bool IsUsingPadding(const mkldnn::memory::desc& dst_md) {
   // make sure a blocked format is used (at least one dimension is blocked)
   bool is_blocked_format =
       dst_md.data.format_kind == mkldnn_blocked && dst_md.data.format_desc.blocking.inner_nblks > 0;
-  return is_blocked_format && !std::equal(dst_md.data.dims, dst_md.data.dims + dst_md.data.ndims,
-                                          dst_md.data.padded_dims);
+  return is_blocked_format &&
+         !std::equal(
+             dst_md.data.dims, dst_md.data.dims + dst_md.data.ndims, dst_md.data.padded_dims);
 }
 
 MKLDNNConcatFwd::MKLDNNConcatFwd(int concat_dim, const std::vector<mkldnn::memory::desc>& data_md)
@@ -50,8 +51,8 @@ MKLDNNConcatFwd::MKLDNNConcatFwd(int concat_dim, const std::vector<mkldnn::memor
     auto plain_dst_tag =
         static_cast<mkldnn::memory::format_tag>(GetDefaultFormat(dst_md.data.ndims));
     auto plain_dst_md = mkldnn::memory::desc(dst_md.dims(), dst_md.data_type(), plain_dst_tag);
-    fwd_pd            = mkldnn::concat::primitive_desc(plain_dst_md, concat_dim, data_md,
-                                            CpuEngine::Get()->get_engine());
+    fwd_pd            = mkldnn::concat::primitive_desc(
+        plain_dst_md, concat_dim, data_md, CpuEngine::Get()->get_engine());
   }
   fwd_ = std::make_shared<mkldnn::concat>(fwd_pd);
 }

--- a/src/operator/nn/mkldnn/mkldnn_convolution-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_convolution-inl.h
@@ -27,11 +27,12 @@
 
 #if MXNET_USE_MKLDNN == 1
 
-#include <vector>
 #include <utility>
+#include <vector>
+
 #include "../convolution-inl.h"
-#include "./mkldnn_ops-inl.h"
 #include "./mkldnn_base-inl.h"
+#include "./mkldnn_ops-inl.h"
 
 namespace mxnet {
 namespace op {
@@ -79,13 +80,21 @@ struct MKLDNNConvFullParam {
 };
 
 std::shared_ptr<mkldnn::convolution_forward::primitive_desc> GetConvFwdImpl(
-    const ConvolutionParam& param, const bool is_train, const NDArray& data, const NDArray& weight,
-    const NDArray* bias, const NDArray& output);
+    const ConvolutionParam& param,
+    const bool is_train,
+    const NDArray& data,
+    const NDArray& weight,
+    const NDArray* bias,
+    const NDArray& output);
 
 class MKLDNNConvForward {
  public:
-  MKLDNNConvForward(const MKLDNNConvFullParam& param, const bool is_train, const NDArray& data,
-                    const NDArray& weight, const NDArray* bias, const NDArray& output);
+  MKLDNNConvForward(const MKLDNNConvFullParam& param,
+                    const bool is_train,
+                    const NDArray& data,
+                    const NDArray& weight,
+                    const NDArray* bias,
+                    const NDArray& output);
 
   const mkldnn::convolution_forward& GetFwd() const { return *fwd_; }
 
@@ -98,25 +107,33 @@ class MKLDNNConvForward {
 
 typedef ParamOpSign<ConvolutionParam> MKLDNNConvSignature;
 
-MKLDNNConvForward& GetConvFwd(const MKLDNNConvFullParam& param, const bool is_train,
-                              const NDArray& data, const NDArray& weight, const NDArray* bias,
+MKLDNNConvForward& GetConvFwd(const MKLDNNConvFullParam& param,
+                              const bool is_train,
+                              const NDArray& data,
+                              const NDArray& weight,
+                              const NDArray* bias,
                               const NDArray& output);
 
-void MKLDNNConvolutionForwardFullFeature(const MKLDNNConvFullParam& param, const OpContext& ctx,
+void MKLDNNConvolutionForwardFullFeature(const MKLDNNConvFullParam& param,
+                                         const OpContext& ctx,
                                          MKLDNNConvForward* fwd,
                                          const std::vector<NDArray>& in_data,
                                          const std::vector<OpReqType>& req,
                                          const std::vector<NDArray>& out_data);
 
-void MKLDNNConvolutionForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+void MKLDNNConvolutionForward(const nnvm::NodeAttrs& attrs,
+                              const OpContext& ctx,
                               const std::vector<NDArray>& in_data,
                               const std::vector<OpReqType>& req,
                               const std::vector<NDArray>& out_data);
 
 class MKLDNNConvBackward {
  public:
-  MKLDNNConvBackward(const MKLDNNConvFullParam& param, const NDArray& data, const NDArray& weight,
-                     const NDArray* bias, const NDArray& output);
+  MKLDNNConvBackward(const MKLDNNConvFullParam& param,
+                     const NDArray& data,
+                     const NDArray& weight,
+                     const NDArray* bias,
+                     const NDArray& output);
 
   const mkldnn::convolution_backward_data& GetBwdData() const { return *bwd_data_; }
 

--- a/src/operator/nn/mkldnn/mkldnn_convolution-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_convolution-inl.h
@@ -96,9 +96,13 @@ class MKLDNNConvForward {
                     const NDArray* bias,
                     const NDArray& output);
 
-  const mkldnn::convolution_forward& GetFwd() const { return *fwd_; }
+  const mkldnn::convolution_forward& GetFwd() const {
+    return *fwd_;
+  }
 
-  const mkldnn::convolution_forward::primitive_desc& GetPd() const { return *pd_; }
+  const mkldnn::convolution_forward::primitive_desc& GetPd() const {
+    return *pd_;
+  }
 
  private:
   std::shared_ptr<mkldnn::convolution_forward> fwd_;
@@ -135,9 +139,13 @@ class MKLDNNConvBackward {
                      const NDArray* bias,
                      const NDArray& output);
 
-  const mkldnn::convolution_backward_data& GetBwdData() const { return *bwd_data_; }
+  const mkldnn::convolution_backward_data& GetBwdData() const {
+    return *bwd_data_;
+  }
 
-  const mkldnn::convolution_backward_weights& GetBwdWeights() const { return *bwd_weight_; }
+  const mkldnn::convolution_backward_weights& GetBwdWeights() const {
+    return *bwd_weight_;
+  }
 
   const mkldnn::convolution_backward_data::primitive_desc& GetDataPd() const {
     return *bwd_data_pd_;

--- a/src/operator/nn/mkldnn/mkldnn_convolution-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_convolution-inl.h
@@ -84,9 +84,8 @@ std::shared_ptr<mkldnn::convolution_forward::primitive_desc> GetConvFwdImpl(
 
 class MKLDNNConvForward {
  public:
-  MKLDNNConvForward(
-      const MKLDNNConvFullParam& param, const bool is_train, const NDArray& data,
-      const NDArray& weight, const NDArray* bias, const NDArray& output);
+  MKLDNNConvForward(const MKLDNNConvFullParam& param, const bool is_train, const NDArray& data,
+                    const NDArray& weight, const NDArray* bias, const NDArray& output);
 
   const mkldnn::convolution_forward& GetFwd() const { return *fwd_; }
 
@@ -99,24 +98,25 @@ class MKLDNNConvForward {
 
 typedef ParamOpSign<ConvolutionParam> MKLDNNConvSignature;
 
-MKLDNNConvForward& GetConvFwd(
-    const MKLDNNConvFullParam& param, const bool is_train, const NDArray& data,
-    const NDArray& weight, const NDArray* bias, const NDArray& output);
+MKLDNNConvForward& GetConvFwd(const MKLDNNConvFullParam& param, const bool is_train,
+                              const NDArray& data, const NDArray& weight, const NDArray* bias,
+                              const NDArray& output);
 
-void MKLDNNConvolutionForwardFullFeature(
-    const MKLDNNConvFullParam& param, const OpContext& ctx, MKLDNNConvForward* fwd,
-    const std::vector<NDArray>& in_data, const std::vector<OpReqType>& req,
-    const std::vector<NDArray>& out_data);
+void MKLDNNConvolutionForwardFullFeature(const MKLDNNConvFullParam& param, const OpContext& ctx,
+                                         MKLDNNConvForward* fwd,
+                                         const std::vector<NDArray>& in_data,
+                                         const std::vector<OpReqType>& req,
+                                         const std::vector<NDArray>& out_data);
 
-void MKLDNNConvolutionForward(
-    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& in_data,
-    const std::vector<OpReqType>& req, const std::vector<NDArray>& out_data);
+void MKLDNNConvolutionForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+                              const std::vector<NDArray>& in_data,
+                              const std::vector<OpReqType>& req,
+                              const std::vector<NDArray>& out_data);
 
 class MKLDNNConvBackward {
  public:
-  MKLDNNConvBackward(
-      const MKLDNNConvFullParam& param, const NDArray& data, const NDArray& weight,
-      const NDArray* bias, const NDArray& output);
+  MKLDNNConvBackward(const MKLDNNConvFullParam& param, const NDArray& data, const NDArray& weight,
+                     const NDArray* bias, const NDArray& output);
 
   const mkldnn::convolution_backward_data& GetBwdData() const { return *bwd_data_; }
 

--- a/src/operator/nn/mkldnn/mkldnn_convolution-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_convolution-inl.h
@@ -20,7 +20,7 @@
 /*!
  * \file mkldnn_convolution-inl.h
  * \brief
-*/
+ */
 
 #ifndef MXNET_OPERATOR_NN_MKLDNN_MKLDNN_CONVOLUTION_INL_H_
 #define MXNET_OPERATOR_NN_MKLDNN_MKLDNN_CONVOLUTION_INL_H_
@@ -47,26 +47,25 @@ struct MKLDNNConvParam : public dmlc::Parameter<MKLDNNConvParam> {
   dmlc::optional<float> max_calib_range;  // max float value calculated from calibration dataset
 
   DMLC_DECLARE_PARAMETER(MKLDNNConvParam) {
-    DMLC_DECLARE_FIELD(with_bn).set_default(false)
-    .describe("Add post batchnorm.");
-    DMLC_DECLARE_FIELD(with_act).set_default(false)
-    .describe("Add post activation");
-    DMLC_DECLARE_FIELD(with_sum).set_default(false)
-    .describe("Add post sum");
-    DMLC_DECLARE_FIELD(with_postsum_act).set_default(false)
-    .describe("Add post activation after sum");
-    DMLC_DECLARE_FIELD(quantized).set_default(false)
-    .describe("enable quantization");
+    DMLC_DECLARE_FIELD(with_bn).set_default(false).describe("Add post batchnorm.");
+    DMLC_DECLARE_FIELD(with_act).set_default(false).describe("Add post activation");
+    DMLC_DECLARE_FIELD(with_sum).set_default(false).describe("Add post sum");
+    DMLC_DECLARE_FIELD(with_postsum_act)
+        .set_default(false)
+        .describe("Add post activation after sum");
+    DMLC_DECLARE_FIELD(quantized).set_default(false).describe("enable quantization");
     DMLC_DECLARE_FIELD(min_calib_range)
-    .set_default(dmlc::optional<float>())
-    .describe("The minimum scalar value in the form of float32 obtained "
-              "through calibration. If present, it will be used to by "
-              "quantized convolution op to calculate primitive scale");
+        .set_default(dmlc::optional<float>())
+        .describe(
+            "The minimum scalar value in the form of float32 obtained "
+            "through calibration. If present, it will be used to by "
+            "quantized convolution op to calculate primitive scale");
     DMLC_DECLARE_FIELD(max_calib_range)
-    .set_default(dmlc::optional<float>())
-    .describe("The maximum scalar value in the form of float32 obtained "
-              "through calibration. If present, it will be used to by "
-              "quantized convolution op to calculate primitive scale");
+        .set_default(dmlc::optional<float>())
+        .describe(
+            "The maximum scalar value in the form of float32 obtained "
+            "through calibration. If present, it will be used to by "
+            "quantized convolution op to calculate primitive scale");
   }
 };
 
@@ -80,17 +79,18 @@ struct MKLDNNConvFullParam {
 };
 
 std::shared_ptr<mkldnn::convolution_forward::primitive_desc> GetConvFwdImpl(
-    const ConvolutionParam &param, const bool is_train, const NDArray &data, const NDArray &weight,
-    const NDArray *bias, const NDArray &output);
+    const ConvolutionParam& param, const bool is_train, const NDArray& data, const NDArray& weight,
+    const NDArray* bias, const NDArray& output);
 
 class MKLDNNConvForward {
  public:
-  MKLDNNConvForward(const MKLDNNConvFullParam &param, const bool is_train, const NDArray &data,
-                    const NDArray &weight, const NDArray *bias, const NDArray &output);
+  MKLDNNConvForward(
+      const MKLDNNConvFullParam& param, const bool is_train, const NDArray& data,
+      const NDArray& weight, const NDArray* bias, const NDArray& output);
 
-  const mkldnn::convolution_forward &GetFwd() const { return *fwd_; }
+  const mkldnn::convolution_forward& GetFwd() const { return *fwd_; }
 
-  const mkldnn::convolution_forward::primitive_desc &GetPd() const { return *pd_; }
+  const mkldnn::convolution_forward::primitive_desc& GetPd() const { return *pd_; }
 
  private:
   std::shared_ptr<mkldnn::convolution_forward> fwd_;
@@ -99,37 +99,34 @@ class MKLDNNConvForward {
 
 typedef ParamOpSign<ConvolutionParam> MKLDNNConvSignature;
 
-MKLDNNConvForward &GetConvFwd(const MKLDNNConvFullParam &param, const bool is_train,
-                              const NDArray &data, const NDArray &weight, const NDArray *bias,
-                              const NDArray &output);
+MKLDNNConvForward& GetConvFwd(
+    const MKLDNNConvFullParam& param, const bool is_train, const NDArray& data,
+    const NDArray& weight, const NDArray* bias, const NDArray& output);
 
-void MKLDNNConvolutionForwardFullFeature(const MKLDNNConvFullParam &param,
-                                         const OpContext &ctx,
-                                         MKLDNNConvForward *fwd,
-                                         const std::vector<NDArray> &in_data,
-                                         const std::vector<OpReqType> &req,
-                                         const std::vector<NDArray> &out_data);
+void MKLDNNConvolutionForwardFullFeature(
+    const MKLDNNConvFullParam& param, const OpContext& ctx, MKLDNNConvForward* fwd,
+    const std::vector<NDArray>& in_data, const std::vector<OpReqType>& req,
+    const std::vector<NDArray>& out_data);
 
-void MKLDNNConvolutionForward(const nnvm::NodeAttrs &attrs,
-                              const OpContext &ctx,
-                              const std::vector<NDArray> &in_data,
-                              const std::vector<OpReqType> &req,
-                              const std::vector<NDArray> &out_data);
+void MKLDNNConvolutionForward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& in_data,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& out_data);
 
 class MKLDNNConvBackward {
  public:
-  MKLDNNConvBackward(const MKLDNNConvFullParam &param, const NDArray &data, const NDArray &weight,
-                     const NDArray *bias, const NDArray &output);
+  MKLDNNConvBackward(
+      const MKLDNNConvFullParam& param, const NDArray& data, const NDArray& weight,
+      const NDArray* bias, const NDArray& output);
 
-  const mkldnn::convolution_backward_data &GetBwdData() const { return *bwd_data_; }
+  const mkldnn::convolution_backward_data& GetBwdData() const { return *bwd_data_; }
 
-  const mkldnn::convolution_backward_weights &GetBwdWeights() const { return *bwd_weight_; }
+  const mkldnn::convolution_backward_weights& GetBwdWeights() const { return *bwd_weight_; }
 
-  const mkldnn::convolution_backward_data::primitive_desc &GetDataPd() const {
+  const mkldnn::convolution_backward_data::primitive_desc& GetDataPd() const {
     return *bwd_data_pd_;
   }
 
-  const mkldnn::convolution_backward_weights::primitive_desc &GetWeightsPd() const {
+  const mkldnn::convolution_backward_weights::primitive_desc& GetWeightsPd() const {
     return *bwd_weight_pd_;
   }
 

--- a/src/operator/nn/mkldnn/mkldnn_convolution.cc
+++ b/src/operator/nn/mkldnn/mkldnn_convolution.cc
@@ -26,9 +26,9 @@
 #if MXNET_USE_MKLDNN == 1
 
 #include "../convolution-inl.h"
-#include "./mkldnn_ops-inl.h"
 #include "./mkldnn_base-inl.h"
 #include "./mkldnn_convolution-inl.h"
+#include "./mkldnn_ops-inl.h"
 
 namespace mxnet {
 namespace op {
@@ -44,8 +44,12 @@ bool SupportMKLDNNConv(const ConvolutionParam& params, const NDArray& input) {
 }
 
 std::shared_ptr<mkldnn::convolution_forward::primitive_desc> GetConvFwdImpl(
-    const MKLDNNConvFullParam& param, const bool is_train, const NDArray& data,
-    const NDArray& weights, const NDArray* bias, const NDArray& output) {
+    const MKLDNNConvFullParam& param,
+    const bool is_train,
+    const NDArray& data,
+    const NDArray& weights,
+    const NDArray* bias,
+    const NDArray& output) {
   auto prop = is_train ? mkldnn::prop_kind::forward_training : mkldnn::prop_kind::forward_scoring;
   auto data_md   = GetMemDesc(data);
   auto weight_md = GetWeightDesc(weights, param.conv_param.num_group, param.mkldnn_param.quantized);
@@ -172,8 +176,11 @@ std::shared_ptr<mkldnn::convolution_forward::primitive_desc> GetConvFwdImpl(
 }
 
 static std::shared_ptr<mkldnn::convolution_backward_data::primitive_desc> GetConvBwdData(
-    const ConvolutionParam& param, const NDArray& data, const NDArray& weight,
-    const NDArray& output, const mkldnn::convolution_forward::primitive_desc& fwd_pd) {
+    const ConvolutionParam& param,
+    const NDArray& data,
+    const NDArray& weight,
+    const NDArray& output,
+    const mkldnn::convolution_forward::primitive_desc& fwd_pd) {
   auto data_md   = GetMemDesc(data);
   auto weight_md = GetWeightDesc(weight, param.num_group);
   auto out_md    = GetMemDesc(output);
@@ -259,8 +266,12 @@ static std::shared_ptr<mkldnn::convolution_backward_data::primitive_desc> GetCon
 }
 
 static std::shared_ptr<mkldnn::convolution_backward_weights::primitive_desc> GetConvBwdWeights(
-    const ConvolutionParam& param, const NDArray& data, const NDArray& weight, const NDArray* bias,
-    const NDArray& output, const mkldnn::convolution_forward::primitive_desc& fwd_pd) {
+    const ConvolutionParam& param,
+    const NDArray& data,
+    const NDArray& weight,
+    const NDArray* bias,
+    const NDArray& output,
+    const mkldnn::convolution_forward::primitive_desc& fwd_pd) {
   auto data_md   = GetMemDesc(data);
   auto weight_md = GetWeightDesc(weight, param.num_group);
   auto out_md    = GetMemDesc(output);
@@ -359,15 +370,21 @@ static std::shared_ptr<mkldnn::convolution_backward_weights::primitive_desc> Get
   }
 }
 
-MKLDNNConvForward::MKLDNNConvForward(const MKLDNNConvFullParam& param, const bool is_train,
-                                     const NDArray& data, const NDArray& weight,
-                                     const NDArray* bias, const NDArray& output)
+MKLDNNConvForward::MKLDNNConvForward(const MKLDNNConvFullParam& param,
+                                     const bool is_train,
+                                     const NDArray& data,
+                                     const NDArray& weight,
+                                     const NDArray* bias,
+                                     const NDArray& output)
     : pd_(GetConvFwdImpl(param, is_train, data, weight, bias, output)) {
   fwd_ = std::make_shared<mkldnn::convolution_forward>(GetPd());
 }
 
-MKLDNNConvForward& GetConvFwd(const MKLDNNConvFullParam& param, const bool is_train,
-                              const NDArray& data, const NDArray& weight, const NDArray* bias,
+MKLDNNConvForward& GetConvFwd(const MKLDNNConvFullParam& param,
+                              const bool is_train,
+                              const NDArray& data,
+                              const NDArray& weight,
+                              const NDArray* bias,
                               const NDArray& output) {
   using conv_fwd_map = std::unordered_map<MKLDNNConvSignature, MKLDNNConvForward, OpHash>;
 #if DMLC_CXX11_THREAD_LOCAL
@@ -394,7 +411,8 @@ MKLDNNConvForward& GetConvFwd(const MKLDNNConvFullParam& param, const bool is_tr
   return it->second;
 }
 
-void MKLDNNConvolutionForwardFullFeature(const MKLDNNConvFullParam& param, const OpContext& ctx,
+void MKLDNNConvolutionForwardFullFeature(const MKLDNNConvFullParam& param,
+                                         const OpContext& ctx,
                                          MKLDNNConvForward* fwd,
                                          const std::vector<NDArray>& in_data,
                                          const std::vector<OpReqType>& req,
@@ -448,7 +466,8 @@ void MKLDNNConvolutionForwardFullFeature(const MKLDNNConvFullParam& param, const
   MKLDNNStream::Get()->Submit();
 }
 
-void MKLDNNConvolutionForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+void MKLDNNConvolutionForward(const nnvm::NodeAttrs& attrs,
+                              const OpContext& ctx,
                               const std::vector<NDArray>& in_data,
                               const std::vector<OpReqType>& req,
                               const std::vector<NDArray>& out_data) {
@@ -461,8 +480,10 @@ void MKLDNNConvolutionForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx
   MKLDNNConvolutionForwardFullFeature(param, ctx, &fwd, in_data, req, out_data);
 }
 
-MKLDNNConvBackward::MKLDNNConvBackward(const MKLDNNConvFullParam& param, const NDArray& data,
-                                       const NDArray& weight, const NDArray* bias,
+MKLDNNConvBackward::MKLDNNConvBackward(const MKLDNNConvFullParam& param,
+                                       const NDArray& data,
+                                       const NDArray& weight,
+                                       const NDArray* bias,
                                        const NDArray& output) {
   const auto fwd_pd = GetConvFwdImpl(param, true, data, weight, bias, output);
   bwd_data_pd_      = GetConvBwdData(param.conv_param, data, weight, output, *fwd_pd);
@@ -471,8 +492,10 @@ MKLDNNConvBackward::MKLDNNConvBackward(const MKLDNNConvFullParam& param, const N
   bwd_weight_       = std::make_shared<mkldnn::convolution_backward_weights>(GetWeightsPd());
 }
 
-static inline MKLDNNConvBackward& GetConvBwd(const MKLDNNConvFullParam& param, const NDArray& data,
-                                             const NDArray& weight, const NDArray* bias,
+static inline MKLDNNConvBackward& GetConvBwd(const MKLDNNConvFullParam& param,
+                                             const NDArray& data,
+                                             const NDArray& weight,
+                                             const NDArray* bias,
                                              const NDArray& output) {
   using mkldnn_conv_bwd_map = std::unordered_map<MKLDNNConvSignature, MKLDNNConvBackward, OpHash>;
 #if DMLC_CXX11_THREAD_LOCAL
@@ -498,7 +521,8 @@ static inline MKLDNNConvBackward& GetConvBwd(const MKLDNNConvFullParam& param, c
   return it->second;
 }
 
-void MKLDNNConvolutionBackward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+void MKLDNNConvolutionBackward(const nnvm::NodeAttrs& attrs,
+                               const OpContext& ctx,
                                const std::vector<NDArray>& inputs,
                                const std::vector<OpReqType>& req,
                                const std::vector<NDArray>& outputs) {

--- a/src/operator/nn/mkldnn/mkldnn_convolution.cc
+++ b/src/operator/nn/mkldnn/mkldnn_convolution.cc
@@ -35,32 +35,25 @@ namespace op {
 
 DMLC_REGISTER_PARAMETER(MKLDNNConvParam);
 
-bool SupportMKLDNNConv(const ConvolutionParam& params, const NDArray &input) {
-  if ((params.kernel.ndim() != 1) &&
-      (params.kernel.ndim() != 2) &&
-      (params.kernel.ndim() != 3))
+bool SupportMKLDNNConv(const ConvolutionParam& params, const NDArray& input) {
+  if ((params.kernel.ndim() != 1) && (params.kernel.ndim() != 2) && (params.kernel.ndim() != 3))
     return false;
   return SupportMKLDNNQuantize(input.dtype()) &&
-         ((input.shape().ndim() == 3) ||
-          (input.shape().ndim() == 4) ||
+         ((input.shape().ndim() == 3) || (input.shape().ndim() == 4) ||
           (input.shape().ndim() == 5));
 }
 
 std::shared_ptr<mkldnn::convolution_forward::primitive_desc> GetConvFwdImpl(
-                                                           const MKLDNNConvFullParam &param,
-                                                           const bool is_train,
-                                                           const NDArray &data,
-                                                           const NDArray &weights,
-                                                           const NDArray *bias,
-                                                           const NDArray &output) {
+    const MKLDNNConvFullParam& param, const bool is_train, const NDArray& data,
+    const NDArray& weights, const NDArray* bias, const NDArray& output) {
   auto prop = is_train ? mkldnn::prop_kind::forward_training : mkldnn::prop_kind::forward_scoring;
-  auto data_md = GetMemDesc(data);
+  auto data_md   = GetMemDesc(data);
   auto weight_md = GetWeightDesc(weights, param.conv_param.num_group, param.mkldnn_param.quantized);
-  auto out_md = GetMemDesc(output);
+  auto out_md    = GetMemDesc(output);
   auto bias_md =
       bias ? (param.mkldnn_param.quantized ? GetMemDesc(*bias, mshadow::kInt32) : GetMemDesc(*bias))
            : mkldnn::memory::desc{
-             {}, mkldnn::memory::data_type::undef, mkldnn::memory::format_tag::any};
+                 {}, mkldnn::memory::data_type::undef, mkldnn::memory::format_tag::any};
   auto bias_md_ptr = bias ? &bias_md : nullptr;
 
   mkldnn::memory::dims strides(param.conv_param.kernel.ndim());
@@ -90,20 +83,20 @@ std::shared_ptr<mkldnn::convolution_forward::primitive_desc> GetConvFwdImpl(
     padding[1] = param.conv_param.pad[1];
     padding[2] = param.conv_param.pad[2];
   } else {
-    LOG(FATAL) << "Unexpected MKL-DNN Conv kernel size "
-               << param.conv_param.kernel.ndim() << ", supporting only 1 or 2 or 3.";
+    LOG(FATAL) << "Unexpected MKL-DNN Conv kernel size " << param.conv_param.kernel.ndim()
+               << ", supporting only 1 or 2 or 3.";
   }
   mkldnn::primitive_attr attr;
   mkldnn::post_ops ops;
   if (param.mkldnn_param.with_act) {
-    const auto &act_param = param.act_param;
+    const auto& act_param = param.act_param;
     ops.append_eltwise(act_param.scale, act_param.alg, act_param.alpha, act_param.beta);
   }
   if (param.mkldnn_param.with_sum) {
     ops.append_sum(param.sum_scale);
   }
   if (param.mkldnn_param.with_postsum_act) {
-    const auto &act_param = param.postsum_act_param;
+    const auto& act_param = param.postsum_act_param;
     ops.append_eltwise(act_param.scale, act_param.alg, act_param.alpha, act_param.beta);
   }
   attr.set_post_ops(ops);
@@ -113,7 +106,7 @@ std::shared_ptr<mkldnn::convolution_forward::primitive_desc> GetConvFwdImpl(
     attr.set_output_scales(mask, param.requantize_scales);
   }
   auto GetConvFwdPd = [&param, &data, &weights, &output,
-                       &attr](const mkldnn::convolution_forward::desc &desc) {
+                       &attr](const mkldnn::convolution_forward::desc& desc) {
     auto engine = CpuEngine::Get()->get_engine();
     try {
       // MKL-DNN introduced padded formats since 0.15 which require more memory
@@ -130,7 +123,7 @@ std::shared_ptr<mkldnn::convolution_forward::primitive_desc> GetConvFwdImpl(
         CHECK(conv_pd->next_impl()) << "No convolution implementation for this request.";
       }
       return conv_pd;
-    } catch (mkldnn::error &e) {
+    } catch (mkldnn::error& e) {
       if (e.status == mkldnn_unimplemented && param.mkldnn_param.quantized) {
         LOG(ERROR) << "AVX512-BW support or Intel(R) MKL dependency is "
                       "required for int8 convolution";
@@ -142,13 +135,14 @@ std::shared_ptr<mkldnn::convolution_forward::primitive_desc> GetConvFwdImpl(
   };
 
   if (param.conv_param.dilate.ndim() == 0 && bias_md_ptr == nullptr) {
-    mkldnn::convolution_forward::desc desc(prop, mkldnn::algorithm::convolution_direct, data_md,
-                                           weight_md, out_md, strides, padding, padding);
+    mkldnn::convolution_forward::desc desc(
+        prop, mkldnn::algorithm::convolution_direct, data_md, weight_md, out_md, strides, padding,
+        padding);
     return GetConvFwdPd(desc);
   } else if (param.conv_param.dilate.ndim() == 0) {
-    mkldnn::convolution_forward::desc desc(prop, mkldnn::algorithm::convolution_direct, data_md,
-                                           weight_md, *bias_md_ptr, out_md, strides, padding,
-                                           padding);
+    mkldnn::convolution_forward::desc desc(
+        prop, mkldnn::algorithm::convolution_direct, data_md, weight_md, *bias_md_ptr, out_md,
+        strides, padding, padding);
     return GetConvFwdPd(desc);
   } else {
     mkldnn::memory::dims dilates(param.conv_param.kernel.ndim());
@@ -166,25 +160,26 @@ std::shared_ptr<mkldnn::convolution_forward::primitive_desc> GetConvFwdImpl(
                  << ", supporting only 1 or 2 or 3.";
     }
     if (bias_md_ptr == nullptr) {
-      mkldnn::convolution_forward::desc desc(prop, mkldnn::algorithm::convolution_direct, data_md,
-                                             weight_md, out_md, strides, dilates, padding, padding);
+      mkldnn::convolution_forward::desc desc(
+          prop, mkldnn::algorithm::convolution_direct, data_md, weight_md, out_md, strides, dilates,
+          padding, padding);
       return GetConvFwdPd(desc);
     } else {
-      mkldnn::convolution_forward::desc desc(prop, mkldnn::algorithm::convolution_direct, data_md,
-                                             weight_md, *bias_md_ptr, out_md, strides, dilates,
-                                             padding, padding);
+      mkldnn::convolution_forward::desc desc(
+          prop, mkldnn::algorithm::convolution_direct, data_md, weight_md, *bias_md_ptr, out_md,
+          strides, dilates, padding, padding);
       return GetConvFwdPd(desc);
     }
   }
 }
 
 static std::shared_ptr<mkldnn::convolution_backward_data::primitive_desc> GetConvBwdData(
-    const ConvolutionParam &param, const NDArray &data, const NDArray &weight,
-    const NDArray &output, const mkldnn::convolution_forward::primitive_desc &fwd_pd) {
-  auto data_md = GetMemDesc(data);
+    const ConvolutionParam& param, const NDArray& data, const NDArray& weight,
+    const NDArray& output, const mkldnn::convolution_forward::primitive_desc& fwd_pd) {
+  auto data_md   = GetMemDesc(data);
   auto weight_md = GetWeightDesc(weight, param.num_group);
-  auto out_md = GetMemDesc(output);
-  auto engine = CpuEngine::Get()->get_engine();
+  auto out_md    = GetMemDesc(output);
+  auto engine    = CpuEngine::Get()->get_engine();
   mkldnn::memory::dims strides(param.kernel.ndim());
   mkldnn::memory::dims padding(param.kernel.ndim());
   if (param.kernel.ndim() == 1) {
@@ -217,7 +212,7 @@ static std::shared_ptr<mkldnn::convolution_backward_data::primitive_desc> GetCon
   }
 
   auto GetConvBwdDataPd = [&data, &weight, &output,
-                           &fwd_pd](const mkldnn::convolution_backward_data::desc &desc) {
+                           &fwd_pd](const mkldnn::convolution_backward_data::desc& desc) {
     auto engine = CpuEngine::Get()->get_engine();
     try {
       // MKL-DNN introduced padded formats since 0.15 which require more memory
@@ -233,15 +228,16 @@ static std::shared_ptr<mkldnn::convolution_backward_data::primitive_desc> GetCon
         CHECK(conv_pd->next_impl()) << "No convolution backward implementation for this request.";
       }
       return conv_pd;
-    } catch (mkldnn::error &e) {
+    } catch (mkldnn::error& e) {
       LOG(ERROR) << e.message;
       throw;
     }
   };
 
   if (param.dilate.ndim() == 0) {
-    mkldnn::convolution_backward_data::desc desc(mkldnn::algorithm::convolution_direct, data_md,
-                                                 weight_md, out_md, strides, padding, padding);
+    mkldnn::convolution_backward_data::desc desc(
+        mkldnn::algorithm::convolution_direct, data_md, weight_md, out_md, strides, padding,
+        padding);
     return GetConvBwdDataPd(desc);
   } else {
     mkldnn::memory::dims dilates(param.kernel.ndim());
@@ -255,23 +251,23 @@ static std::shared_ptr<mkldnn::convolution_backward_data::primitive_desc> GetCon
       dilates[1] = param.dilate[1] - 1;
       dilates[2] = param.dilate[2] - 1;
     } else {
-      LOG(FATAL) << "Unexpected MKL-DNN Conv dilate size "
-                 << param.dilate.ndim() << ", supporting only 1 or 2 or 3.";
+      LOG(FATAL) << "Unexpected MKL-DNN Conv dilate size " << param.dilate.ndim()
+                 << ", supporting only 1 or 2 or 3.";
     }
-    mkldnn::convolution_backward_data::desc desc(mkldnn::algorithm::convolution_direct, data_md,
-                                                 weight_md, out_md, strides, dilates, padding,
-                                                 padding);
+    mkldnn::convolution_backward_data::desc desc(
+        mkldnn::algorithm::convolution_direct, data_md, weight_md, out_md, strides, dilates,
+        padding, padding);
     return GetConvBwdDataPd(desc);
   }
 }
 
 static std::shared_ptr<mkldnn::convolution_backward_weights::primitive_desc> GetConvBwdWeights(
-    const ConvolutionParam &param, const NDArray &data, const NDArray &weight, const NDArray *bias,
-    const NDArray &output, const mkldnn::convolution_forward::primitive_desc &fwd_pd) {
-  auto data_md = GetMemDesc(data);
+    const ConvolutionParam& param, const NDArray& data, const NDArray& weight, const NDArray* bias,
+    const NDArray& output, const mkldnn::convolution_forward::primitive_desc& fwd_pd) {
+  auto data_md   = GetMemDesc(data);
   auto weight_md = GetWeightDesc(weight, param.num_group);
-  auto out_md = GetMemDesc(output);
-  auto engine = CpuEngine::Get()->get_engine();
+  auto out_md    = GetMemDesc(output);
+  auto engine    = CpuEngine::Get()->get_engine();
   mkldnn::memory::dims strides(param.kernel.ndim());
   mkldnn::memory::dims padding(param.kernel.ndim());
   if (param.kernel.ndim() == 1) {
@@ -304,7 +300,7 @@ static std::shared_ptr<mkldnn::convolution_backward_weights::primitive_desc> Get
   }
 
   auto GetConvBwdWeightsPd = [&data, &weight, &output,
-                              &fwd_pd](const mkldnn::convolution_backward_weights::desc &desc) {
+                              &fwd_pd](const mkldnn::convolution_backward_weights::desc& desc) {
     auto engine = CpuEngine::Get()->get_engine();
     try {
       // MKL-DNN introduced padded formats since 0.15 which require more memory
@@ -320,21 +316,22 @@ static std::shared_ptr<mkldnn::convolution_backward_weights::primitive_desc> Get
         CHECK(conv_pd->next_impl()) << "No convolution backward implementation for this request.";
       }
       return conv_pd;
-    } catch (mkldnn::error &e) {
+    } catch (mkldnn::error& e) {
       LOG(ERROR) << e.message;
       throw;
     }
   };
 
   if (param.dilate.ndim() == 0 && bias == nullptr) {
-    mkldnn::convolution_backward_weights::desc desc(mkldnn::algorithm::convolution_direct, data_md,
-                                                    weight_md, out_md, strides, padding, padding);
+    mkldnn::convolution_backward_weights::desc desc(
+        mkldnn::algorithm::convolution_direct, data_md, weight_md, out_md, strides, padding,
+        padding);
     return GetConvBwdWeightsPd(desc);
   } else if (param.dilate.ndim() == 0) {
     auto bias_md = GetMemDesc(*bias);
-    mkldnn::convolution_backward_weights::desc desc(mkldnn::algorithm::convolution_direct, data_md,
-                                                    weight_md, bias_md, out_md, strides, padding,
-                                                    padding);
+    mkldnn::convolution_backward_weights::desc desc(
+        mkldnn::algorithm::convolution_direct, data_md, weight_md, bias_md, out_md, strides,
+        padding, padding);
     return GetConvBwdWeightsPd(desc);
   } else {
     mkldnn::memory::dims dilates(param.kernel.ndim());
@@ -348,34 +345,34 @@ static std::shared_ptr<mkldnn::convolution_backward_weights::primitive_desc> Get
       dilates[1] = param.dilate[1] - 1;
       dilates[2] = param.dilate[2] - 1;
     } else {
-      LOG(FATAL) << "Unexpected MKL-DNN Conv dilate size "
-                 << param.dilate.ndim() << ", supporting only 1 or 2 or 3.";
+      LOG(FATAL) << "Unexpected MKL-DNN Conv dilate size " << param.dilate.ndim()
+                 << ", supporting only 1 or 2 or 3.";
     }
     if (bias == nullptr) {
-      mkldnn::convolution_backward_weights::desc desc(mkldnn::algorithm::convolution_direct,
-                                                      data_md, weight_md, out_md, strides, dilates,
-                                                      padding, padding);
+      mkldnn::convolution_backward_weights::desc desc(
+          mkldnn::algorithm::convolution_direct, data_md, weight_md, out_md, strides, dilates,
+          padding, padding);
       return GetConvBwdWeightsPd(desc);
     } else {
       auto bias_md = GetMemDesc(*bias);
-      mkldnn::convolution_backward_weights::desc desc(mkldnn::algorithm::convolution_direct,
-                                                      data_md, weight_md, bias_md, out_md, strides,
-                                                      dilates, padding, padding);
+      mkldnn::convolution_backward_weights::desc desc(
+          mkldnn::algorithm::convolution_direct, data_md, weight_md, bias_md, out_md, strides,
+          dilates, padding, padding);
       return GetConvBwdWeightsPd(desc);
     }
   }
 }
 
-MKLDNNConvForward::MKLDNNConvForward(const MKLDNNConvFullParam &param, const bool is_train,
-                                     const NDArray &data, const NDArray &weight,
-                                     const NDArray *bias, const NDArray &output)
+MKLDNNConvForward::MKLDNNConvForward(
+    const MKLDNNConvFullParam& param, const bool is_train, const NDArray& data,
+    const NDArray& weight, const NDArray* bias, const NDArray& output)
     : pd_(GetConvFwdImpl(param, is_train, data, weight, bias, output)) {
   fwd_ = std::make_shared<mkldnn::convolution_forward>(GetPd());
 }
 
-MKLDNNConvForward &GetConvFwd(const MKLDNNConvFullParam &param, const bool is_train,
-                              const NDArray &data, const NDArray &weight, const NDArray *bias,
-                              const NDArray &output) {
+MKLDNNConvForward& GetConvFwd(
+    const MKLDNNConvFullParam& param, const bool is_train, const NDArray& data,
+    const NDArray& weight, const NDArray* bias, const NDArray& output) {
   using conv_fwd_map = std::unordered_map<MKLDNNConvSignature, MKLDNNConvForward, OpHash>;
 #if DMLC_CXX11_THREAD_LOCAL
   static thread_local conv_fwd_map fwds;
@@ -396,24 +393,23 @@ MKLDNNConvForward &GetConvFwd(const MKLDNNConvFullParam &param, const bool is_tr
   auto it = fwds.find(key);
   if (it == fwds.end()) {
     auto fwd = MKLDNNConvForward(param, is_train, data, weight, bias, output);
-    it = AddToCache(&fwds, key, fwd);
+    it       = AddToCache(&fwds, key, fwd);
   }
   return it->second;
 }
 
-void MKLDNNConvolutionForwardFullFeature(const MKLDNNConvFullParam &param, const OpContext &ctx,
-                                         MKLDNNConvForward *fwd,
-                                         const std::vector<NDArray> &in_data,
-                                         const std::vector<OpReqType> &req,
-                                         const std::vector<NDArray> &out_data) {
+void MKLDNNConvolutionForwardFullFeature(
+    const MKLDNNConvFullParam& param, const OpContext& ctx, MKLDNNConvForward* fwd,
+    const std::vector<NDArray>& in_data, const std::vector<OpReqType>& req,
+    const std::vector<NDArray>& out_data) {
   TmpMemMgr::Get()->Init(ctx.requested[conv::kTempSpace]);
 
-  auto &data = in_data[conv::kData];
-  auto &weight = in_data[conv::kWeight];
+  auto& data   = in_data[conv::kData];
+  auto& weight = in_data[conv::kWeight];
   bool no_bias = param.conv_param.no_bias && !param.mkldnn_param.with_bn;
 
   auto data_mem = data.GetMKLDNNDataReorder(fwd->GetPd().src_desc());
-  const mkldnn::memory *weight_mem;
+  const mkldnn::memory* weight_mem;
   if (ctx.is_train) {
     // TODO(zhengda) kvstore doesn't handle MKLDNN correctly. Let's reorder it to the default format
     // for now.
@@ -435,15 +431,15 @@ void MKLDNNConvolutionForwardFullFeature(const MKLDNNConvFullParam &param, const
   }
   mkldnn_output_t out_mem;
   if (param.mkldnn_param.with_sum) {
-    out_mem = mkldnn_output_t(OutDataOp::Noop,
-                              const_cast<mkldnn::memory *>(out_data[conv::kOut].GetMKLDNNData()));
+    out_mem = mkldnn_output_t(
+        OutDataOp::Noop, const_cast<mkldnn::memory*>(out_data[conv::kOut].GetMKLDNNData()));
   } else {
     out_mem = CreateMKLDNNMem(out_data[conv::kOut], fwd->GetPd().dst_desc(), req[conv::kOut]);
   }
 
   mkldnn_args_map_t net_args;
   if (!no_bias) {
-    const mkldnn::memory *bias_mem = in_data[conv::kBias].GetMKLDNNData();
+    const mkldnn::memory* bias_mem = in_data[conv::kBias].GetMKLDNNData();
     net_args.insert({MKLDNN_ARG_BIAS, *bias_mem});
   }
 
@@ -455,32 +451,31 @@ void MKLDNNConvolutionForwardFullFeature(const MKLDNNConvFullParam &param, const
   MKLDNNStream::Get()->Submit();
 }
 
-void MKLDNNConvolutionForward(const nnvm::NodeAttrs &attrs, const OpContext &ctx,
-                              const std::vector<NDArray> &in_data,
-                              const std::vector<OpReqType> &req,
-                              const std::vector<NDArray> &out_data) {
+void MKLDNNConvolutionForward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& in_data,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& out_data) {
   MKLDNNConvFullParam param;
   param.conv_param = nnvm::get<ConvolutionParam>(attrs.parsed);
   param.mkldnn_param.Init(std::unordered_map<std::string, std::string>());
-  auto &fwd =
-      GetConvFwd(param, ctx.is_train, in_data[conv::kData], in_data[conv::kWeight],
-                 param.conv_param.no_bias ? nullptr : &in_data[conv::kBias], out_data[conv::kOut]);
+  auto& fwd = GetConvFwd(
+      param, ctx.is_train, in_data[conv::kData], in_data[conv::kWeight],
+      param.conv_param.no_bias ? nullptr : &in_data[conv::kBias], out_data[conv::kOut]);
   MKLDNNConvolutionForwardFullFeature(param, ctx, &fwd, in_data, req, out_data);
 }
 
-MKLDNNConvBackward::MKLDNNConvBackward(const MKLDNNConvFullParam &param, const NDArray &data,
-                                       const NDArray &weight, const NDArray *bias,
-                                       const NDArray &output) {
+MKLDNNConvBackward::MKLDNNConvBackward(
+    const MKLDNNConvFullParam& param, const NDArray& data, const NDArray& weight,
+    const NDArray* bias, const NDArray& output) {
   const auto fwd_pd = GetConvFwdImpl(param, true, data, weight, bias, output);
-  bwd_data_pd_ = GetConvBwdData(param.conv_param, data, weight, output, *fwd_pd);
-  bwd_weight_pd_ = GetConvBwdWeights(param.conv_param, data, weight, bias, output, *fwd_pd);
-  bwd_data_ = std::make_shared<mkldnn::convolution_backward_data>(GetDataPd());
-  bwd_weight_ = std::make_shared<mkldnn::convolution_backward_weights>(GetWeightsPd());
+  bwd_data_pd_      = GetConvBwdData(param.conv_param, data, weight, output, *fwd_pd);
+  bwd_weight_pd_    = GetConvBwdWeights(param.conv_param, data, weight, bias, output, *fwd_pd);
+  bwd_data_         = std::make_shared<mkldnn::convolution_backward_data>(GetDataPd());
+  bwd_weight_       = std::make_shared<mkldnn::convolution_backward_weights>(GetWeightsPd());
 }
 
-static inline MKLDNNConvBackward &GetConvBwd(const MKLDNNConvFullParam &param, const NDArray &data,
-                                             const NDArray &weight, const NDArray *bias,
-                                             const NDArray &output) {
+static inline MKLDNNConvBackward& GetConvBwd(
+    const MKLDNNConvFullParam& param, const NDArray& data, const NDArray& weight,
+    const NDArray* bias, const NDArray& output) {
   using mkldnn_conv_bwd_map = std::unordered_map<MKLDNNConvSignature, MKLDNNConvBackward, OpHash>;
 #if DMLC_CXX11_THREAD_LOCAL
   static thread_local mkldnn_conv_bwd_map bwds;
@@ -500,56 +495,55 @@ static inline MKLDNNConvBackward &GetConvBwd(const MKLDNNConvFullParam &param, c
   auto it = bwds.find(key);
   if (it == bwds.end()) {
     auto bwd = MKLDNNConvBackward(param, data, weight, bias, output);
-    it = AddToCache(&bwds, key, bwd);
+    it       = AddToCache(&bwds, key, bwd);
   }
   return it->second;
 }
 
-void MKLDNNConvolutionBackward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
-                               const std::vector<NDArray>& inputs,
-                               const std::vector<OpReqType>& req,
-                               const std::vector<NDArray>& outputs) {
+void MKLDNNConvolutionBackward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& inputs,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs) {
   TmpMemMgr::Get()->Init(ctx.requested[conv::kTempSpace]);
-  const std::vector<NDArray> &in_grad = outputs;
+  const std::vector<NDArray>& in_grad = outputs;
   MKLDNNConvFullParam full_param;
   full_param.conv_param = nnvm::get<ConvolutionParam>(attrs.parsed);
   full_param.mkldnn_param.Init(std::unordered_map<std::string, std::string>());
 
-  auto &data = inputs[conv::kData + 1];
-  auto &weight = inputs[conv::kWeight + 1];
-  const auto *bias = full_param.conv_param.no_bias ? nullptr : &inputs[conv::kBias + 1];
-  auto &out_grad = inputs[conv::kOut];
+  auto& data       = inputs[conv::kData + 1];
+  auto& weight     = inputs[conv::kWeight + 1];
+  const auto* bias = full_param.conv_param.no_bias ? nullptr : &inputs[conv::kBias + 1];
+  auto& out_grad   = inputs[conv::kOut];
 
-  const ConvolutionParam &param = full_param.conv_param;
+  const ConvolutionParam& param = full_param.conv_param;
 
   CHECK_NE(req[conv::kWeight], kWriteInplace) << "cannot write weight inplace";
-  MKLDNNConvBackward &convBwd = GetConvBwd(full_param, data, weight, bias, out_grad);
-  auto out_grad_mem = out_grad.GetMKLDNNDataReorder(convBwd.GetDataPd().diff_dst_desc());
+  MKLDNNConvBackward& convBwd = GetConvBwd(full_param, data, weight, bias, out_grad);
+  auto out_grad_mem           = out_grad.GetMKLDNNDataReorder(convBwd.GetDataPd().diff_dst_desc());
   if (req[conv::kData]) {
-    auto weight_mem = GetWeights(weight, convBwd.GetDataPd().weights_desc(), param.num_group);
-    auto in_grad_mem = CreateMKLDNNMem(in_grad[conv::kData], convBwd.GetDataPd().diff_src_desc(),
-                                       req[conv::kData]);
-    MKLDNNStream::Get()->RegisterPrimArgs(convBwd.GetBwdData(),
-                                          {{MKLDNN_ARG_DIFF_DST, *out_grad_mem},
-                                           {MKLDNN_ARG_WEIGHTS, *weight_mem},
-                                           {MKLDNN_ARG_DIFF_SRC, *in_grad_mem.second}});
+    auto weight_mem  = GetWeights(weight, convBwd.GetDataPd().weights_desc(), param.num_group);
+    auto in_grad_mem = CreateMKLDNNMem(
+        in_grad[conv::kData], convBwd.GetDataPd().diff_src_desc(), req[conv::kData]);
+    MKLDNNStream::Get()->RegisterPrimArgs(
+        convBwd.GetBwdData(), {{MKLDNN_ARG_DIFF_DST, *out_grad_mem},
+                               {MKLDNN_ARG_WEIGHTS, *weight_mem},
+                               {MKLDNN_ARG_DIFF_SRC, *in_grad_mem.second}});
     CommitOutput(in_grad[conv::kData], in_grad_mem);
   }
   if (req[conv::kWeight] || req[conv::kBias]) {
     if (convBwd.GetDataPd().diff_dst_desc() != convBwd.GetWeightsPd().diff_dst_desc())
       out_grad_mem = out_grad.GetMKLDNNDataReorder(convBwd.GetWeightsPd().diff_dst_desc());
-    auto data_mem = data.GetMKLDNNDataReorder(convBwd.GetWeightsPd().src_desc());
+    auto data_mem       = data.GetMKLDNNDataReorder(convBwd.GetWeightsPd().src_desc());
     auto in_grad_weight = CreateMKLDNNWeightGrad(
         in_grad[conv::kWeight], convBwd.GetWeightsPd().diff_weights_desc(), req[conv::kWeight]);
 
-    mkldnn_args_map_t net_args = {{MKLDNN_ARG_DIFF_DST, *out_grad_mem},
-                                  {MKLDNN_ARG_SRC, *data_mem},
-                                  {MKLDNN_ARG_DIFF_WEIGHTS, *in_grad_weight.second}};
+    mkldnn_args_map_t net_args = {
+        {MKLDNN_ARG_DIFF_DST, *out_grad_mem},
+        {MKLDNN_ARG_SRC, *data_mem},
+        {MKLDNN_ARG_DIFF_WEIGHTS, *in_grad_weight.second}};
     mkldnn_output_t in_grad_bias;
     if (!param.no_bias) {
-      in_grad_bias = CreateMKLDNNMem(in_grad[conv::kBias],
-                                          convBwd.GetWeightsPd().diff_bias_desc(),
-                                          req[conv::kBias]);
+      in_grad_bias = CreateMKLDNNMem(
+          in_grad[conv::kBias], convBwd.GetWeightsPd().diff_bias_desc(), req[conv::kBias]);
       net_args.insert({MKLDNN_ARG_DIFF_BIAS, *in_grad_bias.second});
     }
     MKLDNNStream::Get()->RegisterPrimArgs(convBwd.GetBwdWeights(), net_args);

--- a/src/operator/nn/mkldnn/mkldnn_convolution.cc
+++ b/src/operator/nn/mkldnn/mkldnn_convolution.cc
@@ -135,14 +135,13 @@ std::shared_ptr<mkldnn::convolution_forward::primitive_desc> GetConvFwdImpl(
   };
 
   if (param.conv_param.dilate.ndim() == 0 && bias_md_ptr == nullptr) {
-    mkldnn::convolution_forward::desc desc(
-        prop, mkldnn::algorithm::convolution_direct, data_md, weight_md, out_md, strides, padding,
-        padding);
+    mkldnn::convolution_forward::desc desc(prop, mkldnn::algorithm::convolution_direct, data_md,
+                                           weight_md, out_md, strides, padding, padding);
     return GetConvFwdPd(desc);
   } else if (param.conv_param.dilate.ndim() == 0) {
-    mkldnn::convolution_forward::desc desc(
-        prop, mkldnn::algorithm::convolution_direct, data_md, weight_md, *bias_md_ptr, out_md,
-        strides, padding, padding);
+    mkldnn::convolution_forward::desc desc(prop, mkldnn::algorithm::convolution_direct, data_md,
+                                           weight_md, *bias_md_ptr, out_md, strides, padding,
+                                           padding);
     return GetConvFwdPd(desc);
   } else {
     mkldnn::memory::dims dilates(param.conv_param.kernel.ndim());
@@ -160,14 +159,13 @@ std::shared_ptr<mkldnn::convolution_forward::primitive_desc> GetConvFwdImpl(
                  << ", supporting only 1 or 2 or 3.";
     }
     if (bias_md_ptr == nullptr) {
-      mkldnn::convolution_forward::desc desc(
-          prop, mkldnn::algorithm::convolution_direct, data_md, weight_md, out_md, strides, dilates,
-          padding, padding);
+      mkldnn::convolution_forward::desc desc(prop, mkldnn::algorithm::convolution_direct, data_md,
+                                             weight_md, out_md, strides, dilates, padding, padding);
       return GetConvFwdPd(desc);
     } else {
-      mkldnn::convolution_forward::desc desc(
-          prop, mkldnn::algorithm::convolution_direct, data_md, weight_md, *bias_md_ptr, out_md,
-          strides, dilates, padding, padding);
+      mkldnn::convolution_forward::desc desc(prop, mkldnn::algorithm::convolution_direct, data_md,
+                                             weight_md, *bias_md_ptr, out_md, strides, dilates,
+                                             padding, padding);
       return GetConvFwdPd(desc);
     }
   }
@@ -235,9 +233,8 @@ static std::shared_ptr<mkldnn::convolution_backward_data::primitive_desc> GetCon
   };
 
   if (param.dilate.ndim() == 0) {
-    mkldnn::convolution_backward_data::desc desc(
-        mkldnn::algorithm::convolution_direct, data_md, weight_md, out_md, strides, padding,
-        padding);
+    mkldnn::convolution_backward_data::desc desc(mkldnn::algorithm::convolution_direct, data_md,
+                                                 weight_md, out_md, strides, padding, padding);
     return GetConvBwdDataPd(desc);
   } else {
     mkldnn::memory::dims dilates(param.kernel.ndim());
@@ -254,9 +251,9 @@ static std::shared_ptr<mkldnn::convolution_backward_data::primitive_desc> GetCon
       LOG(FATAL) << "Unexpected MKL-DNN Conv dilate size " << param.dilate.ndim()
                  << ", supporting only 1 or 2 or 3.";
     }
-    mkldnn::convolution_backward_data::desc desc(
-        mkldnn::algorithm::convolution_direct, data_md, weight_md, out_md, strides, dilates,
-        padding, padding);
+    mkldnn::convolution_backward_data::desc desc(mkldnn::algorithm::convolution_direct, data_md,
+                                                 weight_md, out_md, strides, dilates, padding,
+                                                 padding);
     return GetConvBwdDataPd(desc);
   }
 }
@@ -323,15 +320,14 @@ static std::shared_ptr<mkldnn::convolution_backward_weights::primitive_desc> Get
   };
 
   if (param.dilate.ndim() == 0 && bias == nullptr) {
-    mkldnn::convolution_backward_weights::desc desc(
-        mkldnn::algorithm::convolution_direct, data_md, weight_md, out_md, strides, padding,
-        padding);
+    mkldnn::convolution_backward_weights::desc desc(mkldnn::algorithm::convolution_direct, data_md,
+                                                    weight_md, out_md, strides, padding, padding);
     return GetConvBwdWeightsPd(desc);
   } else if (param.dilate.ndim() == 0) {
     auto bias_md = GetMemDesc(*bias);
-    mkldnn::convolution_backward_weights::desc desc(
-        mkldnn::algorithm::convolution_direct, data_md, weight_md, bias_md, out_md, strides,
-        padding, padding);
+    mkldnn::convolution_backward_weights::desc desc(mkldnn::algorithm::convolution_direct, data_md,
+                                                    weight_md, bias_md, out_md, strides, padding,
+                                                    padding);
     return GetConvBwdWeightsPd(desc);
   } else {
     mkldnn::memory::dims dilates(param.kernel.ndim());
@@ -349,30 +345,30 @@ static std::shared_ptr<mkldnn::convolution_backward_weights::primitive_desc> Get
                  << ", supporting only 1 or 2 or 3.";
     }
     if (bias == nullptr) {
-      mkldnn::convolution_backward_weights::desc desc(
-          mkldnn::algorithm::convolution_direct, data_md, weight_md, out_md, strides, dilates,
-          padding, padding);
+      mkldnn::convolution_backward_weights::desc desc(mkldnn::algorithm::convolution_direct,
+                                                      data_md, weight_md, out_md, strides, dilates,
+                                                      padding, padding);
       return GetConvBwdWeightsPd(desc);
     } else {
       auto bias_md = GetMemDesc(*bias);
-      mkldnn::convolution_backward_weights::desc desc(
-          mkldnn::algorithm::convolution_direct, data_md, weight_md, bias_md, out_md, strides,
-          dilates, padding, padding);
+      mkldnn::convolution_backward_weights::desc desc(mkldnn::algorithm::convolution_direct,
+                                                      data_md, weight_md, bias_md, out_md, strides,
+                                                      dilates, padding, padding);
       return GetConvBwdWeightsPd(desc);
     }
   }
 }
 
-MKLDNNConvForward::MKLDNNConvForward(
-    const MKLDNNConvFullParam& param, const bool is_train, const NDArray& data,
-    const NDArray& weight, const NDArray* bias, const NDArray& output)
+MKLDNNConvForward::MKLDNNConvForward(const MKLDNNConvFullParam& param, const bool is_train,
+                                     const NDArray& data, const NDArray& weight,
+                                     const NDArray* bias, const NDArray& output)
     : pd_(GetConvFwdImpl(param, is_train, data, weight, bias, output)) {
   fwd_ = std::make_shared<mkldnn::convolution_forward>(GetPd());
 }
 
-MKLDNNConvForward& GetConvFwd(
-    const MKLDNNConvFullParam& param, const bool is_train, const NDArray& data,
-    const NDArray& weight, const NDArray* bias, const NDArray& output) {
+MKLDNNConvForward& GetConvFwd(const MKLDNNConvFullParam& param, const bool is_train,
+                              const NDArray& data, const NDArray& weight, const NDArray* bias,
+                              const NDArray& output) {
   using conv_fwd_map = std::unordered_map<MKLDNNConvSignature, MKLDNNConvForward, OpHash>;
 #if DMLC_CXX11_THREAD_LOCAL
   static thread_local conv_fwd_map fwds;
@@ -398,10 +394,11 @@ MKLDNNConvForward& GetConvFwd(
   return it->second;
 }
 
-void MKLDNNConvolutionForwardFullFeature(
-    const MKLDNNConvFullParam& param, const OpContext& ctx, MKLDNNConvForward* fwd,
-    const std::vector<NDArray>& in_data, const std::vector<OpReqType>& req,
-    const std::vector<NDArray>& out_data) {
+void MKLDNNConvolutionForwardFullFeature(const MKLDNNConvFullParam& param, const OpContext& ctx,
+                                         MKLDNNConvForward* fwd,
+                                         const std::vector<NDArray>& in_data,
+                                         const std::vector<OpReqType>& req,
+                                         const std::vector<NDArray>& out_data) {
   TmpMemMgr::Get()->Init(ctx.requested[conv::kTempSpace]);
 
   auto& data   = in_data[conv::kData];
@@ -431,8 +428,8 @@ void MKLDNNConvolutionForwardFullFeature(
   }
   mkldnn_output_t out_mem;
   if (param.mkldnn_param.with_sum) {
-    out_mem = mkldnn_output_t(
-        OutDataOp::Noop, const_cast<mkldnn::memory*>(out_data[conv::kOut].GetMKLDNNData()));
+    out_mem = mkldnn_output_t(OutDataOp::Noop,
+                              const_cast<mkldnn::memory*>(out_data[conv::kOut].GetMKLDNNData()));
   } else {
     out_mem = CreateMKLDNNMem(out_data[conv::kOut], fwd->GetPd().dst_desc(), req[conv::kOut]);
   }
@@ -451,21 +448,22 @@ void MKLDNNConvolutionForwardFullFeature(
   MKLDNNStream::Get()->Submit();
 }
 
-void MKLDNNConvolutionForward(
-    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& in_data,
-    const std::vector<OpReqType>& req, const std::vector<NDArray>& out_data) {
+void MKLDNNConvolutionForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+                              const std::vector<NDArray>& in_data,
+                              const std::vector<OpReqType>& req,
+                              const std::vector<NDArray>& out_data) {
   MKLDNNConvFullParam param;
   param.conv_param = nnvm::get<ConvolutionParam>(attrs.parsed);
   param.mkldnn_param.Init(std::unordered_map<std::string, std::string>());
-  auto& fwd = GetConvFwd(
-      param, ctx.is_train, in_data[conv::kData], in_data[conv::kWeight],
-      param.conv_param.no_bias ? nullptr : &in_data[conv::kBias], out_data[conv::kOut]);
+  auto& fwd =
+      GetConvFwd(param, ctx.is_train, in_data[conv::kData], in_data[conv::kWeight],
+                 param.conv_param.no_bias ? nullptr : &in_data[conv::kBias], out_data[conv::kOut]);
   MKLDNNConvolutionForwardFullFeature(param, ctx, &fwd, in_data, req, out_data);
 }
 
-MKLDNNConvBackward::MKLDNNConvBackward(
-    const MKLDNNConvFullParam& param, const NDArray& data, const NDArray& weight,
-    const NDArray* bias, const NDArray& output) {
+MKLDNNConvBackward::MKLDNNConvBackward(const MKLDNNConvFullParam& param, const NDArray& data,
+                                       const NDArray& weight, const NDArray* bias,
+                                       const NDArray& output) {
   const auto fwd_pd = GetConvFwdImpl(param, true, data, weight, bias, output);
   bwd_data_pd_      = GetConvBwdData(param.conv_param, data, weight, output, *fwd_pd);
   bwd_weight_pd_    = GetConvBwdWeights(param.conv_param, data, weight, bias, output, *fwd_pd);
@@ -473,9 +471,9 @@ MKLDNNConvBackward::MKLDNNConvBackward(
   bwd_weight_       = std::make_shared<mkldnn::convolution_backward_weights>(GetWeightsPd());
 }
 
-static inline MKLDNNConvBackward& GetConvBwd(
-    const MKLDNNConvFullParam& param, const NDArray& data, const NDArray& weight,
-    const NDArray* bias, const NDArray& output) {
+static inline MKLDNNConvBackward& GetConvBwd(const MKLDNNConvFullParam& param, const NDArray& data,
+                                             const NDArray& weight, const NDArray* bias,
+                                             const NDArray& output) {
   using mkldnn_conv_bwd_map = std::unordered_map<MKLDNNConvSignature, MKLDNNConvBackward, OpHash>;
 #if DMLC_CXX11_THREAD_LOCAL
   static thread_local mkldnn_conv_bwd_map bwds;
@@ -500,9 +498,10 @@ static inline MKLDNNConvBackward& GetConvBwd(
   return it->second;
 }
 
-void MKLDNNConvolutionBackward(
-    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& inputs,
-    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs) {
+void MKLDNNConvolutionBackward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+                               const std::vector<NDArray>& inputs,
+                               const std::vector<OpReqType>& req,
+                               const std::vector<NDArray>& outputs) {
   TmpMemMgr::Get()->Init(ctx.requested[conv::kTempSpace]);
   const std::vector<NDArray>& in_grad = outputs;
   MKLDNNConvFullParam full_param;
@@ -521,12 +520,12 @@ void MKLDNNConvolutionBackward(
   auto out_grad_mem           = out_grad.GetMKLDNNDataReorder(convBwd.GetDataPd().diff_dst_desc());
   if (req[conv::kData]) {
     auto weight_mem  = GetWeights(weight, convBwd.GetDataPd().weights_desc(), param.num_group);
-    auto in_grad_mem = CreateMKLDNNMem(
-        in_grad[conv::kData], convBwd.GetDataPd().diff_src_desc(), req[conv::kData]);
-    MKLDNNStream::Get()->RegisterPrimArgs(
-        convBwd.GetBwdData(), {{MKLDNN_ARG_DIFF_DST, *out_grad_mem},
-                               {MKLDNN_ARG_WEIGHTS, *weight_mem},
-                               {MKLDNN_ARG_DIFF_SRC, *in_grad_mem.second}});
+    auto in_grad_mem = CreateMKLDNNMem(in_grad[conv::kData], convBwd.GetDataPd().diff_src_desc(),
+                                       req[conv::kData]);
+    MKLDNNStream::Get()->RegisterPrimArgs(convBwd.GetBwdData(),
+                                          {{MKLDNN_ARG_DIFF_DST, *out_grad_mem},
+                                           {MKLDNN_ARG_WEIGHTS, *weight_mem},
+                                           {MKLDNN_ARG_DIFF_SRC, *in_grad_mem.second}});
     CommitOutput(in_grad[conv::kData], in_grad_mem);
   }
   if (req[conv::kWeight] || req[conv::kBias]) {
@@ -536,14 +535,13 @@ void MKLDNNConvolutionBackward(
     auto in_grad_weight = CreateMKLDNNWeightGrad(
         in_grad[conv::kWeight], convBwd.GetWeightsPd().diff_weights_desc(), req[conv::kWeight]);
 
-    mkldnn_args_map_t net_args = {
-        {MKLDNN_ARG_DIFF_DST, *out_grad_mem},
-        {MKLDNN_ARG_SRC, *data_mem},
-        {MKLDNN_ARG_DIFF_WEIGHTS, *in_grad_weight.second}};
+    mkldnn_args_map_t net_args = {{MKLDNN_ARG_DIFF_DST, *out_grad_mem},
+                                  {MKLDNN_ARG_SRC, *data_mem},
+                                  {MKLDNN_ARG_DIFF_WEIGHTS, *in_grad_weight.second}};
     mkldnn_output_t in_grad_bias;
     if (!param.no_bias) {
-      in_grad_bias = CreateMKLDNNMem(
-          in_grad[conv::kBias], convBwd.GetWeightsPd().diff_bias_desc(), req[conv::kBias]);
+      in_grad_bias = CreateMKLDNNMem(in_grad[conv::kBias], convBwd.GetWeightsPd().diff_bias_desc(),
+                                     req[conv::kBias]);
       net_args.insert({MKLDNN_ARG_DIFF_BIAS, *in_grad_bias.second});
     }
     MKLDNNStream::Get()->RegisterPrimArgs(convBwd.GetBwdWeights(), net_args);

--- a/src/operator/nn/mkldnn/mkldnn_copy.cc
+++ b/src/operator/nn/mkldnn/mkldnn_copy.cc
@@ -30,9 +30,8 @@
 namespace mxnet {
 namespace op {
 
-void MKLDNNCopy(
-    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const NDArray& in_data,
-    const OpReqType& req, const NDArray& out_data) {
+void MKLDNNCopy(const nnvm::NodeAttrs& attrs, const OpContext& ctx, const NDArray& in_data,
+                const OpReqType& req, const NDArray& out_data) {
   if (req == kNullOp || req == kWriteInplace) return;
   TmpMemMgr::Get()->Init(ctx.requested[0]);
   auto in_mem = in_data.GetMKLDNNData();

--- a/src/operator/nn/mkldnn/mkldnn_copy.cc
+++ b/src/operator/nn/mkldnn/mkldnn_copy.cc
@@ -23,15 +23,18 @@
  * \author
  */
 
-#include "./mkldnn_ops-inl.h"
 #include "./mkldnn_base-inl.h"
+#include "./mkldnn_ops-inl.h"
 
 #if MXNET_USE_MKLDNN == 1
 namespace mxnet {
 namespace op {
 
-void MKLDNNCopy(const nnvm::NodeAttrs& attrs, const OpContext& ctx, const NDArray& in_data,
-                const OpReqType& req, const NDArray& out_data) {
+void MKLDNNCopy(const nnvm::NodeAttrs& attrs,
+                const OpContext& ctx,
+                const NDArray& in_data,
+                const OpReqType& req,
+                const NDArray& out_data) {
   if (req == kNullOp || req == kWriteInplace) return;
   TmpMemMgr::Get()->Init(ctx.requested[0]);
   auto in_mem = in_data.GetMKLDNNData();

--- a/src/operator/nn/mkldnn/mkldnn_copy.cc
+++ b/src/operator/nn/mkldnn/mkldnn_copy.cc
@@ -35,7 +35,8 @@ void MKLDNNCopy(const nnvm::NodeAttrs& attrs,
                 const NDArray& in_data,
                 const OpReqType& req,
                 const NDArray& out_data) {
-  if (req == kNullOp || req == kWriteInplace) return;
+  if (req == kNullOp || req == kWriteInplace)
+    return;
   TmpMemMgr::Get()->Init(ctx.requested[0]);
   auto in_mem = in_data.GetMKLDNNData();
   if (req == kAddTo) {
@@ -44,7 +45,8 @@ void MKLDNNCopy(const nnvm::NodeAttrs& attrs,
     // as the input output. If not, we'll have to reorder memory.
     auto out_mem = out_data.GetMKLDNNData();
     in_mem       = in_data.GetMKLDNNData(out_mem->get_desc());
-    if (in_mem == nullptr) in_mem = in_data.GetMKLDNNDataReorder(out_mem->get_desc());
+    if (in_mem == nullptr)
+      in_mem = in_data.GetMKLDNNDataReorder(out_mem->get_desc());
     MKLDNNSum(*out_mem, *in_mem, *out_mem);
   } else {
     const_cast<NDArray&>(out_data).CopyFrom(*in_mem);

--- a/src/operator/nn/mkldnn/mkldnn_copy.cc
+++ b/src/operator/nn/mkldnn/mkldnn_copy.cc
@@ -21,7 +21,7 @@
  * \file mkldnn_copy.cc
  * \brief
  * \author
-*/
+ */
 
 #include "./mkldnn_ops-inl.h"
 #include "./mkldnn_base-inl.h"
@@ -30,9 +30,9 @@
 namespace mxnet {
 namespace op {
 
-void MKLDNNCopy(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
-                const NDArray &in_data, const OpReqType &req,
-                const NDArray &out_data) {
+void MKLDNNCopy(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const NDArray& in_data,
+    const OpReqType& req, const NDArray& out_data) {
   if (req == kNullOp || req == kWriteInplace) return;
   TmpMemMgr::Get()->Init(ctx.requested[0]);
   auto in_mem = in_data.GetMKLDNNData();
@@ -41,16 +41,15 @@ void MKLDNNCopy(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
     // We should try and force the input memory has the same format
     // as the input output. If not, we'll have to reorder memory.
     auto out_mem = out_data.GetMKLDNNData();
-    in_mem = in_data.GetMKLDNNData(out_mem ->get_desc());
-    if (in_mem == nullptr)
-      in_mem = in_data.GetMKLDNNDataReorder(out_mem->get_desc());
+    in_mem       = in_data.GetMKLDNNData(out_mem->get_desc());
+    if (in_mem == nullptr) in_mem = in_data.GetMKLDNNDataReorder(out_mem->get_desc());
     MKLDNNSum(*out_mem, *in_mem, *out_mem);
   } else {
-    const_cast<NDArray &>(out_data).CopyFrom(*in_mem);
+    const_cast<NDArray&>(out_data).CopyFrom(*in_mem);
   }
   MKLDNNStream::Get()->Submit();
 }
 
-}   // namespace op
-}   // namespace mxnet
+}  // namespace op
+}  // namespace mxnet
 #endif

--- a/src/operator/nn/mkldnn/mkldnn_deconvolution-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_deconvolution-inl.h
@@ -48,21 +48,19 @@
 namespace mxnet {
 namespace op {
 
-using deconv_fwd_t = mkldnn::deconvolution_forward;
+using deconv_fwd_t    = mkldnn::deconvolution_forward;
 using deconv_fwd_pd_t = mkldnn::deconvolution_forward::primitive_desc;
 
-using deconv_bwd_data_t = mkldnn::deconvolution_backward_data;
+using deconv_bwd_data_t    = mkldnn::deconvolution_backward_data;
 using deconv_bwd_data_pd_t = mkldnn::deconvolution_backward_data::primitive_desc;
 
-using deconv_bwd_weights_t = mkldnn::deconvolution_backward_weights;
+using deconv_bwd_weights_t    = mkldnn::deconvolution_backward_weights;
 using deconv_bwd_weights_pd_t = mkldnn::deconvolution_backward_weights::primitive_desc;
-
-
 
 // Swaps the logical order of dimensions that in plain format would correspond to input and output
 // channels (for example: oihw => iohw, iohw => oihw, goihw => giohw).
-inline mkldnn::memory::desc IOLogicalSwapDesc(const mkldnn::memory::desc &desc,
-                                              const uint32_t num_group) {
+inline mkldnn::memory::desc IOLogicalSwapDesc(
+    const mkldnn::memory::desc& desc, const uint32_t num_group) {
   std::vector<int> order(desc.data.ndims);
   std::iota(std::begin(order), std::end(order), 0);
   const int offset = static_cast<int>(num_group > 1);
@@ -71,158 +69,156 @@ inline mkldnn::memory::desc IOLogicalSwapDesc(const mkldnn::memory::desc &desc,
 }
 
 // Applies IOLogicalSwapDesc to MKLDNN memory of arr
-inline void IOLogicalSwapMKLDNNMem(const NDArray &arr, const uint32_t num_group) {
+inline void IOLogicalSwapMKLDNNMem(const NDArray& arr, const uint32_t num_group) {
   mkldnn::memory::desc desc;
   if (arr.IsMKLDNNData()) {
     desc = arr.GetMKLDNNData()->get_desc();
   } else {
     // GetMKLDNNData won't take groups into account when creating mkldnn::memory, we need to use
     // descriptor from GetWeightDesc but with default format
-    const auto &temp = GetWeightDesc(arr, num_group);
-    desc = mkldnn::memory::desc(
+    const auto& temp = GetWeightDesc(arr, num_group);
+    desc             = mkldnn::memory::desc(
         temp.dims(), temp.data_type(),
         static_cast<mkldnn::memory::format_tag>(GetDefaultFormat(temp.data.ndims)));
   }
-  const_cast<NDArray &>(arr).UpdateMKLDNNMemDesc(IOLogicalSwapDesc(desc, num_group));
+  const_cast<NDArray&>(arr).UpdateMKLDNNMemDesc(IOLogicalSwapDesc(desc, num_group));
 }
 
 // Version of GetWeightsDesc for deconvolution (with swap)
-inline mkldnn::memory::desc GetDeconvWeightsDesc(const NDArray &weights, const uint32_t num_group) {
+inline mkldnn::memory::desc GetDeconvWeightsDesc(const NDArray& weights, const uint32_t num_group) {
   return IOLogicalSwapDesc(GetWeightDesc(weights, num_group), num_group);
 }
-
-
 
 class MKLDNNDeconvFwd {
  public:
   struct Tensors {
-    Tensors(const NDArray &data, const NDArray &weights, const NDArray *const bias,
-            const NDArray &out);
-    Tensors(const bool no_bias, const std::vector<NDArray> &inputs,
-            const std::vector<NDArray> &outputs);
+    Tensors(
+        const NDArray& data, const NDArray& weights, const NDArray* const bias, const NDArray& out);
+    Tensors(
+        const bool no_bias, const std::vector<NDArray>& inputs,
+        const std::vector<NDArray>& outputs);
 
-    const NDArray &data;
-    const NDArray &weights;
-    const NDArray *const bias;
-    const NDArray &out;
+    const NDArray& data;
+    const NDArray& weights;
+    const NDArray* const bias;
+    const NDArray& out;
   };
 
-  static MKLDNNDeconvFwd &GetCached(const DeconvolutionParam &param, const Tensors &tensors);
-  static std::shared_ptr<deconv_fwd_pd_t> CreatePrimitiveDesc(const DeconvolutionParam &param,
-                                                              const Tensors &tensors);
+  static MKLDNNDeconvFwd& GetCached(const DeconvolutionParam& param, const Tensors& tensors);
+  static std::shared_ptr<deconv_fwd_pd_t> CreatePrimitiveDesc(
+      const DeconvolutionParam& param, const Tensors& tensors);
 
-  MKLDNNDeconvFwd(const DeconvolutionParam &param, const Tensors &tensors);
-  void ControlWeightsFormat(const uint32_t num_group, const bool is_train,
-                            const NDArray &weights) const;
-  void Execute(const uint32_t num_group, const OpReqType req, const Tensors &tensors) const;
+  MKLDNNDeconvFwd(const DeconvolutionParam& param, const Tensors& tensors);
+  void ControlWeightsFormat(
+      const uint32_t num_group, const bool is_train, const NDArray& weights) const;
+  void Execute(const uint32_t num_group, const OpReqType req, const Tensors& tensors) const;
 
  private:
-  const mkldnn::memory *DataMem(const NDArray &data) const;
-  const mkldnn::memory *WeightsMem(const uint32_t num_group, const NDArray &weights) const;
-  const mkldnn::memory *BiasMem(const NDArray &bias) const;
+  const mkldnn::memory* DataMem(const NDArray& data) const;
+  const mkldnn::memory* WeightsMem(const uint32_t num_group, const NDArray& weights) const;
+  const mkldnn::memory* BiasMem(const NDArray& bias) const;
 
-  mkldnn_output_t OutMem(const OpReqType req, const NDArray &out) const;
+  mkldnn_output_t OutMem(const OpReqType req, const NDArray& out) const;
 
  private:
   std::shared_ptr<deconv_fwd_t> fwd;
   std::shared_ptr<deconv_fwd_pd_t> fwd_pd;
 };
 
-
-MKLDNNDeconvFwd::Tensors::Tensors(const bool no_bias, const std::vector<NDArray> &inputs,
-                                  const std::vector<NDArray> &outputs)
+MKLDNNDeconvFwd::Tensors::Tensors(
+    const bool no_bias, const std::vector<NDArray>& inputs, const std::vector<NDArray>& outputs)
     : data(inputs[deconv::kData]),
       weights(inputs[deconv::kWeight]),
       bias(no_bias ? nullptr : &inputs[deconv::kBias]),
       out(outputs[deconv::kOut]) {}
 
-MKLDNNDeconvFwd::Tensors::Tensors(const NDArray &data, const NDArray &weights,
-                                  const NDArray *const bias, const NDArray &out)
+MKLDNNDeconvFwd::Tensors::Tensors(
+    const NDArray& data, const NDArray& weights, const NDArray* const bias, const NDArray& out)
     : data(data), weights(weights), bias(bias), out(out) {}
 
-MKLDNNDeconvFwd::MKLDNNDeconvFwd(const DeconvolutionParam &param, const Tensors &tensors)
+MKLDNNDeconvFwd::MKLDNNDeconvFwd(const DeconvolutionParam& param, const Tensors& tensors)
     : fwd_pd(CreatePrimitiveDesc(param, tensors)) {
   fwd = std::make_shared<deconv_fwd_t>(*fwd_pd);
 }
 
-inline const mkldnn::memory *MKLDNNDeconvFwd::DataMem(const NDArray &data) const {
+inline const mkldnn::memory* MKLDNNDeconvFwd::DataMem(const NDArray& data) const {
   return data.GetMKLDNNDataReorder(fwd_pd->src_desc());
 }
 
-inline const mkldnn::memory *MKLDNNDeconvFwd::WeightsMem(const uint32_t num_group,
-                                                         const NDArray &weights) const {
+inline const mkldnn::memory* MKLDNNDeconvFwd::WeightsMem(
+    const uint32_t num_group, const NDArray& weights) const {
   return GetWeights(weights, fwd_pd->weights_desc(), num_group);
 }
 
-inline const mkldnn::memory *MKLDNNDeconvFwd::BiasMem(const NDArray &bias) const {
+inline const mkldnn::memory* MKLDNNDeconvFwd::BiasMem(const NDArray& bias) const {
   return bias.GetMKLDNNData();
 }
 
-inline mkldnn_output_t MKLDNNDeconvFwd::OutMem(const OpReqType req, const NDArray &out) const {
+inline mkldnn_output_t MKLDNNDeconvFwd::OutMem(const OpReqType req, const NDArray& out) const {
   return CreateMKLDNNMem(out, fwd_pd->dst_desc(), req);
 }
-
-
 
 class MKLDNNDeconvBwd {
  public:
   struct ReadTensors {
-    ReadTensors(const bool no_bias, const std::vector<NDArray> &inputs);
-    const NDArray &data;
-    const NDArray &weights;
-    const NDArray *const bias;
-    const NDArray &out_grad;
+    ReadTensors(const bool no_bias, const std::vector<NDArray>& inputs);
+    const NDArray& data;
+    const NDArray& weights;
+    const NDArray* const bias;
+    const NDArray& out_grad;
   };
   struct WriteTensors {
-    WriteTensors(const bool no_bias, const std::vector<NDArray> &outputs);
-    const NDArray &data_grad;
-    const NDArray &weights_grad;
-    const NDArray *const bias_grad;
+    WriteTensors(const bool no_bias, const std::vector<NDArray>& outputs);
+    const NDArray& data_grad;
+    const NDArray& weights_grad;
+    const NDArray* const bias_grad;
   };
 
-  static MKLDNNDeconvBwd &GetCached(const DeconvolutionParam &param,
-                                    const ReadTensors &read_tensors);
+  static MKLDNNDeconvBwd& GetCached(
+      const DeconvolutionParam& param, const ReadTensors& read_tensors);
 
   static std::shared_ptr<deconv_bwd_data_pd_t> CreateDataPrimitiveDesc(
-      const DeconvolutionParam &param, const ReadTensors &read_tensors,
-      const deconv_fwd_pd_t &fwd_pd);
+      const DeconvolutionParam& param, const ReadTensors& read_tensors,
+      const deconv_fwd_pd_t& fwd_pd);
 
   static std::shared_ptr<deconv_bwd_weights_pd_t> CreateWeightsPrimitiveDesc(
-      const DeconvolutionParam &param, const ReadTensors &read_tensors,
-      const deconv_fwd_pd_t &fwd_pd);
+      const DeconvolutionParam& param, const ReadTensors& read_tensors,
+      const deconv_fwd_pd_t& fwd_pd);
 
-  MKLDNNDeconvBwd(const DeconvolutionParam &param, const ReadTensors &read_tensors);
+  MKLDNNDeconvBwd(const DeconvolutionParam& param, const ReadTensors& read_tensors);
 
-  void Execute(const uint32_t num_group, const std::vector<OpReqType> &req,
-               const ReadTensors &read_tensors, const WriteTensors &write_tensors) const;
+  void Execute(
+      const uint32_t num_group, const std::vector<OpReqType>& req, const ReadTensors& read_tensors,
+      const WriteTensors& write_tensors) const;
 
  private:
-  void IOSwapWeightsTensors(const uint32_t num_group, const std::vector<OpReqType> &req,
-                            const NDArray &weights, const NDArray &weights_grad) const;
+  void IOSwapWeightsTensors(
+      const uint32_t num_group, const std::vector<OpReqType>& req, const NDArray& weights,
+      const NDArray& weights_grad) const;
 
   // returns the output gradient memory used to calculate the data (input) gradient,
   // which might be reused when calculating the gradient of weights
-  const mkldnn::memory *ScheduleBwdData(const uint32_t num_group, const OpReqType req,
-                                        const ReadTensors &read_tensors,
-                                        const WriteTensors &write_tensors) const;
+  const mkldnn::memory* ScheduleBwdData(
+      const uint32_t num_group, const OpReqType req, const ReadTensors& read_tensors,
+      const WriteTensors& write_tensors) const;
 
-  void ScheduleBwdWeights(const uint32_t num_group, const std::vector<OpReqType> &req,
-                          const ReadTensors &read_tensors, const WriteTensors &write_tensors,
-                          const mkldnn::memory *const out_grad_mem) const;
+  void ScheduleBwdWeights(
+      const uint32_t num_group, const std::vector<OpReqType>& req, const ReadTensors& read_tensors,
+      const WriteTensors& write_tensors, const mkldnn::memory* const out_grad_mem) const;
 
-  const mkldnn::memory *DataMem(const NDArray &data) const;
-  const mkldnn::memory *WeightsMem(const uint32_t num_group, const NDArray &weights) const;
+  const mkldnn::memory* DataMem(const NDArray& data) const;
+  const mkldnn::memory* WeightsMem(const uint32_t num_group, const NDArray& weights) const;
 
   // for calculating the gradient of data (input)
-  const mkldnn::memory *OutGradMem(const NDArray &out_grad) const;
+  const mkldnn::memory* OutGradMem(const NDArray& out_grad) const;
   // for calculating the gradient of weights
-  const mkldnn::memory *OutGradMem(const NDArray &out_grad,
-                                   const mkldnn::memory *const out_grad_mem) const;
+  const mkldnn::memory* OutGradMem(
+      const NDArray& out_grad, const mkldnn::memory* const out_grad_mem) const;
 
-  mkldnn_output_t DataGradMem(const OpReqType req, const NDArray &data_grad) const;
-  mkldnn_output_t WeightsGradMem(const uint32_t num_group, const OpReqType req,
-                                 const NDArray &weights_grad) const;
-  mkldnn_output_t BiasGradMem(const OpReqType req, const NDArray *const bias) const;
+  mkldnn_output_t DataGradMem(const OpReqType req, const NDArray& data_grad) const;
+  mkldnn_output_t WeightsGradMem(
+      const uint32_t num_group, const OpReqType req, const NDArray& weights_grad) const;
+  mkldnn_output_t BiasGradMem(const OpReqType req, const NDArray* const bias) const;
 
   std::shared_ptr<deconv_bwd_data_pd_t> bwd_data_pd;
   std::shared_ptr<deconv_bwd_weights_pd_t> bwd_weights_pd;
@@ -230,32 +226,31 @@ class MKLDNNDeconvBwd {
   std::shared_ptr<deconv_bwd_weights_t> bwd_weights;
 };
 
-
-MKLDNNDeconvBwd::ReadTensors::ReadTensors(const bool no_bias, const std::vector<NDArray> &inputs)
+MKLDNNDeconvBwd::ReadTensors::ReadTensors(const bool no_bias, const std::vector<NDArray>& inputs)
     : data(inputs[deconv::kData + 1]),
       weights(inputs[deconv::kWeight + 1]),
       bias(no_bias ? nullptr : &inputs[deconv::kBias + 1]),
       out_grad(inputs[deconv::kOut]) {}
 
-MKLDNNDeconvBwd::WriteTensors::WriteTensors(const bool no_bias, const std::vector<NDArray> &outputs)
+MKLDNNDeconvBwd::WriteTensors::WriteTensors(const bool no_bias, const std::vector<NDArray>& outputs)
     : data_grad(outputs[deconv::kData]),
       weights_grad(outputs[deconv::kWeight]),
       bias_grad(no_bias ? nullptr : &outputs[deconv::kBias]) {}
 
-MKLDNNDeconvBwd::MKLDNNDeconvBwd(const DeconvolutionParam &param, const ReadTensors &read_tensors) {
-  const auto &fwd_pd = MKLDNNDeconvFwd::CreatePrimitiveDesc(
-      param, MKLDNNDeconvFwd::Tensors(read_tensors.data, read_tensors.weights, read_tensors.bias,
-                                      read_tensors.out_grad));
-  bwd_data_pd = CreateDataPrimitiveDesc(param, read_tensors, *fwd_pd);
+MKLDNNDeconvBwd::MKLDNNDeconvBwd(const DeconvolutionParam& param, const ReadTensors& read_tensors) {
+  const auto& fwd_pd = MKLDNNDeconvFwd::CreatePrimitiveDesc(
+      param,
+      MKLDNNDeconvFwd::Tensors(
+          read_tensors.data, read_tensors.weights, read_tensors.bias, read_tensors.out_grad));
+  bwd_data_pd    = CreateDataPrimitiveDesc(param, read_tensors, *fwd_pd);
   bwd_weights_pd = CreateWeightsPrimitiveDesc(param, read_tensors, *fwd_pd);
-  bwd_data = std::make_shared<deconv_bwd_data_t>(*bwd_data_pd);
-  bwd_weights = std::make_shared<deconv_bwd_weights_t>(*bwd_weights_pd);
+  bwd_data       = std::make_shared<deconv_bwd_data_t>(*bwd_data_pd);
+  bwd_weights    = std::make_shared<deconv_bwd_weights_t>(*bwd_weights_pd);
 }
 
-inline void MKLDNNDeconvBwd::IOSwapWeightsTensors(const uint32_t num_group,
-                                                  const std::vector<OpReqType> &req,
-                                                  const NDArray &weights,
-                                                  const NDArray &weights_grad) const {
+inline void MKLDNNDeconvBwd::IOSwapWeightsTensors(
+    const uint32_t num_group, const std::vector<OpReqType>& req, const NDArray& weights,
+    const NDArray& weights_grad) const {
   if (req[deconv::kData]) {
     IOLogicalSwapMKLDNNMem(weights, num_group);
   }
@@ -264,58 +259,56 @@ inline void MKLDNNDeconvBwd::IOSwapWeightsTensors(const uint32_t num_group,
   }
 }
 
-inline const mkldnn::memory *MKLDNNDeconvBwd::DataMem(const NDArray &data) const {
+inline const mkldnn::memory* MKLDNNDeconvBwd::DataMem(const NDArray& data) const {
   return data.GetMKLDNNDataReorder(bwd_weights_pd->src_desc());
 }
 
-inline const mkldnn::memory *MKLDNNDeconvBwd::WeightsMem(const uint32_t num_group,
-                                                         const NDArray &weights) const {
+inline const mkldnn::memory* MKLDNNDeconvBwd::WeightsMem(
+    const uint32_t num_group, const NDArray& weights) const {
   return GetWeights(weights, bwd_data_pd->weights_desc(), num_group);
 }
 
-inline const mkldnn::memory *MKLDNNDeconvBwd::OutGradMem(const NDArray &out_grad) const {
+inline const mkldnn::memory* MKLDNNDeconvBwd::OutGradMem(const NDArray& out_grad) const {
   return out_grad.GetMKLDNNDataReorder(bwd_data_pd->diff_dst_desc());
 }
 
-inline const mkldnn::memory *MKLDNNDeconvBwd::OutGradMem(
-    const NDArray &out_grad, const mkldnn::memory *const out_grad_mem) const {
+inline const mkldnn::memory* MKLDNNDeconvBwd::OutGradMem(
+    const NDArray& out_grad, const mkldnn::memory* const out_grad_mem) const {
   return (out_grad_mem && out_grad_mem->get_desc() == bwd_weights_pd->diff_dst_desc())
              ? out_grad_mem
              : out_grad.GetMKLDNNDataReorder(bwd_weights_pd->diff_dst_desc());
 }
 
-inline mkldnn_output_t MKLDNNDeconvBwd::DataGradMem(const OpReqType req,
-                                                    const NDArray &data_grad) const {
+inline mkldnn_output_t MKLDNNDeconvBwd::DataGradMem(
+    const OpReqType req, const NDArray& data_grad) const {
   return CreateMKLDNNMem(data_grad, bwd_data_pd->diff_src_desc(), req);
 }
 
-inline mkldnn_output_t MKLDNNDeconvBwd::WeightsGradMem(const uint32_t num_group,
-                                                       const OpReqType req,
-                                                       const NDArray &weights_grad) const {
+inline mkldnn_output_t MKLDNNDeconvBwd::WeightsGradMem(
+    const uint32_t num_group, const OpReqType req, const NDArray& weights_grad) const {
   // CreateMKLDNNWeightGrad always creates a new tensor as IsDefaultFormat always fails (because
   // of the logical swap - explained in MKLDNNDeconvFwd::Execute). We try to reuse weights_grad
   // memory (which, when not swapped, is always in default format), so here we check if after a
   // swap, weights_md will have a default format
-  const auto &weights_md = bwd_weights_pd->diff_weights_desc();
+  const auto& weights_md = bwd_weights_pd->diff_weights_desc();
   if (req == OpReqType::kWriteTo && IsDefaultFormat(IOLogicalSwapDesc(weights_md, num_group))) {
-    return {OutDataOp::Noop, const_cast<NDArray &>(weights_grad).CreateMKLDNNData(weights_md)};
+    return {OutDataOp::Noop, const_cast<NDArray&>(weights_grad).CreateMKLDNNData(weights_md)};
   }
   return CreateMKLDNNWeightGrad(weights_grad, weights_md, req);
 }
 
-inline mkldnn_output_t MKLDNNDeconvBwd::BiasGradMem(const OpReqType req,
-                                                    const NDArray *const bias) const {
+inline mkldnn_output_t MKLDNNDeconvBwd::BiasGradMem(
+    const OpReqType req, const NDArray* const bias) const {
   return bias ? CreateMKLDNNMem(*bias, bwd_weights_pd->diff_bias_desc(), req)
               : mkldnn_output_t(OutDataOp::Noop, nullptr);
 }
 
-
-
 // Utility class for creating operation descriptors of deconvolution primitives
 class DeconvDescCreator {
  public:
-  DeconvDescCreator(const DeconvolutionParam &param, const NDArray &data, const NDArray &weights,
-                    const NDArray *const bias, const NDArray &out);
+  DeconvDescCreator(
+      const DeconvolutionParam& param, const NDArray& data, const NDArray& weights,
+      const NDArray* const bias, const NDArray& out);
 
   // Imposes plain formats on memory descriptors with padding (so the next selected implementation
   // will pass CheckImplSizeReq). After calling this method, new primitive descriptor (with new
@@ -324,10 +317,10 @@ class DeconvDescCreator {
   // data_size, weights_size, out_size - size requirements of current implementation
   // Returns whether successfully imposed a plain format on any of the data, weights, and output
   // memory descriptors.
-  bool ImposePlainWherePadding(const size_t data_size, const size_t weights_size,
-                               const size_t out_size);
-  bool CheckImplSizeReq(const size_t data_size, const size_t weights_size,
-                        const size_t out_size) const;
+  bool ImposePlainWherePadding(
+      const size_t data_size, const size_t weights_size, const size_t out_size);
+  bool CheckImplSizeReq(
+      const size_t data_size, const size_t weights_size, const size_t out_size) const;
 
   deconv_fwd_t::desc CreateFwdDesc() const;
   deconv_bwd_data_t::desc CreateBwdDataDesc() const;
@@ -344,31 +337,33 @@ class DeconvDescCreator {
   mkldnn::memory::dims dilates;
 };
 
-
-inline bool DeconvDescCreator::CheckImplSizeReq(const size_t data_size, const size_t weights_size,
-                                                const size_t out_size) const {
+inline bool DeconvDescCreator::CheckImplSizeReq(
+    const size_t data_size, const size_t weights_size, const size_t out_size) const {
   // MKLDNN introduced padded formats since 0.15 which require more memory
   // compared to the actual size of the tensor. Currently, MKLDNN operators
   // still reuse memory from memory planning, so here we need to accept only a
   // kernel that has the expected memory size requirements (which is suboptimal)
-  return (data_size == GetMemDescSize(data_md) && weights_size == GetMemDescSize(weights_md) &&
-          out_size == GetMemDescSize(out_md));
+  return (
+      data_size == GetMemDescSize(data_md) && weights_size == GetMemDescSize(weights_md) &&
+      out_size == GetMemDescSize(out_md));
 }
 
 inline deconv_fwd_t::desc DeconvDescCreator::CreateFwdDesc() const {
-  return deconv_fwd_t::desc(mkldnn::prop_kind::forward_training,
-                            mkldnn::algorithm::deconvolution_direct, data_md, weights_md, bias_md,
-                            out_md, strides, dilates, padding, padding);
+  return deconv_fwd_t::desc(
+      mkldnn::prop_kind::forward_training, mkldnn::algorithm::deconvolution_direct, data_md,
+      weights_md, bias_md, out_md, strides, dilates, padding, padding);
 }
 
 inline deconv_bwd_data_t::desc DeconvDescCreator::CreateBwdDataDesc() const {
-  return deconv_bwd_data_t::desc(mkldnn::algorithm::deconvolution_direct, data_md, weights_md,
-                                 out_md, strides, dilates, padding, padding);
+  return deconv_bwd_data_t::desc(
+      mkldnn::algorithm::deconvolution_direct, data_md, weights_md, out_md, strides, dilates,
+      padding, padding);
 }
 
 inline deconv_bwd_weights_t::desc DeconvDescCreator::CreateBwdWeightsDesc() const {
-  return deconv_bwd_weights_t::desc(mkldnn::algorithm::deconvolution_direct, data_md, weights_md,
-                                    bias_md, out_md, strides, dilates, padding, padding);
+  return deconv_bwd_weights_t::desc(
+      mkldnn::algorithm::deconvolution_direct, data_md, weights_md, bias_md, out_md, strides,
+      dilates, padding, padding);
 }
 
 }  // namespace op

--- a/src/operator/nn/mkldnn/mkldnn_deconvolution-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_deconvolution-inl.h
@@ -30,8 +30,9 @@
  *       (diff_bias) bias_grad <---|      |<--- weight
  *                                 |______|<--- bias
  *
- * "out" in this (and .cc) file will always refer to the output of Deconv FWD and
- * "out_grad" to its gradient. The corresponding MKLDNN names are in parentheses.
+ * "out" in this (and .cc) file will always refer to the output of Deconv FWD
+ * and "out_grad" to its gradient. The corresponding MKLDNN names are in
+ * parentheses.
  */
 #ifndef MXNET_OPERATOR_NN_MKLDNN_MKLDNN_DECONVOLUTION_INL_H_
 #define MXNET_OPERATOR_NN_MKLDNN_MKLDNN_DECONVOLUTION_INL_H_
@@ -57,8 +58,9 @@ using deconv_bwd_data_pd_t = mkldnn::deconvolution_backward_data::primitive_desc
 using deconv_bwd_weights_t    = mkldnn::deconvolution_backward_weights;
 using deconv_bwd_weights_pd_t = mkldnn::deconvolution_backward_weights::primitive_desc;
 
-// Swaps the logical order of dimensions that in plain format would correspond to input and output
-// channels (for example: oihw => iohw, iohw => oihw, goihw => giohw).
+// Swaps the logical order of dimensions that in plain format would correspond
+// to input and output channels (for example: oihw => iohw, iohw => oihw, goihw
+// => giohw).
 inline mkldnn::memory::desc IOLogicalSwapDesc(const mkldnn::memory::desc& desc,
                                               const uint32_t num_group) {
   std::vector<int> order(desc.data.ndims);
@@ -74,11 +76,13 @@ inline void IOLogicalSwapMKLDNNMem(const NDArray& arr, const uint32_t num_group)
   if (arr.IsMKLDNNData()) {
     desc = arr.GetMKLDNNData()->get_desc();
   } else {
-    // GetMKLDNNData won't take groups into account when creating mkldnn::memory, we need to use
-    // descriptor from GetWeightDesc but with default format
+    // GetMKLDNNData won't take groups into account when creating
+    // mkldnn::memory, we need to use descriptor from GetWeightDesc but with
+    // default format
     const auto& temp = GetWeightDesc(arr, num_group);
     desc             = mkldnn::memory::desc(
-        temp.dims(), temp.data_type(),
+        temp.dims(),
+        temp.data_type(),
         static_cast<mkldnn::memory::format_tag>(GetDefaultFormat(temp.data.ndims)));
   }
   const_cast<NDArray&>(arr).UpdateMKLDNNMemDesc(IOLogicalSwapDesc(desc, num_group));
@@ -206,8 +210,8 @@ class MKLDNNDeconvBwd {
                             const NDArray& weights,
                             const NDArray& weights_grad) const;
 
-  // returns the output gradient memory used to calculate the data (input) gradient,
-  // which might be reused when calculating the gradient of weights
+  // returns the output gradient memory used to calculate the data (input)
+  // gradient, which might be reused when calculating the gradient of weights
   const mkldnn::memory* ScheduleBwdData(const uint32_t num_group,
                                         const OpReqType req,
                                         const ReadTensors& read_tensors,
@@ -253,8 +257,9 @@ MKLDNNDeconvBwd::WriteTensors::WriteTensors(const bool no_bias, const std::vecto
 
 MKLDNNDeconvBwd::MKLDNNDeconvBwd(const DeconvolutionParam& param, const ReadTensors& read_tensors) {
   const auto& fwd_pd = MKLDNNDeconvFwd::CreatePrimitiveDesc(
-      param, MKLDNNDeconvFwd::Tensors(read_tensors.data, read_tensors.weights, read_tensors.bias,
-                                      read_tensors.out_grad));
+      param,
+      MKLDNNDeconvFwd::Tensors(
+          read_tensors.data, read_tensors.weights, read_tensors.bias, read_tensors.out_grad));
   bwd_data_pd    = CreateDataPrimitiveDesc(param, read_tensors, *fwd_pd);
   bwd_weights_pd = CreateWeightsPrimitiveDesc(param, read_tensors, *fwd_pd);
   bwd_data       = std::make_shared<deconv_bwd_data_t>(*bwd_data_pd);
@@ -287,7 +292,8 @@ inline const mkldnn::memory* MKLDNNDeconvBwd::OutGradMem(const NDArray& out_grad
 }
 
 inline const mkldnn::memory* MKLDNNDeconvBwd::OutGradMem(
-    const NDArray& out_grad, const mkldnn::memory* const out_grad_mem) const {
+    const NDArray& out_grad,
+    const mkldnn::memory* const out_grad_mem) const {
   return (out_grad_mem && out_grad_mem->get_desc() == bwd_weights_pd->diff_dst_desc())
              ? out_grad_mem
              : out_grad.GetMKLDNNDataReorder(bwd_weights_pd->diff_dst_desc());
@@ -301,9 +307,10 @@ inline mkldnn_output_t MKLDNNDeconvBwd::DataGradMem(const OpReqType req,
 inline mkldnn_output_t MKLDNNDeconvBwd::WeightsGradMem(const uint32_t num_group,
                                                        const OpReqType req,
                                                        const NDArray& weights_grad) const {
-  // CreateMKLDNNWeightGrad always creates a new tensor as IsDefaultFormat always fails (because
-  // of the logical swap - explained in MKLDNNDeconvFwd::Execute). We try to reuse weights_grad
-  // memory (which, when not swapped, is always in default format), so here we check if after a
+  // CreateMKLDNNWeightGrad always creates a new tensor as IsDefaultFormat
+  // always fails (because of the logical swap - explained in
+  // MKLDNNDeconvFwd::Execute). We try to reuse weights_grad memory (which, when
+  // not swapped, is always in default format), so here we check if after a
   // swap, weights_md will have a default format
   const auto& weights_md = bwd_weights_pd->diff_weights_desc();
   if (req == OpReqType::kWriteTo && IsDefaultFormat(IOLogicalSwapDesc(weights_md, num_group))) {
@@ -327,13 +334,13 @@ class DeconvDescCreator {
                     const NDArray* const bias,
                     const NDArray& out);
 
-  // Imposes plain formats on memory descriptors with padding (so the next selected implementation
-  // will pass CheckImplSizeReq). After calling this method, new primitive descriptor (with new
-  // operator descriptor) should be created, which should select an implementation with matching
-  // size requirements.
-  // data_size, weights_size, out_size - size requirements of current implementation
-  // Returns whether successfully imposed a plain format on any of the data, weights, and output
-  // memory descriptors.
+  // Imposes plain formats on memory descriptors with padding (so the next
+  // selected implementation will pass CheckImplSizeReq). After calling this
+  // method, new primitive descriptor (with new operator descriptor) should be
+  // created, which should select an implementation with matching size
+  // requirements. data_size, weights_size, out_size - size requirements of
+  // current implementation Returns whether successfully imposed a plain format
+  // on any of the data, weights, and output memory descriptors.
   bool ImposePlainWherePadding(const size_t data_size,
                                const size_t weights_size,
                                const size_t out_size);
@@ -369,18 +376,38 @@ inline bool DeconvDescCreator::CheckImplSizeReq(const size_t data_size,
 
 inline deconv_fwd_t::desc DeconvDescCreator::CreateFwdDesc() const {
   return deconv_fwd_t::desc(mkldnn::prop_kind::forward_training,
-                            mkldnn::algorithm::deconvolution_direct, data_md, weights_md, bias_md,
-                            out_md, strides, dilates, padding, padding);
+                            mkldnn::algorithm::deconvolution_direct,
+                            data_md,
+                            weights_md,
+                            bias_md,
+                            out_md,
+                            strides,
+                            dilates,
+                            padding,
+                            padding);
 }
 
 inline deconv_bwd_data_t::desc DeconvDescCreator::CreateBwdDataDesc() const {
-  return deconv_bwd_data_t::desc(mkldnn::algorithm::deconvolution_direct, data_md, weights_md,
-                                 out_md, strides, dilates, padding, padding);
+  return deconv_bwd_data_t::desc(mkldnn::algorithm::deconvolution_direct,
+                                 data_md,
+                                 weights_md,
+                                 out_md,
+                                 strides,
+                                 dilates,
+                                 padding,
+                                 padding);
 }
 
 inline deconv_bwd_weights_t::desc DeconvDescCreator::CreateBwdWeightsDesc() const {
-  return deconv_bwd_weights_t::desc(mkldnn::algorithm::deconvolution_direct, data_md, weights_md,
-                                    bias_md, out_md, strides, dilates, padding, padding);
+  return deconv_bwd_weights_t::desc(mkldnn::algorithm::deconvolution_direct,
+                                    data_md,
+                                    weights_md,
+                                    bias_md,
+                                    out_md,
+                                    strides,
+                                    dilates,
+                                    padding,
+                                    padding);
 }
 
 }  // namespace op

--- a/src/operator/nn/mkldnn/mkldnn_deconvolution.cc
+++ b/src/operator/nn/mkldnn/mkldnn_deconvolution.cc
@@ -28,29 +28,26 @@
 namespace mxnet {
 namespace op {
 
-bool SupportMKLDNNDeconv(const DeconvolutionParam &params, const NDArray &input) {
+bool SupportMKLDNNDeconv(const DeconvolutionParam& params, const NDArray& input) {
   return params.kernel.ndim() >= 1 && params.kernel.ndim() <= 3 &&
          input.shape().ndim() == (params.kernel.ndim() + 2) &&
          (input.dtype() == mshadow::kFloat32 || input.dtype() == mshadow::kBfloat16);
 }
 
-
-
-void MKLDNNDeconvolutionForward(const nnvm::NodeAttrs &attrs, const OpContext &ctx,
-                                const std::vector<NDArray> &inputs,
-                                const std::vector<OpReqType> &req,
-                                const std::vector<NDArray> &outputs) {
+void MKLDNNDeconvolutionForward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& inputs,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs) {
   TmpMemMgr::Get()->Init(ctx.requested[deconv::kTempSpace]);
-  const auto &param = nnvm::get<DeconvolutionParam>(attrs.parsed);
+  const auto& param  = nnvm::get<DeconvolutionParam>(attrs.parsed);
   const auto tensors = MKLDNNDeconvFwd::Tensors(param.no_bias, inputs, outputs);
-  const auto &fwd = MKLDNNDeconvFwd::GetCached(param, tensors);
+  const auto& fwd    = MKLDNNDeconvFwd::GetCached(param, tensors);
 
   fwd.ControlWeightsFormat(param.num_group, ctx.is_train, tensors.weights);
   fwd.Execute(param.num_group, req[deconv::kOut], tensors);
 }
 
-MKLDNNDeconvFwd &MKLDNNDeconvFwd::GetCached(const DeconvolutionParam &param,
-                                            const Tensors &tensors) {
+MKLDNNDeconvFwd& MKLDNNDeconvFwd::GetCached(
+    const DeconvolutionParam& param, const Tensors& tensors) {
   using deconv_fwd_map = std::unordered_map<DeconvSignature, MKLDNNDeconvFwd, OpHash>;
 #if DMLC_CXX11_THREAD_LOCAL
   static thread_local deconv_fwd_map fwds;
@@ -74,13 +71,13 @@ MKLDNNDeconvFwd &MKLDNNDeconvFwd::GetCached(const DeconvolutionParam &param,
 }
 
 std::shared_ptr<deconv_fwd_pd_t> MKLDNNDeconvFwd::CreatePrimitiveDesc(
-    const DeconvolutionParam &param, const Tensors &tensors) {
+    const DeconvolutionParam& param, const Tensors& tensors) {
   DeconvDescCreator ddc(param, tensors.data, tensors.weights, tensors.bias, tensors.out);
-  const auto &engine = CpuEngine::Get()->get_engine();
-  const auto pd = std::make_shared<deconv_fwd_pd_t>(ddc.CreateFwdDesc(), engine);
-  const auto get_data_size = [&pd]() { return pd->src_desc().get_size(); };
+  const auto& engine          = CpuEngine::Get()->get_engine();
+  const auto pd               = std::make_shared<deconv_fwd_pd_t>(ddc.CreateFwdDesc(), engine);
+  const auto get_data_size    = [&pd]() { return pd->src_desc().get_size(); };
   const auto get_weights_size = [&pd]() { return pd->weights_desc().get_size(); };
-  const auto get_out_size = [&pd]() { return pd->dst_desc().get_size(); };
+  const auto get_out_size     = [&pd]() { return pd->dst_desc().get_size(); };
 
   while (!ddc.CheckImplSizeReq(get_data_size(), get_weights_size(), get_out_size())) {
     if (!pd->next_impl()) {
@@ -94,8 +91,8 @@ std::shared_ptr<deconv_fwd_pd_t> MKLDNNDeconvFwd::CreatePrimitiveDesc(
   return pd;
 }
 
-void MKLDNNDeconvFwd::ControlWeightsFormat(const uint32_t num_group, const bool is_train,
-                                           const NDArray &weights) const {
+void MKLDNNDeconvFwd::ControlWeightsFormat(
+    const uint32_t num_group, const bool is_train, const NDArray& weights) const {
   if (is_train) {
     // TODO(zhengda) kvstore doesn't handle MKLDNN correctly. Let's reorder it
     // to the default format for now.
@@ -111,14 +108,15 @@ void MKLDNNDeconvFwd::ControlWeightsFormat(const uint32_t num_group, const bool 
       // The data conversion happens after the weights array is used.
       weights.MKLDNNDataReorderAsync(IOLogicalSwapDesc(fwd_pd->weights_desc(), num_group));
     } else {
-      CHECK(weights.GetMKLDNNData()->get_desc() ==
-            IOLogicalSwapDesc(fwd_pd->weights_desc(), num_group));
+      CHECK(
+          weights.GetMKLDNNData()->get_desc() ==
+          IOLogicalSwapDesc(fwd_pd->weights_desc(), num_group));
     }
   }
 }
 
-void MKLDNNDeconvFwd::Execute(const uint32_t num_group, const OpReqType req,
-                              const Tensors &tensors) const {
+void MKLDNNDeconvFwd::Execute(
+    const uint32_t num_group, const OpReqType req, const Tensors& tensors) const {
   // MXNet (correctly) assumes that deconvolution is implemented using convolution primitives.
   // For that, we would pass input tensor in place of output and output tensor in place of input
   // (for appropriate convolution primitives: deconvolution forward = convolution backward data,
@@ -142,7 +140,7 @@ void MKLDNNDeconvFwd::Execute(const uint32_t num_group, const OpReqType req,
   IOLogicalSwapMKLDNNMem(tensors.weights, num_group);
   {
     mkldnn_args_map_t net_args;
-    const auto &out_mem = OutMem(req, tensors.out);
+    const auto& out_mem = OutMem(req, tensors.out);
 
     net_args.insert({MKLDNN_ARG_SRC, *DataMem(tensors.data)});
     net_args.insert({MKLDNN_ARG_WEIGHTS, *WeightsMem(num_group, tensors.weights)});
@@ -159,25 +157,22 @@ void MKLDNNDeconvFwd::Execute(const uint32_t num_group, const OpReqType req,
   IOLogicalSwapMKLDNNMem(tensors.weights, num_group);  // swap back from oihw to iohw
 }
 
-
-
-void MKLDNNDeconvolutionBackward(const nnvm::NodeAttrs &attrs, const OpContext &ctx,
-                                 const std::vector<NDArray> &inputs,
-                                 const std::vector<OpReqType> &req,
-                                 const std::vector<NDArray> &outputs) {
+void MKLDNNDeconvolutionBackward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& inputs,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs) {
   CHECK_NE(req[deconv::kWeight], kWriteInplace) << "Cannot write weights inplace";
 
   TmpMemMgr::Get()->Init(ctx.requested[deconv::kTempSpace]);
-  const auto &param = nnvm::get<DeconvolutionParam>(attrs.parsed);
-  const auto read_tensors = MKLDNNDeconvBwd::ReadTensors(param.no_bias, inputs);
+  const auto& param        = nnvm::get<DeconvolutionParam>(attrs.parsed);
+  const auto read_tensors  = MKLDNNDeconvBwd::ReadTensors(param.no_bias, inputs);
   const auto write_tensors = MKLDNNDeconvBwd::WriteTensors(param.no_bias, outputs);
-  MKLDNNDeconvBwd &bwd = MKLDNNDeconvBwd::GetCached(param, read_tensors);
+  MKLDNNDeconvBwd& bwd     = MKLDNNDeconvBwd::GetCached(param, read_tensors);
 
   bwd.Execute(param.num_group, req, read_tensors, write_tensors);
 }
 
-MKLDNNDeconvBwd &MKLDNNDeconvBwd::GetCached(const DeconvolutionParam &param,
-                                            const ReadTensors &read_tensors) {
+MKLDNNDeconvBwd& MKLDNNDeconvBwd::GetCached(
+    const DeconvolutionParam& param, const ReadTensors& read_tensors) {
   using deconv_bwd_map = std::unordered_map<DeconvSignature, MKLDNNDeconvBwd, OpHash>;
 #if DMLC_CXX11_THREAD_LOCAL
   static thread_local deconv_bwd_map bwds;
@@ -201,15 +196,15 @@ MKLDNNDeconvBwd &MKLDNNDeconvBwd::GetCached(const DeconvolutionParam &param,
 }
 
 std::shared_ptr<deconv_bwd_data_pd_t> MKLDNNDeconvBwd::CreateDataPrimitiveDesc(
-    const DeconvolutionParam &param, const ReadTensors &read_tensors,
-    const deconv_fwd_pd_t &fwd_pd) {
-  DeconvDescCreator ddc(param, read_tensors.data, read_tensors.weights, nullptr,
-                        read_tensors.out_grad);
-  const auto &engine = CpuEngine::Get()->get_engine();
+    const DeconvolutionParam& param, const ReadTensors& read_tensors,
+    const deconv_fwd_pd_t& fwd_pd) {
+  DeconvDescCreator ddc(
+      param, read_tensors.data, read_tensors.weights, nullptr, read_tensors.out_grad);
+  const auto& engine = CpuEngine::Get()->get_engine();
   const auto pd = std::make_shared<deconv_bwd_data_pd_t>(ddc.CreateBwdDataDesc(), engine, fwd_pd);
-  const auto get_data_size = [&pd]() { return pd->diff_src_desc().get_size(); };
+  const auto get_data_size    = [&pd]() { return pd->diff_src_desc().get_size(); };
   const auto get_weights_size = [&pd]() { return pd->weights_desc().get_size(); };
-  const auto get_out_size = [&pd]() { return pd->diff_dst_desc().get_size(); };
+  const auto get_out_size     = [&pd]() { return pd->diff_dst_desc().get_size(); };
 
   while (!ddc.CheckImplSizeReq(get_data_size(), get_weights_size(), get_out_size())) {
     if (!pd->next_impl()) {
@@ -224,16 +219,16 @@ std::shared_ptr<deconv_bwd_data_pd_t> MKLDNNDeconvBwd::CreateDataPrimitiveDesc(
 }
 
 std::shared_ptr<deconv_bwd_weights_pd_t> MKLDNNDeconvBwd::CreateWeightsPrimitiveDesc(
-    const DeconvolutionParam &param, const ReadTensors &read_tensors,
-    const deconv_fwd_pd_t &fwd_pd) {
-  DeconvDescCreator ddc(param, read_tensors.data, read_tensors.weights, read_tensors.bias,
-                        read_tensors.out_grad);
-  const auto &engine = CpuEngine::Get()->get_engine();
+    const DeconvolutionParam& param, const ReadTensors& read_tensors,
+    const deconv_fwd_pd_t& fwd_pd) {
+  DeconvDescCreator ddc(
+      param, read_tensors.data, read_tensors.weights, read_tensors.bias, read_tensors.out_grad);
+  const auto& engine = CpuEngine::Get()->get_engine();
   const auto pd =
       std::make_shared<deconv_bwd_weights_pd_t>(ddc.CreateBwdWeightsDesc(), engine, fwd_pd);
-  const auto get_data_size = [&pd]() { return pd->src_desc().get_size(); };
+  const auto get_data_size    = [&pd]() { return pd->src_desc().get_size(); };
   const auto get_weights_size = [&pd]() { return pd->diff_weights_desc().get_size(); };
-  const auto get_out_size = [&pd]() { return pd->diff_dst_desc().get_size(); };
+  const auto get_out_size     = [&pd]() { return pd->diff_dst_desc().get_size(); };
 
   while (!ddc.CheckImplSizeReq(get_data_size(), get_weights_size(), get_out_size())) {
     if (!pd->next_impl()) {
@@ -247,13 +242,13 @@ std::shared_ptr<deconv_bwd_weights_pd_t> MKLDNNDeconvBwd::CreateWeightsPrimitive
   return pd;
 }
 
-void MKLDNNDeconvBwd::Execute(const uint32_t num_group, const std::vector<OpReqType> &req,
-                              const ReadTensors &read_tensors,
-                              const WriteTensors &write_tensors) const {
+void MKLDNNDeconvBwd::Execute(
+    const uint32_t num_group, const std::vector<OpReqType>& req, const ReadTensors& read_tensors,
+    const WriteTensors& write_tensors) const {
   // swaps are explained in MKLDNNDeconvFwd::Execute
   IOSwapWeightsTensors(num_group, req, read_tensors.weights, write_tensors.weights_grad);
   {
-    auto *const out_grad_mem =
+    auto* const out_grad_mem =
         ScheduleBwdData(num_group, req[deconv::kData], read_tensors, write_tensors);
     ScheduleBwdWeights(num_group, req, read_tensors, write_tensors, out_grad_mem);
     MKLDNNStream::Get()->Submit();
@@ -261,14 +256,13 @@ void MKLDNNDeconvBwd::Execute(const uint32_t num_group, const std::vector<OpReqT
   IOSwapWeightsTensors(num_group, req, read_tensors.weights, write_tensors.weights_grad);
 }
 
-const mkldnn::memory *MKLDNNDeconvBwd::ScheduleBwdData(const uint32_t num_group,
-                                                       const OpReqType req,
-                                                       const ReadTensors &read_tensors,
-                                                       const WriteTensors &write_tensors) const {
+const mkldnn::memory* MKLDNNDeconvBwd::ScheduleBwdData(
+    const uint32_t num_group, const OpReqType req, const ReadTensors& read_tensors,
+    const WriteTensors& write_tensors) const {
   if (req) {
     mkldnn_args_map_t net_args;
-    auto *const out_grad_mem = OutGradMem(read_tensors.out_grad);
-    const auto &data_grad_mem = DataGradMem(req, write_tensors.data_grad);
+    auto* const out_grad_mem  = OutGradMem(read_tensors.out_grad);
+    const auto& data_grad_mem = DataGradMem(req, write_tensors.data_grad);
 
     net_args.insert({MKLDNN_ARG_DIFF_DST, *out_grad_mem});
     net_args.insert({MKLDNN_ARG_WEIGHTS, *WeightsMem(num_group, read_tensors.weights)});
@@ -282,18 +276,16 @@ const mkldnn::memory *MKLDNNDeconvBwd::ScheduleBwdData(const uint32_t num_group,
   return nullptr;
 }
 
-void MKLDNNDeconvBwd::ScheduleBwdWeights(const uint32_t num_group,
-                                         const std::vector<OpReqType> &req,
-                                         const ReadTensors &read_tensors,
-                                         const WriteTensors &write_tensors,
-                                         const mkldnn::memory *const out_grad_mem) const {
+void MKLDNNDeconvBwd::ScheduleBwdWeights(
+    const uint32_t num_group, const std::vector<OpReqType>& req, const ReadTensors& read_tensors,
+    const WriteTensors& write_tensors, const mkldnn::memory* const out_grad_mem) const {
   OpReqType weight_req = req[deconv::kWeight];
-  OpReqType bias_req = req.size() > deconv::kBias ? req[deconv::kBias] : OpReqType::kNullOp;
+  OpReqType bias_req   = req.size() > deconv::kBias ? req[deconv::kBias] : OpReqType::kNullOp;
   if (weight_req || bias_req) {
     mkldnn_args_map_t net_args;
-    const auto &weights_grad_mem =
+    const auto& weights_grad_mem =
         WeightsGradMem(num_group, weight_req, write_tensors.weights_grad);
-    const auto &bias_grad_mem = BiasGradMem(bias_req, write_tensors.bias_grad);
+    const auto& bias_grad_mem = BiasGradMem(bias_req, write_tensors.bias_grad);
 
     net_args.insert({MKLDNN_ARG_DIFF_DST, *OutGradMem(read_tensors.out_grad, out_grad_mem)});
     net_args.insert({MKLDNN_ARG_SRC, *DataMem(read_tensors.data)});
@@ -311,11 +303,9 @@ void MKLDNNDeconvBwd::ScheduleBwdWeights(const uint32_t num_group,
   }
 }
 
-
-
-DeconvDescCreator::DeconvDescCreator(const DeconvolutionParam &param, const NDArray &data,
-                                     const NDArray &weights, const NDArray *const bias,
-                                     const NDArray &out)
+DeconvDescCreator::DeconvDescCreator(
+    const DeconvolutionParam& param, const NDArray& data, const NDArray& weights,
+    const NDArray* const bias, const NDArray& out)
     : data_md(GetMemDesc(data)),
       weights_md(GetDeconvWeightsDesc(weights, param.num_group)),
       bias_md(bias ? GetMemDesc(*bias) : mkldnn::memory::desc()),
@@ -334,22 +324,23 @@ DeconvDescCreator::DeconvDescCreator(const DeconvolutionParam &param, const NDAr
   }
 }
 
-bool DeconvDescCreator::ImposePlainWherePadding(const size_t data_size, const size_t weights_size,
-                                                const size_t out_size) {
+bool DeconvDescCreator::ImposePlainWherePadding(
+    const size_t data_size, const size_t weights_size, const size_t out_size) {
   // Changing only one at a time, so maybe better implementations will be selected (than entirely
   // plain one)
   if (data_md.data.format_kind == dnnl_format_kind_any && data_size != GetMemDescSize(data_md)) {
     data_md = GetDesc(data_md, GetDefaultFormat(data_md));
     return true;
-  } else if (out_md.data.format_kind == dnnl_format_kind_any &&
-             out_size != GetMemDescSize(out_md)) {
+  } else if (
+      out_md.data.format_kind == dnnl_format_kind_any && out_size != GetMemDescSize(out_md)) {
     out_md = GetDesc(out_md, GetDefaultFormat(out_md));
     return true;
-  } else if (weights_md.data.format_kind == dnnl_format_kind_any &&
-             weights_size != GetMemDescSize(weights_md)) {
+  } else if (
+      weights_md.data.format_kind == dnnl_format_kind_any &&
+      weights_size != GetMemDescSize(weights_md)) {
     const int num_gr = (weights_md.data.ndims > data_md.data.ndims) ? weights_md.data.dims[0] : 1;
-    weights_md = IOLogicalSwapDesc(weights_md, num_gr);
-    weights_md = IOLogicalSwapDesc(GetDesc(weights_md, GetDefaultFormat(weights_md)), num_gr);
+    weights_md       = IOLogicalSwapDesc(weights_md, num_gr);
+    weights_md       = IOLogicalSwapDesc(GetDesc(weights_md, GetDefaultFormat(weights_md)), num_gr);
     return true;
   }
   return false;

--- a/src/operator/nn/mkldnn/mkldnn_deconvolution.cc
+++ b/src/operator/nn/mkldnn/mkldnn_deconvolution.cc
@@ -34,7 +34,8 @@ bool SupportMKLDNNDeconv(const DeconvolutionParam& params, const NDArray& input)
          (input.dtype() == mshadow::kFloat32 || input.dtype() == mshadow::kBfloat16);
 }
 
-void MKLDNNDeconvolutionForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+void MKLDNNDeconvolutionForward(const nnvm::NodeAttrs& attrs,
+                                const OpContext& ctx,
                                 const std::vector<NDArray>& inputs,
                                 const std::vector<OpReqType>& req,
                                 const std::vector<NDArray>& outputs) {
@@ -92,7 +93,8 @@ std::shared_ptr<deconv_fwd_pd_t> MKLDNNDeconvFwd::CreatePrimitiveDesc(
   return pd;
 }
 
-void MKLDNNDeconvFwd::ControlWeightsFormat(const uint32_t num_group, const bool is_train,
+void MKLDNNDeconvFwd::ControlWeightsFormat(const uint32_t num_group,
+                                           const bool is_train,
                                            const NDArray& weights) const {
   if (is_train) {
     // TODO(zhengda) kvstore doesn't handle MKLDNN correctly. Let's reorder it
@@ -115,7 +117,8 @@ void MKLDNNDeconvFwd::ControlWeightsFormat(const uint32_t num_group, const bool 
   }
 }
 
-void MKLDNNDeconvFwd::Execute(const uint32_t num_group, const OpReqType req,
+void MKLDNNDeconvFwd::Execute(const uint32_t num_group,
+                              const OpReqType req,
                               const Tensors& tensors) const {
   // MXNet (correctly) assumes that deconvolution is implemented using convolution primitives.
   // For that, we would pass input tensor in place of output and output tensor in place of input
@@ -157,7 +160,8 @@ void MKLDNNDeconvFwd::Execute(const uint32_t num_group, const OpReqType req,
   IOLogicalSwapMKLDNNMem(tensors.weights, num_group);  // swap back from oihw to iohw
 }
 
-void MKLDNNDeconvolutionBackward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+void MKLDNNDeconvolutionBackward(const nnvm::NodeAttrs& attrs,
+                                 const OpContext& ctx,
                                  const std::vector<NDArray>& inputs,
                                  const std::vector<OpReqType>& req,
                                  const std::vector<NDArray>& outputs) {
@@ -197,7 +201,8 @@ MKLDNNDeconvBwd& MKLDNNDeconvBwd::GetCached(const DeconvolutionParam& param,
 }
 
 std::shared_ptr<deconv_bwd_data_pd_t> MKLDNNDeconvBwd::CreateDataPrimitiveDesc(
-    const DeconvolutionParam& param, const ReadTensors& read_tensors,
+    const DeconvolutionParam& param,
+    const ReadTensors& read_tensors,
     const deconv_fwd_pd_t& fwd_pd) {
   DeconvDescCreator ddc(param, read_tensors.data, read_tensors.weights, nullptr,
                         read_tensors.out_grad);
@@ -220,7 +225,8 @@ std::shared_ptr<deconv_bwd_data_pd_t> MKLDNNDeconvBwd::CreateDataPrimitiveDesc(
 }
 
 std::shared_ptr<deconv_bwd_weights_pd_t> MKLDNNDeconvBwd::CreateWeightsPrimitiveDesc(
-    const DeconvolutionParam& param, const ReadTensors& read_tensors,
+    const DeconvolutionParam& param,
+    const ReadTensors& read_tensors,
     const deconv_fwd_pd_t& fwd_pd) {
   DeconvDescCreator ddc(param, read_tensors.data, read_tensors.weights, read_tensors.bias,
                         read_tensors.out_grad);
@@ -243,7 +249,8 @@ std::shared_ptr<deconv_bwd_weights_pd_t> MKLDNNDeconvBwd::CreateWeightsPrimitive
   return pd;
 }
 
-void MKLDNNDeconvBwd::Execute(const uint32_t num_group, const std::vector<OpReqType>& req,
+void MKLDNNDeconvBwd::Execute(const uint32_t num_group,
+                              const std::vector<OpReqType>& req,
                               const ReadTensors& read_tensors,
                               const WriteTensors& write_tensors) const {
   // swaps are explained in MKLDNNDeconvFwd::Execute
@@ -307,8 +314,10 @@ void MKLDNNDeconvBwd::ScheduleBwdWeights(const uint32_t num_group,
   }
 }
 
-DeconvDescCreator::DeconvDescCreator(const DeconvolutionParam& param, const NDArray& data,
-                                     const NDArray& weights, const NDArray* const bias,
+DeconvDescCreator::DeconvDescCreator(const DeconvolutionParam& param,
+                                     const NDArray& data,
+                                     const NDArray& weights,
+                                     const NDArray* const bias,
                                      const NDArray& out)
     : data_md(GetMemDesc(data)),
       weights_md(GetDeconvWeightsDesc(weights, param.num_group)),
@@ -328,7 +337,8 @@ DeconvDescCreator::DeconvDescCreator(const DeconvolutionParam& param, const NDAr
   }
 }
 
-bool DeconvDescCreator::ImposePlainWherePadding(const size_t data_size, const size_t weights_size,
+bool DeconvDescCreator::ImposePlainWherePadding(const size_t data_size,
+                                                const size_t weights_size,
                                                 const size_t out_size) {
   // Changing only one at a time, so maybe better implementations will be selected (than entirely
   // plain one)

--- a/src/operator/nn/mkldnn/mkldnn_fully_connected-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_fully_connected-inl.h
@@ -57,7 +57,9 @@ struct MKLDNNFCParam : public dmlc::Parameter<MKLDNNFCParam> {
         .describe("Whether to enable float32 output");
     DMLC_DECLARE_FIELD(with_eltwise)
         .set_default(false)
-        .describe("Whether there's a post with_eltwise after FullyConnected operator");
+        .describe(
+            "Whether there's a post with_eltwise after FullyConnected "
+            "operator");
     DMLC_DECLARE_FIELD(with_sum).set_default(false).describe("Add post sum");
     DMLC_DECLARE_FIELD(min_calib_range)
         .set_default(dmlc::optional<float>())
@@ -105,7 +107,9 @@ class MKLDNNFullyConnectedForward {
     fwd_ = std::make_shared<mkldnn::inner_product_forward>(fwd_pd);
   }
 
-  const mkldnn::inner_product_forward& GetFwd() const { return *fwd_; }
+  const mkldnn::inner_product_forward& GetFwd() const {
+    return *fwd_;
+  }
 
  private:
   std::shared_ptr<mkldnn::inner_product_forward> fwd_;

--- a/src/operator/nn/mkldnn/mkldnn_fully_connected-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_fully_connected-inl.h
@@ -29,9 +29,10 @@
 
 #if MXNET_USE_MKLDNN == 1
 
-#include <vector>
-#include <string>
 #include <memory>
+#include <string>
+#include <vector>
+
 #include "../fully_connected-inl.h"
 #include "./mkldnn_base-inl.h"
 
@@ -49,14 +50,15 @@ struct MKLDNNFCParam : public dmlc::Parameter<MKLDNNFCParam> {
   dmlc::optional<bool> channel_wise_quantize;
 
   DMLC_DECLARE_PARAMETER(MKLDNNFCParam) {
-    DMLC_DECLARE_FIELD(quantized).set_default(false)
-    .describe("Whether it's a quantized FullyConnected operator");
-    DMLC_DECLARE_FIELD(enable_float_output).set_default(false)
-    .describe("Whether to enable float32 output");
-    DMLC_DECLARE_FIELD(with_eltwise).set_default(false)
-    .describe("Whether there's a post with_eltwise after FullyConnected operator");
-    DMLC_DECLARE_FIELD(with_sum).set_default(false)
-    .describe("Add post sum");
+    DMLC_DECLARE_FIELD(quantized).set_default(false).describe(
+        "Whether it's a quantized FullyConnected operator");
+    DMLC_DECLARE_FIELD(enable_float_output)
+        .set_default(false)
+        .describe("Whether to enable float32 output");
+    DMLC_DECLARE_FIELD(with_eltwise)
+        .set_default(false)
+        .describe("Whether there's a post with_eltwise after FullyConnected operator");
+    DMLC_DECLARE_FIELD(with_sum).set_default(false).describe("Add post sum");
     DMLC_DECLARE_FIELD(min_calib_range)
         .set_default(dmlc::optional<float>())
         .describe(
@@ -83,7 +85,8 @@ struct MKLDNNFCFullParam {
 };
 
 mkldnn::inner_product_forward::primitive_desc GetFCFwdImpl(const MKLDNNFCFullParam& full_param,
-                                                           const bool is_train, const NDArray& data,
+                                                           const bool is_train,
+                                                           const NDArray& data,
                                                            const NDArray& weight,
                                                            const NDArray* bias,
                                                            const mkldnn::memory::desc& out_md);
@@ -92,8 +95,11 @@ class MKLDNNFullyConnectedForward {
  public:
   mkldnn::inner_product_forward::primitive_desc fwd_pd;
 
-  MKLDNNFullyConnectedForward(const MKLDNNFCFullParam& full_param, const bool is_train,
-                              const NDArray& data, const NDArray& weight, const NDArray* bias,
+  MKLDNNFullyConnectedForward(const MKLDNNFCFullParam& full_param,
+                              const bool is_train,
+                              const NDArray& data,
+                              const NDArray& weight,
+                              const NDArray* bias,
                               const mkldnn::memory::desc& out_md)
       : fwd_pd(GetFCFwdImpl(full_param, is_train, data, weight, bias, out_md)) {
     fwd_ = std::make_shared<mkldnn::inner_product_forward>(fwd_pd);
@@ -107,18 +113,26 @@ class MKLDNNFullyConnectedForward {
 
 typedef ParamOpSign<FullyConnectedParam> MKLDNNFullyconSignature;
 
-MKLDNNFullyConnectedForward& GetFCFwd(const FullyConnectedParam& param, const bool is_train,
-                                      const NDArray& data, const NDArray& weight,
-                                      const NDArray* bias, const mkldnn::memory::desc& out_md);
+MKLDNNFullyConnectedForward& GetFCFwd(const FullyConnectedParam& param,
+                                      const bool is_train,
+                                      const NDArray& data,
+                                      const NDArray& weight,
+                                      const NDArray* bias,
+                                      const mkldnn::memory::desc& out_md);
 
-void MKLDNNFCFlattenData(const FullyConnectedParam& param, const NDArray& out_data,
-                         NDArray* in_data, mkldnn::memory::desc* out_md);
+void MKLDNNFCFlattenData(const FullyConnectedParam& param,
+                         const NDArray& out_data,
+                         NDArray* in_data,
+                         mkldnn::memory::desc* out_md);
 
-void MKLDNNFCForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
-                     const std::vector<NDArray>& in_data, const std::vector<OpReqType>& req,
+void MKLDNNFCForward(const nnvm::NodeAttrs& attrs,
+                     const OpContext& ctx,
+                     const std::vector<NDArray>& in_data,
+                     const std::vector<OpReqType>& req,
                      const std::vector<NDArray>& out_data);
 
-void MKLDNNFCForwardFullFeature(const MKLDNNFCFullParam& param, const OpContext& ctx,
+void MKLDNNFCForwardFullFeature(const MKLDNNFCFullParam& param,
+                                const OpContext& ctx,
                                 MKLDNNFullyConnectedForward* fwd,
                                 const std::vector<NDArray>& in_data,
                                 const std::vector<OpReqType>& req,

--- a/src/operator/nn/mkldnn/mkldnn_fully_connected-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_fully_connected-inl.h
@@ -22,7 +22,7 @@
  * \file mkldnn_fully_connected-inl.h
  * \brief Common functions used by MKLDNN (Quantized) FullyConnected operator
  * \author Ciyong Chen
-*/
+ */
 
 #ifndef MXNET_OPERATOR_NN_MKLDNN_MKLDNN_FULLY_CONNECTED_INL_H_
 #define MXNET_OPERATOR_NN_MKLDNN_MKLDNN_FULLY_CONNECTED_INL_H_
@@ -38,7 +38,7 @@
 namespace mxnet {
 namespace op {
 
-struct MKLDNNFCParam: public dmlc::Parameter<MKLDNNFCParam> {
+struct MKLDNNFCParam : public dmlc::Parameter<MKLDNNFCParam> {
   bool quantized;
   bool enable_float_output;
   bool with_eltwise;
@@ -58,18 +58,20 @@ struct MKLDNNFCParam: public dmlc::Parameter<MKLDNNFCParam> {
     DMLC_DECLARE_FIELD(with_sum).set_default(false)
     .describe("Add post sum");
     DMLC_DECLARE_FIELD(min_calib_range)
-    .set_default(dmlc::optional<float>())
-    .describe("The minimum scalar value in the form of float32 obtained "
-              "through calibration. If present, it will be used to by "
-              "quantized fullyconnected op to calculate primitive scale");
+        .set_default(dmlc::optional<float>())
+        .describe(
+            "The minimum scalar value in the form of float32 obtained "
+            "through calibration. If present, it will be used to by "
+            "quantized fullyconnected op to calculate primitive scale");
     DMLC_DECLARE_FIELD(max_calib_range)
-    .set_default(dmlc::optional<float>())
-    .describe("The maximum scalar value in the form of float32 obtained "
-              "through calibration. If present, it will be used to by "
-              "quantized fullyconnected op to calculate primitive scale");
+        .set_default(dmlc::optional<float>())
+        .describe(
+            "The maximum scalar value in the form of float32 obtained "
+            "through calibration. If present, it will be used to by "
+            "quantized fullyconnected op to calculate primitive scale");
     DMLC_DECLARE_FIELD(channel_wise_quantize)
-    .set_default(dmlc::optional<bool>())
-    .describe("Whether support channel-wise-quantize for weight.");
+        .set_default(dmlc::optional<bool>())
+        .describe("Whether support channel-wise-quantize for weight.");
   }
 };
 
@@ -81,25 +83,21 @@ struct MKLDNNFCFullParam {
 };
 
 mkldnn::inner_product_forward::primitive_desc GetFCFwdImpl(
-    const MKLDNNFCFullParam &full_param, const bool is_train,
-    const NDArray &data, const NDArray &weight, const NDArray *bias,
-    const mkldnn::memory::desc &out_md);
+    const MKLDNNFCFullParam& full_param, const bool is_train, const NDArray& data,
+    const NDArray& weight, const NDArray* bias, const mkldnn::memory::desc& out_md);
 
 class MKLDNNFullyConnectedForward {
  public:
   mkldnn::inner_product_forward::primitive_desc fwd_pd;
 
-  MKLDNNFullyConnectedForward(const MKLDNNFCFullParam &full_param, const bool is_train,
-                              const NDArray &data, const NDArray &weight,
-                              const NDArray *bias,
-                              const mkldnn::memory::desc &out_md)
+  MKLDNNFullyConnectedForward(
+      const MKLDNNFCFullParam& full_param, const bool is_train, const NDArray& data,
+      const NDArray& weight, const NDArray* bias, const mkldnn::memory::desc& out_md)
       : fwd_pd(GetFCFwdImpl(full_param, is_train, data, weight, bias, out_md)) {
-          fwd_ = std::make_shared<mkldnn::inner_product_forward>(fwd_pd);
-      }
-
-  const mkldnn::inner_product_forward &GetFwd() const {
-    return *fwd_;
+    fwd_ = std::make_shared<mkldnn::inner_product_forward>(fwd_pd);
   }
+
+  const mkldnn::inner_product_forward& GetFwd() const { return *fwd_; }
 
  private:
   std::shared_ptr<mkldnn::inner_product_forward> fwd_;
@@ -107,27 +105,22 @@ class MKLDNNFullyConnectedForward {
 
 typedef ParamOpSign<FullyConnectedParam> MKLDNNFullyconSignature;
 
-MKLDNNFullyConnectedForward &GetFCFwd(
-    const FullyConnectedParam &param, const bool is_train,
-    const NDArray &data, const NDArray &weight,
-    const NDArray *bias, const mkldnn::memory::desc &out_md);
+MKLDNNFullyConnectedForward& GetFCFwd(
+    const FullyConnectedParam& param, const bool is_train, const NDArray& data,
+    const NDArray& weight, const NDArray* bias, const mkldnn::memory::desc& out_md);
 
-void MKLDNNFCFlattenData(const FullyConnectedParam &param,
-                         const NDArray &out_data,
-                         NDArray *in_data,
-                         mkldnn::memory::desc *out_md);
+void MKLDNNFCFlattenData(
+    const FullyConnectedParam& param, const NDArray& out_data, NDArray* in_data,
+    mkldnn::memory::desc* out_md);
 
-void MKLDNNFCForward(const nnvm::NodeAttrs &attrs, const OpContext &ctx,
-                     const std::vector<NDArray> &in_data,
-                     const std::vector<OpReqType> &req,
-                     const std::vector<NDArray> &out_data);
+void MKLDNNFCForward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& in_data,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& out_data);
 
-void MKLDNNFCForwardFullFeature(const MKLDNNFCFullParam &param,
-                                const OpContext &ctx,
-                                MKLDNNFullyConnectedForward *fwd,
-                                const std::vector<NDArray> &in_data,
-                                const std::vector<OpReqType> &req,
-                                const std::vector<NDArray> &out_data);
+void MKLDNNFCForwardFullFeature(
+    const MKLDNNFCFullParam& param, const OpContext& ctx, MKLDNNFullyConnectedForward* fwd,
+    const std::vector<NDArray>& in_data, const std::vector<OpReqType>& req,
+    const std::vector<NDArray>& out_data);
 
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/nn/mkldnn/mkldnn_fully_connected-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_fully_connected-inl.h
@@ -82,17 +82,19 @@ struct MKLDNNFCFullParam {
   std::vector<float> output_scales = {0.0f};
 };
 
-mkldnn::inner_product_forward::primitive_desc GetFCFwdImpl(
-    const MKLDNNFCFullParam& full_param, const bool is_train, const NDArray& data,
-    const NDArray& weight, const NDArray* bias, const mkldnn::memory::desc& out_md);
+mkldnn::inner_product_forward::primitive_desc GetFCFwdImpl(const MKLDNNFCFullParam& full_param,
+                                                           const bool is_train, const NDArray& data,
+                                                           const NDArray& weight,
+                                                           const NDArray* bias,
+                                                           const mkldnn::memory::desc& out_md);
 
 class MKLDNNFullyConnectedForward {
  public:
   mkldnn::inner_product_forward::primitive_desc fwd_pd;
 
-  MKLDNNFullyConnectedForward(
-      const MKLDNNFCFullParam& full_param, const bool is_train, const NDArray& data,
-      const NDArray& weight, const NDArray* bias, const mkldnn::memory::desc& out_md)
+  MKLDNNFullyConnectedForward(const MKLDNNFCFullParam& full_param, const bool is_train,
+                              const NDArray& data, const NDArray& weight, const NDArray* bias,
+                              const mkldnn::memory::desc& out_md)
       : fwd_pd(GetFCFwdImpl(full_param, is_train, data, weight, bias, out_md)) {
     fwd_ = std::make_shared<mkldnn::inner_product_forward>(fwd_pd);
   }
@@ -105,22 +107,22 @@ class MKLDNNFullyConnectedForward {
 
 typedef ParamOpSign<FullyConnectedParam> MKLDNNFullyconSignature;
 
-MKLDNNFullyConnectedForward& GetFCFwd(
-    const FullyConnectedParam& param, const bool is_train, const NDArray& data,
-    const NDArray& weight, const NDArray* bias, const mkldnn::memory::desc& out_md);
+MKLDNNFullyConnectedForward& GetFCFwd(const FullyConnectedParam& param, const bool is_train,
+                                      const NDArray& data, const NDArray& weight,
+                                      const NDArray* bias, const mkldnn::memory::desc& out_md);
 
-void MKLDNNFCFlattenData(
-    const FullyConnectedParam& param, const NDArray& out_data, NDArray* in_data,
-    mkldnn::memory::desc* out_md);
+void MKLDNNFCFlattenData(const FullyConnectedParam& param, const NDArray& out_data,
+                         NDArray* in_data, mkldnn::memory::desc* out_md);
 
-void MKLDNNFCForward(
-    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& in_data,
-    const std::vector<OpReqType>& req, const std::vector<NDArray>& out_data);
+void MKLDNNFCForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+                     const std::vector<NDArray>& in_data, const std::vector<OpReqType>& req,
+                     const std::vector<NDArray>& out_data);
 
-void MKLDNNFCForwardFullFeature(
-    const MKLDNNFCFullParam& param, const OpContext& ctx, MKLDNNFullyConnectedForward* fwd,
-    const std::vector<NDArray>& in_data, const std::vector<OpReqType>& req,
-    const std::vector<NDArray>& out_data);
+void MKLDNNFCForwardFullFeature(const MKLDNNFCFullParam& param, const OpContext& ctx,
+                                MKLDNNFullyConnectedForward* fwd,
+                                const std::vector<NDArray>& in_data,
+                                const std::vector<OpReqType>& req,
+                                const std::vector<NDArray>& out_data);
 
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/nn/mkldnn/mkldnn_fully_connected.cc
+++ b/src/operator/nn/mkldnn/mkldnn_fully_connected.cc
@@ -22,7 +22,7 @@
  * \file mkldnn_fully_connected.cc
  * \brief MKLDNN FullyConnected operator
  * \author Da Zheng, Ciyong Chen
-*/
+ */
 
 #if MXNET_USE_MKLDNN == 1
 #include <unordered_map>
@@ -34,23 +34,21 @@ namespace op {
 DMLC_REGISTER_PARAMETER(MKLDNNFCParam);
 
 mkldnn::inner_product_forward::primitive_desc GetFCFwdImpl(
-    const MKLDNNFCFullParam &full_param, const bool is_train,
-    const NDArray &data, const NDArray &weight, const NDArray *bias,
-    const mkldnn::memory::desc &out_md) {
-  auto data_md = GetMemDesc(data);
-  auto weight_md = full_param.mkldnn_param.quantized ?
-    GetFCWeightDesc(weight, mshadow::kInt8) : GetFCWeightDesc(weight);
-  auto engine = CpuEngine::Get()->get_engine();
+    const MKLDNNFCFullParam& full_param, const bool is_train, const NDArray& data,
+    const NDArray& weight, const NDArray* bias, const mkldnn::memory::desc& out_md) {
+  auto data_md   = GetMemDesc(data);
+  auto weight_md = full_param.mkldnn_param.quantized ? GetFCWeightDesc(weight, mshadow::kInt8)
+                                                     : GetFCWeightDesc(weight);
+  auto engine    = CpuEngine::Get()->get_engine();
   auto propagation =
-    is_train ? mkldnn::prop_kind::forward_training : mkldnn::prop_kind::forward_scoring;
+      is_train ? mkldnn::prop_kind::forward_training : mkldnn::prop_kind::forward_scoring;
 
   mkldnn::primitive_attr attr;
   mkldnn::post_ops ops;
   if (full_param.mkldnn_param.with_eltwise) {
-    ops.append_eltwise(full_param.eltwise_param.scale,
-                       full_param.eltwise_param.alg,
-                       full_param.eltwise_param.alpha,
-                       full_param.eltwise_param.beta);
+    ops.append_eltwise(
+        full_param.eltwise_param.scale, full_param.eltwise_param.alg,
+        full_param.eltwise_param.alpha, full_param.eltwise_param.beta);
   }
   if (full_param.mkldnn_param.with_sum) {
     ops.append_sum(full_param.mkldnn_param.sum_scale);
@@ -62,13 +60,11 @@ mkldnn::inner_product_forward::primitive_desc GetFCFwdImpl(
     attr.set_output_scales(mask, full_param.output_scales);
   }
 
-  auto GetFCFwdPd = [&full_param, &attr,
-                     &engine](const mkldnn::inner_product_forward::desc &desc) {
+  auto GetFCFwdPd = [&full_param, &attr, &engine](const mkldnn::inner_product_forward::desc& desc) {
     try {
       return mkldnn::inner_product_forward::primitive_desc(desc, attr, engine);
-    } catch (mkldnn::error &e) {
-      if (e.status == mkldnn_unimplemented &&
-          full_param.mkldnn_param.quantized) {
+    } catch (mkldnn::error& e) {
+      if (e.status == mkldnn_unimplemented && full_param.mkldnn_param.quantized) {
         LOG(ERROR) << "AVX512-BW support or MKLDNN v0.18 is required for INT8 fully_connected.";
       } else {
         LOG(ERROR) << e.message;
@@ -78,69 +74,62 @@ mkldnn::inner_product_forward::primitive_desc GetFCFwdImpl(
   };
 
   if (bias) {
-    if ((*bias).shape().ndim() != 1)
-      LOG(FATAL) << "Unexpected shape for bias " << (*bias).shape();
+    if ((*bias).shape().ndim() != 1) LOG(FATAL) << "Unexpected shape for bias " << (*bias).shape();
     auto bias_md =
-       full_param.mkldnn_param.quantized ? GetMemDesc(*bias, mshadow::kInt32) : GetMemDesc(*bias);
-    mkldnn::inner_product_forward::desc desc(propagation,
-        data_md, weight_md, bias_md, out_md);
+        full_param.mkldnn_param.quantized ? GetMemDesc(*bias, mshadow::kInt32) : GetMemDesc(*bias);
+    mkldnn::inner_product_forward::desc desc(propagation, data_md, weight_md, bias_md, out_md);
     return GetFCFwdPd(desc);
   } else {
-    mkldnn::inner_product_forward::desc desc(propagation,
-        data_md, weight_md, out_md);
+    mkldnn::inner_product_forward::desc desc(propagation, data_md, weight_md, out_md);
     return GetFCFwdPd(desc);
   }
 }
 
 inline static mkldnn::inner_product_backward_data::primitive_desc GetFCBwdData(
-    const NDArray &data, const NDArray &weight, const NDArray &output,
+    const NDArray& data, const NDArray& weight, const NDArray& output,
     mkldnn::inner_product_forward::primitive_desc fwd_pd) {
-  auto data_md = GetMemDesc(data);
+  auto data_md   = GetMemDesc(data);
   auto weight_md = GetFCWeightDesc(weight);
-  auto out_md = GetMemDesc(output);
-  auto engine = CpuEngine::Get()->get_engine();
+  auto out_md    = GetMemDesc(output);
+  auto engine    = CpuEngine::Get()->get_engine();
   mkldnn::inner_product_backward_data::desc desc(data_md, weight_md, out_md);
   return mkldnn::inner_product_backward_data::primitive_desc(desc, engine, fwd_pd);
 }
 
 inline static mkldnn::inner_product_backward_weights::primitive_desc GetFCBwdWeights(
-    const NDArray &data, const NDArray &weight, const NDArray *bias,
-    const NDArray &output, mkldnn::inner_product_forward::primitive_desc fwd_pd) {
-  auto data_md = GetMemDesc(data);
+    const NDArray& data, const NDArray& weight, const NDArray* bias, const NDArray& output,
+    mkldnn::inner_product_forward::primitive_desc fwd_pd) {
+  auto data_md   = GetMemDesc(data);
   auto weight_md = GetFCWeightDesc(weight);
-  auto out_md = GetMemDesc(output);
-  auto engine = CpuEngine::Get()->get_engine();
+  auto out_md    = GetMemDesc(output);
+  auto engine    = CpuEngine::Get()->get_engine();
   if (bias) {
     auto bias_md = GetMemDesc(*bias);
-    mkldnn::inner_product_backward_weights::desc desc(data_md,
-        weight_md, bias_md, out_md);
-    return mkldnn::inner_product_backward_weights::primitive_desc(
-        desc, engine, fwd_pd);
+    mkldnn::inner_product_backward_weights::desc desc(data_md, weight_md, bias_md, out_md);
+    return mkldnn::inner_product_backward_weights::primitive_desc(desc, engine, fwd_pd);
   } else {
-    mkldnn::inner_product_backward_weights::desc desc(data_md,
-        weight_md, out_md);
-    return mkldnn::inner_product_backward_weights::primitive_desc(
-        desc, engine, fwd_pd);
+    mkldnn::inner_product_backward_weights::desc desc(data_md, weight_md, out_md);
+    return mkldnn::inner_product_backward_weights::primitive_desc(desc, engine, fwd_pd);
   }
 }
 
-MKLDNNFullyConnectedForward &GetFCFwd(
-    const FullyConnectedParam &param, const bool is_train,
-    const NDArray &data, const NDArray &weight,
-    const NDArray *bias, const mkldnn::memory::desc &out_md) {
+MKLDNNFullyConnectedForward& GetFCFwd(
+    const FullyConnectedParam& param, const bool is_train, const NDArray& data,
+    const NDArray& weight, const NDArray* bias, const mkldnn::memory::desc& out_md) {
 #if DMLC_CXX11_THREAD_LOCAL
-  static thread_local std::unordered_map<MKLDNNFullyconSignature,
-              MKLDNNFullyConnectedForward, OpHash> fcFwds;
+  static thread_local std::unordered_map<
+      MKLDNNFullyconSignature, MKLDNNFullyConnectedForward, OpHash>
+      fcFwds;
 #else
-  static MX_THREAD_LOCAL std::unordered_map<MKLDNNFullyconSignature,
-              MKLDNNFullyConnectedForward, OpHash> fcFwds;
+  static MX_THREAD_LOCAL
+      std::unordered_map<MKLDNNFullyconSignature, MKLDNNFullyConnectedForward, OpHash>
+          fcFwds;
 #endif
   MKLDNNFullyconSignature key(param);
   key.AddSign(is_train);
   key.AddSign(data);
   key.AddSign(weight);
-  if (bias)
-    key.AddSign(*bias);
+  if (bias) key.AddSign(*bias);
 
   auto it = fcFwds.find(key);
   if (it == fcFwds.end()) {
@@ -153,42 +142,40 @@ MKLDNNFullyConnectedForward &GetFCFwd(
   return it->second;
 }
 
-void MKLDNNFCFlattenData(const FullyConnectedParam &param,
-                         const NDArray &out_data,
-                         NDArray *in_data,
-                         mkldnn::memory::desc *out_md) {
+void MKLDNNFCFlattenData(
+    const FullyConnectedParam& param, const NDArray& out_data, NDArray* in_data,
+    mkldnn::memory::desc* out_md) {
   const mxnet::TShape ishape = in_data->shape();
   const mxnet::TShape oshape = out_data.shape();
   if (ishape.ndim() != 2) {
     if (!param.flatten) {
-      *in_data = in_data->MKLDNNDataReshape(Shape2(ishape.ProdShape(0, ishape.ndim()-1),
-                                                    ishape[ishape.ndim()-1]));
-      mkldnn::memory::dims out_dims{static_cast<int>(oshape.ProdShape(0, oshape.ndim()-1)),
-        static_cast<int>(oshape[ishape.ndim()-1])};
-      *out_md = mkldnn::memory::desc(out_dims, get_mkldnn_type(out_data.dtype()),
-                                     mkldnn::memory::format_tag::any);
+      *in_data = in_data->MKLDNNDataReshape(
+          Shape2(ishape.ProdShape(0, ishape.ndim() - 1), ishape[ishape.ndim() - 1]));
+      mkldnn::memory::dims out_dims{
+          static_cast<int>(oshape.ProdShape(0, oshape.ndim() - 1)),
+          static_cast<int>(oshape[ishape.ndim() - 1])};
+      *out_md = mkldnn::memory::desc(
+          out_dims, get_mkldnn_type(out_data.dtype()), mkldnn::memory::format_tag::any);
     } else {
       *in_data = in_data->MKLDNNDataReshape(Shape2(ishape[0], ishape.ProdShape(1, ishape.ndim())));
-      mkldnn::memory::dims out_dims{static_cast<int>(oshape[0]),
-        static_cast<int>(oshape.ProdShape(1, oshape.ndim()))};
-      *out_md = mkldnn::memory::desc(out_dims, get_mkldnn_type(out_data.dtype()),
-                                     mkldnn::memory::format_tag::any);
+      mkldnn::memory::dims out_dims{
+          static_cast<int>(oshape[0]), static_cast<int>(oshape.ProdShape(1, oshape.ndim()))};
+      *out_md = mkldnn::memory::desc(
+          out_dims, get_mkldnn_type(out_data.dtype()), mkldnn::memory::format_tag::any);
     }
   }
 }
 
-void MKLDNNFCForwardFullFeature(const MKLDNNFCFullParam &full_param,
-                                const OpContext &ctx,
-                                MKLDNNFullyConnectedForward *fwd,
-                                const std::vector<NDArray> &in_data,
-                                const std::vector<OpReqType> &req,
-                                const std::vector<NDArray> &out_data) {
+void MKLDNNFCForwardFullFeature(
+    const MKLDNNFCFullParam& full_param, const OpContext& ctx, MKLDNNFullyConnectedForward* fwd,
+    const std::vector<NDArray>& in_data, const std::vector<OpReqType>& req,
+    const std::vector<NDArray>& out_data) {
   TmpMemMgr::Get()->Init(ctx.requested[fullc::kTempSpace]);
   NDArray weight = in_data[fullc::kWeight];
-  NDArray data = in_data[fullc::kData];
+  NDArray data   = in_data[fullc::kData];
 
   auto data_mem = data.GetMKLDNNDataReorder(fwd->fwd_pd.src_desc());
-  const mkldnn::memory *weight_mem;
+  const mkldnn::memory* weight_mem;
   if (ctx.is_train) {
     if (weight.IsMKLDNNData()) {
       weight.Reorder2DefaultAsync();
@@ -201,8 +188,8 @@ void MKLDNNFCForwardFullFeature(const MKLDNNFCFullParam &full_param,
       weight_mem = GetWeights(weight, fwd->fwd_pd.weights_desc(), 1);
     }
   }
-  auto out_mem = CreateMKLDNNMem(out_data[fullc::kOut],
-                                 fwd->fwd_pd.dst_desc(), req[fullc::kOut], &data);
+  auto out_mem =
+      CreateMKLDNNMem(out_data[fullc::kOut], fwd->fwd_pd.dst_desc(), req[fullc::kOut], &data);
 
   mkldnn_args_map_t args = {
       {MKLDNN_ARG_SRC, *data_mem},
@@ -210,8 +197,7 @@ void MKLDNNFCForwardFullFeature(const MKLDNNFCFullParam &full_param,
       {MKLDNN_ARG_DST, *out_mem.second},
   };
   if (!full_param.default_param.no_bias) {
-    auto bias_mem = in_data[fullc::kBias].GetMKLDNNDataReorder(
-        fwd->fwd_pd.bias_desc());
+    auto bias_mem         = in_data[fullc::kBias].GetMKLDNNDataReorder(fwd->fwd_pd.bias_desc());
     args[MKLDNN_ARG_BIAS] = *bias_mem;
   }
   MKLDNNStream::Get()->RegisterPrimArgs(fwd->GetFwd(), args);
@@ -219,22 +205,19 @@ void MKLDNNFCForwardFullFeature(const MKLDNNFCFullParam &full_param,
   MKLDNNStream::Get()->Submit();
 }
 
-void MKLDNNFCForward(const nnvm::NodeAttrs &attrs, const OpContext &ctx,
-                     const std::vector<NDArray> &in_data,
-                     const std::vector<OpReqType> &req,
-                     const std::vector<NDArray> &out_data) {
+void MKLDNNFCForward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& in_data,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& out_data) {
   MKLDNNFCFullParam full_param;
   full_param.default_param = nnvm::get<FullyConnectedParam>(attrs.parsed);
   full_param.mkldnn_param.Init(std::unordered_map<std::string, std::string>());
 
-  NDArray data = in_data[fullc::kData];
+  NDArray data                = in_data[fullc::kData];
   mkldnn::memory::desc out_md = GetMemDesc(out_data[fullc::kOut]);
-  MKLDNNFCFlattenData(full_param.default_param, out_data[fullc::kOut],
-                      &data, &out_md);
-  auto &fwd = GetFCFwd(full_param.default_param, ctx.is_train, data,
-                       in_data[fullc::kWeight],
-                       full_param.default_param.no_bias ? nullptr : &in_data[fullc::kBias],
-                       out_md);
+  MKLDNNFCFlattenData(full_param.default_param, out_data[fullc::kOut], &data, &out_md);
+  auto& fwd = GetFCFwd(
+      full_param.default_param, ctx.is_train, data, in_data[fullc::kWeight],
+      full_param.default_param.no_bias ? nullptr : &in_data[fullc::kBias], out_md);
   std::vector<NDArray> new_inputs;
   if (full_param.default_param.no_bias)
     new_inputs = {data, in_data[fullc::kWeight]};
@@ -243,61 +226,54 @@ void MKLDNNFCForward(const nnvm::NodeAttrs &attrs, const OpContext &ctx,
   MKLDNNFCForwardFullFeature(full_param, ctx, &fwd, new_inputs, req, out_data);
 }
 
-void MKLDNNFCBackward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
-                      const std::vector<NDArray> &inputs,
-                      const std::vector<OpReqType> &req,
-                      const std::vector<NDArray> &outputs) {
+void MKLDNNFCBackward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& inputs,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs) {
   TmpMemMgr::Get()->Init(ctx.requested[fullc::kTempSpace]);
-  const std::vector<NDArray> &in_grad = outputs;
+  const std::vector<NDArray>& in_grad = outputs;
   MKLDNNFCFullParam full_param;
   full_param.default_param = nnvm::get<FullyConnectedParam>(attrs.parsed);
   full_param.mkldnn_param.Init(std::unordered_map<std::string, std::string>());
   const FullyConnectedParam& param = full_param.default_param;
-  const mxnet::TShape& ishape = inputs[fullc::kData + 1].shape();
-  const mxnet::TShape& oshape = inputs[fullc::kOut].shape();
+  const mxnet::TShape& ishape      = inputs[fullc::kData + 1].shape();
+  const mxnet::TShape& oshape      = inputs[fullc::kOut].shape();
 
   NDArray weight = inputs[fullc::kWeight + 1];
-  NDArray data = inputs[fullc::kData + 1];
+  NDArray data   = inputs[fullc::kData + 1];
   if (data.shape().ndim() != 2 && !param.flatten)
-    data = data.MKLDNNDataReshape(Shape2(ishape.ProdShape(0, ishape.ndim()-1),
-                                     ishape[ishape.ndim()-1]));
+    data = data.MKLDNNDataReshape(
+        Shape2(ishape.ProdShape(0, ishape.ndim() - 1), ishape[ishape.ndim() - 1]));
   else if (data.shape().ndim() != 2)
-    data = data.MKLDNNDataReshape(Shape2(ishape[0],
-                                     ishape.ProdShape(1, ishape.ndim())));
+    data = data.MKLDNNDataReshape(Shape2(ishape[0], ishape.ProdShape(1, ishape.ndim())));
   NDArray out_grad = inputs[fullc::kOut];
   if (out_grad.shape().ndim() != 2 && !param.flatten)
-    out_grad = out_grad.MKLDNNDataReshape(Shape2(oshape.ProdShape(0, oshape.ndim()-1),
-                                             oshape[oshape.ndim()-1]));
+    out_grad = out_grad.MKLDNNDataReshape(
+        Shape2(oshape.ProdShape(0, oshape.ndim() - 1), oshape[oshape.ndim() - 1]));
   else if (out_grad.shape().ndim() != 2)
-    out_grad = out_grad.MKLDNNDataReshape(Shape2(oshape[0],
-                                             oshape.ProdShape(1, oshape.ndim())));
+    out_grad = out_grad.MKLDNNDataReshape(Shape2(oshape[0], oshape.ProdShape(1, oshape.ndim())));
 
-
-  mkldnn::inner_product_forward::primitive_desc fwd_pd = GetFCFwdImpl(full_param, ctx.is_train,
-      data, weight, param.no_bias ? nullptr : &in_grad[fullc::kBias], GetMemDesc(out_grad));
+  mkldnn::inner_product_forward::primitive_desc fwd_pd = GetFCFwdImpl(
+      full_param, ctx.is_train, data, weight, param.no_bias ? nullptr : &in_grad[fullc::kBias],
+      GetMemDesc(out_grad));
 
   CHECK_NE(req[fullc::kWeight], kWriteInplace) << "cannot write weight inplace";
   if (req[fullc::kWeight]) {
-    mkldnn::inner_product_backward_weights::primitive_desc ipBwdWeights_pd
-      = GetFCBwdWeights(data, weight, param.no_bias ? nullptr : &in_grad[fullc::kBias],
-          out_grad, fwd_pd);
-    auto out_grad_mem = out_grad.GetMKLDNNDataReorder(
-        ipBwdWeights_pd.diff_dst_desc());
-    auto data_mem = data.GetMKLDNNDataReorder(ipBwdWeights_pd.src_desc());
-    auto in_grad_weight = CreateMKLDNNWeightGrad(in_grad[fullc::kWeight],
-                                                 ipBwdWeights_pd.diff_weights_desc(),
-                                                 req[fullc::kWeight]);
+    mkldnn::inner_product_backward_weights::primitive_desc ipBwdWeights_pd = GetFCBwdWeights(
+        data, weight, param.no_bias ? nullptr : &in_grad[fullc::kBias], out_grad, fwd_pd);
+    auto out_grad_mem   = out_grad.GetMKLDNNDataReorder(ipBwdWeights_pd.diff_dst_desc());
+    auto data_mem       = data.GetMKLDNNDataReorder(ipBwdWeights_pd.src_desc());
+    auto in_grad_weight = CreateMKLDNNWeightGrad(
+        in_grad[fullc::kWeight], ipBwdWeights_pd.diff_weights_desc(), req[fullc::kWeight]);
     mkldnn_args_map_t args = {
-      {MKLDNN_ARG_DIFF_DST, *out_grad_mem},
-      {MKLDNN_ARG_SRC, *data_mem},
-      {MKLDNN_ARG_DIFF_WEIGHTS, *in_grad_weight.second},
+        {MKLDNN_ARG_DIFF_DST, *out_grad_mem},
+        {MKLDNN_ARG_SRC, *data_mem},
+        {MKLDNN_ARG_DIFF_WEIGHTS, *in_grad_weight.second},
     };
 
     mkldnn_output_t in_grad_bias;
     if (!param.no_bias) {
-      in_grad_bias = CreateMKLDNNMem(in_grad[fullc::kBias],
-                                     ipBwdWeights_pd.diff_bias_desc(),
-                                     req[fullc::kBias]);
+      in_grad_bias = CreateMKLDNNMem(
+          in_grad[fullc::kBias], ipBwdWeights_pd.diff_bias_desc(), req[fullc::kBias]);
       args[MKLDNN_ARG_DIFF_BIAS] = *in_grad_bias.second;
     }
     MKLDNNStream::Get()->RegisterPrimArgs(
@@ -306,19 +282,16 @@ void MKLDNNFCBackward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
     CommitOutput(in_grad[fullc::kBias], in_grad_bias);
   }
   if (req[fullc::kData]) {
-    mkldnn::inner_product_backward_data::primitive_desc ipBwdData_pd = GetFCBwdData(
-        data, weight, out_grad, fwd_pd);
-    auto out_grad_mem = out_grad.GetMKLDNNDataReorder(
-        ipBwdData_pd.diff_dst_desc());
-    auto weight_mem = weight.GetMKLDNNDataReorder(ipBwdData_pd.weights_desc());
-    auto in_grad_mem = CreateMKLDNNMem(in_grad[fullc::kData],
-                                       ipBwdData_pd.diff_src_desc(),
-                                       req[fullc::kData]);
+    mkldnn::inner_product_backward_data::primitive_desc ipBwdData_pd =
+        GetFCBwdData(data, weight, out_grad, fwd_pd);
+    auto out_grad_mem = out_grad.GetMKLDNNDataReorder(ipBwdData_pd.diff_dst_desc());
+    auto weight_mem   = weight.GetMKLDNNDataReorder(ipBwdData_pd.weights_desc());
+    auto in_grad_mem =
+        CreateMKLDNNMem(in_grad[fullc::kData], ipBwdData_pd.diff_src_desc(), req[fullc::kData]);
     mkldnn_args_map_t args = {
-      {MKLDNN_ARG_DIFF_DST, *out_grad_mem},
-      {MKLDNN_ARG_WEIGHTS, *weight_mem},
-      {MKLDNN_ARG_DIFF_SRC, *in_grad_mem.second}
-    };
+        {MKLDNN_ARG_DIFF_DST, *out_grad_mem},
+        {MKLDNN_ARG_WEIGHTS, *weight_mem},
+        {MKLDNN_ARG_DIFF_SRC, *in_grad_mem.second}};
 
     MKLDNNStream::Get()->RegisterPrimArgs(mkldnn::inner_product_backward_data(ipBwdData_pd), args);
     CommitOutput(in_grad[fullc::kData], in_grad_mem);

--- a/src/operator/nn/mkldnn/mkldnn_fully_connected.cc
+++ b/src/operator/nn/mkldnn/mkldnn_fully_connected.cc
@@ -26,6 +26,7 @@
 
 #if MXNET_USE_MKLDNN == 1
 #include <unordered_map>
+
 #include "mkldnn_fully_connected-inl.h"
 
 namespace mxnet {
@@ -34,7 +35,8 @@ namespace op {
 DMLC_REGISTER_PARAMETER(MKLDNNFCParam);
 
 mkldnn::inner_product_forward::primitive_desc GetFCFwdImpl(const MKLDNNFCFullParam& full_param,
-                                                           const bool is_train, const NDArray& data,
+                                                           const bool is_train,
+                                                           const NDArray& data,
                                                            const NDArray& weight,
                                                            const NDArray* bias,
                                                            const mkldnn::memory::desc& out_md) {
@@ -87,7 +89,9 @@ mkldnn::inner_product_forward::primitive_desc GetFCFwdImpl(const MKLDNNFCFullPar
 }
 
 inline static mkldnn::inner_product_backward_data::primitive_desc GetFCBwdData(
-    const NDArray& data, const NDArray& weight, const NDArray& output,
+    const NDArray& data,
+    const NDArray& weight,
+    const NDArray& output,
     mkldnn::inner_product_forward::primitive_desc fwd_pd) {
   auto data_md   = GetMemDesc(data);
   auto weight_md = GetFCWeightDesc(weight);
@@ -98,7 +102,10 @@ inline static mkldnn::inner_product_backward_data::primitive_desc GetFCBwdData(
 }
 
 inline static mkldnn::inner_product_backward_weights::primitive_desc GetFCBwdWeights(
-    const NDArray& data, const NDArray& weight, const NDArray* bias, const NDArray& output,
+    const NDArray& data,
+    const NDArray& weight,
+    const NDArray* bias,
+    const NDArray& output,
     mkldnn::inner_product_forward::primitive_desc fwd_pd) {
   auto data_md   = GetMemDesc(data);
   auto weight_md = GetFCWeightDesc(weight);
@@ -114,9 +121,12 @@ inline static mkldnn::inner_product_backward_weights::primitive_desc GetFCBwdWei
   }
 }
 
-MKLDNNFullyConnectedForward& GetFCFwd(const FullyConnectedParam& param, const bool is_train,
-                                      const NDArray& data, const NDArray& weight,
-                                      const NDArray* bias, const mkldnn::memory::desc& out_md) {
+MKLDNNFullyConnectedForward& GetFCFwd(const FullyConnectedParam& param,
+                                      const bool is_train,
+                                      const NDArray& data,
+                                      const NDArray& weight,
+                                      const NDArray* bias,
+                                      const mkldnn::memory::desc& out_md) {
 #if DMLC_CXX11_THREAD_LOCAL
   static thread_local std::unordered_map<MKLDNNFullyconSignature, MKLDNNFullyConnectedForward,
                                          OpHash>
@@ -143,8 +153,10 @@ MKLDNNFullyConnectedForward& GetFCFwd(const FullyConnectedParam& param, const bo
   return it->second;
 }
 
-void MKLDNNFCFlattenData(const FullyConnectedParam& param, const NDArray& out_data,
-                         NDArray* in_data, mkldnn::memory::desc* out_md) {
+void MKLDNNFCFlattenData(const FullyConnectedParam& param,
+                         const NDArray& out_data,
+                         NDArray* in_data,
+                         mkldnn::memory::desc* out_md) {
   const mxnet::TShape ishape = in_data->shape();
   const mxnet::TShape oshape = out_data.shape();
   if (ishape.ndim() != 2) {
@@ -165,7 +177,8 @@ void MKLDNNFCFlattenData(const FullyConnectedParam& param, const NDArray& out_da
   }
 }
 
-void MKLDNNFCForwardFullFeature(const MKLDNNFCFullParam& full_param, const OpContext& ctx,
+void MKLDNNFCForwardFullFeature(const MKLDNNFCFullParam& full_param,
+                                const OpContext& ctx,
                                 MKLDNNFullyConnectedForward* fwd,
                                 const std::vector<NDArray>& in_data,
                                 const std::vector<OpReqType>& req,
@@ -205,8 +218,10 @@ void MKLDNNFCForwardFullFeature(const MKLDNNFCFullParam& full_param, const OpCon
   MKLDNNStream::Get()->Submit();
 }
 
-void MKLDNNFCForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
-                     const std::vector<NDArray>& in_data, const std::vector<OpReqType>& req,
+void MKLDNNFCForward(const nnvm::NodeAttrs& attrs,
+                     const OpContext& ctx,
+                     const std::vector<NDArray>& in_data,
+                     const std::vector<OpReqType>& req,
                      const std::vector<NDArray>& out_data) {
   MKLDNNFCFullParam full_param;
   full_param.default_param = nnvm::get<FullyConnectedParam>(attrs.parsed);
@@ -225,8 +240,10 @@ void MKLDNNFCForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
   MKLDNNFCForwardFullFeature(full_param, ctx, &fwd, new_inputs, req, out_data);
 }
 
-void MKLDNNFCBackward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
-                      const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+void MKLDNNFCBackward(const nnvm::NodeAttrs& attrs,
+                      const OpContext& ctx,
+                      const std::vector<NDArray>& inputs,
+                      const std::vector<OpReqType>& req,
                       const std::vector<NDArray>& outputs) {
   TmpMemMgr::Get()->Init(ctx.requested[fullc::kTempSpace]);
   const std::vector<NDArray>& in_grad = outputs;

--- a/src/operator/nn/mkldnn/mkldnn_log_softmax.cc
+++ b/src/operator/nn/mkldnn/mkldnn_log_softmax.cc
@@ -49,8 +49,8 @@ static mkldnn::logsoftmax_backward::primitive_desc GetLogSoftmaxBwdPd(
   return mkldnn::logsoftmax_backward::primitive_desc(desc, cpu_engine, hint_fwd_pd);
 }
 
-bool SupportMKLDNNLogSoftmax(
-    const SoftmaxParam& param, const NDArray& data, const NDArray& output) {
+bool SupportMKLDNNLogSoftmax(const SoftmaxParam& param, const NDArray& data,
+                             const NDArray& output) {
   const int ndim      = data.shape().ndim();
   const int in_dtype  = data.dtype();
   const int out_dtype = output.dtype();
@@ -84,9 +84,9 @@ class MKLDNNLogSoftmaxFwd {
 
 typedef ParamOpSign<SoftmaxParam> MKLDNNSoftmaxSignature;
 
-static MKLDNNLogSoftmaxFwd& GetLogSoftmaxFwd(
-    const SoftmaxParam& param, const int real_axis, const bool is_train, const NDArray& data,
-    const NDArray& output) {
+static MKLDNNLogSoftmaxFwd& GetLogSoftmaxFwd(const SoftmaxParam& param, const int real_axis,
+                                             const bool is_train, const NDArray& data,
+                                             const NDArray& output) {
 #if DMLC_CXX11_THREAD_LOCAL
   static thread_local std::unordered_map<MKLDNNSoftmaxSignature, MKLDNNLogSoftmaxFwd, OpHash> fwds;
 #else
@@ -108,9 +108,9 @@ static MKLDNNLogSoftmaxFwd& GetLogSoftmaxFwd(
   return it->second;
 }
 
-void MKLDNNLogSoftmaxForward(
-    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const NDArray& in_data,
-    const OpReqType& req, const NDArray& out_data) {
+void MKLDNNLogSoftmaxForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+                             const NDArray& in_data, const OpReqType& req,
+                             const NDArray& out_data) {
   if (req == kNullOp) return;
   // same as the FCompute path, log_softmax only supports kWriteTo and kWriteInplace for now.
   CHECK_NE(req, kAddTo);
@@ -130,9 +130,8 @@ class MKLDNNLogSoftmaxBwd {
  public:
   mkldnn::logsoftmax_backward::primitive_desc pd;
 
-  MKLDNNLogSoftmaxBwd(
-      const mkldnn::memory& diff_mem, const mkldnn::memory& data_mem, const int axis,
-      const mkldnn::logsoftmax_forward::primitive_desc& hint_fwd_pd)
+  MKLDNNLogSoftmaxBwd(const mkldnn::memory& diff_mem, const mkldnn::memory& data_mem,
+                      const int axis, const mkldnn::logsoftmax_forward::primitive_desc& hint_fwd_pd)
       : pd(GetLogSoftmaxBwdPd(diff_mem, data_mem, axis, hint_fwd_pd)) {
     bwd_ = std::make_shared<mkldnn::logsoftmax_backward>(pd);
   }
@@ -143,9 +142,9 @@ class MKLDNNLogSoftmaxBwd {
   std::shared_ptr<mkldnn::logsoftmax_backward> bwd_;
 };
 
-static MKLDNNLogSoftmaxBwd& GetLogSoftmaxBwd(
-    const SoftmaxParam& param, const int real_axis, const std::vector<NDArray>& data,
-    const std::vector<NDArray>& output) {
+static MKLDNNLogSoftmaxBwd& GetLogSoftmaxBwd(const SoftmaxParam& param, const int real_axis,
+                                             const std::vector<NDArray>& data,
+                                             const std::vector<NDArray>& output) {
 #if DMLC_CXX11_THREAD_LOCAL
   static thread_local std::unordered_map<MKLDNNSoftmaxSignature, MKLDNNLogSoftmaxBwd, OpHash> bwds;
 #else
@@ -169,9 +168,10 @@ static MKLDNNLogSoftmaxBwd& GetLogSoftmaxBwd(
   return it->second;
 }
 
-void MKLDNNLogSoftmaxBackward(
-    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& in_data,
-    const std::vector<OpReqType>& req, const std::vector<NDArray>& out_data) {
+void MKLDNNLogSoftmaxBackward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+                              const std::vector<NDArray>& in_data,
+                              const std::vector<OpReqType>& req,
+                              const std::vector<NDArray>& out_data) {
   if (req[0] == kNullOp) return;
   CHECK_EQ(in_data.size(), 2U);
   const SoftmaxParam& param = nnvm::get<SoftmaxParam>(attrs.parsed);
@@ -182,10 +182,9 @@ void MKLDNNLogSoftmaxBackward(
 
   auto out_mem           = CreateMKLDNNMem(out_data[0], bwd.pd.diff_src_desc(), req[0]);
   MKLDNNStream* stream   = MKLDNNStream::Get();
-  mkldnn_args_map_t args = {
-      {MKLDNN_ARG_DST, *data_mem},
-      {MKLDNN_ARG_DIFF_DST, *diff_mem},
-      {MKLDNN_ARG_DIFF_SRC, *out_mem.second}};
+  mkldnn_args_map_t args = {{MKLDNN_ARG_DST, *data_mem},
+                            {MKLDNN_ARG_DIFF_DST, *diff_mem},
+                            {MKLDNN_ARG_DIFF_SRC, *out_mem.second}};
 
   stream->RegisterPrimArgs(bwd.GetBwd(), args);
   CommitOutput(out_data[0], out_mem);

--- a/src/operator/nn/mkldnn/mkldnn_log_softmax.cc
+++ b/src/operator/nn/mkldnn/mkldnn_log_softmax.cc
@@ -23,8 +23,8 @@
  */
 
 #include "../softmax-inl.h"
-#include "./mkldnn_ops-inl.h"
 #include "./mkldnn_base-inl.h"
+#include "./mkldnn_ops-inl.h"
 
 #if MXNET_USE_MKLDNN == 1
 namespace mxnet {
@@ -40,7 +40,9 @@ static mkldnn::logsoftmax_forward::primitive_desc GetLogSoftmaxFwdPd(
 }
 
 static mkldnn::logsoftmax_backward::primitive_desc GetLogSoftmaxBwdPd(
-    const mkldnn::memory& diff_mem, const mkldnn::memory& data_mem, const int axis,
+    const mkldnn::memory& diff_mem,
+    const mkldnn::memory& data_mem,
+    const int axis,
     const mkldnn::logsoftmax_forward::primitive_desc& hint_fwd_pd) {
   mkldnn::memory::desc diff_md = diff_mem.get_desc();
   mkldnn::memory::desc data_md = data_mem.get_desc();
@@ -49,7 +51,8 @@ static mkldnn::logsoftmax_backward::primitive_desc GetLogSoftmaxBwdPd(
   return mkldnn::logsoftmax_backward::primitive_desc(desc, cpu_engine, hint_fwd_pd);
 }
 
-bool SupportMKLDNNLogSoftmax(const SoftmaxParam& param, const NDArray& data,
+bool SupportMKLDNNLogSoftmax(const SoftmaxParam& param,
+                             const NDArray& data,
                              const NDArray& output) {
   const int ndim      = data.shape().ndim();
   const int in_dtype  = data.dtype();
@@ -84,8 +87,10 @@ class MKLDNNLogSoftmaxFwd {
 
 typedef ParamOpSign<SoftmaxParam> MKLDNNSoftmaxSignature;
 
-static MKLDNNLogSoftmaxFwd& GetLogSoftmaxFwd(const SoftmaxParam& param, const int real_axis,
-                                             const bool is_train, const NDArray& data,
+static MKLDNNLogSoftmaxFwd& GetLogSoftmaxFwd(const SoftmaxParam& param,
+                                             const int real_axis,
+                                             const bool is_train,
+                                             const NDArray& data,
                                              const NDArray& output) {
 #if DMLC_CXX11_THREAD_LOCAL
   static thread_local std::unordered_map<MKLDNNSoftmaxSignature, MKLDNNLogSoftmaxFwd, OpHash> fwds;
@@ -108,8 +113,10 @@ static MKLDNNLogSoftmaxFwd& GetLogSoftmaxFwd(const SoftmaxParam& param, const in
   return it->second;
 }
 
-void MKLDNNLogSoftmaxForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
-                             const NDArray& in_data, const OpReqType& req,
+void MKLDNNLogSoftmaxForward(const nnvm::NodeAttrs& attrs,
+                             const OpContext& ctx,
+                             const NDArray& in_data,
+                             const OpReqType& req,
                              const NDArray& out_data) {
   if (req == kNullOp) return;
   // same as the FCompute path, log_softmax only supports kWriteTo and kWriteInplace for now.
@@ -130,8 +137,10 @@ class MKLDNNLogSoftmaxBwd {
  public:
   mkldnn::logsoftmax_backward::primitive_desc pd;
 
-  MKLDNNLogSoftmaxBwd(const mkldnn::memory& diff_mem, const mkldnn::memory& data_mem,
-                      const int axis, const mkldnn::logsoftmax_forward::primitive_desc& hint_fwd_pd)
+  MKLDNNLogSoftmaxBwd(const mkldnn::memory& diff_mem,
+                      const mkldnn::memory& data_mem,
+                      const int axis,
+                      const mkldnn::logsoftmax_forward::primitive_desc& hint_fwd_pd)
       : pd(GetLogSoftmaxBwdPd(diff_mem, data_mem, axis, hint_fwd_pd)) {
     bwd_ = std::make_shared<mkldnn::logsoftmax_backward>(pd);
   }
@@ -142,7 +151,8 @@ class MKLDNNLogSoftmaxBwd {
   std::shared_ptr<mkldnn::logsoftmax_backward> bwd_;
 };
 
-static MKLDNNLogSoftmaxBwd& GetLogSoftmaxBwd(const SoftmaxParam& param, const int real_axis,
+static MKLDNNLogSoftmaxBwd& GetLogSoftmaxBwd(const SoftmaxParam& param,
+                                             const int real_axis,
                                              const std::vector<NDArray>& data,
                                              const std::vector<NDArray>& output) {
 #if DMLC_CXX11_THREAD_LOCAL
@@ -168,7 +178,8 @@ static MKLDNNLogSoftmaxBwd& GetLogSoftmaxBwd(const SoftmaxParam& param, const in
   return it->second;
 }
 
-void MKLDNNLogSoftmaxBackward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+void MKLDNNLogSoftmaxBackward(const nnvm::NodeAttrs& attrs,
+                              const OpContext& ctx,
                               const std::vector<NDArray>& in_data,
                               const std::vector<OpReqType>& req,
                               const std::vector<NDArray>& out_data) {

--- a/src/operator/nn/mkldnn/mkldnn_log_softmax.cc
+++ b/src/operator/nn/mkldnn/mkldnn_log_softmax.cc
@@ -20,7 +20,7 @@
 /*!
  * \file mkldnn_log_softmax.cc
  * \brief Implementation of log_softmax function with MKLDNN support
-*/
+ */
 
 #include "../softmax-inl.h"
 #include "./mkldnn_ops-inl.h"
@@ -31,43 +31,34 @@ namespace mxnet {
 namespace op {
 
 static mkldnn::logsoftmax_forward::primitive_desc GetLogSoftmaxFwdPd(
-                                  bool is_train,
-                                  const int axis,
-                                  const mkldnn::memory &input_mem) {
+    bool is_train, const int axis, const mkldnn::memory& input_mem) {
   mkldnn::memory::desc data_md = input_mem.get_desc();
-  auto cpu_engine = CpuEngine::Get()->get_engine();
-  auto prop = is_train ? mkldnn::prop_kind::forward_training
-                       : mkldnn::prop_kind::forward_scoring;
+  auto cpu_engine              = CpuEngine::Get()->get_engine();
+  auto prop = is_train ? mkldnn::prop_kind::forward_training : mkldnn::prop_kind::forward_scoring;
   auto desc = mkldnn::logsoftmax_forward::desc(prop, data_md, axis);
   return mkldnn::logsoftmax_forward::primitive_desc(desc, cpu_engine);
 }
 
 static mkldnn::logsoftmax_backward::primitive_desc GetLogSoftmaxBwdPd(
-                                const mkldnn::memory &diff_mem,
-                                const mkldnn::memory &data_mem,
-                                const int axis,
-                                const mkldnn::logsoftmax_forward::primitive_desc &hint_fwd_pd) {
+    const mkldnn::memory& diff_mem, const mkldnn::memory& data_mem, const int axis,
+    const mkldnn::logsoftmax_forward::primitive_desc& hint_fwd_pd) {
   mkldnn::memory::desc diff_md = diff_mem.get_desc();
   mkldnn::memory::desc data_md = data_mem.get_desc();
-  auto cpu_engine = CpuEngine::Get()->get_engine();
-  auto desc = mkldnn::logsoftmax_backward::desc(diff_md, data_md, axis);
+  auto cpu_engine              = CpuEngine::Get()->get_engine();
+  auto desc                    = mkldnn::logsoftmax_backward::desc(diff_md, data_md, axis);
   return mkldnn::logsoftmax_backward::primitive_desc(desc, cpu_engine, hint_fwd_pd);
 }
 
-
-bool SupportMKLDNNLogSoftmax(const SoftmaxParam &param,
-                             const NDArray &data,
-                             const NDArray &output) {
-  const int ndim = data.shape().ndim();
-  const int in_dtype = data.dtype();
+bool SupportMKLDNNLogSoftmax(
+    const SoftmaxParam& param, const NDArray& data, const NDArray& output) {
+  const int ndim      = data.shape().ndim();
+  const int in_dtype  = data.dtype();
   const int out_dtype = output.dtype();
-  const int axis = CheckAxis(param.axis, ndim);
+  const int axis      = CheckAxis(param.axis, ndim);
   // MKLDNN does not support temperature argument in their log_softmax function
   // now. Need update this once they start to support it.
   // Currently, MKLDNN shows bad performance when log_softmax is not performed on the last dimension
-  if (param.temperature.has_value() ||
-      in_dtype != mshadow::kFloat32 ||
-      in_dtype != out_dtype ||
+  if (param.temperature.has_value() || in_dtype != mshadow::kFloat32 || in_dtype != out_dtype ||
       axis != (ndim - 1)) {
     return false;
   }
@@ -80,15 +71,12 @@ class MKLDNNLogSoftmaxFwd {
  public:
   mkldnn::logsoftmax_forward::primitive_desc pd;
 
-  MKLDNNLogSoftmaxFwd(const bool is_train,
-                      const int axis,
-                      const mkldnn::memory &input) : pd(GetLogSoftmaxFwdPd(is_train, axis, input)) {
+  MKLDNNLogSoftmaxFwd(const bool is_train, const int axis, const mkldnn::memory& input)
+      : pd(GetLogSoftmaxFwdPd(is_train, axis, input)) {
     fwd_ = std::make_shared<mkldnn::logsoftmax_forward>(pd);
   }
 
-  const mkldnn::logsoftmax_forward &GetFwd() const {
-    return *fwd_;
-  }
+  const mkldnn::logsoftmax_forward& GetFwd() const { return *fwd_; }
 
  private:
   std::shared_ptr<mkldnn::logsoftmax_forward> fwd_;
@@ -96,19 +84,14 @@ class MKLDNNLogSoftmaxFwd {
 
 typedef ParamOpSign<SoftmaxParam> MKLDNNSoftmaxSignature;
 
-static MKLDNNLogSoftmaxFwd &GetLogSoftmaxFwd(const SoftmaxParam &param,
-                                             const int real_axis,
-                                             const bool is_train,
-                                             const NDArray &data,
-                                             const NDArray &output) {
+static MKLDNNLogSoftmaxFwd& GetLogSoftmaxFwd(
+    const SoftmaxParam& param, const int real_axis, const bool is_train, const NDArray& data,
+    const NDArray& output) {
 #if DMLC_CXX11_THREAD_LOCAL
-  static thread_local std::unordered_map<MKLDNNSoftmaxSignature,
-                                         MKLDNNLogSoftmaxFwd,
-                                         OpHash> fwds;
+  static thread_local std::unordered_map<MKLDNNSoftmaxSignature, MKLDNNLogSoftmaxFwd, OpHash> fwds;
 #else
-  static MX_THREAD_LOCAL std::unordered_map<MKLDNNSoftmaxSignature,
-                                            MKLDNNLogSoftmaxFwd,
-                                            OpHash> fwds;
+  static MX_THREAD_LOCAL std::unordered_map<MKLDNNSoftmaxSignature, MKLDNNLogSoftmaxFwd, OpHash>
+      fwds;
 #endif
 
   MKLDNNSoftmaxSignature key(param);
@@ -125,22 +108,20 @@ static MKLDNNLogSoftmaxFwd &GetLogSoftmaxFwd(const SoftmaxParam &param,
   return it->second;
 }
 
-void MKLDNNLogSoftmaxForward(const nnvm::NodeAttrs& attrs,
-                             const OpContext &ctx,
-                             const NDArray &in_data,
-                             const OpReqType &req,
-                             const NDArray &out_data) {
+void MKLDNNLogSoftmaxForward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const NDArray& in_data,
+    const OpReqType& req, const NDArray& out_data) {
   if (req == kNullOp) return;
   // same as the FCompute path, log_softmax only supports kWriteTo and kWriteInplace for now.
   CHECK_NE(req, kAddTo);
 
   const SoftmaxParam& param = nnvm::get<SoftmaxParam>(attrs.parsed);
-  int axis = CheckAxis(param.axis, in_data.shape().ndim());
-  auto fwd = GetLogSoftmaxFwd(param, axis, ctx.is_train, in_data, out_data);
+  int axis                  = CheckAxis(param.axis, in_data.shape().ndim());
+  auto fwd                  = GetLogSoftmaxFwd(param, axis, ctx.is_train, in_data, out_data);
 
-  auto in_mem = in_data.GetMKLDNNData();
-  auto out_mem = out_data.GetMKLDNNData(fwd.pd.dst_desc());
-  MKLDNNStream *stream = MKLDNNStream::Get();
+  auto in_mem          = in_data.GetMKLDNNData();
+  auto out_mem         = out_data.GetMKLDNNData(fwd.pd.dst_desc());
+  MKLDNNStream* stream = MKLDNNStream::Get();
   stream->RegisterPrimArgs(fwd.GetFwd(), {{MKLDNN_ARG_SRC, *in_mem}, {MKLDNN_ARG_DST, *out_mem}});
   stream->Submit();
 }
@@ -149,34 +130,27 @@ class MKLDNNLogSoftmaxBwd {
  public:
   mkldnn::logsoftmax_backward::primitive_desc pd;
 
-  MKLDNNLogSoftmaxBwd(const mkldnn::memory &diff_mem,
-                      const mkldnn::memory &data_mem,
-                      const int axis,
-                      const mkldnn::logsoftmax_forward::primitive_desc &hint_fwd_pd) :
-                                    pd(GetLogSoftmaxBwdPd(diff_mem, data_mem, axis, hint_fwd_pd)) {
+  MKLDNNLogSoftmaxBwd(
+      const mkldnn::memory& diff_mem, const mkldnn::memory& data_mem, const int axis,
+      const mkldnn::logsoftmax_forward::primitive_desc& hint_fwd_pd)
+      : pd(GetLogSoftmaxBwdPd(diff_mem, data_mem, axis, hint_fwd_pd)) {
     bwd_ = std::make_shared<mkldnn::logsoftmax_backward>(pd);
   }
 
-  const mkldnn::logsoftmax_backward &GetBwd() const {
-    return *bwd_;
-  }
+  const mkldnn::logsoftmax_backward& GetBwd() const { return *bwd_; }
 
  private:
   std::shared_ptr<mkldnn::logsoftmax_backward> bwd_;
 };
 
-static MKLDNNLogSoftmaxBwd &GetLogSoftmaxBwd(const SoftmaxParam &param,
-                                             const int real_axis,
-                                             const std::vector<NDArray> &data,
-                                             const std::vector<NDArray> &output) {
+static MKLDNNLogSoftmaxBwd& GetLogSoftmaxBwd(
+    const SoftmaxParam& param, const int real_axis, const std::vector<NDArray>& data,
+    const std::vector<NDArray>& output) {
 #if DMLC_CXX11_THREAD_LOCAL
-  static thread_local std::unordered_map<MKLDNNSoftmaxSignature,
-                                         MKLDNNLogSoftmaxBwd,
-                                         OpHash> bwds;
+  static thread_local std::unordered_map<MKLDNNSoftmaxSignature, MKLDNNLogSoftmaxBwd, OpHash> bwds;
 #else
-  static MX_THREAD_LOCAL std::unordered_map<MKLDNNSoftmaxSignature,
-                                            MKLDNNLogSoftmaxBwd,
-                                            OpHash> bwds;
+  static MX_THREAD_LOCAL std::unordered_map<MKLDNNSoftmaxSignature, MKLDNNLogSoftmaxBwd, OpHash>
+      bwds;
 #endif
 
   MKLDNNSoftmaxSignature key(param);
@@ -188,39 +162,36 @@ static MKLDNNLogSoftmaxBwd &GetLogSoftmaxBwd(const SoftmaxParam &param,
   if (it == bwds.end()) {
     auto diff_mem = data[0].GetMKLDNNData();
     auto data_mem = data[1].GetMKLDNNData();
-    auto fwd_pd = GetLogSoftmaxFwdPd(true, real_axis, *data_mem);
+    auto fwd_pd   = GetLogSoftmaxFwdPd(true, real_axis, *data_mem);
     MKLDNNLogSoftmaxBwd bwd(*diff_mem, *data_mem, real_axis, fwd_pd);
     it = AddToCache(&bwds, key, bwd);
   }
   return it->second;
 }
 
-void MKLDNNLogSoftmaxBackward(const nnvm::NodeAttrs& attrs,
-                              const OpContext &ctx,
-                              const std::vector<NDArray> &in_data,
-                              const std::vector<OpReqType> &req,
-                              const std::vector<NDArray> &out_data) {
+void MKLDNNLogSoftmaxBackward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& in_data,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& out_data) {
   if (req[0] == kNullOp) return;
   CHECK_EQ(in_data.size(), 2U);
   const SoftmaxParam& param = nnvm::get<SoftmaxParam>(attrs.parsed);
-  int axis = CheckAxis(param.axis, in_data[1].shape().ndim());
-  auto diff_mem = in_data[0].GetMKLDNNData();
-  auto data_mem = in_data[1].GetMKLDNNData();
-  auto bwd = GetLogSoftmaxBwd(param, axis, in_data, out_data);
+  int axis                  = CheckAxis(param.axis, in_data[1].shape().ndim());
+  auto diff_mem             = in_data[0].GetMKLDNNData();
+  auto data_mem             = in_data[1].GetMKLDNNData();
+  auto bwd                  = GetLogSoftmaxBwd(param, axis, in_data, out_data);
 
-  auto out_mem = CreateMKLDNNMem(out_data[0], bwd.pd.diff_src_desc(), req[0]);
-  MKLDNNStream *stream = MKLDNNStream::Get();
+  auto out_mem           = CreateMKLDNNMem(out_data[0], bwd.pd.diff_src_desc(), req[0]);
+  MKLDNNStream* stream   = MKLDNNStream::Get();
   mkldnn_args_map_t args = {
-    { MKLDNN_ARG_DST, *data_mem },
-    { MKLDNN_ARG_DIFF_DST, *diff_mem },
-    { MKLDNN_ARG_DIFF_SRC, *out_mem.second }
-  };
+      {MKLDNN_ARG_DST, *data_mem},
+      {MKLDNN_ARG_DIFF_DST, *diff_mem},
+      {MKLDNN_ARG_DIFF_SRC, *out_mem.second}};
 
   stream->RegisterPrimArgs(bwd.GetBwd(), args);
   CommitOutput(out_data[0], out_mem);
   stream->Submit();
 }
 
-}   // namespace op
-}   // namespace mxnet
+}  // namespace op
+}  // namespace mxnet
 #endif

--- a/src/operator/nn/mkldnn/mkldnn_log_softmax.cc
+++ b/src/operator/nn/mkldnn/mkldnn_log_softmax.cc
@@ -30,8 +30,8 @@
 namespace mxnet {
 namespace op {
 
-static mkldnn::logsoftmax_forward::primitive_desc GetLogSoftmaxFwdPd(
-    bool is_train, const int axis, const mkldnn::memory& input_mem) {
+static mkldnn::logsoftmax_forward::primitive_desc
+GetLogSoftmaxFwdPd(bool is_train, const int axis, const mkldnn::memory& input_mem) {
   mkldnn::memory::desc data_md = input_mem.get_desc();
   auto cpu_engine              = CpuEngine::Get()->get_engine();
   auto prop = is_train ? mkldnn::prop_kind::forward_training : mkldnn::prop_kind::forward_scoring;
@@ -60,7 +60,8 @@ bool SupportMKLDNNLogSoftmax(const SoftmaxParam& param,
   const int axis      = CheckAxis(param.axis, ndim);
   // MKLDNN does not support temperature argument in their log_softmax function
   // now. Need update this once they start to support it.
-  // Currently, MKLDNN shows bad performance when log_softmax is not performed on the last dimension
+  // Currently, MKLDNN shows bad performance when log_softmax is not performed
+  // on the last dimension
   if (param.temperature.has_value() || in_dtype != mshadow::kFloat32 || in_dtype != out_dtype ||
       axis != (ndim - 1)) {
     return false;
@@ -79,7 +80,9 @@ class MKLDNNLogSoftmaxFwd {
     fwd_ = std::make_shared<mkldnn::logsoftmax_forward>(pd);
   }
 
-  const mkldnn::logsoftmax_forward& GetFwd() const { return *fwd_; }
+  const mkldnn::logsoftmax_forward& GetFwd() const {
+    return *fwd_;
+  }
 
  private:
   std::shared_ptr<mkldnn::logsoftmax_forward> fwd_;
@@ -118,8 +121,10 @@ void MKLDNNLogSoftmaxForward(const nnvm::NodeAttrs& attrs,
                              const NDArray& in_data,
                              const OpReqType& req,
                              const NDArray& out_data) {
-  if (req == kNullOp) return;
-  // same as the FCompute path, log_softmax only supports kWriteTo and kWriteInplace for now.
+  if (req == kNullOp)
+    return;
+  // same as the FCompute path, log_softmax only supports kWriteTo and
+  // kWriteInplace for now.
   CHECK_NE(req, kAddTo);
 
   const SoftmaxParam& param = nnvm::get<SoftmaxParam>(attrs.parsed);
@@ -145,7 +150,9 @@ class MKLDNNLogSoftmaxBwd {
     bwd_ = std::make_shared<mkldnn::logsoftmax_backward>(pd);
   }
 
-  const mkldnn::logsoftmax_backward& GetBwd() const { return *bwd_; }
+  const mkldnn::logsoftmax_backward& GetBwd() const {
+    return *bwd_;
+  }
 
  private:
   std::shared_ptr<mkldnn::logsoftmax_backward> bwd_;
@@ -183,7 +190,8 @@ void MKLDNNLogSoftmaxBackward(const nnvm::NodeAttrs& attrs,
                               const std::vector<NDArray>& in_data,
                               const std::vector<OpReqType>& req,
                               const std::vector<NDArray>& out_data) {
-  if (req[0] == kNullOp) return;
+  if (req[0] == kNullOp)
+    return;
   CHECK_EQ(in_data.size(), 2U);
   const SoftmaxParam& param = nnvm::get<SoftmaxParam>(attrs.parsed);
   int axis                  = CheckAxis(param.axis, in_data[1].shape().ndim());

--- a/src/operator/nn/mkldnn/mkldnn_lrn-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_lrn-inl.h
@@ -21,7 +21,7 @@
  * \file mkldnn_lrn-inl.h
  * \brief
  * \Author: Patric Zhao, patric.zhao@intel.com
-*/
+ */
 #ifndef MXNET_OPERATOR_NN_MKLDNN_MKLDNN_LRN_INL_H_
 #define MXNET_OPERATOR_NN_MKLDNN_MKLDNN_LRN_INL_H_
 
@@ -35,21 +35,21 @@
 namespace mxnet {
 namespace op {
 
-inline mkldnn::algorithm GetMKLDNNLRNAlgo(const LRNParam &param) {
+inline mkldnn::algorithm GetMKLDNNLRNAlgo(const LRNParam& param) {
   // TODO(Patric): lrn_within_channel will cause core dump in MKLDNN backward
   //               Need to confirm with MKLDNN team and fix later
   return mkldnn::algorithm::lrn_across_channels;
 }
 
 inline mkldnn::lrn_forward::primitive_desc GetLRNFwdDesc(
-    const LRNParam &param, const bool is_train, const mkldnn::memory::desc &src_md) {
-  mkldnn::engine &engine = CpuEngine::Get()->get_engine();
-  const mkldnn::algorithm  alg = GetMKLDNNLRNAlgo(param);
-  const float alpha = param.alpha;
-  const float beta = param.beta;
-  const int   nsize = param.nsize;
-  const float k = param.knorm;
-  auto kind = mkldnn::prop_kind::forward_training;
+    const LRNParam& param, const bool is_train, const mkldnn::memory::desc& src_md) {
+  mkldnn::engine& engine      = CpuEngine::Get()->get_engine();
+  const mkldnn::algorithm alg = GetMKLDNNLRNAlgo(param);
+  const float alpha           = param.alpha;
+  const float beta            = param.beta;
+  const int nsize             = param.nsize;
+  const float k               = param.knorm;
+  auto kind                   = mkldnn::prop_kind::forward_training;
   if (is_train) {
     kind = mkldnn::prop_kind::forward_training;
   } else {
@@ -60,78 +60,64 @@ inline mkldnn::lrn_forward::primitive_desc GetLRNFwdDesc(
 }
 
 inline mkldnn::lrn_backward::primitive_desc GetLRNBwdDesc(
-    const LRNParam &param, const mkldnn::memory::desc &data_in_md,
-    const mkldnn::memory::desc &diff_md,
-    const mkldnn::lrn_forward::primitive_desc &lrnFwd_desc) {
-  mkldnn::engine &engine = CpuEngine::Get()->get_engine();
+    const LRNParam& param, const mkldnn::memory::desc& data_in_md,
+    const mkldnn::memory::desc& diff_md, const mkldnn::lrn_forward::primitive_desc& lrnFwd_desc) {
+  mkldnn::engine& engine      = CpuEngine::Get()->get_engine();
   const mkldnn::algorithm alg = GetMKLDNNLRNAlgo(param);
-  const float alpha = param.alpha;
-  const float beta = param.beta;
-  const int nsize = param.nsize;
-  const float k = param.knorm;
+  const float alpha           = param.alpha;
+  const float beta            = param.beta;
+  const int nsize             = param.nsize;
+  const float k               = param.knorm;
 
-  mkldnn::lrn_backward::desc lrnBwd_desc(alg, data_in_md,
-                diff_md, nsize, alpha, beta, k);
-  return mkldnn::lrn_backward::primitive_desc(lrnBwd_desc,
-                               engine, lrnFwd_desc);
+  mkldnn::lrn_backward::desc lrnBwd_desc(alg, data_in_md, diff_md, nsize, alpha, beta, k);
+  return mkldnn::lrn_backward::primitive_desc(lrnBwd_desc, engine, lrnFwd_desc);
 }
-
 
 typedef ParamOpSign<LRNParam> MKLDNNLRNSignature;
 
 // LRN Forward Class
 class MKLDNNLRNFwd {
  public:
-  MKLDNNLRNFwd(const LRNParam& param,
-               bool  is_train,
-               const NDArray &in_data) {
+  MKLDNNLRNFwd(const LRNParam& param, bool is_train, const NDArray& in_data) {
     _Init(param, is_train, in_data);
   }
 
   ~MKLDNNLRNFwd() {}
 
-  void Execute(const OpContext &ctx,
-               const NDArray &in_data,
-               const OpReqType req,
-               const NDArray &out_data);
+  void Execute(
+      const OpContext& ctx, const NDArray& in_data, const OpReqType req, const NDArray& out_data);
 
-  mkldnn::lrn_forward &GetFwd();
-  const mkldnn::memory *GetWs();
-  mkldnn::lrn_forward::primitive_desc &GetFwdPd();
+  mkldnn::lrn_forward& GetFwd();
+  const mkldnn::memory* GetWs();
+  mkldnn::lrn_forward::primitive_desc& GetFwdPd();
 
  private:
   std::shared_ptr<mkldnn::lrn_forward> fwd;
   mkldnn::lrn_forward::primitive_desc fwd_pd;
 
  private:
-  void _Init(const LRNParam &param, bool is_train, const NDArray &in_data);
+  void _Init(const LRNParam& param, bool is_train, const NDArray& in_data);
 };  // End of LRN Forword Class
 
-void MKLDNNLRNFwd::_Init(const LRNParam &param,
-                         bool is_train,
-                         const NDArray &in_data) {
-  mkldnn::memory::desc in_data_md =
-      in_data.GetMKLDNNData()->get_desc();
-  this->fwd_pd =
-      GetLRNFwdDesc(param, is_train, in_data_md);
+void MKLDNNLRNFwd::_Init(const LRNParam& param, bool is_train, const NDArray& in_data) {
+  mkldnn::memory::desc in_data_md = in_data.GetMKLDNNData()->get_desc();
+  this->fwd_pd                    = GetLRNFwdDesc(param, is_train, in_data_md);
 
   this->fwd = std::shared_ptr<mkldnn::lrn_forward>(new mkldnn::lrn_forward(this->fwd_pd));
 }
 
-void MKLDNNLRNFwd::Execute(const OpContext &ctx,
-                            const NDArray &in_data,
-                            const OpReqType req,
-                            const NDArray &out_data) {
+void MKLDNNLRNFwd::Execute(
+    const OpContext& ctx, const NDArray& in_data, const OpReqType req, const NDArray& out_data) {
   auto output_mem_t = CreateMKLDNNMem(out_data, (this->fwd_pd).dst_desc(), req);
 
   mkldnn_args_map_t args = {
-    { MKLDNN_ARG_SRC, *in_data.GetMKLDNNData()},
-    { MKLDNN_ARG_DST, *output_mem_t.second },
+      {MKLDNN_ARG_SRC, *in_data.GetMKLDNNData()},
+      {MKLDNN_ARG_DST, *output_mem_t.second},
   };
   std::shared_ptr<mkldnn::memory> workspace;
   if (ctx.is_train) {
     auto engine = CpuEngine::Get()->get_engine();
-    workspace = std::make_shared<mkldnn::memory>((this->fwd_pd).workspace_desc(), engine);
+    workspace   = std::make_shared<mkldnn::memory>((this->fwd_pd).workspace_desc(), engine);
     args[MKLDNN_ARG_WORKSPACE] = *(workspace);
   }
   MKLDNNStream::Get()->RegisterPrimArgs(*(this->fwd), args);
@@ -139,26 +125,20 @@ void MKLDNNLRNFwd::Execute(const OpContext &ctx,
   MKLDNNStream::Get()->Submit();
 }
 
-mkldnn::lrn_forward &MKLDNNLRNFwd::GetFwd() { return *this->fwd; }
-mkldnn::lrn_forward::primitive_desc &MKLDNNLRNFwd::GetFwdPd() { return this->fwd_pd; }
+mkldnn::lrn_forward& MKLDNNLRNFwd::GetFwd() { return *this->fwd; }
+mkldnn::lrn_forward::primitive_desc& MKLDNNLRNFwd::GetFwdPd() { return this->fwd_pd; }
 
 // End of LRN Class and its functions
 
-static MKLDNNLRNFwd &GetLRNFwd(const LRNParam& param,
-                               const OpContext &ctx,
-                               const NDArray &in_data) {
+static MKLDNNLRNFwd& GetLRNFwd(
+    const LRNParam& param, const OpContext& ctx, const NDArray& in_data) {
 #if DMLC_CXX11_THREAD_LOCAL
-  static thread_local std::unordered_map<MKLDNNLRNSignature,
-                                         MKLDNNLRNFwd,
-                                         OpHash> lrn_fwds;
+  static thread_local std::unordered_map<MKLDNNLRNSignature, MKLDNNLRNFwd, OpHash> lrn_fwds;
 #else
-  static MX_THREAD_LOCAL std::unordered_map<MKLDNNLRNSignature,
-                                            MKLDNNLRNFwd,
-                                            OpHash> lrn_fwds;
+  static MX_THREAD_LOCAL std::unordered_map<MKLDNNLRNSignature, MKLDNNLRNFwd, OpHash> lrn_fwds;
 #endif
   auto kind_ =
-      ctx.is_train ? mkldnn::prop_kind::forward_training
-                   : mkldnn::prop_kind::forward_scoring;
+      ctx.is_train ? mkldnn::prop_kind::forward_training : mkldnn::prop_kind::forward_scoring;
 
   MKLDNNLRNSignature key(param);
   key.AddSign(static_cast<int>(kind_));
@@ -172,13 +152,12 @@ static MKLDNNLRNFwd &GetLRNFwd(const LRNParam& param,
   return it->second;
 }
 
-void MKLDNNLRNForward(const nnvm::NodeAttrs &attrs, const OpContext &ctx,
-                      const NDArray &in_data, const OpReqType req,
-                      const NDArray &out_data) {
-  const LRNParam &param = nnvm::get<LRNParam>(attrs.parsed);
-  auto in_buffer = in_data;
-  if (in_buffer.IsView() && in_buffer.IsMKLDNNData())
-    in_buffer = in_buffer.Reorder2Default();
+void MKLDNNLRNForward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const NDArray& in_data, const OpReqType req,
+    const NDArray& out_data) {
+  const LRNParam& param = nnvm::get<LRNParam>(attrs.parsed);
+  auto in_buffer        = in_data;
+  if (in_buffer.IsView() && in_buffer.IsMKLDNNData()) in_buffer = in_buffer.Reorder2Default();
   MKLDNNLRNFwd fwd = GetLRNFwd(param, ctx, in_buffer);
   fwd.Execute(ctx, in_buffer, req, out_data);
 }
@@ -193,41 +172,39 @@ class MKLDNNLRNBwd {
 
   ~MKLDNNLRNBwd() {}
 
-  MKLDNNLRNBwd(const LRNParam &param, const mkldnn::memory::desc in_data_md,
-               const mkldnn::memory::desc diff_md)
+  MKLDNNLRNBwd(
+      const LRNParam& param, const mkldnn::memory::desc in_data_md,
+      const mkldnn::memory::desc diff_md)
       : fwd_pd(GetLRNFwdDesc(param, true, in_data_md)),
         bwd_pd(GetLRNBwdDesc(param, in_data_md, diff_md, this->fwd_pd)) {
-          bwd = std::make_shared<mkldnn::lrn_backward>(bwd_pd);
-        }
+    bwd = std::make_shared<mkldnn::lrn_backward>(bwd_pd);
+  }
 
-  const mkldnn::lrn_backward &GetBwd() const { return *bwd; }
+  const mkldnn::lrn_backward& GetBwd() const { return *bwd; }
 
-  void Execute(const NDArray &out_grad,
-                  const NDArray &in_data,
-                  const NDArray &in_grad,
-                  const mkldnn_output_t &diff_src_mem) {
-    auto engine = CpuEngine::Get()->get_engine();
+  void Execute(
+      const NDArray& out_grad, const NDArray& in_data, const NDArray& in_grad,
+      const mkldnn_output_t& diff_src_mem) {
+    auto engine    = CpuEngine::Get()->get_engine();
     auto workspace = std::make_shared<mkldnn::memory>((this->fwd_pd).workspace_desc(), engine);
     mkldnn_args_map_t args = {
-      { MKLDNN_ARG_SRC, *in_data.GetMKLDNNData() },
-      { MKLDNN_ARG_DIFF_DST, *out_grad.GetMKLDNNData()},
-      { MKLDNN_ARG_WORKSPACE, *workspace },
-      { MKLDNN_ARG_DIFF_SRC, *diff_src_mem.second }
-    };
+        {MKLDNN_ARG_SRC, *in_data.GetMKLDNNData()},
+        {MKLDNN_ARG_DIFF_DST, *out_grad.GetMKLDNNData()},
+        {MKLDNN_ARG_WORKSPACE, *workspace},
+        {MKLDNN_ARG_DIFF_SRC, *diff_src_mem.second}};
     MKLDNNStream::Get()->RegisterPrimArgs(*(this->bwd), args);
     CommitOutput(in_grad, diff_src_mem);
     MKLDNNStream::Get()->Submit();
   }
 };  // End of LRN Class
 
-static MKLDNNLRNBwd &GetLRNBwd(const LRNParam &param, const NDArray &in_data,
-                               const NDArray &in_grad, const NDArray &out_grad) {
+static MKLDNNLRNBwd& GetLRNBwd(
+    const LRNParam& param, const NDArray& in_data, const NDArray& in_grad,
+    const NDArray& out_grad) {
 #if DMLC_CXX11_THREAD_LOCAL
-  static thread_local
-      std::unordered_map<MKLDNNLRNSignature, MKLDNNLRNBwd, OpHash> lrn_bwds;
+  static thread_local std::unordered_map<MKLDNNLRNSignature, MKLDNNLRNBwd, OpHash> lrn_bwds;
 #else
-  static MX_THREAD_LOCAL
-      std::unordered_map<MKLDNNLRNSignature, MKLDNNLRNBwd, OpHash> lrn_bwds;
+  static MX_THREAD_LOCAL std::unordered_map<MKLDNNLRNSignature, MKLDNNLRNBwd, OpHash> lrn_bwds;
 #endif
   MKLDNNLRNSignature key(param);
   key.AddSign(in_data);
@@ -236,31 +213,28 @@ static MKLDNNLRNBwd &GetLRNBwd(const LRNParam &param, const NDArray &in_data,
 
   auto it = lrn_bwds.find(key);
   if (it == lrn_bwds.end()) {
-    const mkldnn::memory::desc in_data_md =
-        in_data.GetMKLDNNData()->get_desc();
-    const mkldnn::memory::desc diff_md =
-        out_grad.GetMKLDNNData()->get_desc();
+    const mkldnn::memory::desc in_data_md = in_data.GetMKLDNNData()->get_desc();
+    const mkldnn::memory::desc diff_md    = out_grad.GetMKLDNNData()->get_desc();
     MKLDNNLRNBwd bwd(param, in_data_md, diff_md);
     it = AddToCache(&lrn_bwds, key, bwd);
   }
   return it->second;
 }
 
-void MKLDNNLRNBackward(const nnvm::NodeAttrs &attrs, const OpContext &ctx,
-                       const std::vector<NDArray> &inputs, const std::vector<OpReqType> &req,
-                       const std::vector<NDArray> &outputs) {
+void MKLDNNLRNBackward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& inputs,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs) {
   if (req[0] == kNullOp) {
     return;
   }
-  const LRNParam &param = nnvm::get<LRNParam>(attrs.parsed);
-  const NDArray &out_grad = inputs[0];
-  const NDArray &in_data = inputs[1];
-  const NDArray &in_grad = outputs[0];
+  const LRNParam& param   = nnvm::get<LRNParam>(attrs.parsed);
+  const NDArray& out_grad = inputs[0];
+  const NDArray& in_data  = inputs[1];
+  const NDArray& in_grad  = outputs[0];
   // TODO(alex): (MXNET-846) figure out why in_grad output incorrect when in_data is nchw8c
-  const auto in_buffer = in_data.Reorder2Default();
-  MKLDNNLRNBwd &bwd = GetLRNBwd(param, in_buffer, in_grad, out_grad);
-  mkldnn_output_t diff_src_mem =
-      CreateMKLDNNMem(in_grad, bwd.bwd_pd.diff_src_desc(), req[0]);
+  const auto in_buffer         = in_data.Reorder2Default();
+  MKLDNNLRNBwd& bwd            = GetLRNBwd(param, in_buffer, in_grad, out_grad);
+  mkldnn_output_t diff_src_mem = CreateMKLDNNMem(in_grad, bwd.bwd_pd.diff_src_desc(), req[0]);
 
   bwd.Execute(out_grad, in_buffer, in_grad, diff_src_mem);
 }

--- a/src/operator/nn/mkldnn/mkldnn_lrn-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_lrn-inl.h
@@ -133,8 +133,12 @@ void MKLDNNLRNFwd::Execute(const OpContext& ctx,
   MKLDNNStream::Get()->Submit();
 }
 
-mkldnn::lrn_forward& MKLDNNLRNFwd::GetFwd() { return *this->fwd; }
-mkldnn::lrn_forward::primitive_desc& MKLDNNLRNFwd::GetFwdPd() { return this->fwd_pd; }
+mkldnn::lrn_forward& MKLDNNLRNFwd::GetFwd() {
+  return *this->fwd;
+}
+mkldnn::lrn_forward::primitive_desc& MKLDNNLRNFwd::GetFwdPd() {
+  return this->fwd_pd;
+}
 
 // End of LRN Class and its functions
 
@@ -168,7 +172,8 @@ void MKLDNNLRNForward(const nnvm::NodeAttrs& attrs,
                       const NDArray& out_data) {
   const LRNParam& param = nnvm::get<LRNParam>(attrs.parsed);
   auto in_buffer        = in_data;
-  if (in_buffer.IsView() && in_buffer.IsMKLDNNData()) in_buffer = in_buffer.Reorder2Default();
+  if (in_buffer.IsView() && in_buffer.IsMKLDNNData())
+    in_buffer = in_buffer.Reorder2Default();
   MKLDNNLRNFwd fwd = GetLRNFwd(param, ctx, in_buffer);
   fwd.Execute(ctx, in_buffer, req, out_data);
 }
@@ -191,7 +196,9 @@ class MKLDNNLRNBwd {
     bwd = std::make_shared<mkldnn::lrn_backward>(bwd_pd);
   }
 
-  const mkldnn::lrn_backward& GetBwd() const { return *bwd; }
+  const mkldnn::lrn_backward& GetBwd() const {
+    return *bwd;
+  }
 
   void Execute(const NDArray& out_grad,
                const NDArray& in_data,
@@ -245,7 +252,8 @@ void MKLDNNLRNBackward(const nnvm::NodeAttrs& attrs,
   const NDArray& out_grad = inputs[0];
   const NDArray& in_data  = inputs[1];
   const NDArray& in_grad  = outputs[0];
-  // TODO(alex): (MXNET-846) figure out why in_grad output incorrect when in_data is nchw8c
+  // TODO(alex): (MXNET-846) figure out why in_grad output incorrect when
+  // in_data is nchw8c
   const auto in_buffer         = in_data.Reorder2Default();
   MKLDNNLRNBwd& bwd            = GetLRNBwd(param, in_buffer, in_grad, out_grad);
   mkldnn_output_t diff_src_mem = CreateMKLDNNMem(in_grad, bwd.bwd_pd.diff_src_desc(), req[0]);

--- a/src/operator/nn/mkldnn/mkldnn_ops-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_ops-inl.h
@@ -21,11 +21,10 @@
  * \file mkldnn_ops-inl.h
  * \brief
  * \author Da Zheng
-*/
+ */
 
 #ifndef MXNET_OPERATOR_NN_MKLDNN_MKLDNN_OPS_INL_H_
 #define MXNET_OPERATOR_NN_MKLDNN_MKLDNN_OPS_INL_H_
-
 
 #include <mxnet/io.h>
 #include <mxnet/base.h>
@@ -43,85 +42,74 @@ namespace mxnet {
 namespace op {
 
 /* For fully connected. */
-void MKLDNNFCForward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
-                     const std::vector<NDArray> &in_data,
-                     const std::vector<OpReqType> &req,
-                     const std::vector<NDArray> &out_data);
-void MKLDNNFCBackward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
-                      const std::vector<NDArray> &inputs,
-                      const std::vector<OpReqType> &req,
-                      const std::vector<NDArray> &outputs);
+void MKLDNNFCForward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& in_data,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& out_data);
+void MKLDNNFCBackward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& inputs,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs);
 
 /* For convolution. */
-void MKLDNNConvolutionForward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
-                              const std::vector<NDArray> &in_data,
-                              const std::vector<OpReqType> &req,
-                              const std::vector<NDArray> &out_data);
-void MKLDNNConvolutionBackward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
-                               const std::vector<NDArray>& inputs,
-                               const std::vector<OpReqType>& req,
-                               const std::vector<NDArray>& outputs);
+void MKLDNNConvolutionForward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& in_data,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& out_data);
+void MKLDNNConvolutionBackward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& inputs,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs);
 
 /* For deconvolution */
-void MKLDNNDeconvolutionForward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
-                                const std::vector<NDArray> &in_data,
-                                const std::vector<OpReqType> &req,
-                                const std::vector<NDArray> &out_data);
-void MKLDNNDeconvolutionBackward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
-                                 const std::vector<NDArray>& inputs,
-                                 const std::vector<OpReqType>& req,
-                                 const std::vector<NDArray>& outputs);
+void MKLDNNDeconvolutionForward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& in_data,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& out_data);
+void MKLDNNDeconvolutionBackward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& inputs,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs);
 
 /* For activation */
-void MKLDNNActivationForward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
-                             const NDArray &in_data, const OpReqType &req,
-                             const NDArray &out_data);
-void MKLDNNActivationBackward(const nnvm::NodeAttrs &attrs, const OpContext &ctx,
-                              const std::vector<NDArray> &inputs,
-                              const std::vector<OpReqType> &req,
-                              const std::vector<NDArray> &outputs);
+void MKLDNNActivationForward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const NDArray& in_data,
+    const OpReqType& req, const NDArray& out_data);
+void MKLDNNActivationBackward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& inputs,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs);
 
-void MKLDNNLeakyReluForward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
-                            const NDArray &in_data, const OpReqType &req,
-                            const NDArray &out_data);
-void MKLDNNLeakyReluBackward(const nnvm::NodeAttrs &attrs, const OpContext &ctx,
-                             const std::vector<NDArray> &inputs,
-                             const std::vector<OpReqType> &req,
-                             const std::vector<NDArray> &outputs);
+void MKLDNNLeakyReluForward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const NDArray& in_data,
+    const OpReqType& req, const NDArray& out_data);
+void MKLDNNLeakyReluBackward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& inputs,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs);
 
 /* For softmax */
-void MKLDNNSoftmaxForward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
-                          const NDArray &in_data, const OpReqType &req,
-                          const NDArray &out_data);
-void MKLDNNSoftmaxBackward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
-                           const std::vector<NDArray> &in_data,
-                           const std::vector<OpReqType> &req,
-                           const std::vector<NDArray> &out_data);
+void MKLDNNSoftmaxForward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const NDArray& in_data,
+    const OpReqType& req, const NDArray& out_data);
+void MKLDNNSoftmaxBackward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& in_data,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& out_data);
 
 /* For log_softmax */
-void MKLDNNLogSoftmaxForward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
-                             const NDArray &in_data, const OpReqType &req,
-                             const NDArray &out_data);
-void MKLDNNLogSoftmaxBackward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
-                              const std::vector<NDArray> &in_data,
-                              const std::vector<OpReqType> &req,
-                              const std::vector<NDArray> &out_data);
+void MKLDNNLogSoftmaxForward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const NDArray& in_data,
+    const OpReqType& req, const NDArray& out_data);
+void MKLDNNLogSoftmaxBackward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& in_data,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& out_data);
 
 /* For softmax_output */
-void MKLDNNSoftmaxOutputForward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
-                                const std::vector<NDArray> &in_data,
-                                const std::vector<OpReqType> &req,
-                                const std::vector<NDArray> &out_data);
+void MKLDNNSoftmaxOutputForward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& in_data,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& out_data);
 
 /* For sum */
-void MKLDNNSumForward(const nnvm::NodeAttrs &attrs, const OpContext &ctx,
-                      const std::vector<NDArray> &inputs, const std::vector<OpReqType> &req,
-                      const std::vector<NDArray> &outputs);
+void MKLDNNSumForward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& inputs,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs);
 
 /* For copy */
-void MKLDNNCopy(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
-                const NDArray &in_data, const OpReqType &req,
-                const NDArray &out_data);
+void MKLDNNCopy(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const NDArray& in_data,
+    const OpReqType& req, const NDArray& out_data);
 
 /* For concat */
 void MKLDNNConcatForward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,

--- a/src/operator/nn/mkldnn/mkldnn_ops-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_ops-inl.h
@@ -26,13 +26,14 @@
 #ifndef MXNET_OPERATOR_NN_MKLDNN_MKLDNN_OPS_INL_H_
 #define MXNET_OPERATOR_NN_MKLDNN_MKLDNN_OPS_INL_H_
 
-#include <mxnet/io.h>
+#include <dmlc/logging.h>
+#include <dmlc/optional.h>
 #include <mxnet/base.h>
+#include <mxnet/io.h>
 #include <mxnet/ndarray.h>
 #include <mxnet/operator.h>
 #include <mxnet/operator_util.h>
-#include <dmlc/logging.h>
-#include <dmlc/optional.h>
+
 #include <vector>
 
 #if MXNET_USE_MKLDNN == 1
@@ -42,75 +43,108 @@ namespace mxnet {
 namespace op {
 
 /* For fully connected. */
-void MKLDNNFCForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
-                     const std::vector<NDArray>& in_data, const std::vector<OpReqType>& req,
+void MKLDNNFCForward(const nnvm::NodeAttrs& attrs,
+                     const OpContext& ctx,
+                     const std::vector<NDArray>& in_data,
+                     const std::vector<OpReqType>& req,
                      const std::vector<NDArray>& out_data);
-void MKLDNNFCBackward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
-                      const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+void MKLDNNFCBackward(const nnvm::NodeAttrs& attrs,
+                      const OpContext& ctx,
+                      const std::vector<NDArray>& inputs,
+                      const std::vector<OpReqType>& req,
                       const std::vector<NDArray>& outputs);
 
 /* For convolution. */
-void MKLDNNConvolutionForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+void MKLDNNConvolutionForward(const nnvm::NodeAttrs& attrs,
+                              const OpContext& ctx,
                               const std::vector<NDArray>& in_data,
                               const std::vector<OpReqType>& req,
                               const std::vector<NDArray>& out_data);
-void MKLDNNConvolutionBackward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+void MKLDNNConvolutionBackward(const nnvm::NodeAttrs& attrs,
+                               const OpContext& ctx,
                                const std::vector<NDArray>& inputs,
                                const std::vector<OpReqType>& req,
                                const std::vector<NDArray>& outputs);
 
 /* For deconvolution */
-void MKLDNNDeconvolutionForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+void MKLDNNDeconvolutionForward(const nnvm::NodeAttrs& attrs,
+                                const OpContext& ctx,
                                 const std::vector<NDArray>& in_data,
                                 const std::vector<OpReqType>& req,
                                 const std::vector<NDArray>& out_data);
-void MKLDNNDeconvolutionBackward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+void MKLDNNDeconvolutionBackward(const nnvm::NodeAttrs& attrs,
+                                 const OpContext& ctx,
                                  const std::vector<NDArray>& inputs,
                                  const std::vector<OpReqType>& req,
                                  const std::vector<NDArray>& outputs);
 
 /* For activation */
-void MKLDNNActivationForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
-                             const NDArray& in_data, const OpReqType& req, const NDArray& out_data);
-void MKLDNNActivationBackward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
-                              const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+void MKLDNNActivationForward(const nnvm::NodeAttrs& attrs,
+                             const OpContext& ctx,
+                             const NDArray& in_data,
+                             const OpReqType& req,
+                             const NDArray& out_data);
+void MKLDNNActivationBackward(const nnvm::NodeAttrs& attrs,
+                              const OpContext& ctx,
+                              const std::vector<NDArray>& inputs,
+                              const std::vector<OpReqType>& req,
                               const std::vector<NDArray>& outputs);
 
-void MKLDNNLeakyReluForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
-                            const NDArray& in_data, const OpReqType& req, const NDArray& out_data);
-void MKLDNNLeakyReluBackward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
-                             const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+void MKLDNNLeakyReluForward(const nnvm::NodeAttrs& attrs,
+                            const OpContext& ctx,
+                            const NDArray& in_data,
+                            const OpReqType& req,
+                            const NDArray& out_data);
+void MKLDNNLeakyReluBackward(const nnvm::NodeAttrs& attrs,
+                             const OpContext& ctx,
+                             const std::vector<NDArray>& inputs,
+                             const std::vector<OpReqType>& req,
                              const std::vector<NDArray>& outputs);
 
 /* For softmax */
-void MKLDNNSoftmaxForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
-                          const NDArray& in_data, const OpReqType& req, const NDArray& out_data);
-void MKLDNNSoftmaxBackward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
-                           const std::vector<NDArray>& in_data, const std::vector<OpReqType>& req,
+void MKLDNNSoftmaxForward(const nnvm::NodeAttrs& attrs,
+                          const OpContext& ctx,
+                          const NDArray& in_data,
+                          const OpReqType& req,
+                          const NDArray& out_data);
+void MKLDNNSoftmaxBackward(const nnvm::NodeAttrs& attrs,
+                           const OpContext& ctx,
+                           const std::vector<NDArray>& in_data,
+                           const std::vector<OpReqType>& req,
                            const std::vector<NDArray>& out_data);
 
 /* For log_softmax */
-void MKLDNNLogSoftmaxForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
-                             const NDArray& in_data, const OpReqType& req, const NDArray& out_data);
-void MKLDNNLogSoftmaxBackward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+void MKLDNNLogSoftmaxForward(const nnvm::NodeAttrs& attrs,
+                             const OpContext& ctx,
+                             const NDArray& in_data,
+                             const OpReqType& req,
+                             const NDArray& out_data);
+void MKLDNNLogSoftmaxBackward(const nnvm::NodeAttrs& attrs,
+                              const OpContext& ctx,
                               const std::vector<NDArray>& in_data,
                               const std::vector<OpReqType>& req,
                               const std::vector<NDArray>& out_data);
 
 /* For softmax_output */
-void MKLDNNSoftmaxOutputForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+void MKLDNNSoftmaxOutputForward(const nnvm::NodeAttrs& attrs,
+                                const OpContext& ctx,
                                 const std::vector<NDArray>& in_data,
                                 const std::vector<OpReqType>& req,
                                 const std::vector<NDArray>& out_data);
 
 /* For sum */
-void MKLDNNSumForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
-                      const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+void MKLDNNSumForward(const nnvm::NodeAttrs& attrs,
+                      const OpContext& ctx,
+                      const std::vector<NDArray>& inputs,
+                      const std::vector<OpReqType>& req,
                       const std::vector<NDArray>& outputs);
 
 /* For copy */
-void MKLDNNCopy(const nnvm::NodeAttrs& attrs, const OpContext& ctx, const NDArray& in_data,
-                const OpReqType& req, const NDArray& out_data);
+void MKLDNNCopy(const nnvm::NodeAttrs& attrs,
+                const OpContext& ctx,
+                const NDArray& in_data,
+                const OpReqType& req,
+                const NDArray& out_data);
 
 /* For concat */
 void MKLDNNConcatForward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,

--- a/src/operator/nn/mkldnn/mkldnn_ops-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_ops-inl.h
@@ -42,74 +42,75 @@ namespace mxnet {
 namespace op {
 
 /* For fully connected. */
-void MKLDNNFCForward(
-    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& in_data,
-    const std::vector<OpReqType>& req, const std::vector<NDArray>& out_data);
-void MKLDNNFCBackward(
-    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& inputs,
-    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs);
+void MKLDNNFCForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+                     const std::vector<NDArray>& in_data, const std::vector<OpReqType>& req,
+                     const std::vector<NDArray>& out_data);
+void MKLDNNFCBackward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+                      const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+                      const std::vector<NDArray>& outputs);
 
 /* For convolution. */
-void MKLDNNConvolutionForward(
-    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& in_data,
-    const std::vector<OpReqType>& req, const std::vector<NDArray>& out_data);
-void MKLDNNConvolutionBackward(
-    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& inputs,
-    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs);
+void MKLDNNConvolutionForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+                              const std::vector<NDArray>& in_data,
+                              const std::vector<OpReqType>& req,
+                              const std::vector<NDArray>& out_data);
+void MKLDNNConvolutionBackward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+                               const std::vector<NDArray>& inputs,
+                               const std::vector<OpReqType>& req,
+                               const std::vector<NDArray>& outputs);
 
 /* For deconvolution */
-void MKLDNNDeconvolutionForward(
-    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& in_data,
-    const std::vector<OpReqType>& req, const std::vector<NDArray>& out_data);
-void MKLDNNDeconvolutionBackward(
-    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& inputs,
-    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs);
+void MKLDNNDeconvolutionForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+                                const std::vector<NDArray>& in_data,
+                                const std::vector<OpReqType>& req,
+                                const std::vector<NDArray>& out_data);
+void MKLDNNDeconvolutionBackward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+                                 const std::vector<NDArray>& inputs,
+                                 const std::vector<OpReqType>& req,
+                                 const std::vector<NDArray>& outputs);
 
 /* For activation */
-void MKLDNNActivationForward(
-    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const NDArray& in_data,
-    const OpReqType& req, const NDArray& out_data);
-void MKLDNNActivationBackward(
-    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& inputs,
-    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs);
+void MKLDNNActivationForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+                             const NDArray& in_data, const OpReqType& req, const NDArray& out_data);
+void MKLDNNActivationBackward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+                              const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+                              const std::vector<NDArray>& outputs);
 
-void MKLDNNLeakyReluForward(
-    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const NDArray& in_data,
-    const OpReqType& req, const NDArray& out_data);
-void MKLDNNLeakyReluBackward(
-    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& inputs,
-    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs);
+void MKLDNNLeakyReluForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+                            const NDArray& in_data, const OpReqType& req, const NDArray& out_data);
+void MKLDNNLeakyReluBackward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+                             const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+                             const std::vector<NDArray>& outputs);
 
 /* For softmax */
-void MKLDNNSoftmaxForward(
-    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const NDArray& in_data,
-    const OpReqType& req, const NDArray& out_data);
-void MKLDNNSoftmaxBackward(
-    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& in_data,
-    const std::vector<OpReqType>& req, const std::vector<NDArray>& out_data);
+void MKLDNNSoftmaxForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+                          const NDArray& in_data, const OpReqType& req, const NDArray& out_data);
+void MKLDNNSoftmaxBackward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+                           const std::vector<NDArray>& in_data, const std::vector<OpReqType>& req,
+                           const std::vector<NDArray>& out_data);
 
 /* For log_softmax */
-void MKLDNNLogSoftmaxForward(
-    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const NDArray& in_data,
-    const OpReqType& req, const NDArray& out_data);
-void MKLDNNLogSoftmaxBackward(
-    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& in_data,
-    const std::vector<OpReqType>& req, const std::vector<NDArray>& out_data);
+void MKLDNNLogSoftmaxForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+                             const NDArray& in_data, const OpReqType& req, const NDArray& out_data);
+void MKLDNNLogSoftmaxBackward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+                              const std::vector<NDArray>& in_data,
+                              const std::vector<OpReqType>& req,
+                              const std::vector<NDArray>& out_data);
 
 /* For softmax_output */
-void MKLDNNSoftmaxOutputForward(
-    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& in_data,
-    const std::vector<OpReqType>& req, const std::vector<NDArray>& out_data);
+void MKLDNNSoftmaxOutputForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+                                const std::vector<NDArray>& in_data,
+                                const std::vector<OpReqType>& req,
+                                const std::vector<NDArray>& out_data);
 
 /* For sum */
-void MKLDNNSumForward(
-    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& inputs,
-    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs);
+void MKLDNNSumForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+                      const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+                      const std::vector<NDArray>& outputs);
 
 /* For copy */
-void MKLDNNCopy(
-    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const NDArray& in_data,
-    const OpReqType& req, const NDArray& out_data);
+void MKLDNNCopy(const nnvm::NodeAttrs& attrs, const OpContext& ctx, const NDArray& in_data,
+                const OpReqType& req, const NDArray& out_data);
 
 /* For concat */
 void MKLDNNConcatForward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,

--- a/src/operator/nn/mkldnn/mkldnn_ops-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_ops-inl.h
@@ -147,35 +147,37 @@ void MKLDNNCopy(const nnvm::NodeAttrs& attrs,
                 const NDArray& out_data);
 
 /* For concat */
-void MKLDNNConcatForward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
-                         const std::vector<NDArray> &in_data,
-                         const std::vector<OpReqType> &req,
-                         const std::vector<NDArray> &out_data);
-void MKLDNNConcatBackward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
+void MKLDNNConcatForward(const nnvm::NodeAttrs& attrs,
+                         const OpContext& ctx,
+                         const std::vector<NDArray>& in_data,
+                         const std::vector<OpReqType>& req,
+                         const std::vector<NDArray>& out_data);
+void MKLDNNConcatBackward(const nnvm::NodeAttrs& attrs,
+                          const OpContext& ctx,
                           const std::vector<NDArray>& inputs,
                           const std::vector<OpReqType>& req,
                           const std::vector<NDArray>& outputs);
 
 /* For batch dot */
-void MKLDNNBatchDotForward(const nnvm::NodeAttrs &attrs, const OpContext &ctx,
-                           const std::vector<NDArray> &inputs,
-                           const std::vector<OpReqType> &req,
-                           const std::vector<NDArray> &outputs);
+void MKLDNNBatchDotForward(const nnvm::NodeAttrs& attrs,
+                           const OpContext& ctx,
+                           const std::vector<NDArray>& inputs,
+                           const std::vector<OpReqType>& req,
+                           const std::vector<NDArray>& outputs);
 
-void MKLDNNSum(const mkldnn::memory &arr1, const mkldnn::memory &arr2,
-               const mkldnn::memory &out);
+void MKLDNNSum(const mkldnn::memory& arr1, const mkldnn::memory& arr2, const mkldnn::memory& out);
 
 void MKLDNNTransposeForward(const nnvm::NodeAttrs& attrs,
-                            const OpContext &ctx,
-                            const NDArray &data,
-                            const OpReqType &req,
-                            const NDArray &output);
+                            const OpContext& ctx,
+                            const NDArray& data,
+                            const OpReqType& req,
+                            const NDArray& output);
 
 void MKLDNNReshapeForward(const nnvm::NodeAttrs& attrs,
-                          const OpContext &ctx,
-                          const NDArray &input,
-                          const OpReqType &req,
-                          const NDArray &output);
+                          const OpContext& ctx,
+                          const NDArray& input,
+                          const OpReqType& req,
+                          const NDArray& output);
 }  // namespace op
 }  // namespace mxnet
 

--- a/src/operator/nn/mkldnn/mkldnn_pooling-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_pooling-inl.h
@@ -26,8 +26,9 @@
 
 #if MXNET_USE_MKLDNN == 1
 
-#include <utility>
 #include <mkldnn.hpp>
+#include <utility>
+
 #include "../pooling-inl.h"
 #include "./mkldnn_base-inl.h"
 
@@ -36,16 +37,23 @@ namespace op {
 
 class MKLDNNPoolingFwd {
  public:
-  MKLDNNPoolingFwd(const mxnet::NDArray& input, const mxnet::NDArray& output,
-                   const mkldnn::memory::dims& kernel, const mkldnn::memory::dims& strides,
-                   const mkldnn::memory::dims& pad_l, const mkldnn::memory::dims& pad_r,
-                   const mkldnn::algorithm alg_kind, const bool with_workspace, const bool is_train)
+  MKLDNNPoolingFwd(const mxnet::NDArray& input,
+                   const mxnet::NDArray& output,
+                   const mkldnn::memory::dims& kernel,
+                   const mkldnn::memory::dims& strides,
+                   const mkldnn::memory::dims& pad_l,
+                   const mkldnn::memory::dims& pad_r,
+                   const mkldnn::algorithm alg_kind,
+                   const bool with_workspace,
+                   const bool is_train)
       : with_workspace_(with_workspace), fwd_(nullptr) {
     Init(input, output, kernel, strides, pad_l, pad_r, is_train, alg_kind);
   }
 
   ~MKLDNNPoolingFwd() {}
-  void Execute(const NDArray& in_data, const OpReqType req, const NDArray& out_data,
+  void Execute(const NDArray& in_data,
+               const OpReqType req,
+               const NDArray& out_data,
                const NDArray* workspace);
 
  private:
@@ -55,10 +63,14 @@ class MKLDNNPoolingFwd {
   std::shared_ptr<mkldnn::pooling_forward> fwd_;
 
  private:
-  void Init(const mxnet::NDArray& input, const mxnet::NDArray& output,
-            const mkldnn::memory::dims& kernel, const mkldnn::memory::dims& strides,
-            const mkldnn::memory::dims& pad_l, const mkldnn::memory::dims& pad_r,
-            const bool is_train, const mkldnn::algorithm alg_kind);
+  void Init(const mxnet::NDArray& input,
+            const mxnet::NDArray& output,
+            const mkldnn::memory::dims& kernel,
+            const mkldnn::memory::dims& strides,
+            const mkldnn::memory::dims& pad_l,
+            const mkldnn::memory::dims& pad_r,
+            const bool is_train,
+            const mkldnn::algorithm alg_kind);
 };
 
 class MKLDNNPoolingBwd {
@@ -133,14 +145,23 @@ inline bool MKLDNNRequireWorkspace(const PoolingParam& param) {
 }
 
 typedef ParamOpSign<PoolingParam> MKLDNNPoolingSignature;
-void MKLDNNPoolingCompute(const OpContext& ctx, const PoolingParam& param, const NDArray& in_data,
-                          const OpReqType req, const NDArray& out_data, const NDArray* workspace);
+void MKLDNNPoolingCompute(const OpContext& ctx,
+                          const PoolingParam& param,
+                          const NDArray& in_data,
+                          const OpReqType req,
+                          const NDArray& out_data,
+                          const NDArray* workspace);
 
-void MKLDNNPoolingGradCompute(const OpContext& ctx, const PoolingParam& param,
-                              const NDArray& out_grad, const NDArray& in_data,
-                              const NDArray* workspace, const OpReqType req,
+void MKLDNNPoolingGradCompute(const OpContext& ctx,
+                              const PoolingParam& param,
+                              const NDArray& out_grad,
+                              const NDArray& in_data,
+                              const NDArray* workspace,
+                              const OpReqType req,
                               const NDArray& in_grad);
-MKLDNNPoolingFwd& GetPoolingFwd(const PoolingParam& param, const bool is_train, const NDArray& data,
+MKLDNNPoolingFwd& GetPoolingFwd(const PoolingParam& param,
+                                const bool is_train,
+                                const NDArray& data,
                                 const NDArray& output);
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/nn/mkldnn/mkldnn_pooling-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_pooling-inl.h
@@ -112,27 +112,35 @@ inline bool SupportMKLDNNPooling(const PoolingParam& param, const NDArray& input
         (dtype == mshadow::kFloat32 || dtype == mshadow::kBfloat16)))
     return false;
 
-  if (!SupportMKLDNNPooling(param)) return false;
+  if (!SupportMKLDNNPooling(param))
+    return false;
 
   if (param.pooling_convention == pool_enum::kValid) {
     return true;
   } else {
     if (param.pool_type == pool_enum::kAvgPooling) {
-      // mkldnn works differently when padding is asymmetric, so let's skip this case.
+      // mkldnn works differently when padding is asymmetric, so let's skip this
+      // case.
       bool is_symmetric = true;
       switch (ndim) {
         case 5:
-          is_symmetric = is_symmetric &&
-                         (param.pad[2] == GetPaddingSizeFull(dshape[4], param.pad[2], param.pad[2],
-                                                             param.kernel[2], param.stride[2]));
+          is_symmetric =
+              is_symmetric &&
+              (param.pad[2] ==
+               GetPaddingSizeFull(
+                   dshape[4], param.pad[2], param.pad[2], param.kernel[2], param.stride[2]));
         case 4:
-          is_symmetric = is_symmetric &&
-                         (param.pad[1] == GetPaddingSizeFull(dshape[3], param.pad[1], param.pad[1],
-                                                             param.kernel[1], param.stride[1]));
+          is_symmetric =
+              is_symmetric &&
+              (param.pad[1] ==
+               GetPaddingSizeFull(
+                   dshape[3], param.pad[1], param.pad[1], param.kernel[1], param.stride[1]));
         case 3:
-          is_symmetric = is_symmetric &&
-                         (param.pad[0] == GetPaddingSizeFull(dshape[2], param.pad[0], param.pad[0],
-                                                             param.kernel[0], param.stride[0]));
+          is_symmetric =
+              is_symmetric &&
+              (param.pad[0] ==
+               GetPaddingSizeFull(
+                   dshape[2], param.pad[0], param.pad[0], param.kernel[0], param.stride[0]));
       }
       return is_symmetric;
     }

--- a/src/operator/nn/mkldnn/mkldnn_pooling-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_pooling-inl.h
@@ -20,7 +20,7 @@
 /*!
  * \file mkldnn_pooling-inl.h
  * \brief
-*/
+ */
 #ifndef MXNET_OPERATOR_NN_MKLDNN_MKLDNN_POOLING_INL_H_
 #define MXNET_OPERATOR_NN_MKLDNN_MKLDNN_POOLING_INL_H_
 
@@ -36,25 +36,19 @@ namespace op {
 
 class MKLDNNPoolingFwd {
  public:
-  MKLDNNPoolingFwd(const mxnet::NDArray &input,
-                   const mxnet::NDArray &output,
-                   const mkldnn::memory::dims &kernel,
-                   const mkldnn::memory::dims &strides,
-                   const mkldnn::memory::dims &pad_l,
-                   const mkldnn::memory::dims &pad_r,
-                   const mkldnn::algorithm alg_kind,
-                   const bool with_workspace, const bool is_train):
-                   with_workspace_(with_workspace),
-                   fwd_(nullptr) {
-    Init(input, output, kernel, strides, pad_l, pad_r,
-         is_train, alg_kind);
+  MKLDNNPoolingFwd(
+      const mxnet::NDArray& input, const mxnet::NDArray& output, const mkldnn::memory::dims& kernel,
+      const mkldnn::memory::dims& strides, const mkldnn::memory::dims& pad_l,
+      const mkldnn::memory::dims& pad_r, const mkldnn::algorithm alg_kind,
+      const bool with_workspace, const bool is_train)
+      : with_workspace_(with_workspace), fwd_(nullptr) {
+    Init(input, output, kernel, strides, pad_l, pad_r, is_train, alg_kind);
   }
 
   ~MKLDNNPoolingFwd() {}
-  void Execute(const NDArray &in_data,
-               const OpReqType req,
-               const NDArray& out_data,
-               const NDArray *workspace);
+  void Execute(
+      const NDArray& in_data, const OpReqType req, const NDArray& out_data,
+      const NDArray* workspace);
 
  private:
   bool with_workspace_;
@@ -63,13 +57,10 @@ class MKLDNNPoolingFwd {
   std::shared_ptr<mkldnn::pooling_forward> fwd_;
 
  private:
-  void Init(const mxnet::NDArray &input,
-            const mxnet::NDArray &output,
-            const mkldnn::memory::dims &kernel,
-            const mkldnn::memory::dims &strides,
-            const mkldnn::memory::dims &pad_l,
-            const mkldnn::memory::dims &pad_r,
-            const bool is_train, const mkldnn::algorithm alg_kind);
+  void Init(
+      const mxnet::NDArray& input, const mxnet::NDArray& output, const mkldnn::memory::dims& kernel,
+      const mkldnn::memory::dims& strides, const mkldnn::memory::dims& pad_l,
+      const mkldnn::memory::dims& pad_r, const bool is_train, const mkldnn::algorithm alg_kind);
 };
 
 class MKLDNNPoolingBwd {
@@ -79,12 +70,11 @@ class MKLDNNPoolingBwd {
  public:
   const mkldnn::pooling_backward::primitive_desc pd;
 
-  MKLDNNPoolingBwd(const mkldnn::pooling_backward::primitive_desc &pdesc,
-                   bool with_ws);
+  MKLDNNPoolingBwd(const mkldnn::pooling_backward::primitive_desc& pdesc, bool with_ws);
 
   ~MKLDNNPoolingBwd() {}
-  const mkldnn::pooling_backward &GetBwd();
-  const mkldnn::pooling_backward::primitive_desc &GetPd();
+  const mkldnn::pooling_backward& GetBwd();
+  const mkldnn::pooling_backward::primitive_desc& GetPd();
 };
 
 inline int GetPaddingSizeFull(dim_t x, int padl, int padr, int k, int s) {
@@ -95,28 +85,24 @@ inline int GetPaddingSizeFull(dim_t x, int padl, int padr, int k, int s) {
   }
 }
 
-inline bool SupportMKLDNNPooling(const PoolingParam &param) {
-  return (param.kernel.ndim() == 1 || param.kernel.ndim() == 2 ||
-          param.kernel.ndim() == 3) &&
-         (param.pool_type == pool_enum::kMaxPooling ||
-          param.pool_type == pool_enum::kAvgPooling) &&
+inline bool SupportMKLDNNPooling(const PoolingParam& param) {
+  return (param.kernel.ndim() == 1 || param.kernel.ndim() == 2 || param.kernel.ndim() == 3) &&
+         (param.pool_type == pool_enum::kMaxPooling || param.pool_type == pool_enum::kAvgPooling) &&
          (!param.layout.has_value() ||
-         (param.layout.value() == mshadow::kNCW || param.layout.value() == mshadow::kNCHW ||
-          param.layout.value() == mshadow::kNCDHW));
+          (param.layout.value() == mshadow::kNCW || param.layout.value() == mshadow::kNCHW ||
+           param.layout.value() == mshadow::kNCDHW));
 }
 
-inline bool SupportMKLDNNPooling(const PoolingParam &param,
-                                 const NDArray &input) {
+inline bool SupportMKLDNNPooling(const PoolingParam& param, const NDArray& input) {
   const auto dshape = input.shape();
-  const auto ndim = dshape.ndim();
-  const auto dtype = input.dtype();
+  const auto ndim   = dshape.ndim();
+  const auto dtype  = input.dtype();
 
   if (!(SupportStorageMKLDNN(input.storage_type()) && (ndim == 3 || ndim == 4 || ndim == 5) &&
-       (dtype == mshadow::kFloat32 || dtype == mshadow::kBfloat16)))
+        (dtype == mshadow::kFloat32 || dtype == mshadow::kBfloat16)))
     return false;
 
-  if (!SupportMKLDNNPooling(param))
-    return false;
+  if (!SupportMKLDNNPooling(param)) return false;
 
   if (param.pooling_convention == pool_enum::kValid) {
     return true;
@@ -126,14 +112,17 @@ inline bool SupportMKLDNNPooling(const PoolingParam &param,
       bool is_symmetric = true;
       switch (ndim) {
         case 5:
-          is_symmetric = is_symmetric && (param.pad[2] == GetPaddingSizeFull(dshape[4],
-                                param.pad[2], param.pad[2], param.kernel[2], param.stride[2]));
+          is_symmetric = is_symmetric && (param.pad[2] == GetPaddingSizeFull(
+                                                              dshape[4], param.pad[2], param.pad[2],
+                                                              param.kernel[2], param.stride[2]));
         case 4:
-          is_symmetric = is_symmetric && (param.pad[1] == GetPaddingSizeFull(dshape[3],
-                                param.pad[1], param.pad[1], param.kernel[1], param.stride[1]));
+          is_symmetric = is_symmetric && (param.pad[1] == GetPaddingSizeFull(
+                                                              dshape[3], param.pad[1], param.pad[1],
+                                                              param.kernel[1], param.stride[1]));
         case 3:
-          is_symmetric = is_symmetric && (param.pad[0] == GetPaddingSizeFull(dshape[2],
-                                param.pad[0], param.pad[0], param.kernel[0], param.stride[0]));
+          is_symmetric = is_symmetric && (param.pad[0] == GetPaddingSizeFull(
+                                                              dshape[2], param.pad[0], param.pad[0],
+                                                              param.kernel[0], param.stride[0]));
       }
       return is_symmetric;
     }
@@ -141,23 +130,20 @@ inline bool SupportMKLDNNPooling(const PoolingParam &param,
   }
 }
 
-inline bool MKLDNNRequireWorkspace(const PoolingParam &param) {
+inline bool MKLDNNRequireWorkspace(const PoolingParam& param) {
   return param.pool_type != pool_enum::kAvgPooling;
 }
 
 typedef ParamOpSign<PoolingParam> MKLDNNPoolingSignature;
-void MKLDNNPoolingCompute(const OpContext &ctx, const PoolingParam &param,
-                          const NDArray &in_data, const OpReqType req,
-                          const NDArray &out_data, const NDArray *workspace);
+void MKLDNNPoolingCompute(
+    const OpContext& ctx, const PoolingParam& param, const NDArray& in_data, const OpReqType req,
+    const NDArray& out_data, const NDArray* workspace);
 
-void MKLDNNPoolingGradCompute(const OpContext &ctx, const PoolingParam &param,
-                              const NDArray &out_grad, const NDArray &in_data,
-                              const NDArray *workspace, const OpReqType req,
-                              const NDArray &in_grad);
-MKLDNNPoolingFwd &GetPoolingFwd(const PoolingParam &param,
-                                const bool is_train,
-                                const NDArray &data,
-                                const NDArray &output);
+void MKLDNNPoolingGradCompute(
+    const OpContext& ctx, const PoolingParam& param, const NDArray& out_grad,
+    const NDArray& in_data, const NDArray* workspace, const OpReqType req, const NDArray& in_grad);
+MKLDNNPoolingFwd& GetPoolingFwd(
+    const PoolingParam& param, const bool is_train, const NDArray& data, const NDArray& output);
 }  // namespace op
 }  // namespace mxnet
 #endif  // MXNET_USE_MKLDNN == 1

--- a/src/operator/nn/mkldnn/mkldnn_pooling-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_pooling-inl.h
@@ -36,19 +36,17 @@ namespace op {
 
 class MKLDNNPoolingFwd {
  public:
-  MKLDNNPoolingFwd(
-      const mxnet::NDArray& input, const mxnet::NDArray& output, const mkldnn::memory::dims& kernel,
-      const mkldnn::memory::dims& strides, const mkldnn::memory::dims& pad_l,
-      const mkldnn::memory::dims& pad_r, const mkldnn::algorithm alg_kind,
-      const bool with_workspace, const bool is_train)
+  MKLDNNPoolingFwd(const mxnet::NDArray& input, const mxnet::NDArray& output,
+                   const mkldnn::memory::dims& kernel, const mkldnn::memory::dims& strides,
+                   const mkldnn::memory::dims& pad_l, const mkldnn::memory::dims& pad_r,
+                   const mkldnn::algorithm alg_kind, const bool with_workspace, const bool is_train)
       : with_workspace_(with_workspace), fwd_(nullptr) {
     Init(input, output, kernel, strides, pad_l, pad_r, is_train, alg_kind);
   }
 
   ~MKLDNNPoolingFwd() {}
-  void Execute(
-      const NDArray& in_data, const OpReqType req, const NDArray& out_data,
-      const NDArray* workspace);
+  void Execute(const NDArray& in_data, const OpReqType req, const NDArray& out_data,
+               const NDArray* workspace);
 
  private:
   bool with_workspace_;
@@ -57,10 +55,10 @@ class MKLDNNPoolingFwd {
   std::shared_ptr<mkldnn::pooling_forward> fwd_;
 
  private:
-  void Init(
-      const mxnet::NDArray& input, const mxnet::NDArray& output, const mkldnn::memory::dims& kernel,
-      const mkldnn::memory::dims& strides, const mkldnn::memory::dims& pad_l,
-      const mkldnn::memory::dims& pad_r, const bool is_train, const mkldnn::algorithm alg_kind);
+  void Init(const mxnet::NDArray& input, const mxnet::NDArray& output,
+            const mkldnn::memory::dims& kernel, const mkldnn::memory::dims& strides,
+            const mkldnn::memory::dims& pad_l, const mkldnn::memory::dims& pad_r,
+            const bool is_train, const mkldnn::algorithm alg_kind);
 };
 
 class MKLDNNPoolingBwd {
@@ -112,17 +110,17 @@ inline bool SupportMKLDNNPooling(const PoolingParam& param, const NDArray& input
       bool is_symmetric = true;
       switch (ndim) {
         case 5:
-          is_symmetric = is_symmetric && (param.pad[2] == GetPaddingSizeFull(
-                                                              dshape[4], param.pad[2], param.pad[2],
-                                                              param.kernel[2], param.stride[2]));
+          is_symmetric = is_symmetric &&
+                         (param.pad[2] == GetPaddingSizeFull(dshape[4], param.pad[2], param.pad[2],
+                                                             param.kernel[2], param.stride[2]));
         case 4:
-          is_symmetric = is_symmetric && (param.pad[1] == GetPaddingSizeFull(
-                                                              dshape[3], param.pad[1], param.pad[1],
-                                                              param.kernel[1], param.stride[1]));
+          is_symmetric = is_symmetric &&
+                         (param.pad[1] == GetPaddingSizeFull(dshape[3], param.pad[1], param.pad[1],
+                                                             param.kernel[1], param.stride[1]));
         case 3:
-          is_symmetric = is_symmetric && (param.pad[0] == GetPaddingSizeFull(
-                                                              dshape[2], param.pad[0], param.pad[0],
-                                                              param.kernel[0], param.stride[0]));
+          is_symmetric = is_symmetric &&
+                         (param.pad[0] == GetPaddingSizeFull(dshape[2], param.pad[0], param.pad[0],
+                                                             param.kernel[0], param.stride[0]));
       }
       return is_symmetric;
     }
@@ -135,15 +133,15 @@ inline bool MKLDNNRequireWorkspace(const PoolingParam& param) {
 }
 
 typedef ParamOpSign<PoolingParam> MKLDNNPoolingSignature;
-void MKLDNNPoolingCompute(
-    const OpContext& ctx, const PoolingParam& param, const NDArray& in_data, const OpReqType req,
-    const NDArray& out_data, const NDArray* workspace);
+void MKLDNNPoolingCompute(const OpContext& ctx, const PoolingParam& param, const NDArray& in_data,
+                          const OpReqType req, const NDArray& out_data, const NDArray* workspace);
 
-void MKLDNNPoolingGradCompute(
-    const OpContext& ctx, const PoolingParam& param, const NDArray& out_grad,
-    const NDArray& in_data, const NDArray* workspace, const OpReqType req, const NDArray& in_grad);
-MKLDNNPoolingFwd& GetPoolingFwd(
-    const PoolingParam& param, const bool is_train, const NDArray& data, const NDArray& output);
+void MKLDNNPoolingGradCompute(const OpContext& ctx, const PoolingParam& param,
+                              const NDArray& out_grad, const NDArray& in_data,
+                              const NDArray* workspace, const OpReqType req,
+                              const NDArray& in_grad);
+MKLDNNPoolingFwd& GetPoolingFwd(const PoolingParam& param, const bool is_train, const NDArray& data,
+                                const NDArray& output);
 }  // namespace op
 }  // namespace mxnet
 #endif  // MXNET_USE_MKLDNN == 1

--- a/src/operator/nn/mkldnn/mkldnn_pooling.cc
+++ b/src/operator/nn/mkldnn/mkldnn_pooling.cc
@@ -72,7 +72,8 @@ void MKLDNNPoolingFwd::Execute(const NDArray& in_data,
                                const NDArray& out_data,
                                const NDArray* workspace) {
   NDArray in_buffer = in_data;
-  if (in_data.IsView() && in_data.IsMKLDNNData()) in_buffer = in_data.Reorder2Default();
+  if (in_data.IsView() && in_data.IsMKLDNNData())
+    in_buffer = in_data.Reorder2Default();
 
   auto input_mem     = in_buffer.GetMKLDNNData();
   auto output_mem_t_ = CreateMKLDNNMem(out_data, this->fwd_pd_->dst_desc(), req);
@@ -89,8 +90,8 @@ void MKLDNNPoolingFwd::Execute(const NDArray& in_data,
       LOG(FATAL) << "MKLDNN Pooling: incorrect workspace input";
     }
 
-    auto ws = std::make_shared<mkldnn::memory>((*(this->fwd_pd_)).workspace_desc(), engine,
-                                               workspace->GetMKLDNNData()->get_data_handle());
+    auto ws = std::make_shared<mkldnn::memory>(
+        (*(this->fwd_pd_)).workspace_desc(), engine, workspace->GetMKLDNNData()->get_data_handle());
     args[MKLDNN_ARG_WORKSPACE] = *ws;
   }
   if (this->fwd_) {
@@ -136,8 +137,11 @@ void PrepareKernels(mkldnn::memory::dims* kernel,
   }
   if (param.pooling_convention == pool_enum::kFull) {
     for (int idx = 0; idx < kernel_ndims; ++idx) {
-      pad_r->at(idx) = GetPaddingSizeFull(data_md.data.dims[idx + 2], pad_l->at(idx),
-                                          pad_r->at(idx), kernel->at(idx), strides->at(idx));
+      pad_r->at(idx) = GetPaddingSizeFull(data_md.data.dims[idx + 2],
+                                          pad_l->at(idx),
+                                          pad_r->at(idx),
+                                          kernel->at(idx),
+                                          strides->at(idx));
     }
   }
   if (param.global_pool) {
@@ -171,8 +175,10 @@ void InitPoolingPrimitiveParams(const PoolingParam& param,
     CHECK(param.pool_type == pool_enum::kAvgPooling || param.pool_type == pool_enum::kMaxPooling)
         << "Padding implemented only for average and max pooling.";
     CHECK_LT(pad_l[0], kernel[0]);
-    if (kernel_ndims > 1) CHECK_LT(pad_l[1], kernel[1]);
-    if (kernel_ndims > 2) CHECK_LT(pad_l[2], kernel[2]);
+    if (kernel_ndims > 1)
+      CHECK_LT(pad_l[1], kernel[1]);
+    if (kernel_ndims > 2)
+      CHECK_LT(pad_l[2], kernel[2]);
   }
 }
 
@@ -197,8 +203,8 @@ mkldnn::pooling_forward::primitive_desc GetPoolingFwdPdesc(const PoolingParam& p
     kind = mkldnn::prop_kind::forward_training;
   }
 
-  const mkldnn::pooling_forward::desc poolingFwd_desc(kind, alg, data_md, out_md, strides, kernel,
-                                                      pad_l, pad_r);
+  const mkldnn::pooling_forward::desc poolingFwd_desc(
+      kind, alg, data_md, out_md, strides, kernel, pad_l, pad_r);
   return mkldnn::pooling_forward::primitive_desc(poolingFwd_desc, CpuEngine::Get()->get_engine());
 }
 
@@ -235,8 +241,8 @@ MKLDNNPoolingFwd& GetPoolingFwd(const PoolingParam& param,
     InitPoolingPrimitiveParams(param, data_md, kernel, strides, pad_l, pad_r);
 
     const mkldnn::algorithm alg = GetMKLDNNPoolAlgo(param);
-    MKLDNNPoolingFwd fwd(data, output, kernel, strides, pad_l, pad_r, alg, with_workspace,
-                         is_train);
+    MKLDNNPoolingFwd fwd(
+        data, output, kernel, strides, pad_l, pad_r, alg, with_workspace, is_train);
     it = AddToCache(&pooling_fwds, key, fwd);
   }
   return it->second;
@@ -258,7 +264,9 @@ MKLDNNPoolingBwd::MKLDNNPoolingBwd(const mkldnn::pooling_backward::primitive_des
   bwd = std::make_shared<mkldnn::pooling_backward>(pd);
 }
 
-const mkldnn::pooling_backward& MKLDNNPoolingBwd::GetBwd() { return *this->bwd; }
+const mkldnn::pooling_backward& MKLDNNPoolingBwd::GetBwd() {
+  return *this->bwd;
+}
 
 MKLDNNPoolingBwd& GetPoolingBwd(const PoolingParam& param,
                                 const NDArray& in_data,

--- a/src/operator/nn/mkldnn/mkldnn_pooling.cc
+++ b/src/operator/nn/mkldnn/mkldnn_pooling.cc
@@ -34,10 +34,14 @@ static inline mkldnn::memory::data_type get_data_type(const mkldnn::memory::desc
   return static_cast<mkldnn::memory::data_type>(md.data_type());
 }
 
-void MKLDNNPoolingFwd::Init(const mxnet::NDArray& input, const mxnet::NDArray& output,
-                            const mkldnn::memory::dims& kernel, const mkldnn::memory::dims& strides,
-                            const mkldnn::memory::dims& pad_l, const mkldnn::memory::dims& pad_r,
-                            const bool is_train, const mkldnn::algorithm alg_kind) {
+void MKLDNNPoolingFwd::Init(const mxnet::NDArray& input,
+                            const mxnet::NDArray& output,
+                            const mkldnn::memory::dims& kernel,
+                            const mkldnn::memory::dims& strides,
+                            const mkldnn::memory::dims& pad_l,
+                            const mkldnn::memory::dims& pad_r,
+                            const bool is_train,
+                            const mkldnn::algorithm alg_kind) {
   const auto src_md           = input.GetMKLDNNData()->get_desc();
   const auto dst_md           = GetMemDesc(output);
   const mkldnn::engine engine = CpuEngine::Get()->get_engine();
@@ -63,7 +67,9 @@ void MKLDNNPoolingFwd::Init(const mxnet::NDArray& input, const mxnet::NDArray& o
   return;
 }
 
-void MKLDNNPoolingFwd::Execute(const NDArray& in_data, const OpReqType req, const NDArray& out_data,
+void MKLDNNPoolingFwd::Execute(const NDArray& in_data,
+                               const OpReqType req,
+                               const NDArray& out_data,
                                const NDArray* workspace) {
   NDArray in_buffer = in_data;
   if (in_data.IsView() && in_data.IsMKLDNNData()) in_buffer = in_data.Reorder2Default();
@@ -112,9 +118,12 @@ mkldnn::algorithm GetMKLDNNPoolAlgo(const PoolingParam& param) {
   }
 }
 
-void PrepareKernels(mkldnn::memory::dims* kernel, mkldnn::memory::dims* strides,
-                    mkldnn::memory::dims* pad_l, mkldnn::memory::dims* pad_r,
-                    const PoolingParam& param, const mkldnn::memory::desc& data_md,
+void PrepareKernels(mkldnn::memory::dims* kernel,
+                    mkldnn::memory::dims* strides,
+                    mkldnn::memory::dims* pad_l,
+                    mkldnn::memory::dims* pad_r,
+                    const PoolingParam& param,
+                    const mkldnn::memory::desc& data_md,
                     int kernel_ndims) {
   CHECK_GE(param.pad.ndim(), kernel_ndims);
   CHECK_GE(param.stride.ndim(), kernel_ndims);
@@ -143,7 +152,8 @@ void PrepareKernels(mkldnn::memory::dims* kernel, mkldnn::memory::dims* strides,
   }
 }
 
-void InitPoolingPrimitiveParams(const PoolingParam& param, const mkldnn::memory::desc& data_md,
+void InitPoolingPrimitiveParams(const PoolingParam& param,
+                                const mkldnn::memory::desc& data_md,
                                 const mkldnn::memory::dims& new_kernel,
                                 const mkldnn::memory::dims& new_strides,
                                 const mkldnn::memory::dims& new_pad_l,
@@ -192,7 +202,9 @@ mkldnn::pooling_forward::primitive_desc GetPoolingFwdPdesc(const PoolingParam& p
   return mkldnn::pooling_forward::primitive_desc(poolingFwd_desc, CpuEngine::Get()->get_engine());
 }
 
-MKLDNNPoolingFwd& GetPoolingFwd(const PoolingParam& param, const bool is_train, const NDArray& data,
+MKLDNNPoolingFwd& GetPoolingFwd(const PoolingParam& param,
+                                const bool is_train,
+                                const NDArray& data,
                                 const NDArray& output) {
 #if DMLC_CXX11_THREAD_LOCAL
   static thread_local std::unordered_map<MKLDNNPoolingSignature, MKLDNNPoolingFwd, OpHash>
@@ -230,8 +242,12 @@ MKLDNNPoolingFwd& GetPoolingFwd(const PoolingParam& param, const bool is_train, 
   return it->second;
 }
 
-void MKLDNNPoolingCompute(const OpContext& ctx, const PoolingParam& param, const NDArray& in_data,
-                          const OpReqType req, const NDArray& out_data, const NDArray* workspace) {
+void MKLDNNPoolingCompute(const OpContext& ctx,
+                          const PoolingParam& param,
+                          const NDArray& in_data,
+                          const OpReqType req,
+                          const NDArray& out_data,
+                          const NDArray* workspace) {
   auto& fwd = GetPoolingFwd(param, ctx.is_train, in_data, out_data);
   fwd.Execute(in_data, req, out_data, workspace);
 }
@@ -244,8 +260,10 @@ MKLDNNPoolingBwd::MKLDNNPoolingBwd(const mkldnn::pooling_backward::primitive_des
 
 const mkldnn::pooling_backward& MKLDNNPoolingBwd::GetBwd() { return *this->bwd; }
 
-MKLDNNPoolingBwd& GetPoolingBwd(const PoolingParam& param, const NDArray& in_data,
-                                const NDArray& in_grad, const NDArray& out_grad) {
+MKLDNNPoolingBwd& GetPoolingBwd(const PoolingParam& param,
+                                const NDArray& in_data,
+                                const NDArray& in_grad,
+                                const NDArray& out_grad) {
 #if DMLC_CXX11_THREAD_LOCAL
   static thread_local std::unordered_map<MKLDNNPoolingSignature, MKLDNNPoolingBwd, OpHash>
       pooling_bwds;
@@ -297,9 +315,12 @@ MKLDNNPoolingBwd& GetPoolingBwd(const PoolingParam& param, const NDArray& in_dat
   return it->second;
 }
 
-void MKLDNNPoolingGradCompute(const OpContext& ctx, const PoolingParam& param,
-                              const NDArray& out_grad, const NDArray& in_data,
-                              const NDArray* workspace, const OpReqType req,
+void MKLDNNPoolingGradCompute(const OpContext& ctx,
+                              const PoolingParam& param,
+                              const NDArray& out_grad,
+                              const NDArray& in_data,
+                              const NDArray* workspace,
+                              const OpReqType req,
                               const NDArray& in_grad) {
   if (req == kNullOp) {
     return;

--- a/src/operator/nn/mkldnn/mkldnn_pooling.cc
+++ b/src/operator/nn/mkldnn/mkldnn_pooling.cc
@@ -21,7 +21,7 @@
  * \file mkldnn_pooling.cc
  * \brief
  * \author Tao Lv
-*/
+ */
 
 #if MXNET_USE_MKLDNN == 1
 
@@ -30,21 +30,18 @@
 namespace mxnet {
 namespace op {
 
-static inline mkldnn::memory::data_type get_data_type(const mkldnn::memory::desc &md) {
+static inline mkldnn::memory::data_type get_data_type(const mkldnn::memory::desc& md) {
   return static_cast<mkldnn::memory::data_type>(md.data_type());
 }
 
-void MKLDNNPoolingFwd::Init(const mxnet::NDArray &input, const mxnet::NDArray &output,
-                            const mkldnn::memory::dims &kernel,
-                            const mkldnn::memory::dims &strides,
-                            const mkldnn::memory::dims &pad_l,
-                            const mkldnn::memory::dims &pad_r,
-                            const bool is_train, const mkldnn::algorithm alg_kind) {
-  const auto src_md = input.GetMKLDNNData()->get_desc();
-  const auto dst_md = GetMemDesc(output);
+void MKLDNNPoolingFwd::Init(
+    const mxnet::NDArray& input, const mxnet::NDArray& output, const mkldnn::memory::dims& kernel,
+    const mkldnn::memory::dims& strides, const mkldnn::memory::dims& pad_l,
+    const mkldnn::memory::dims& pad_r, const bool is_train, const mkldnn::algorithm alg_kind) {
+  const auto src_md           = input.GetMKLDNNData()->get_desc();
+  const auto dst_md           = GetMemDesc(output);
   const mkldnn::engine engine = CpuEngine::Get()->get_engine();
-  if (alg_kind != mkldnn::algorithm::pooling_max &&
-      alg_kind != mkldnn::algorithm::pooling_avg &&
+  if (alg_kind != mkldnn::algorithm::pooling_max && alg_kind != mkldnn::algorithm::pooling_avg &&
       alg_kind != mkldnn::algorithm::pooling_avg_include_padding &&
       alg_kind != mkldnn::algorithm::pooling_avg_exclude_padding) {
     LOG(FATAL) << "MKLDNN Pooling: algorithm is not supported";
@@ -58,28 +55,26 @@ void MKLDNNPoolingFwd::Init(const mxnet::NDArray &input, const mxnet::NDArray &o
     LOG(INFO) << "MKLDNN Pooling: training with prop_kind is forward_scoring";
   }
 
-  const auto fwd_desc = mkldnn::pooling_forward::desc(prop, alg_kind, src_md, dst_md,
-                                                      strides, kernel, pad_l, pad_r);
+  const auto fwd_desc =
+      mkldnn::pooling_forward::desc(prop, alg_kind, src_md, dst_md, strides, kernel, pad_l, pad_r);
   this->fwd_pd_.reset(new mkldnn::pooling_forward::primitive_desc(fwd_desc, engine));
   this->fwd_.reset(new mkldnn::pooling_forward(*(this->fwd_pd_)));
 
   return;
 }
 
-void MKLDNNPoolingFwd::Execute(const NDArray &in_data,
-                               const OpReqType req,
-                               const NDArray& out_data,
-                               const NDArray *workspace) {
+void MKLDNNPoolingFwd::Execute(
+    const NDArray& in_data, const OpReqType req, const NDArray& out_data,
+    const NDArray* workspace) {
   NDArray in_buffer = in_data;
-  if (in_data.IsView() && in_data.IsMKLDNNData())
-    in_buffer = in_data.Reorder2Default();
+  if (in_data.IsView() && in_data.IsMKLDNNData()) in_buffer = in_data.Reorder2Default();
 
-  auto input_mem = in_buffer.GetMKLDNNData();
+  auto input_mem     = in_buffer.GetMKLDNNData();
   auto output_mem_t_ = CreateMKLDNNMem(out_data, this->fwd_pd_->dst_desc(), req);
 
   mkldnn_args_map_t args = {
-    {MKLDNN_ARG_SRC, *input_mem },
-    {MKLDNN_ARG_DST, *(output_mem_t_.second) },
+      {MKLDNN_ARG_SRC, *input_mem},
+      {MKLDNN_ARG_DST, *(output_mem_t_.second)},
   };
 
   if (this->with_workspace_) {
@@ -89,8 +84,8 @@ void MKLDNNPoolingFwd::Execute(const NDArray &in_data,
       LOG(FATAL) << "MKLDNN Pooling: incorrect workspace input";
     }
 
-    auto ws = std::make_shared<mkldnn::memory>((*(this->fwd_pd_)).workspace_desc(),
-                      engine, workspace->GetMKLDNNData()->get_data_handle());
+    auto ws = std::make_shared<mkldnn::memory>(
+        (*(this->fwd_pd_)).workspace_desc(), engine, workspace->GetMKLDNNData()->get_data_handle());
     args[MKLDNN_ARG_WORKSPACE] = *ws;
   }
   if (this->fwd_) {
@@ -102,13 +97,12 @@ void MKLDNNPoolingFwd::Execute(const NDArray &in_data,
   }
 }
 
-mkldnn::algorithm GetMKLDNNPoolAlgo(const PoolingParam &param) {
+mkldnn::algorithm GetMKLDNNPoolAlgo(const PoolingParam& param) {
   switch (param.pool_type) {
     case pool_enum::kMaxPooling:
       return mkldnn::algorithm::pooling_max;
     case pool_enum::kAvgPooling:
-      if (param.count_include_pad.has_value() &&
-          !param.count_include_pad.value()) {
+      if (param.count_include_pad.has_value() && !param.count_include_pad.value()) {
         return mkldnn::algorithm::pooling_avg_exclude_padding;
       } else {
         return mkldnn::algorithm::pooling_avg_include_padding;
@@ -119,29 +113,29 @@ mkldnn::algorithm GetMKLDNNPoolAlgo(const PoolingParam &param) {
   }
 }
 
-void PrepareKernels(mkldnn::memory::dims *kernel, mkldnn::memory::dims *strides,
-                    mkldnn::memory::dims *pad_l, mkldnn::memory::dims *pad_r,
-                    const PoolingParam &param,
-                    const mkldnn::memory::desc &data_md, int kernel_ndims) {
+void PrepareKernels(
+    mkldnn::memory::dims* kernel, mkldnn::memory::dims* strides, mkldnn::memory::dims* pad_l,
+    mkldnn::memory::dims* pad_r, const PoolingParam& param, const mkldnn::memory::desc& data_md,
+    int kernel_ndims) {
   CHECK_GE(param.pad.ndim(), kernel_ndims);
   CHECK_GE(param.stride.ndim(), kernel_ndims);
 
   for (int idx = 0; idx < kernel_ndims; ++idx) {
-    kernel->at(idx) = param.kernel[idx];
-    pad_l->at(idx) = param.pad[idx];
-    pad_r->at(idx) = param.pad[idx];
+    kernel->at(idx)  = param.kernel[idx];
+    pad_l->at(idx)   = param.pad[idx];
+    pad_r->at(idx)   = param.pad[idx];
     strides->at(idx) = param.stride[idx];
   }
   if (param.pooling_convention == pool_enum::kFull) {
     for (int idx = 0; idx < kernel_ndims; ++idx) {
-      pad_r->at(idx) =
-          GetPaddingSizeFull(data_md.data.dims[idx + 2], pad_l->at(idx),
-                             pad_r->at(idx), kernel->at(idx), strides->at(idx));
+      pad_r->at(idx) = GetPaddingSizeFull(
+          data_md.data.dims[idx + 2], pad_l->at(idx), pad_r->at(idx), kernel->at(idx),
+          strides->at(idx));
     }
   }
   if (param.global_pool) {
     for (int idx = 0; idx < kernel_ndims; ++idx) {
-      kernel->at(idx) = data_md.data.dims[idx + 2];
+      kernel->at(idx)  = data_md.data.dims[idx + 2];
       strides->at(idx) = 1;
       pad_l->at(idx) = pad_r->at(idx) = 0;
     }
@@ -151,25 +145,21 @@ void PrepareKernels(mkldnn::memory::dims *kernel, mkldnn::memory::dims *strides,
   }
 }
 
-void InitPoolingPrimitiveParams(const PoolingParam &param,
-                                const mkldnn::memory::desc &data_md,
-                                const mkldnn::memory::dims &new_kernel,
-                                const mkldnn::memory::dims &new_strides,
-                                const mkldnn::memory::dims &new_pad_l,
-                                const mkldnn::memory::dims &new_pad_r) {
-  const int kernel_ndims = param.kernel.ndim();
-  mkldnn::memory::dims &kernel = const_cast<mkldnn::memory::dims &>(new_kernel);
-  mkldnn::memory::dims &strides =
-      const_cast<mkldnn::memory::dims &>(new_strides);
-  mkldnn::memory::dims &pad_l = const_cast<mkldnn::memory::dims &>(new_pad_l);
-  mkldnn::memory::dims &pad_r = const_cast<mkldnn::memory::dims &>(new_pad_r);
+void InitPoolingPrimitiveParams(
+    const PoolingParam& param, const mkldnn::memory::desc& data_md,
+    const mkldnn::memory::dims& new_kernel, const mkldnn::memory::dims& new_strides,
+    const mkldnn::memory::dims& new_pad_l, const mkldnn::memory::dims& new_pad_r) {
+  const int kernel_ndims        = param.kernel.ndim();
+  mkldnn::memory::dims& kernel  = const_cast<mkldnn::memory::dims&>(new_kernel);
+  mkldnn::memory::dims& strides = const_cast<mkldnn::memory::dims&>(new_strides);
+  mkldnn::memory::dims& pad_l   = const_cast<mkldnn::memory::dims&>(new_pad_l);
+  mkldnn::memory::dims& pad_r   = const_cast<mkldnn::memory::dims&>(new_pad_r);
 
   PrepareKernels(&kernel, &strides, &pad_l, &pad_r, param, data_md, kernel_ndims);
 
   if (pad_l[0] != 0 || (kernel_ndims == 2 && pad_l[1] != 0) ||
       (kernel_ndims == 3 && pad_l[2] != 0)) {
-    CHECK(param.pool_type == pool_enum::kAvgPooling ||
-          param.pool_type == pool_enum::kMaxPooling)
+    CHECK(param.pool_type == pool_enum::kAvgPooling || param.pool_type == pool_enum::kMaxPooling)
         << "Padding implemented only for average and max pooling.";
     CHECK_LT(pad_l[0], kernel[0]);
     if (kernel_ndims > 1) CHECK_LT(pad_l[1], kernel[1]);
@@ -178,10 +168,10 @@ void InitPoolingPrimitiveParams(const PoolingParam &param,
 }
 
 mkldnn::pooling_forward::primitive_desc GetPoolingFwdPdesc(
-    const PoolingParam &param, const bool is_train, const mkldnn::memory::desc &data_md,
-    const mkldnn::memory::desc &out_md) {
+    const PoolingParam& param, const bool is_train, const mkldnn::memory::desc& data_md,
+    const mkldnn::memory::desc& out_md) {
   CHECK(param.kernel.ndim() == 1 || param.kernel.ndim() == 2 || param.kernel.ndim() == 3)
-        << "Not Implemented";
+      << "Not Implemented";
 
   const int kernel_ndims = param.kernel.ndim();
   mkldnn::memory::dims kernel(kernel_ndims);
@@ -192,28 +182,24 @@ mkldnn::pooling_forward::primitive_desc GetPoolingFwdPdesc(
   InitPoolingPrimitiveParams(param, data_md, kernel, strides, pad_l, pad_r);
 
   const mkldnn::algorithm alg = GetMKLDNNPoolAlgo(param);
-  mkldnn::prop_kind kind = mkldnn::prop_kind::forward_scoring;
+  mkldnn::prop_kind kind      = mkldnn::prop_kind::forward_scoring;
   if (is_train && alg != mkldnn::algorithm::pooling_avg) {
     kind = mkldnn::prop_kind::forward_training;
   }
 
-  const mkldnn::pooling_forward::desc poolingFwd_desc(kind, alg, data_md, out_md, strides,
-                                                      kernel, pad_l, pad_r);
+  const mkldnn::pooling_forward::desc poolingFwd_desc(
+      kind, alg, data_md, out_md, strides, kernel, pad_l, pad_r);
   return mkldnn::pooling_forward::primitive_desc(poolingFwd_desc, CpuEngine::Get()->get_engine());
 }
 
-MKLDNNPoolingFwd &GetPoolingFwd(const PoolingParam &param,
-                                const bool is_train,
-                                const NDArray &data,
-                                const NDArray &output) {
+MKLDNNPoolingFwd& GetPoolingFwd(
+    const PoolingParam& param, const bool is_train, const NDArray& data, const NDArray& output) {
 #if DMLC_CXX11_THREAD_LOCAL
-  static thread_local std::unordered_map<MKLDNNPoolingSignature,
-                                         MKLDNNPoolingFwd,
-                                         OpHash> pooling_fwds;
+  static thread_local std::unordered_map<MKLDNNPoolingSignature, MKLDNNPoolingFwd, OpHash>
+      pooling_fwds;
 #else
-  static MX_THREAD_LOCAL std::unordered_map<MKLDNNPoolingSignature,
-                                            MKLDNNPoolingFwd,
-                                            OpHash> pooling_fwds;
+  static MX_THREAD_LOCAL std::unordered_map<MKLDNNPoolingSignature, MKLDNNPoolingFwd, OpHash>
+      pooling_fwds;
 #endif
 
   bool with_workspace = is_train && MKLDNNRequireWorkspace(param);
@@ -226,7 +212,7 @@ MKLDNNPoolingFwd &GetPoolingFwd(const PoolingParam &param,
   auto it = pooling_fwds.find(key);
   if (it == pooling_fwds.end()) {
     CHECK(param.kernel.ndim() == 1 || param.kernel.ndim() == 2 || param.kernel.ndim() == 3)
-          << "Not Implemented";
+        << "Not Implemented";
     auto data_md = data.GetMKLDNNData()->get_desc();
 
     const auto kernel_ndims = param.kernel.ndim();
@@ -237,42 +223,37 @@ MKLDNNPoolingFwd &GetPoolingFwd(const PoolingParam &param,
     InitPoolingPrimitiveParams(param, data_md, kernel, strides, pad_l, pad_r);
 
     const mkldnn::algorithm alg = GetMKLDNNPoolAlgo(param);
-    MKLDNNPoolingFwd fwd(data, output, kernel, strides,
-                         pad_l, pad_r, alg, with_workspace, is_train);
+    MKLDNNPoolingFwd fwd(
+        data, output, kernel, strides, pad_l, pad_r, alg, with_workspace, is_train);
     it = AddToCache(&pooling_fwds, key, fwd);
   }
   return it->second;
 }
 
-void MKLDNNPoolingCompute(const OpContext &ctx, const PoolingParam &param,
-                          const NDArray &in_data, const OpReqType req,
-                          const NDArray &out_data, const NDArray *workspace) {
-  auto &fwd = GetPoolingFwd(param, ctx.is_train, in_data, out_data);
+void MKLDNNPoolingCompute(
+    const OpContext& ctx, const PoolingParam& param, const NDArray& in_data, const OpReqType req,
+    const NDArray& out_data, const NDArray* workspace) {
+  auto& fwd = GetPoolingFwd(param, ctx.is_train, in_data, out_data);
   fwd.Execute(in_data, req, out_data, workspace);
 }
 
 MKLDNNPoolingBwd::MKLDNNPoolingBwd(
-    const mkldnn::pooling_backward::primitive_desc &pdesc, bool with_ws)
+    const mkldnn::pooling_backward::primitive_desc& pdesc, bool with_ws)
     : with_workspace(with_ws), pd(pdesc) {
-      bwd = std::make_shared<mkldnn::pooling_backward>(pd);
-    }
-
-const mkldnn::pooling_backward &MKLDNNPoolingBwd::GetBwd() {
-  return *this->bwd;
+  bwd = std::make_shared<mkldnn::pooling_backward>(pd);
 }
 
-MKLDNNPoolingBwd &GetPoolingBwd(const PoolingParam &param,
-                                const NDArray &in_data,
-                                const NDArray &in_grad,
-                                const NDArray &out_grad) {
+const mkldnn::pooling_backward& MKLDNNPoolingBwd::GetBwd() { return *this->bwd; }
+
+MKLDNNPoolingBwd& GetPoolingBwd(
+    const PoolingParam& param, const NDArray& in_data, const NDArray& in_grad,
+    const NDArray& out_grad) {
 #if DMLC_CXX11_THREAD_LOCAL
-  static thread_local
-      std::unordered_map<MKLDNNPoolingSignature,
-                         MKLDNNPoolingBwd, OpHash> pooling_bwds;
+  static thread_local std::unordered_map<MKLDNNPoolingSignature, MKLDNNPoolingBwd, OpHash>
+      pooling_bwds;
 #else
-  static MX_THREAD_LOCAL
-      std::unordered_map<MKLDNNPoolingSignature,
-                         MKLDNNPoolingBwd, OpHash> pooling_bwds;
+  static MX_THREAD_LOCAL std::unordered_map<MKLDNNPoolingSignature, MKLDNNPoolingBwd, OpHash>
+      pooling_bwds;
 #endif
 
   bool with_workspace = MKLDNNRequireWorkspace(param);
@@ -283,20 +264,21 @@ MKLDNNPoolingBwd &GetPoolingBwd(const PoolingParam &param,
 
   auto it = pooling_bwds.find(key);
   if (it == pooling_bwds.end()) {
-    auto input_mem = in_data.GetMKLDNNData();
+    auto input_mem                     = in_data.GetMKLDNNData();
     const mkldnn::memory::desc data_md = input_mem->get_desc();
 
     auto dst_dims = mkldnn::memory::dims(out_grad.shape().begin(), out_grad.shape().end());
-    auto any = mkldnn::memory::format_tag::any;
-    auto dst_md = mkldnn::memory::desc(dst_dims, get_data_type(data_md), any);
+    auto any      = mkldnn::memory::format_tag::any;
+    auto dst_md   = mkldnn::memory::desc(dst_dims, get_data_type(data_md), any);
 
     // fwd hint
     auto fwd_pd = GetPoolingFwdPdesc(param, true, data_md, dst_md);
 
     // creat bwd desc
     auto diff_src_dims = mkldnn::memory::dims(in_grad.shape().begin(), in_grad.shape().end());
-    auto diff_src_md = mkldnn::memory::desc(diff_src_dims, get_data_type(data_md), any);
-    auto cpu_engine = CpuEngine::Get()->get_engine();;
+    auto diff_src_md   = mkldnn::memory::desc(diff_src_dims, get_data_type(data_md), any);
+    auto cpu_engine    = CpuEngine::Get()->get_engine();
+    ;
     auto alg = GetMKLDNNPoolAlgo(param);
 
     const int kernel_ndims = param.kernel.ndim();
@@ -308,8 +290,8 @@ MKLDNNPoolingBwd &GetPoolingBwd(const PoolingParam &param,
     InitPoolingPrimitiveParams(param, data_md, kernel, strides, pad_l, pad_r);
 
     // use dst_md as diff_dst_md with any format
-    auto bwd_desc = mkldnn::pooling_backward::desc(alg, diff_src_md, dst_md,
-                                                   strides, kernel, pad_l, pad_r);
+    auto bwd_desc =
+        mkldnn::pooling_backward::desc(alg, diff_src_md, dst_md, strides, kernel, pad_l, pad_r);
     auto pdesc = mkldnn::pooling_backward::primitive_desc(bwd_desc, cpu_engine, fwd_pd);
 
     MKLDNNPoolingBwd bwd(pdesc, with_workspace);
@@ -318,22 +300,21 @@ MKLDNNPoolingBwd &GetPoolingBwd(const PoolingParam &param,
   return it->second;
 }
 
-void MKLDNNPoolingGradCompute(const OpContext &ctx, const PoolingParam &param,
-                              const NDArray &out_grad, const NDArray &in_data,
-                              const NDArray *workspace, const OpReqType req,
-                              const NDArray &in_grad) {
+void MKLDNNPoolingGradCompute(
+    const OpContext& ctx, const PoolingParam& param, const NDArray& out_grad,
+    const NDArray& in_data, const NDArray* workspace, const OpReqType req, const NDArray& in_grad) {
   if (req == kNullOp) {
     return;
   }
 
   TmpMemMgr::Get()->Init(ctx.requested[0]);
 
-  auto &bwd = GetPoolingBwd(param, in_data, in_grad, out_grad);
-  auto diff_dst_mem = out_grad.GetMKLDNNDataReorder(bwd.pd.diff_dst_desc());
-  auto diff_src_mem = CreateMKLDNNMem(in_grad, bwd.pd.diff_src_desc(), req);
+  auto& bwd              = GetPoolingBwd(param, in_data, in_grad, out_grad);
+  auto diff_dst_mem      = out_grad.GetMKLDNNDataReorder(bwd.pd.diff_dst_desc());
+  auto diff_src_mem      = CreateMKLDNNMem(in_grad, bwd.pd.diff_src_desc(), req);
   mkldnn_args_map_t args = {
-    {MKLDNN_ARG_DIFF_DST, *diff_dst_mem},
-    {MKLDNN_ARG_DIFF_SRC, *diff_src_mem.second},
+      {MKLDNN_ARG_DIFF_DST, *diff_dst_mem},
+      {MKLDNN_ARG_DIFF_SRC, *diff_src_mem.second},
   };
   if (MKLDNNRequireWorkspace(param) && workspace != nullptr) {
     args[MKLDNN_ARG_WORKSPACE] = *(workspace->GetMKLDNNData());

--- a/src/operator/nn/mkldnn/mkldnn_reshape-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_reshape-inl.h
@@ -41,19 +41,15 @@ class MKLDNNReshapeFwd {
   std::vector<mkldnn::primitive> prims_;
 
  public:
-  MKLDNNReshapeFwd(const OpReqType &req,
-                   const NDArray &input,
-                   const NDArray &output);
+  MKLDNNReshapeFwd(const OpReqType& req, const NDArray& input, const NDArray& output);
   int GetWorkspaceSize();
-  void Execute(const NDArray &input,
-               const NDArray &output,
-               const OpReqType &req,
-               void* workspace = nullptr);
+  void Execute(
+      const NDArray& input, const NDArray& output, const OpReqType& req, void* workspace = nullptr);
 };
 
 typedef OpSignature MKLDNNReshapeSignature;
-MKLDNNReshapeFwd &GetReshapeForward(const OpReqType &req, const NDArray &input,
-                                    const NDArray &output);
+MKLDNNReshapeFwd& GetReshapeForward(
+    const OpReqType& req, const NDArray& input, const NDArray& output);
 }  // namespace op
 }  // namespace mxnet
 

--- a/src/operator/nn/mkldnn/mkldnn_reshape-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_reshape-inl.h
@@ -28,8 +28,9 @@
 
 #if MXNET_USE_MKLDNN == 1
 #include <vector>
-#include "mkldnn_base-inl.h"
+
 #include "../../tensor/matrix_op-inl.h"
+#include "mkldnn_base-inl.h"
 
 namespace mxnet {
 namespace op {
@@ -43,12 +44,15 @@ class MKLDNNReshapeFwd {
  public:
   MKLDNNReshapeFwd(const OpReqType& req, const NDArray& input, const NDArray& output);
   int GetWorkspaceSize();
-  void Execute(const NDArray& input, const NDArray& output, const OpReqType& req,
+  void Execute(const NDArray& input,
+               const NDArray& output,
+               const OpReqType& req,
                void* workspace = nullptr);
 };
 
 typedef OpSignature MKLDNNReshapeSignature;
-MKLDNNReshapeFwd& GetReshapeForward(const OpReqType& req, const NDArray& input,
+MKLDNNReshapeFwd& GetReshapeForward(const OpReqType& req,
+                                    const NDArray& input,
                                     const NDArray& output);
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/nn/mkldnn/mkldnn_reshape-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_reshape-inl.h
@@ -43,13 +43,13 @@ class MKLDNNReshapeFwd {
  public:
   MKLDNNReshapeFwd(const OpReqType& req, const NDArray& input, const NDArray& output);
   int GetWorkspaceSize();
-  void Execute(
-      const NDArray& input, const NDArray& output, const OpReqType& req, void* workspace = nullptr);
+  void Execute(const NDArray& input, const NDArray& output, const OpReqType& req,
+               void* workspace = nullptr);
 };
 
 typedef OpSignature MKLDNNReshapeSignature;
-MKLDNNReshapeFwd& GetReshapeForward(
-    const OpReqType& req, const NDArray& input, const NDArray& output);
+MKLDNNReshapeFwd& GetReshapeForward(const OpReqType& req, const NDArray& input,
+                                    const NDArray& output);
 }  // namespace op
 }  // namespace mxnet
 

--- a/src/operator/nn/mkldnn/mkldnn_reshape.cc
+++ b/src/operator/nn/mkldnn/mkldnn_reshape.cc
@@ -46,10 +46,10 @@ MKLDNNReshapeFwd::MKLDNNReshapeFwd(const OpReqType& req,
 
   out_ = std::make_shared<mkldnn::memory>(temp_desc, engine, nullptr);
   if (req == kWriteInplace) {
-    // If the input has MKL-DNN internal layout, we need reorder it to a temporal buffer with
-    // default layout and copy from the temporal buffer back to output buffer which has the same
-    // address with input buffer.
-    // If the input has default layout, then nothing need to do.
+    // If the input has MKL-DNN internal layout, we need reorder it to a
+    // temporal buffer with default layout and copy from the temporal buffer
+    // back to output buffer which has the same address with input buffer. If
+    // the input has default layout, then nothing need to do.
     if (input.IsMKLDNNData()) {
       temp_ = std::make_shared<mkldnn::memory>(temp_desc, engine, nullptr);
       prims_.push_back(mkldnn::reorder(*in_mem, *temp_));  // reorder to default
@@ -62,7 +62,9 @@ MKLDNNReshapeFwd::MKLDNNReshapeFwd(const OpReqType& req,
   }
 }
 
-int MKLDNNReshapeFwd::GetWorkspaceSize() { return temp_ ? temp_->get_desc().get_size() : 0; }
+int MKLDNNReshapeFwd::GetWorkspaceSize() {
+  return temp_ ? temp_->get_desc().get_size() : 0;
+}
 
 void MKLDNNReshapeFwd::Execute(const NDArray& input,
                                const NDArray& output,
@@ -118,8 +120,8 @@ void MKLDNNReshapeForward(const nnvm::NodeAttrs& attrs,
                           const NDArray& input,
                           const OpReqType& req,
                           const NDArray& output) {
-  // For mkldnn non-supported input, it shouldn't hold mkldnn memory, so let's simply fallback to
-  // naive implement.
+  // For mkldnn non-supported input, it shouldn't hold mkldnn memory, so let's
+  // simply fallback to naive implement.
   const int input_ndims = input.shape().ndim();
   if ((input_ndims < 1 || input_ndims > 4) || !SupportMKLDNNQuantize(input.dtype())) {
     if (req != kWriteInplace) {
@@ -127,7 +129,8 @@ void MKLDNNReshapeForward(const nnvm::NodeAttrs& attrs,
     }
     return;
   }
-  if (req == kNullOp) return;
+  if (req == kNullOp)
+    return;
   CHECK_NE(req, kAddTo) << "kAddTo is not supported yet";
   auto fwd     = GetReshapeForward(req, input, output);
   auto ws_size = fwd.GetWorkspaceSize();

--- a/src/operator/nn/mkldnn/mkldnn_reshape.cc
+++ b/src/operator/nn/mkldnn/mkldnn_reshape.cc
@@ -25,14 +25,15 @@
 
 #if MXNET_USE_MKLDNN == 1
 #include "../../tensor/elemwise_unary_op.h"
-#include "./mkldnn_ops-inl.h"
 #include "./mkldnn_base-inl.h"
+#include "./mkldnn_ops-inl.h"
 #include "./mkldnn_reshape-inl.h"
 
 namespace mxnet {
 namespace op {
 
-MKLDNNReshapeFwd::MKLDNNReshapeFwd(const OpReqType& req, const NDArray& input,
+MKLDNNReshapeFwd::MKLDNNReshapeFwd(const OpReqType& req,
+                                   const NDArray& input,
                                    const NDArray& output) {
   const auto engine = CpuEngine::Get()->get_engine();
   auto in_mem       = input.GetMKLDNNData();
@@ -63,7 +64,9 @@ MKLDNNReshapeFwd::MKLDNNReshapeFwd(const OpReqType& req, const NDArray& input,
 
 int MKLDNNReshapeFwd::GetWorkspaceSize() { return temp_ ? temp_->get_desc().get_size() : 0; }
 
-void MKLDNNReshapeFwd::Execute(const NDArray& input, const NDArray& output, const OpReqType& req,
+void MKLDNNReshapeFwd::Execute(const NDArray& input,
+                               const NDArray& output,
+                               const OpReqType& req,
                                void* workspace) {
   auto stream = MKLDNNStream::Get();
   auto in_mem = input.GetMKLDNNData();
@@ -90,7 +93,8 @@ void MKLDNNReshapeFwd::Execute(const NDArray& input, const NDArray& output, cons
   const_cast<NDArray&>(output).InvalidateMKLDNNData();
 }
 
-MKLDNNReshapeFwd& GetReshapeForward(const OpReqType& req, const NDArray& input,
+MKLDNNReshapeFwd& GetReshapeForward(const OpReqType& req,
+                                    const NDArray& input,
                                     const NDArray& output) {
 #if DMLC_CXX11_THREAD_LOCAL
   static thread_local std::unordered_map<MKLDNNReshapeSignature, MKLDNNReshapeFwd, OpHash> fwds;
@@ -109,8 +113,11 @@ MKLDNNReshapeFwd& GetReshapeForward(const OpReqType& req, const NDArray& input,
   return it->second;
 }
 
-void MKLDNNReshapeForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx, const NDArray& input,
-                          const OpReqType& req, const NDArray& output) {
+void MKLDNNReshapeForward(const nnvm::NodeAttrs& attrs,
+                          const OpContext& ctx,
+                          const NDArray& input,
+                          const OpReqType& req,
+                          const NDArray& output) {
   // For mkldnn non-supported input, it shouldn't hold mkldnn memory, so let's simply fallback to
   // naive implement.
   const int input_ndims = input.shape().ndim();

--- a/src/operator/nn/mkldnn/mkldnn_reshape.cc
+++ b/src/operator/nn/mkldnn/mkldnn_reshape.cc
@@ -32,8 +32,8 @@
 namespace mxnet {
 namespace op {
 
-MKLDNNReshapeFwd::MKLDNNReshapeFwd(
-    const OpReqType& req, const NDArray& input, const NDArray& output) {
+MKLDNNReshapeFwd::MKLDNNReshapeFwd(const OpReqType& req, const NDArray& input,
+                                   const NDArray& output) {
   const auto engine = CpuEngine::Get()->get_engine();
   auto in_mem       = input.GetMKLDNNData();
 
@@ -63,8 +63,8 @@ MKLDNNReshapeFwd::MKLDNNReshapeFwd(
 
 int MKLDNNReshapeFwd::GetWorkspaceSize() { return temp_ ? temp_->get_desc().get_size() : 0; }
 
-void MKLDNNReshapeFwd::Execute(
-    const NDArray& input, const NDArray& output, const OpReqType& req, void* workspace) {
+void MKLDNNReshapeFwd::Execute(const NDArray& input, const NDArray& output, const OpReqType& req,
+                               void* workspace) {
   auto stream = MKLDNNStream::Get();
   auto in_mem = input.GetMKLDNNData();
   // register primitives and arguments
@@ -90,8 +90,8 @@ void MKLDNNReshapeFwd::Execute(
   const_cast<NDArray&>(output).InvalidateMKLDNNData();
 }
 
-MKLDNNReshapeFwd& GetReshapeForward(
-    const OpReqType& req, const NDArray& input, const NDArray& output) {
+MKLDNNReshapeFwd& GetReshapeForward(const OpReqType& req, const NDArray& input,
+                                    const NDArray& output) {
 #if DMLC_CXX11_THREAD_LOCAL
   static thread_local std::unordered_map<MKLDNNReshapeSignature, MKLDNNReshapeFwd, OpHash> fwds;
 #else
@@ -109,9 +109,8 @@ MKLDNNReshapeFwd& GetReshapeForward(
   return it->second;
 }
 
-void MKLDNNReshapeForward(
-    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const NDArray& input, const OpReqType& req,
-    const NDArray& output) {
+void MKLDNNReshapeForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx, const NDArray& input,
+                          const OpReqType& req, const NDArray& output) {
   // For mkldnn non-supported input, it shouldn't hold mkldnn memory, so let's simply fallback to
   // naive implement.
   const int input_ndims = input.shape().ndim();

--- a/src/operator/nn/mkldnn/mkldnn_rnn-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_rnn-inl.h
@@ -63,9 +63,8 @@ struct MKLDNNRnnLayerParam {
   size_t native_single_b_size;  // bias size of a single cell from framework
   size_t single_state_size;     // state size of a single cell, hy, cy
 
-  MKLDNNRnnLayerParam(
-      int num_layer, int batch_size, int seq_len, int input_size, int state_size, int mode,
-      bool bidirectional = true)
+  MKLDNNRnnLayerParam(int num_layer, int batch_size, int seq_len, int input_size, int state_size,
+                      int mode, bool bidirectional = true)
       : mode(mode),
         bidirectional(bidirectional),
         state_outputs(true),
@@ -84,8 +83,8 @@ struct MKLDNNRnnFullParam {
   LayerParamVector layer_params;
 };
 
-MKLDNNRnnFullParam MKLDNNRnnFullParamParser(
-    const RNNParam& rnn_param, const int seq_len, const int batch_size, const int input_size);
+MKLDNNRnnFullParam MKLDNNRnnFullParamParser(const RNNParam& rnn_param, const int seq_len,
+                                            const int batch_size, const int input_size);
 
 /*
  * Use this to allocate memory from MKLDNNRnnOp temporary space.
@@ -184,28 +183,24 @@ class RnnPrimitive {
   mkldnn::memory::desc workspace_desc_;
 };
 
-RnnPrimitive GetRnnFwdPrim(
-    const MKLDNNRnnLayerParam& layer_param, const bool is_train, const NDArray& data,
-    const NDArray& params);
+RnnPrimitive GetRnnFwdPrim(const MKLDNNRnnLayerParam& layer_param, const bool is_train,
+                           const NDArray& data, const NDArray& params);
 
 /*
  * Use this to manage memory and primitive of MKL-DNN RNN forward inference.
  */
 class MKLDNNRnnForward {
  public:
-  MKLDNNRnnForward(
-      const MKLDNNRnnLayerParam& layer_param, const bool is_train, const NDArray& data,
-      const NDArray& params)
+  MKLDNNRnnForward(const MKLDNNRnnLayerParam& layer_param, const bool is_train, const NDArray& data,
+                   const NDArray& params)
       : initialized_(false),
         param_(layer_param),
         fwd_inf_(GetRnnFwdPrim(layer_param, false, data, params)) {}
 
-  void SetNewDataMem(
-      void* x, void* hx, void* cx, void* y, void* hy, void* cy,
-      const int dtype = mshadow::kFloat32);
-  void SetWeightsMem(
-      MKLDNNRnnMemMgr* mgr, void* w_ptr, void* b_ptr, const bool is_train = false,
-      const int dtype = mshadow::kFloat32);
+  void SetNewDataMem(void* x, void* hx, void* cx, void* y, void* hy, void* cy,
+                     const int dtype = mshadow::kFloat32);
+  void SetWeightsMem(MKLDNNRnnMemMgr* mgr, void* w_ptr, void* b_ptr, const bool is_train = false,
+                     const int dtype = mshadow::kFloat32);
   void ReorderWeights();
 
   const mkldnn::primitive& GetFwd() const { return fwd_inf_.GetPrim(); }
@@ -261,9 +256,8 @@ typedef std::shared_ptr<mkldnn::memory> mkldnn_shared_mem_t;
  */
 class MKLDNNRnnForwardTraining {
  public:
-  MKLDNNRnnForwardTraining(
-      const MKLDNNRnnLayerParam& layer_param, const bool is_train, const NDArray& data,
-      const NDArray& params)
+  MKLDNNRnnForwardTraining(const MKLDNNRnnLayerParam& layer_param, const bool is_train,
+                           const NDArray& data, const NDArray& params)
       : fwd_trn_(GetRnnFwdPrim(layer_param, is_train, data, params)), param_(&layer_param) {}
 
   void SetTrnMem(const MKLDNNRnnForward& fwd);
@@ -351,8 +345,8 @@ class RnnBwdPrimitive {
   mkldnn::memory::desc diff_bias_desc_;
   friend class MKLDNNRnnBackward;
 };
-RnnBwdPrimitive GetRnnBwdPrim(
-    const MKLDNNRnnForwardTraining& fwd, const NDArray& data, const NDArray& params);
+RnnBwdPrimitive GetRnnBwdPrim(const MKLDNNRnnForwardTraining& fwd, const NDArray& data,
+                              const NDArray& params);
 
 /*
  * Use this to manage memory and primitive of MKL-DNN RNN backward.
@@ -364,13 +358,12 @@ class MKLDNNRnnBackward {
 
   void FetchDataWeightsMem(const MKLDNNRnnForwardTraining& fwd);
   void SetWeightsGradsMem();
-  void SetDataGradsMem(
-      void* diff_src, void* diff_state, void* diff_statecell, void* diff_out, void* diff_state_out,
-      void* diff_statecell_out, const int dtype = mshadow::kFloat32);
+  void SetDataGradsMem(void* diff_src, void* diff_state, void* diff_statecell, void* diff_out,
+                       void* diff_state_out, void* diff_statecell_out,
+                       const int dtype = mshadow::kFloat32);
   void SetNativeWeightsGrads() const;
-  void CommitWeightsGrads(
-      void* diff_weights, void* diff_bias, const OpReqType req,
-      const int dtype = mshadow::kFloat32);
+  void CommitWeightsGrads(void* diff_weights, void* diff_bias, const OpReqType req,
+                          const int dtype = mshadow::kFloat32);
 
   const mkldnn::primitive& GetBwd() const { return *bwd_.primitive_; }
   const mkldnn_args_map_t& GetArgsMap() const { return net_args_; }
@@ -401,19 +394,17 @@ class MKLDNNRnnBackward {
  */
 class MKLDNNRnnOp {
  public:
-  explicit MKLDNNRnnOp(
-      const RNNParam& param, const int seq_len, const int batch_size, const int input_size)
+  explicit MKLDNNRnnOp(const RNNParam& param, const int seq_len, const int batch_size,
+                       const int input_size)
       : initialized_(false),
         weights_version_(0),
         full_param_(MKLDNNRnnFullParamParser(param, seq_len, batch_size, input_size)) {}
 
-  void Forward(
-      const OpContext& ctx, const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
-      const std::vector<NDArray>& outputs);
+  void Forward(const OpContext& ctx, const std::vector<NDArray>& inputs,
+               const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs);
 
-  void Backward(
-      const OpContext& ctx, const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
-      const std::vector<NDArray>& outputs);
+  void Backward(const OpContext& ctx, const std::vector<NDArray>& inputs,
+                const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs);
 
   const RNNParam& GetParam() const { return full_param_.default_param; }
 
@@ -432,9 +423,8 @@ class MKLDNNRnnOp {
   // Used to store the intermediate diff_src of multi_layer
   mkldnn_shared_mem_t diff_src;
 
-  void Init(
-      const OpContext& ctx, const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
-      const std::vector<NDArray>& outputs);
+  void Init(const OpContext& ctx, const std::vector<NDArray>& inputs,
+            const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs);
 };
 
 inline bool SupportMKLDNNRnn(const int input_dtype) {

--- a/src/operator/nn/mkldnn/mkldnn_rnn-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_rnn-inl.h
@@ -57,7 +57,8 @@ struct MKLDNNRnnLayerParam {
   dims dst_dims;           // Dimensions of output in format_tag::tnc
   dims state_dims;         // Dimensions of the state cell in format_tag::ldnc
 
-  size_t workspace_size;        // used for the cached mkl-dnn memory in Forward inference
+  size_t workspace_size;        // used for the cached mkl-dnn memory in Forward
+                                // inference
   size_t reserve_size;          // used for the reserved cached memory in Backward
   size_t single_w_size;         // weights size of a single cell
   size_t single_b_size;         // bias size of a single cell from mkl-dnn
@@ -114,7 +115,9 @@ class MKLDNNRnnMemMgr {
  public:
   void Init(dim_t size, const Context& ctx, int dtype = mshadow::kFloat32);
 
-  void RegisterMem(std::shared_ptr<const mkldnn::memory> mem) { mem_holder.push_back(mem); }
+  void RegisterMem(std::shared_ptr<const mkldnn::memory> mem) {
+    mem_holder.push_back(mem);
+  }
 
   mkldnn::memory* Alloc(const mkldnn::memory::desc& md);
 };
@@ -174,14 +177,24 @@ class RnnPrimitive {
     return *this;
   }
 
-  const void* GetPrimDesc() const { return fwd_pd_.get(); }
-  const mkldnn::primitive& GetPrim() const { return *primitive_; }
+  const void* GetPrimDesc() const {
+    return fwd_pd_.get();
+  }
+  const mkldnn::primitive& GetPrim() const {
+    return *primitive_;
+  }
 
-  const mkldnn::memory::desc& GetLayerDesc() const { return weights_layer_desc_; }
+  const mkldnn::memory::desc& GetLayerDesc() const {
+    return weights_layer_desc_;
+  }
 
-  const mkldnn::memory::desc& GetIterDesc() const { return weights_iter_desc_; }
+  const mkldnn::memory::desc& GetIterDesc() const {
+    return weights_iter_desc_;
+  }
 
-  const mkldnn::memory::desc& GetWorkspaceDesc() const { return workspace_desc_; }
+  const mkldnn::memory::desc& GetWorkspaceDesc() const {
+    return workspace_desc_;
+  }
 
  private:
   std::shared_ptr<void> fwd_pd_;
@@ -223,7 +236,9 @@ class MKLDNNRnnForward {
                      const int dtype     = mshadow::kFloat32);
   void ReorderWeights();
 
-  const mkldnn::primitive& GetFwd() const { return fwd_inf_.GetPrim(); }
+  const mkldnn::primitive& GetFwd() const {
+    return fwd_inf_.GetPrim();
+  }
 
   const size_t GetSize(int dtype) const {
     size_t bytes = mshadow::mshadow_sizeof(dtype);
@@ -233,12 +248,20 @@ class MKLDNNRnnForward {
     return size / bytes + 1;
   }
 
-  const MKLDNNRnnLayerParam& GetParam() const { return param_; }
+  const MKLDNNRnnLayerParam& GetParam() const {
+    return param_;
+  }
 
-  const mkldnn_args_map_t& GetArgsMap() const { return net_args_; }
+  const mkldnn_args_map_t& GetArgsMap() const {
+    return net_args_;
+  }
 
-  const bool IsInitialized() const { return initialized_; }
-  void Reset() { initialized_ = false; }
+  const bool IsInitialized() const {
+    return initialized_;
+  }
+  void Reset() {
+    initialized_ = false;
+  }
 
  private:
   bool initialized_;
@@ -285,10 +308,18 @@ class MKLDNNRnnForwardTraining {
   void SetTrnMem(const MKLDNNRnnForward& fwd);
   void FetchData(const MKLDNNRnnForward& fwd);
 
-  const MKLDNNRnnLayerParam& GetParam() const { return *param_; }
-  const void* GetPrimDesc() const { return fwd_trn_.GetPrimDesc(); }
-  const mkldnn::primitive& GetFwd() const { return fwd_trn_.GetPrim(); }
-  const mkldnn_args_map_t& GetArgsMap() const { return net_args_; }
+  const MKLDNNRnnLayerParam& GetParam() const {
+    return *param_;
+  }
+  const void* GetPrimDesc() const {
+    return fwd_trn_.GetPrimDesc();
+  }
+  const mkldnn::primitive& GetFwd() const {
+    return fwd_trn_.GetPrim();
+  }
+  const mkldnn_args_map_t& GetArgsMap() const {
+    return net_args_;
+  }
 
  private:
   RnnPrimitive fwd_trn_;
@@ -394,8 +425,12 @@ class MKLDNNRnnBackward {
                           const OpReqType req,
                           const int dtype = mshadow::kFloat32);
 
-  const mkldnn::primitive& GetBwd() const { return *bwd_.primitive_; }
-  const mkldnn_args_map_t& GetArgsMap() const { return net_args_; }
+  const mkldnn::primitive& GetBwd() const {
+    return *bwd_.primitive_;
+  }
+  const mkldnn_args_map_t& GetArgsMap() const {
+    return net_args_;
+  }
 
  private:
   bool initialized_;
@@ -416,10 +451,10 @@ class MKLDNNRnnBackward {
 
 /*
  * Use MKLDNNRnnOp to manage fused or unfused RNN layers. A MKLDNNRnnOp contains
- * the parameter(s) and primitive(s) of RNN layer(s). According to the direction,
- * input size, and state size, multple layers could be inplemented by unfused and
- * fused layers - MKLDNNRnnForward, which holds the memory and forward primitive
- * of MKL-DNN.
+ * the parameter(s) and primitive(s) of RNN layer(s). According to the
+ * direction, input size, and state size, multple layers could be inplemented by
+ * unfused and fused layers - MKLDNNRnnForward, which holds the memory and
+ * forward primitive of MKL-DNN.
  */
 class MKLDNNRnnOp {
  public:
@@ -441,7 +476,9 @@ class MKLDNNRnnOp {
                 const std::vector<OpReqType>& req,
                 const std::vector<NDArray>& outputs);
 
-  const RNNParam& GetParam() const { return full_param_.default_param; }
+  const RNNParam& GetParam() const {
+    return full_param_.default_param;
+  }
 
  private:
   bool initialized_;
@@ -472,7 +509,8 @@ inline bool SupportMKLDNNRnn(const int input_dtype) {
 }
 
 inline bool SupportMKLDNNRnn(const RNNParam& param, const int input_dtype) {
-  if (param.projection_size.has_value()) return false;
+  if (param.projection_size.has_value())
+    return false;
   return SupportMKLDNNRnn(input_dtype);
 }
 

--- a/src/operator/nn/mkldnn/mkldnn_rnn-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_rnn-inl.h
@@ -22,7 +22,7 @@
  * \file mkldnn_rnn-inl.h
  * \brief Common functions used by MKLDNN RNN operator
  * \author Zixuan Wei
-*/
+ */
 
 #ifndef MXNET_OPERATOR_NN_MKLDNN_MKLDNN_RNN_INL_H_
 #define MXNET_OPERATOR_NN_MKLDNN_MKLDNN_RNN_INL_H_
@@ -38,7 +38,7 @@ namespace op {
 
 struct MKLDNNRnnLayerParam {
   using memory = mkldnn::memory;
-  using dims = mkldnn::memory::dims;
+  using dims   = mkldnn::memory::dims;
 
   int mode;
   bool bidirectional;
@@ -56,19 +56,24 @@ struct MKLDNNRnnLayerParam {
   dims dst_dims;           // Dimensions of output in format_tag::tnc
   dims state_dims;         // Dimensions of the state cell in format_tag::ldnc
 
-  size_t workspace_size;  // used for the cached mkl-dnn memory in Forward inference
-  size_t reserve_size;    // used for the reserved cached memory in Backward
-  size_t single_w_size;   // weights size of a single cell
-  size_t single_b_size;   // bias size of a single cell from mkl-dnn
+  size_t workspace_size;        // used for the cached mkl-dnn memory in Forward inference
+  size_t reserve_size;          // used for the reserved cached memory in Backward
+  size_t single_w_size;         // weights size of a single cell
+  size_t single_b_size;         // bias size of a single cell from mkl-dnn
   size_t native_single_b_size;  // bias size of a single cell from framework
   size_t single_state_size;     // state size of a single cell, hy, cy
 
-  MKLDNNRnnLayerParam(int num_layer, int batch_size, int seq_len,
-                      int input_size, int state_size,
-                      int mode, bool bidirectional = true)
-      : mode(mode), bidirectional(bidirectional), state_outputs(true),
-        num_layer(num_layer), batch_size(batch_size), input_size(input_size),
-        state_size(state_size), seq_len(seq_len) { }
+  MKLDNNRnnLayerParam(
+      int num_layer, int batch_size, int seq_len, int input_size, int state_size, int mode,
+      bool bidirectional = true)
+      : mode(mode),
+        bidirectional(bidirectional),
+        state_outputs(true),
+        num_layer(num_layer),
+        batch_size(batch_size),
+        input_size(input_size),
+        state_size(state_size),
+        seq_len(seq_len) {}
 
   void SetDims();
 };
@@ -79,8 +84,8 @@ struct MKLDNNRnnFullParam {
   LayerParamVector layer_params;
 };
 
-MKLDNNRnnFullParam MKLDNNRnnFullParamParser(const RNNParam& rnn_param, const int seq_len,
-                                            const int batch_size, const int input_size);
+MKLDNNRnnFullParam MKLDNNRnnFullParamParser(
+    const RNNParam& rnn_param, const int seq_len, const int batch_size, const int input_size);
 
 /*
  * Use this to allocate memory from MKLDNNRnnOp temporary space.
@@ -89,24 +94,22 @@ class MKLDNNRnnMemMgr {
   // The memory buffer in NDArray life-cycle
   NDArray workspace_;
   // This points to the memory buffer from a NDArray
-  char *curr_mem;
+  char* curr_mem;
   // The total bytes of the workspace of a MKLDNNRnnOp
   size_t mem_size = 0;
   // The current available memory bytes
-  size_t curr_size = 0;
-  const size_t alignment = kMKLDNNAlign;
+  size_t curr_size                 = 0;
+  const size_t alignment           = kMKLDNNAlign;
   const mkldnn::engine& cpu_engine = CpuEngine::Get()->get_engine();
   // Here we hold all memory related to the stateful RNN operators
-  std::vector<std::shared_ptr<const mkldnn::memory> > mem_holder;
+  std::vector<std::shared_ptr<const mkldnn::memory>> mem_holder;
 
  public:
   void Init(dim_t size, const Context& ctx, int dtype = mshadow::kFloat32);
 
-  void RegisterMem(std::shared_ptr<const mkldnn::memory> mem) {
-    mem_holder.push_back(mem);
-  }
+  void RegisterMem(std::shared_ptr<const mkldnn::memory> mem) { mem_holder.push_back(mem); }
 
-  mkldnn::memory *Alloc(const mkldnn::memory::desc &md);
+  mkldnn::memory* Alloc(const mkldnn::memory::desc& md);
 };
 
 /*
@@ -117,19 +120,19 @@ class RnnPrimitive {
   /* Create a RnnPrimitive with rnn type:
    * lstm_forward, lbr_gru_forward, vanilla_rnn_forward
    */
-  template<typename rnn_fwd, typename... Args>
+  template <typename rnn_fwd, typename... Args>
   static RnnPrimitive Create(Args&&... args) {
     RnnPrimitive rnn_fwd_prim;
     auto fwd_desc = typename rnn_fwd::desc(std::forward<Args>(args)...);
     rnn_fwd_prim.fwd_pd_.reset(
-      new typename rnn_fwd::primitive_desc(fwd_desc, CpuEngine::Get()->get_engine()),
-      [](typename rnn_fwd::primitive_desc* pd) {
-        delete reinterpret_cast<typename rnn_fwd::primitive_desc*>(pd);
-      });
+        new typename rnn_fwd::primitive_desc(fwd_desc, CpuEngine::Get()->get_engine()),
+        [](typename rnn_fwd::primitive_desc* pd) {
+          delete reinterpret_cast<typename rnn_fwd::primitive_desc*>(pd);
+        });
     auto fwd_pd = reinterpret_cast<typename rnn_fwd::primitive_desc*>(rnn_fwd_prim.fwd_pd_.get());
     rnn_fwd_prim.weights_layer_desc_ = fwd_pd->weights_layer_desc();
     rnn_fwd_prim.weights_iter_desc_  = fwd_pd->weights_iter_desc();
-    rnn_fwd_prim.workspace_desc_ = fwd_pd->workspace_desc();
+    rnn_fwd_prim.workspace_desc_     = fwd_pd->workspace_desc();
 
     rnn_fwd_prim.primitive_ = std::shared_ptr<mkldnn::primitive>(new rnn_fwd(*fwd_pd));
 
@@ -137,28 +140,28 @@ class RnnPrimitive {
   }
 
   RnnPrimitive() {
-    this->fwd_pd_ = nullptr;
-    this->primitive_ = nullptr;
+    this->fwd_pd_             = nullptr;
+    this->primitive_          = nullptr;
     this->weights_layer_desc_ = mkldnn::memory::desc();
-    this->weights_iter_desc_ = mkldnn::memory::desc();
-    this->workspace_desc_ = mkldnn::memory::desc();
+    this->weights_iter_desc_  = mkldnn::memory::desc();
+    this->workspace_desc_     = mkldnn::memory::desc();
   }
 
   RnnPrimitive(const RnnPrimitive& rnn_fwd_prim) {
-    this->fwd_pd_ = rnn_fwd_prim.fwd_pd_;
-    this->primitive_ = rnn_fwd_prim.primitive_;
+    this->fwd_pd_             = rnn_fwd_prim.fwd_pd_;
+    this->primitive_          = rnn_fwd_prim.primitive_;
     this->weights_layer_desc_ = rnn_fwd_prim.weights_layer_desc_;
-    this->weights_iter_desc_ = rnn_fwd_prim.weights_iter_desc_;
-    this->workspace_desc_ = rnn_fwd_prim.workspace_desc_;
+    this->weights_iter_desc_  = rnn_fwd_prim.weights_iter_desc_;
+    this->workspace_desc_     = rnn_fwd_prim.workspace_desc_;
   }
 
   RnnPrimitive& operator=(const RnnPrimitive& rnn_fwd_prim) {
     if (this != &rnn_fwd_prim) {
-      this->fwd_pd_ = rnn_fwd_prim.fwd_pd_;
-      this->primitive_ = rnn_fwd_prim.primitive_;
+      this->fwd_pd_             = rnn_fwd_prim.fwd_pd_;
+      this->primitive_          = rnn_fwd_prim.primitive_;
       this->weights_layer_desc_ = rnn_fwd_prim.weights_layer_desc_;
-      this->weights_iter_desc_ = rnn_fwd_prim.weights_iter_desc_;
-      this->workspace_desc_ = rnn_fwd_prim.workspace_desc_;
+      this->weights_iter_desc_  = rnn_fwd_prim.weights_iter_desc_;
+      this->workspace_desc_     = rnn_fwd_prim.workspace_desc_;
     }
 
     return *this;
@@ -167,17 +170,11 @@ class RnnPrimitive {
   const void* GetPrimDesc() const { return fwd_pd_.get(); }
   const mkldnn::primitive& GetPrim() const { return *primitive_; }
 
-  const mkldnn::memory::desc& GetLayerDesc() const {
-    return weights_layer_desc_;
-  }
+  const mkldnn::memory::desc& GetLayerDesc() const { return weights_layer_desc_; }
 
-  const mkldnn::memory::desc& GetIterDesc() const {
-    return weights_iter_desc_;
-  }
+  const mkldnn::memory::desc& GetIterDesc() const { return weights_iter_desc_; }
 
-  const mkldnn::memory::desc& GetWorkspaceDesc() const {
-    return workspace_desc_;
-  }
+  const mkldnn::memory::desc& GetWorkspaceDesc() const { return workspace_desc_; }
 
  private:
   std::shared_ptr<void> fwd_pd_;
@@ -187,40 +184,43 @@ class RnnPrimitive {
   mkldnn::memory::desc workspace_desc_;
 };
 
-RnnPrimitive GetRnnFwdPrim(const MKLDNNRnnLayerParam &layer_param, const bool is_train,
-                           const NDArray &data, const NDArray &params);
+RnnPrimitive GetRnnFwdPrim(
+    const MKLDNNRnnLayerParam& layer_param, const bool is_train, const NDArray& data,
+    const NDArray& params);
 
 /*
- * Use this to manage memory and primitive of MKL-DNN RNN forward inference. 
+ * Use this to manage memory and primitive of MKL-DNN RNN forward inference.
  */
 class MKLDNNRnnForward {
  public:
-  MKLDNNRnnForward(const MKLDNNRnnLayerParam &layer_param, const bool is_train,
-                   const NDArray &data, const NDArray &params)
-      : initialized_(false), param_(layer_param),
-        fwd_inf_(GetRnnFwdPrim(layer_param, false, data, params)) { }
+  MKLDNNRnnForward(
+      const MKLDNNRnnLayerParam& layer_param, const bool is_train, const NDArray& data,
+      const NDArray& params)
+      : initialized_(false),
+        param_(layer_param),
+        fwd_inf_(GetRnnFwdPrim(layer_param, false, data, params)) {}
 
-  void SetNewDataMem(void* x, void* hx, void* cx,
-                     void* y, void* hy, void* cy,
-                     const int dtype = mshadow::kFloat32);
-  void SetWeightsMem(MKLDNNRnnMemMgr* mgr, void* w_ptr, void* b_ptr,
-                     const bool is_train = false,
-                     const int dtype = mshadow::kFloat32);
+  void SetNewDataMem(
+      void* x, void* hx, void* cx, void* y, void* hy, void* cy,
+      const int dtype = mshadow::kFloat32);
+  void SetWeightsMem(
+      MKLDNNRnnMemMgr* mgr, void* w_ptr, void* b_ptr, const bool is_train = false,
+      const int dtype = mshadow::kFloat32);
   void ReorderWeights();
 
   const mkldnn::primitive& GetFwd() const { return fwd_inf_.GetPrim(); }
 
   const size_t GetSize(int dtype) const {
     size_t bytes = mshadow::mshadow_sizeof(dtype);
-    size_t size = 0;
+    size_t size  = 0;
     size += fwd_inf_.GetLayerDesc().get_size();
     size += fwd_inf_.GetIterDesc().get_size();
     return size / bytes + 1;
   }
 
-  const MKLDNNRnnLayerParam &GetParam() const { return param_; }
+  const MKLDNNRnnLayerParam& GetParam() const { return param_; }
 
-  const mkldnn_args_map_t &GetArgsMap() const { return net_args_; }
+  const mkldnn_args_map_t& GetArgsMap() const { return net_args_; }
 
   const bool IsInitialized() const { return initialized_; }
   void Reset() { initialized_ = false; }
@@ -228,14 +228,14 @@ class MKLDNNRnnForward {
  private:
   bool initialized_;
   MKLDNNRnnLayerParam param_;
-  RnnPrimitive fwd_inf_;    // forward inference primitive
+  RnnPrimitive fwd_inf_;  // forward inference primitive
 
-  mkldnn::memory *weights_layer_ = nullptr;
-  mkldnn::memory *weights_iter_ = nullptr;
-  mkldnn::memory *bias_ = nullptr;
+  mkldnn::memory* weights_layer_ = nullptr;
+  mkldnn::memory* weights_iter_  = nullptr;
+  mkldnn::memory* bias_          = nullptr;
 
-  mkldnn::memory *weights_layer_r_ = nullptr;
-  mkldnn::memory *weights_iter_r_ = nullptr;
+  mkldnn::memory* weights_layer_r_ = nullptr;
+  mkldnn::memory* weights_iter_r_  = nullptr;
 
   /*
    * net_args must contain some keys as below:
@@ -261,10 +261,10 @@ typedef std::shared_ptr<mkldnn::memory> mkldnn_shared_mem_t;
  */
 class MKLDNNRnnForwardTraining {
  public:
-  MKLDNNRnnForwardTraining(const MKLDNNRnnLayerParam &layer_param, const bool is_train,
-                           const NDArray &data, const NDArray &params)
-    : fwd_trn_(GetRnnFwdPrim(layer_param, is_train, data, params)),
-      param_(&layer_param) { }
+  MKLDNNRnnForwardTraining(
+      const MKLDNNRnnLayerParam& layer_param, const bool is_train, const NDArray& data,
+      const NDArray& params)
+      : fwd_trn_(GetRnnFwdPrim(layer_param, is_train, data, params)), param_(&layer_param) {}
 
   void SetTrnMem(const MKLDNNRnnForward& fwd);
   void FetchData(const MKLDNNRnnForward& fwd);
@@ -279,8 +279,8 @@ class MKLDNNRnnForwardTraining {
   const MKLDNNRnnLayerParam* param_;
 
   mkldnn_shared_mem_t weights_layer_ = nullptr;
-  mkldnn_shared_mem_t weights_iter_ = nullptr;
-  mkldnn::memory* bias_ = nullptr;
+  mkldnn_shared_mem_t weights_iter_  = nullptr;
+  mkldnn::memory* bias_              = nullptr;
 
   mkldnn_shared_mem_t workspace_ = nullptr;
 
@@ -296,15 +296,15 @@ class MKLDNNRnnForwardTraining {
 class RnnBwdPrimitive {
  public:
   template <typename rnn_fwd, typename rnn_bwd, typename... Args>
-  static RnnBwdPrimitive Create(typename rnn_fwd::primitive_desc const & fwd_pd, Args&&... args) {
+  static RnnBwdPrimitive Create(typename rnn_fwd::primitive_desc const& fwd_pd, Args&&... args) {
     RnnBwdPrimitive bwd_prim;
     typename rnn_bwd::desc bwd_desc(std::forward<Args>(args)...);
     typename rnn_bwd::primitive_desc bwd_pd(bwd_desc, CpuEngine::Get()->get_engine(), fwd_pd);
-    bwd_prim.weights_layer_desc_ = bwd_pd.weights_layer_desc();
-    bwd_prim.weights_iter_desc_ = bwd_pd.weights_iter_desc();
+    bwd_prim.weights_layer_desc_      = bwd_pd.weights_layer_desc();
+    bwd_prim.weights_iter_desc_       = bwd_pd.weights_iter_desc();
     bwd_prim.diff_weights_layer_desc_ = bwd_pd.diff_weights_layer_desc();
-    bwd_prim.diff_weights_iter_desc_ = bwd_pd.diff_weights_iter_desc();
-    bwd_prim.diff_bias_desc_ = bwd_pd.diff_bias_desc();
+    bwd_prim.diff_weights_iter_desc_  = bwd_pd.diff_weights_iter_desc();
+    bwd_prim.diff_bias_desc_          = bwd_pd.diff_bias_desc();
 
     bwd_prim.primitive_ = std::shared_ptr<mkldnn::primitive>(new rnn_bwd(bwd_pd));
 
@@ -312,31 +312,31 @@ class RnnBwdPrimitive {
   }
 
   RnnBwdPrimitive() {
-    this->primitive_ = nullptr;
-    this->weights_layer_desc_ = mkldnn::memory::desc();
-    this->weights_iter_desc_ = mkldnn::memory::desc();
+    this->primitive_               = nullptr;
+    this->weights_layer_desc_      = mkldnn::memory::desc();
+    this->weights_iter_desc_       = mkldnn::memory::desc();
     this->diff_weights_layer_desc_ = mkldnn::memory::desc();
-    this->diff_weights_iter_desc_ = mkldnn::memory::desc();
-    this->diff_bias_desc_ = mkldnn::memory::desc();
+    this->diff_weights_iter_desc_  = mkldnn::memory::desc();
+    this->diff_bias_desc_          = mkldnn::memory::desc();
   }
 
   RnnBwdPrimitive(const RnnBwdPrimitive& bwd) {
-    this->primitive_ = bwd.primitive_;
-    this->weights_layer_desc_ = bwd.weights_layer_desc_;
-    this->weights_iter_desc_ = bwd.weights_iter_desc_;
+    this->primitive_               = bwd.primitive_;
+    this->weights_layer_desc_      = bwd.weights_layer_desc_;
+    this->weights_iter_desc_       = bwd.weights_iter_desc_;
     this->diff_weights_layer_desc_ = bwd.diff_weights_layer_desc_;
-    this->diff_weights_iter_desc_ = bwd.diff_weights_iter_desc_;
-    this->diff_bias_desc_ = bwd.diff_bias_desc_;
+    this->diff_weights_iter_desc_  = bwd.diff_weights_iter_desc_;
+    this->diff_bias_desc_          = bwd.diff_bias_desc_;
   }
 
   RnnBwdPrimitive& operator=(const RnnBwdPrimitive& bwd) {
     if (this != &bwd) {
-      this->primitive_ = bwd.primitive_;
-      this->weights_layer_desc_ = bwd.weights_layer_desc_;
-      this->weights_iter_desc_ = bwd.weights_iter_desc_;
+      this->primitive_               = bwd.primitive_;
+      this->weights_layer_desc_      = bwd.weights_layer_desc_;
+      this->weights_iter_desc_       = bwd.weights_iter_desc_;
       this->diff_weights_layer_desc_ = bwd.diff_weights_layer_desc_;
-      this->diff_weights_iter_desc_ = bwd.diff_weights_iter_desc_;
-      this->diff_bias_desc_ = bwd.diff_bias_desc_;
+      this->diff_weights_iter_desc_  = bwd.diff_weights_iter_desc_;
+      this->diff_bias_desc_          = bwd.diff_bias_desc_;
     }
 
     return *this;
@@ -351,28 +351,26 @@ class RnnBwdPrimitive {
   mkldnn::memory::desc diff_bias_desc_;
   friend class MKLDNNRnnBackward;
 };
-RnnBwdPrimitive GetRnnBwdPrim(const MKLDNNRnnForwardTraining& fwd,
-                              const NDArray& data, const NDArray& params);
+RnnBwdPrimitive GetRnnBwdPrim(
+    const MKLDNNRnnForwardTraining& fwd, const NDArray& data, const NDArray& params);
 
 /*
  * Use this to manage memory and primitive of MKL-DNN RNN backward.
  */
 class MKLDNNRnnBackward {
  public:
-  MKLDNNRnnBackward(const MKLDNNRnnForwardTraining& fwd,
-                    const NDArray& data, const NDArray& params)
-      : bwd_(GetRnnBwdPrim(fwd, data, params)),
-        fwd_ptr_(&fwd) { }
+  MKLDNNRnnBackward(const MKLDNNRnnForwardTraining& fwd, const NDArray& data, const NDArray& params)
+      : bwd_(GetRnnBwdPrim(fwd, data, params)), fwd_ptr_(&fwd) {}
 
   void FetchDataWeightsMem(const MKLDNNRnnForwardTraining& fwd);
   void SetWeightsGradsMem();
-  void SetDataGradsMem(void* diff_src, void* diff_state, void* diff_statecell,
-                       void* diff_out, void* diff_state_out, void* diff_statecell_out,
-                       const int dtype = mshadow::kFloat32);
+  void SetDataGradsMem(
+      void* diff_src, void* diff_state, void* diff_statecell, void* diff_out, void* diff_state_out,
+      void* diff_statecell_out, const int dtype = mshadow::kFloat32);
   void SetNativeWeightsGrads() const;
-  void CommitWeightsGrads(void* diff_weights, void* diff_bias,
-                          const OpReqType req,
-                          const int dtype = mshadow::kFloat32);
+  void CommitWeightsGrads(
+      void* diff_weights, void* diff_bias, const OpReqType req,
+      const int dtype = mshadow::kFloat32);
 
   const mkldnn::primitive& GetBwd() const { return *bwd_.primitive_; }
   const mkldnn_args_map_t& GetArgsMap() const { return net_args_; }
@@ -403,20 +401,19 @@ class MKLDNNRnnBackward {
  */
 class MKLDNNRnnOp {
  public:
-  explicit MKLDNNRnnOp(const RNNParam &param, const int seq_len,
-                       const int batch_size, const int input_size)
-      : initialized_(false), weights_version_(0),
-        full_param_(MKLDNNRnnFullParamParser(param, seq_len, batch_size, input_size)) { }
+  explicit MKLDNNRnnOp(
+      const RNNParam& param, const int seq_len, const int batch_size, const int input_size)
+      : initialized_(false),
+        weights_version_(0),
+        full_param_(MKLDNNRnnFullParamParser(param, seq_len, batch_size, input_size)) {}
 
-  void Forward(const OpContext &ctx,
-               const std::vector<NDArray> &inputs,
-               const std::vector<OpReqType> &req,
-               const std::vector<NDArray> &outputs);
+  void Forward(
+      const OpContext& ctx, const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+      const std::vector<NDArray>& outputs);
 
-  void Backward(const OpContext &ctx,
-                const std::vector<NDArray> &inputs,
-                const std::vector<OpReqType> &req,
-                const std::vector<NDArray> &outputs);
+  void Backward(
+      const OpContext& ctx, const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+      const std::vector<NDArray>& outputs);
 
   const RNNParam& GetParam() const { return full_param_.default_param; }
 
@@ -425,20 +422,19 @@ class MKLDNNRnnOp {
   size_t weights_version_;
   MKLDNNRnnFullParam full_param_;
   MKLDNNRnnMemMgr mgr_;
-  std::vector<MKLDNNRnnForward> fwd_inf_vec_;              // forward inference layers
-  std::vector<MKLDNNRnnForwardTraining> fwd_trn_vec_;      // forward training layers
-  std::vector<MKLDNNRnnBackward> bwd_vec_;                 // backward layers
+  std::vector<MKLDNNRnnForward> fwd_inf_vec_;          // forward inference layers
+  std::vector<MKLDNNRnnForwardTraining> fwd_trn_vec_;  // forward training layers
+  std::vector<MKLDNNRnnBackward> bwd_vec_;             // backward layers
 
   // Used to store the intermediate results of multi-layer
-  std::vector<mkldnn::memory *> dst_;
+  std::vector<mkldnn::memory*> dst_;
 
   // Used to store the intermediate diff_src of multi_layer
   mkldnn_shared_mem_t diff_src;
 
-  void Init(const OpContext &ctx,
-            const std::vector<NDArray> &inputs,
-            const std::vector<OpReqType> &req,
-            const std::vector<NDArray> &outputs);
+  void Init(
+      const OpContext& ctx, const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+      const std::vector<NDArray>& outputs);
 };
 
 inline bool SupportMKLDNNRnn(const int input_dtype) {
@@ -448,7 +444,7 @@ inline bool SupportMKLDNNRnn(const int input_dtype) {
   return false;
 }
 
-inline bool SupportMKLDNNRnn(const RNNParam &param, const int input_dtype) {
+inline bool SupportMKLDNNRnn(const RNNParam& param, const int input_dtype) {
   if (param.projection_size.has_value()) return false;
   return SupportMKLDNNRnn(input_dtype);
 }

--- a/src/operator/nn/mkldnn/mkldnn_rnn.cc
+++ b/src/operator/nn/mkldnn/mkldnn_rnn.cc
@@ -22,7 +22,7 @@
  * \file mkldnn_rnn.cc
  * \brief Common functions used by MKLDNN RNN operator
  * \author Zixuan Wei
-*/
+ */
 
 #if MXNET_USE_MKLDNN == 1
 
@@ -50,7 +50,7 @@ inline int GetRnnGatesNum(int mode) {
 void MKLDNNRnnLayerParam::SetDims() {
   const int ngates = GetRnnGatesNum(mode);
   //* NOTES: LBR-GRU's new gate formula needs two bias. So it has one more bias with LBR-GRU
-  const int nbias = mode == rnn_enum::kGru ? (ngates + 1) : ngates;
+  const int nbias         = mode == rnn_enum::kGru ? (ngates + 1) : ngates;
   const int num_direction = bidirectional ? 2 : 1;
 
   src_dims.assign({seq_len, batch_size, input_size});
@@ -61,29 +61,30 @@ void MKLDNNRnnLayerParam::SetDims() {
   state_dims.assign({num_layer, num_direction, batch_size, state_size});
 
   // unidirectional size of a single cell
-  single_w_size = (input_size + state_size) * ngates * state_size;
-  single_b_size = nbias * state_size;
+  single_w_size        = (input_size + state_size) * ngates * state_size;
+  single_b_size        = nbias * state_size;
   native_single_b_size = ngates * state_size * 2;  // native RNN variants have double bias
-  single_state_size = batch_size * state_size;
+  single_state_size    = batch_size * state_size;
 
   // Get workspace size for cached weights memory
   // multiplication of tensor dimensions
   static auto tz_volume = [](const memory::dims& tz_dims) {
-    return std::accumulate(tz_dims.begin(), tz_dims.end(), static_cast<memory::dim>(1),
+    return std::accumulate(
+        tz_dims.begin(), tz_dims.end(), static_cast<memory::dim>(1),
         std::multiplies<memory::dim>());
   };
 
-  workspace_size = tz_volume(weight_layer_dims) + tz_volume(weight_iter_dims) +
-      tz_volume(bias_dims);
+  workspace_size =
+      tz_volume(weight_layer_dims) + tz_volume(weight_iter_dims) + tz_volume(bias_dims);
   reserve_size = 0;
 }
 
-MKLDNNRnnFullParam MKLDNNRnnFullParamParser(const RNNParam& rnn_param, const int seq_len,
-                                            const int batch_size, const int input_size) {
+MKLDNNRnnFullParam MKLDNNRnnFullParamParser(
+    const RNNParam& rnn_param, const int seq_len, const int batch_size, const int input_size) {
   MKLDNNRnnFullParam full_param;
-  full_param.default_param = rnn_param;
-  size_t state_size = rnn_param.state_size;
-  LayerParamVector &layer_params = full_param.layer_params;
+  full_param.default_param       = rnn_param;
+  size_t state_size              = rnn_param.state_size;
+  LayerParamVector& layer_params = full_param.layer_params;
 
   full_param.default_param.seq_length_ = seq_len;
   full_param.default_param.batch_size_ = batch_size;
@@ -92,18 +93,18 @@ MKLDNNRnnFullParam MKLDNNRnnFullParamParser(const RNNParam& rnn_param, const int
   if (rnn_param.bidirectional) {  // unfused bidirectional multi-layer RNN
     layer_params.emplace_back(1, batch_size, seq_len, input_size, state_size, rnn_param.mode);
     for (size_t layer = 1; layer < rnn_param.num_layers; ++layer) {
-      layer_params.emplace_back(1, batch_size, seq_len, state_size * 2, state_size,
-          rnn_param.mode);
+      layer_params.emplace_back(1, batch_size, seq_len, state_size * 2, state_size, rnn_param.mode);
     }
   } else if (input_size == static_cast<int>(state_size)) {  // fused multi-layer RNN
-    layer_params.emplace_back(rnn_param.num_layers, batch_size, seq_len, input_size,
-        state_size, rnn_param.mode, false);
+    layer_params.emplace_back(
+        rnn_param.num_layers, batch_size, seq_len, input_size, state_size, rnn_param.mode, false);
   } else {  // unfused 1st layer, plus fused 2-end layers
-    layer_params.emplace_back(1, batch_size, seq_len, input_size, state_size, rnn_param.mode,
-        false);
+    layer_params.emplace_back(
+        1, batch_size, seq_len, input_size, state_size, rnn_param.mode, false);
     if (rnn_param.num_layers > 1)
-      layer_params.emplace_back(rnn_param.num_layers - 1, batch_size, seq_len, state_size,
-          state_size, rnn_param.mode, false);
+      layer_params.emplace_back(
+          rnn_param.num_layers - 1, batch_size, seq_len, state_size, state_size, rnn_param.mode,
+          false);
   }
 
   // Set dims, workspace size, and state_outputs flag
@@ -116,20 +117,20 @@ MKLDNNRnnFullParam MKLDNNRnnFullParamParser(const RNNParam& rnn_param, const int
 
 void MKLDNNRnnMemMgr::Init(dim_t size, const Context& ctx, int dtype) {
   workspace_ = NDArray(TShape({size}), ctx, false, dtype);
-  curr_mem = static_cast<char *>(workspace_.data().dptr_);
-  mem_size = size * mshadow::mshadow_sizeof(dtype);
-  curr_size = size * mshadow::mshadow_sizeof(dtype);
+  curr_mem   = static_cast<char*>(workspace_.data().dptr_);
+  mem_size   = size * mshadow::mshadow_sizeof(dtype);
+  curr_size  = size * mshadow::mshadow_sizeof(dtype);
 }
 
-mkldnn::memory *MKLDNNRnnMemMgr::Alloc(const mkldnn::memory::desc &md) {
+mkldnn::memory* MKLDNNRnnMemMgr::Alloc(const mkldnn::memory::desc& md) {
   if (curr_mem == nullptr) {
-    curr_mem = static_cast<char *>(workspace_.data().dptr_);
+    curr_mem = static_cast<char*>(workspace_.data().dptr_);
   }
 
   mkldnn_mem_ptr ret(new mkldnn::memory());
-  size_t addr = reinterpret_cast<size_t>(curr_mem);
+  size_t addr       = reinterpret_cast<size_t>(curr_mem);
   size_t last_chunk = addr % alignment;
-  size_t padding = alignment - last_chunk;
+  size_t padding    = alignment - last_chunk;
   addr += padding;
   CHECK_EQ(addr % alignment, 0);
 
@@ -138,23 +139,24 @@ mkldnn::memory *MKLDNNRnnMemMgr::Alloc(const mkldnn::memory::desc &md) {
     ret.reset(new mkldnn::memory(md, cpu_engine));
   } else {
     curr_mem += (md.get_size() + padding);
-    ret.reset(new mkldnn::memory(md, cpu_engine, reinterpret_cast<void *>(addr)));
+    ret.reset(new mkldnn::memory(md, cpu_engine, reinterpret_cast<void*>(addr)));
   }
   RegisterMem(ret);
   return ret.get();
 }
 
 RnnPrimitive GetRnnFwdPrim(
-    const MKLDNNRnnLayerParam &layer_param, const bool is_train,
-    const NDArray &data, const NDArray &params) {
+    const MKLDNNRnnLayerParam& layer_param, const bool is_train, const NDArray& data,
+    const NDArray& params) {
   using namespace mkldnn;
-  using tag = mkldnn::memory::format_tag;
-  const int mode = layer_param.mode;
-  memory::data_type data_type = get_mkldnn_type(data.dtype());
+  using tag                     = mkldnn::memory::format_tag;
+  const int mode                = layer_param.mode;
+  memory::data_type data_type   = get_mkldnn_type(data.dtype());
   memory::data_type weight_type = get_mkldnn_type(params.dtype());
   const prop_kind prop = is_train ? prop_kind::forward_training : prop_kind::forward_inference;
-  const rnn_direction mkldnn_rnn_direction = layer_param.bidirectional ?
-      rnn_direction::bidirectional_concat : rnn_direction::unidirectional;
+  const rnn_direction mkldnn_rnn_direction = layer_param.bidirectional
+                                                 ? rnn_direction::bidirectional_concat
+                                                 : rnn_direction::unidirectional;
 
   auto src_layer_desc    = memory::desc(layer_param.src_dims, data_type, tag::tnc);
   auto weight_layer_desc = memory::desc(layer_param.weight_layer_dims, weight_type, tag::any);
@@ -162,28 +164,29 @@ RnnPrimitive GetRnnFwdPrim(
   auto bias_desc         = memory::desc(layer_param.bias_dims, data_type, tag::ldgo);
   auto dst_layer_desc    = memory::desc(layer_param.dst_dims, data_type, tag::tnc);
   auto src_state_desc    = memory::desc(layer_param.state_dims, data_type, tag::ldnc);
-  auto dst_state_desc = layer_param.state_outputs ? memory::desc(
-      layer_param.state_dims, data_type, tag::ldnc) : memory::desc();
+  auto dst_state_desc    = layer_param.state_outputs
+                               ? memory::desc(layer_param.state_dims, data_type, tag::ldnc)
+                               : memory::desc();
 
   auto fwd = RnnPrimitive();
   switch (mode) {
     case rnn_enum::kLstm:
-      fwd = RnnPrimitive::Create<lstm_forward>(prop, mkldnn_rnn_direction,
-          src_layer_desc, src_state_desc, src_state_desc, weight_layer_desc,
-          weight_iter_desc, bias_desc, dst_layer_desc, dst_state_desc,
+      fwd = RnnPrimitive::Create<lstm_forward>(
+          prop, mkldnn_rnn_direction, src_layer_desc, src_state_desc, src_state_desc,
+          weight_layer_desc, weight_iter_desc, bias_desc, dst_layer_desc, dst_state_desc,
           dst_state_desc);
       break;
     case rnn_enum::kGru:
-      fwd = RnnPrimitive::Create<lbr_gru_forward>(prop, mkldnn_rnn_direction,
-          src_layer_desc, src_state_desc, weight_layer_desc,
+      fwd = RnnPrimitive::Create<lbr_gru_forward>(
+          prop, mkldnn_rnn_direction, src_layer_desc, src_state_desc, weight_layer_desc,
           weight_iter_desc, bias_desc, dst_layer_desc, dst_state_desc);
       break;
     case rnn_enum::kRnnRelu:
     case rnn_enum::kRnnTanh:
-      fwd = RnnPrimitive::Create<vanilla_rnn_forward>(prop,
-          mode == rnn_enum::kRnnTanh ? algorithm::eltwise_tanh : algorithm::eltwise_relu,
-          mkldnn_rnn_direction, src_layer_desc, src_state_desc, weight_layer_desc,
-          weight_iter_desc, bias_desc, dst_layer_desc, dst_state_desc);
+      fwd = RnnPrimitive::Create<vanilla_rnn_forward>(
+          prop, mode == rnn_enum::kRnnTanh ? algorithm::eltwise_tanh : algorithm::eltwise_relu,
+          mkldnn_rnn_direction, src_layer_desc, src_state_desc, weight_layer_desc, weight_iter_desc,
+          bias_desc, dst_layer_desc, dst_state_desc);
       break;
     default:
       LOG(FATAL) << "unsupported RNN mode:" << mode;
@@ -192,17 +195,18 @@ RnnPrimitive GetRnnFwdPrim(
   return fwd;
 }
 
-RnnBwdPrimitive GetRnnBwdPrim(const MKLDNNRnnForwardTraining &fwd,
-                              const NDArray &data, const NDArray &params) {
+RnnBwdPrimitive GetRnnBwdPrim(
+    const MKLDNNRnnForwardTraining& fwd, const NDArray& data, const NDArray& params) {
   using namespace mkldnn;
-  using tag = mkldnn::memory::format_tag;
+  using tag                              = mkldnn::memory::format_tag;
   const MKLDNNRnnLayerParam& layer_param = fwd.GetParam();
-  const int mode = layer_param.mode;
-  memory::data_type data_type = get_mkldnn_type(data.dtype());
-  memory::data_type weight_type = get_mkldnn_type(params.dtype());
-  const prop_kind prop = prop_kind::backward;
-  rnn_direction mkldnn_rnn_direction = layer_param.bidirectional ?
-      rnn_direction::bidirectional_concat : rnn_direction::unidirectional;
+  const int mode                         = layer_param.mode;
+  memory::data_type data_type            = get_mkldnn_type(data.dtype());
+  memory::data_type weight_type          = get_mkldnn_type(params.dtype());
+  const prop_kind prop                   = prop_kind::backward;
+  rnn_direction mkldnn_rnn_direction     = layer_param.bidirectional
+                                               ? rnn_direction::bidirectional_concat
+                                               : rnn_direction::unidirectional;
 
   auto src_layer_desc    = memory::desc(layer_param.src_dims, data_type, tag::tnc);
   auto weight_layer_desc = memory::desc(layer_param.weight_layer_dims, weight_type, tag::any);
@@ -210,52 +214,50 @@ RnnBwdPrimitive GetRnnBwdPrim(const MKLDNNRnnForwardTraining &fwd,
   auto bias_desc         = memory::desc(layer_param.bias_dims, data_type, tag::ldgo);
   auto dst_layer_desc    = memory::desc(layer_param.dst_dims, data_type, tag::tnc);
   auto src_state_desc    = memory::desc(layer_param.state_dims, data_type, tag::ldnc);
-  auto dst_state_desc = layer_param.state_outputs ? memory::desc(
-      layer_param.state_dims, data_type, tag::ldnc) : memory::desc();
+  auto dst_state_desc    = layer_param.state_outputs
+                               ? memory::desc(layer_param.state_dims, data_type, tag::ldnc)
+                               : memory::desc();
 
   const void* fwd_pd = fwd.GetPrimDesc();
-  auto bwd = RnnBwdPrimitive();
+  auto bwd           = RnnBwdPrimitive();
   switch (mode) {
     case rnn_enum::kLstm: {
       const lstm_forward::primitive_desc* pd =
           reinterpret_cast<const lstm_forward::primitive_desc*>(fwd_pd);
-      bwd = RnnBwdPrimitive::Create<lstm_forward, lstm_backward>(*pd,
-          prop, mkldnn_rnn_direction,
+      bwd = RnnBwdPrimitive::Create<lstm_forward, lstm_backward>(
+          *pd, prop, mkldnn_rnn_direction,
           // data desc
-          src_layer_desc, src_state_desc, src_state_desc, weight_layer_desc,
-          weight_iter_desc, bias_desc, dst_layer_desc, dst_state_desc,
-          dst_state_desc,
+          src_layer_desc, src_state_desc, src_state_desc, weight_layer_desc, weight_iter_desc,
+          bias_desc, dst_layer_desc, dst_state_desc, dst_state_desc,
           // diff desc
-          src_layer_desc, src_state_desc, src_state_desc, weight_layer_desc,
-          weight_iter_desc, bias_desc, dst_layer_desc, dst_state_desc,
-          dst_state_desc);
+          src_layer_desc, src_state_desc, src_state_desc, weight_layer_desc, weight_iter_desc,
+          bias_desc, dst_layer_desc, dst_state_desc, dst_state_desc);
     } break;
     case rnn_enum::kGru: {
       const lbr_gru_forward::primitive_desc* pd =
           reinterpret_cast<const lbr_gru_forward::primitive_desc*>(fwd_pd);
-      bwd = RnnBwdPrimitive::Create<lbr_gru_forward, lbr_gru_backward>(*pd,
-          prop, mkldnn_rnn_direction,
+      bwd = RnnBwdPrimitive::Create<lbr_gru_forward, lbr_gru_backward>(
+          *pd, prop, mkldnn_rnn_direction,
           // data desc
-          src_layer_desc, src_state_desc, weight_layer_desc,
-          weight_iter_desc, bias_desc, dst_layer_desc, dst_state_desc,
+          src_layer_desc, src_state_desc, weight_layer_desc, weight_iter_desc, bias_desc,
+          dst_layer_desc, dst_state_desc,
           // diff desc
-          src_layer_desc, src_state_desc, weight_layer_desc,
-          weight_iter_desc, bias_desc, dst_layer_desc, dst_state_desc);
+          src_layer_desc, src_state_desc, weight_layer_desc, weight_iter_desc, bias_desc,
+          dst_layer_desc, dst_state_desc);
     } break;
     case rnn_enum::kRnnRelu:
     case rnn_enum::kRnnTanh: {
       const vanilla_rnn_forward::primitive_desc* pd =
           reinterpret_cast<const vanilla_rnn_forward::primitive_desc*>(fwd_pd);
       bwd = RnnBwdPrimitive::Create<vanilla_rnn_forward, vanilla_rnn_backward>(
-          *pd, prop,
-          mode == rnn_enum::kRnnTanh ? algorithm::eltwise_tanh : algorithm::eltwise_relu,
+          *pd, prop, mode == rnn_enum::kRnnTanh ? algorithm::eltwise_tanh : algorithm::eltwise_relu,
           mkldnn_rnn_direction,
           // data desc
-          src_layer_desc, src_state_desc, weight_layer_desc,
-          weight_iter_desc, bias_desc, dst_layer_desc, dst_state_desc,
+          src_layer_desc, src_state_desc, weight_layer_desc, weight_iter_desc, bias_desc,
+          dst_layer_desc, dst_state_desc,
           // diff desc
-          src_layer_desc, src_state_desc, weight_layer_desc,
-          weight_iter_desc, bias_desc, dst_layer_desc, dst_state_desc);
+          src_layer_desc, src_state_desc, weight_layer_desc, weight_iter_desc, bias_desc,
+          dst_layer_desc, dst_state_desc);
     } break;
     default:
       LOG(FATAL) << "unsupported RNN mode:" << mode;
@@ -277,11 +279,10 @@ RnnBwdPrimitive GetRnnBwdPrim(const MKLDNNRnnForwardTraining &fwd,
  *
  * All the memory blocks are in goi format.
  */
-static void ConcatWeights(const mkldnn::memory &dst,
-                          const int concat_dimension,
-                          const std::vector<void*> &src_ptrs,
-                          const mkldnn::memory::format_tag src_format) {
-  using memory = mkldnn::memory;
+static void ConcatWeights(
+    const mkldnn::memory& dst, const int concat_dimension, const std::vector<void*>& src_ptrs,
+    const mkldnn::memory::format_tag src_format) {
+  using memory    = mkldnn::memory;
   auto cpu_engine = dst.get_engine();
   mkldnn::stream s(cpu_engine);
   const memory::desc& dst_desc = dst.get_desc();
@@ -293,41 +294,39 @@ static void ConcatWeights(const mkldnn::memory &dst,
   std::unordered_map<int, memory> concat_args;
 
   for (size_t i = 0; i < src_ptrs.size(); ++i) {
-    src_descs.emplace_back(src_dims,
-        static_cast<memory::data_type>(dst_desc.data.data_type), src_format);
-    concat_args.emplace(MKLDNN_ARG_MULTIPLE_SRC + i,
-        memory(src_descs.back(), cpu_engine, src_ptrs.at(i)));
+    src_descs.emplace_back(
+        src_dims, static_cast<memory::data_type>(dst_desc.data.data_type), src_format);
+    concat_args.emplace(
+        MKLDNN_ARG_MULTIPLE_SRC + i, memory(src_descs.back(), cpu_engine, src_ptrs.at(i)));
   }
   concat_args.emplace(MKLDNN_ARG_DST, dst);
 
-  auto concat_pd = mkldnn::concat::primitive_desc(dst.get_desc(),
-      concat_dimension, src_descs, cpu_engine);
+  auto concat_pd =
+      mkldnn::concat::primitive_desc(dst.get_desc(), concat_dimension, src_descs, cpu_engine);
   mkldnn::concat(concat_pd).execute(s, concat_args);
 }
 
 #define RNN_HANDLE_FUNC_NAME set_handle
-#define RNN_HANDLE_FUNC(RNN_FUNC_NAME)                                         \
-auto RNN_FUNC_NAME = [&cpu_engine, &args](int arg_name, const desc& md,        \
-    void* handle) {                                                            \
-  if (args.find(arg_name) != args.end()) {                                     \
-    if (handle != nullptr) args.at(arg_name).set_data_handle(handle);          \
-  } else {                                                                     \
-    args[arg_name] = handle ? mkldnn::memory(md, cpu_engine, handle)           \
-        : mkldnn::memory(md, cpu_engine);                                      \
-  }                                                                            \
-}
+#define RNN_HANDLE_FUNC(RNN_FUNC_NAME)                                                      \
+  auto RNN_FUNC_NAME = [&cpu_engine, &args](int arg_name, const desc& md, void* handle) {   \
+    if (args.find(arg_name) != args.end()) {                                                \
+      if (handle != nullptr) args.at(arg_name).set_data_handle(handle);                     \
+    } else {                                                                                \
+      args[arg_name] =                                                                      \
+          handle ? mkldnn::memory(md, cpu_engine, handle) : mkldnn::memory(md, cpu_engine); \
+    }                                                                                       \
+  }
 
 #define RNN_FWD_SET(NAME, DIMS, TAG, HANDLE, DTYPE) \
-RNN_FWD_SET_(RNN_HANDLE_FUNC_NAME, NAME, DIMS, TAG, HANDLE, DTYPE)
+  RNN_FWD_SET_(RNN_HANDLE_FUNC_NAME, NAME, DIMS, TAG, HANDLE, DTYPE)
 
 #define RNN_FWD_SET_(FUNC, NAME, DIMS, TAG, HANDLE, DTYPE) \
-FUNC(MKLDNN_ARG_##NAME, {DIMS, get_mkldnn_type(DTYPE), TAG}, HANDLE)
+  FUNC(MKLDNN_ARG_##NAME, {DIMS, get_mkldnn_type(DTYPE), TAG}, HANDLE)
 
-#define RNN_BWD_SET(NAME, ARGS, HANDLE) \
-RNN_BWD_SET_(RNN_HANDLE_FUNC_NAME, NAME, ARGS, HANDLE)
+#define RNN_BWD_SET(NAME, ARGS, HANDLE) RNN_BWD_SET_(RNN_HANDLE_FUNC_NAME, NAME, ARGS, HANDLE)
 
 #define RNN_BWD_SET_(FUNC, NAME, ARGS, HANDLE) \
-FUNC(MKLDNN_ARG_DIFF_##NAME, ARGS.at(MKLDNN_ARG_##NAME).get_desc(), HANDLE)
+  FUNC(MKLDNN_ARG_DIFF_##NAME, ARGS.at(MKLDNN_ARG_##NAME).get_desc(), HANDLE)
 
 /*
  * Set new src data handler to Forward memory. The memory primitives are
@@ -336,19 +335,18 @@ FUNC(MKLDNN_ARG_DIFF_##NAME, ARGS.at(MKLDNN_ARG_##NAME).get_desc(), HANDLE)
  * nullptr, it may run with non-state_ouput or non-LSTM mode. Thus, the
  * corresponding memory should be a empty mkldnn::memory().
  */
-void MKLDNNRnnForward::SetNewDataMem(void* x, void* hx, void* cx,
-                                     void* y, void* hy, void* cy,
-                                     const int dtype) {
-  using desc = mkldnn::memory::desc;
-  using format_tag = mkldnn::memory::format_tag;
-  auto& cpu_engine = CpuEngine::Get()->get_engine();
+void MKLDNNRnnForward::SetNewDataMem(
+    void* x, void* hx, void* cx, void* y, void* hy, void* cy, const int dtype) {
+  using desc              = mkldnn::memory::desc;
+  using format_tag        = mkldnn::memory::format_tag;
+  auto& cpu_engine        = CpuEngine::Get()->get_engine();
   mkldnn_args_map_t& args = net_args_;
 
   RNN_HANDLE_FUNC(RNN_HANDLE_FUNC_NAME);
 
   // Set various data memory
-  RNN_FWD_SET(SRC,      param_.src_dims,   format_tag::tnc,  x,  dtype);
-  RNN_FWD_SET(DST,      param_.dst_dims,   format_tag::tnc,  y,  dtype);
+  RNN_FWD_SET(SRC, param_.src_dims, format_tag::tnc, x, dtype);
+  RNN_FWD_SET(DST, param_.dst_dims, format_tag::tnc, y, dtype);
   RNN_FWD_SET(SRC_ITER, param_.state_dims, format_tag::ldnc, hx, dtype);
 
   if (param_.state_outputs) {
@@ -363,14 +361,11 @@ void MKLDNNRnnForward::SetNewDataMem(void* x, void* hx, void* cx,
   }
 }
 
-inline void MKLDNNMemoryReorder(const mkldnn::memory& src,
-                                const mkldnn::memory& dst) {
+inline void MKLDNNMemoryReorder(const mkldnn::memory& src, const mkldnn::memory& dst) {
 #if DMLC_CXX11_THREAD_LOCAL
-  static thread_local std::unordered_map<OpSignature,
-      mkldnn::reorder, OpHash> reorderPrimitives;
+  static thread_local std::unordered_map<OpSignature, mkldnn::reorder, OpHash> reorderPrimitives;
 #else
-  static MX_THREAD_LOCAL std::unordered_map<OpSignature,
-      mkldnn::reorder, OpHash> reorderPrimitives;
+  static MX_THREAD_LOCAL std::unordered_map<OpSignature, mkldnn::reorder, OpHash> reorderPrimitives;
 #endif
   OpSignature key{};
   key.AddSign(src);
@@ -379,7 +374,7 @@ inline void MKLDNNMemoryReorder(const mkldnn::memory& src,
   auto it = reorderPrimitives.find(key);
   if (it == reorderPrimitives.end()) {
     auto reorder = mkldnn::reorder(src, dst);
-    it = AddToCache(&reorderPrimitives, key, reorder);
+    it           = AddToCache(&reorderPrimitives, key, reorder);
   }
 
   mkldnn_args_map_t net_args;
@@ -397,15 +392,13 @@ void MKLDNNRnnForward::ReorderWeights() {
   MKLDNNMemoryReorder(*weights_iter_r_, *weights_iter_);
 }
 
-void AdjustGruGateOrder(char* weight,
-                        const size_t input_size,
-                        const size_t hidden_size,
-                        const int dtype) {
+void AdjustGruGateOrder(
+    char* weight, const size_t input_size, const size_t hidden_size, const int dtype) {
   // mxnet gru gate order is reset, update and new gates
   // mkldnn gru gate order is update, reset and new gates
   size_t single_weight_bytes = input_size * hidden_size * mshadow::mshadow_sizeof(dtype);
-  char* weight_reset = weight;
-  char* weight_update = weight + single_weight_bytes;
+  char* weight_reset         = weight;
+  char* weight_update        = weight + single_weight_bytes;
   std::swap_ranges(weight_reset, weight_update, weight_update);
 }
 
@@ -413,33 +406,32 @@ void AdjustGruGateOrder(char* weight,
  * Fuse uni-directional bias among single layer.
  */
 template <typename DType>
-void FuseBias(DType* fuse_bias, DType* native_bias,
-              const int mode, const size_t state_size) {
-  const size_t ngates = GetRnnGatesNum(mode);
+void FuseBias(DType* fuse_bias, DType* native_bias, const int mode, const size_t state_size) {
+  const size_t ngates   = GetRnnGatesNum(mode);
   const int omp_threads = mxnet::engine::OpenMP::Get()->GetRecommendedOMPThreadCount();
-  const size_t nbias = mode == rnn_enum::kGru ? ngates + 1 : ngates;
+  const size_t nbias    = mode == rnn_enum::kGru ? ngates + 1 : ngates;
   // MSVC-14.0 (OpenMP 2.0 compatible) doesn't support unsigned integral type in
   // OpenMP 'for' statement.
   const int state_size_ = static_cast<int>(state_size);
   const int single_b_sz = static_cast<int>(nbias * state_size);
-  DType* bx = native_bias;
-  DType* bh = native_bias + state_size * ngates;
+  DType* bx             = native_bias;
+  DType* bh             = native_bias + state_size * ngates;
   if (mode == rnn_enum::kGru) {
-    // While mxnet gru gate order is reset, update and new gates,
-    // mkldnn gru gate order is update, reset and new gates. So
-    // we need to swap the order of reset and update from mxnet.
-    #pragma omp parallel for num_threads(omp_threads)
+// While mxnet gru gate order is reset, update and new gates,
+// mkldnn gru gate order is update, reset and new gates. So
+// we need to swap the order of reset and update from mxnet.
+#pragma omp parallel for num_threads(omp_threads)
     for (int j = 0; j < state_size_; j++) {
       // Swap summed reset, update bias
       fuse_bias[j + state_size] = bx[j] + bh[j];
-      fuse_bias[j] = bx[j + state_size] + bh[j + state_size];
+      fuse_bias[j]              = bx[j + state_size] + bh[j + state_size];
 
       // Memcpy two new gates
       fuse_bias[j + 2 * state_size] = bx[j + 2 * state_size];
       fuse_bias[j + 3 * state_size] = bh[j + 2 * state_size];
     }
   } else {
-    #pragma omp parallel for num_threads(omp_threads)
+#pragma omp parallel for num_threads(omp_threads)
     for (int j = 0; j < single_b_sz; ++j) {
       // Sum two bias
       fuse_bias[j] = bx[j] + bh[j];
@@ -447,8 +439,8 @@ void FuseBias(DType* fuse_bias, DType* native_bias,
   }
 }
 
-inline void EmplaceNetArgs(mkldnn_args_map_t* net_args, const int arg_name,
-                           const mkldnn::memory* mem) {
+inline void EmplaceNetArgs(
+    mkldnn_args_map_t* net_args, const int arg_name, const mkldnn::memory* mem) {
   if (net_args->find(arg_name) != net_args->end()) {
     if (net_args->at(arg_name).get_data_handle() == mem->get_data_handle()) {
       return;
@@ -469,9 +461,9 @@ inline void EmplaceNetArgs(mkldnn_args_map_t* net_args, const int arg_name,
  * memory with preferred format_tag. Finally, native bias is fused to MKLDNN
  * bias memory.
  */
-void MKLDNNRnnForward::SetWeightsMem(MKLDNNRnnMemMgr* mgr, void *w_ptr, void *b_ptr,
-                                     const bool is_train, const int dtype) {
-  using format_tag = mkldnn::memory::format_tag;
+void MKLDNNRnnForward::SetWeightsMem(
+    MKLDNNRnnMemMgr* mgr, void* w_ptr, void* b_ptr, const bool is_train, const int dtype) {
+  using format_tag  = mkldnn::memory::format_tag;
   auto mkldnn_dtype = get_mkldnn_type(dtype);
   // Get the weights' memory for RNN forward primitive
   if (weights_layer_ == nullptr) {
@@ -481,36 +473,33 @@ void MKLDNNRnnForward::SetWeightsMem(MKLDNNRnnMemMgr* mgr, void *w_ptr, void *b_
     weights_iter_ = mgr->Alloc(fwd_inf_.GetIterDesc());
   }
   if (bias_ == nullptr) {
-    bias_ = mgr->Alloc(
-        {param_.bias_dims, mkldnn_dtype, format_tag::ldgo});
+    bias_ = mgr->Alloc({param_.bias_dims, mkldnn_dtype, format_tag::ldgo});
   }
 
   // Get the intermediate memory for weights concat & reorder
   if (weights_layer_r_ == nullptr) {
-    weights_layer_r_ = mgr->Alloc(
-        {param_.weight_layer_dims, mkldnn_dtype, format_tag::ldgoi});
+    weights_layer_r_ = mgr->Alloc({param_.weight_layer_dims, mkldnn_dtype, format_tag::ldgoi});
   }
   if (weights_iter_r_ == nullptr) {
-    weights_iter_r_ = mgr->Alloc(
-        {param_.weight_iter_dims, mkldnn_dtype, format_tag::ldgoi});
+    weights_iter_r_ = mgr->Alloc({param_.weight_iter_dims, mkldnn_dtype, format_tag::ldgoi});
   }
 
   // Get the bytes of a real type
   size_t dtype_bytes = mshadow::mshadow_sizeof(dtype);
 
   // convert void* to char* for arithmetic operations
-  char *weights_ptr = static_cast<char *>(w_ptr);
-  size_t wx_bytes = GetRnnGatesNum(param_.mode) * param_.state_size *
-        param_.input_size * dtype_bytes;  //* DIMS: ngates x state_size x input_size
-  size_t wh_bytes = GetRnnGatesNum(param_.mode) * param_.state_size *
-        param_.state_size * dtype_bytes;  //* DIMS: ngates x state_size x state_size
-  char *l2r_wx = weights_ptr;
-  char *l2r_wh = l2r_wx + wx_bytes;       //* DIMS: ngates x state_size * state_size
+  char* weights_ptr = static_cast<char*>(w_ptr);
+  size_t wx_bytes   = GetRnnGatesNum(param_.mode) * param_.state_size * param_.input_size *
+                    dtype_bytes;  //* DIMS: ngates x state_size x input_size
+  size_t wh_bytes = GetRnnGatesNum(param_.mode) * param_.state_size * param_.state_size *
+                    dtype_bytes;  //* DIMS: ngates x state_size x state_size
+  char* l2r_wx = weights_ptr;
+  char* l2r_wh = l2r_wx + wx_bytes;  //* DIMS: ngates x state_size * state_size
 
   if (param_.num_layer == 1 && param_.bidirectional) {
     //* single bidirectinal layer, concat weights on direction axis
-    char *r2l_wx = weights_ptr + param_.single_w_size * dtype_bytes;
-    char *r2l_wh = r2l_wx + wx_bytes;  //* DIMS: ngates x state_size * state_size
+    char* r2l_wx = weights_ptr + param_.single_w_size * dtype_bytes;
+    char* r2l_wh = r2l_wx + wx_bytes;  //* DIMS: ngates x state_size * state_size
     ConcatWeights(*weights_layer_r_, 1, {l2r_wx, r2l_wx}, format_tag::ldgoi);
     ConcatWeights(*weights_iter_r_, 1, {l2r_wh, r2l_wh}, format_tag::ldgoi);
   } else if (param_.num_layer == 1 && !param_.bidirectional) {
@@ -519,11 +508,11 @@ void MKLDNNRnnForward::SetWeightsMem(MKLDNNRnnMemMgr* mgr, void *w_ptr, void *b_
     std::memcpy(weights_iter_r_->get_data_handle(), l2r_wh, wh_bytes);
   } else if (param_.num_layer > 1 && !param_.bidirectional) {
     //* concat fused multi-layer weights on layer axis
-    std::vector<void *> l2r_wx_ptrs;
-    std::vector<void *> l2r_wh_ptrs;
+    std::vector<void*> l2r_wx_ptrs;
+    std::vector<void*> l2r_wh_ptrs;
     for (int lyr = 0; lyr < param_.num_layer; ++lyr) {
-      char *lth_wx = l2r_wx + lyr * param_.single_w_size * dtype_bytes;
-      char *lth_wh = lth_wx + wx_bytes;
+      char* lth_wx = l2r_wx + lyr * param_.single_w_size * dtype_bytes;
+      char* lth_wh = lth_wx + wx_bytes;
       l2r_wx_ptrs.push_back(lth_wx);
       l2r_wh_ptrs.push_back(lth_wh);
     }
@@ -551,7 +540,7 @@ void MKLDNNRnnForward::SetWeightsMem(MKLDNNRnnMemMgr* mgr, void *w_ptr, void *b_
   // Process bias
   MSHADOW_REAL_TYPE_SWITCH(dtype, DType, {
     DType* native_b_ptr = static_cast<DType*>(b_ptr);
-    DType* fused_bias = static_cast<DType*>(bias_->get_data_handle());
+    DType* fused_bias   = static_cast<DType*>(bias_->get_data_handle());
     for (int lyr = 0; lyr < param_.num_layer; ++lyr) {
       for (int d = 0; d < param_.bidirectional + 1; ++d) {
         FuseBias<DType>(fused_bias, native_b_ptr, param_.mode, param_.state_size);
@@ -563,8 +552,8 @@ void MKLDNNRnnForward::SetWeightsMem(MKLDNNRnnMemMgr* mgr, void *w_ptr, void *b_
 
   // insert weights into net_args
   EmplaceNetArgs(&this->net_args_, MKLDNN_ARG_WEIGHTS_LAYER, this->weights_layer_);
-  EmplaceNetArgs(&this->net_args_, MKLDNN_ARG_WEIGHTS_ITER,  this->weights_iter_);
-  EmplaceNetArgs(&this->net_args_, MKLDNN_ARG_BIAS,          this->bias_);
+  EmplaceNetArgs(&this->net_args_, MKLDNN_ARG_WEIGHTS_ITER, this->weights_iter_);
+  EmplaceNetArgs(&this->net_args_, MKLDNN_ARG_BIAS, this->bias_);
 
   if (!is_train) {
     // Reorder after adjustment only when is_train == false. When is_train == true, i.e.
@@ -578,9 +567,9 @@ void MKLDNNRnnForward::SetWeightsMem(MKLDNNRnnMemMgr* mgr, void *w_ptr, void *b_
 }
 
 void MKLDNNRnnForwardTraining::SetTrnMem(const MKLDNNRnnForward& fwd) {
-  using memory = mkldnn::memory;
+  using memory           = mkldnn::memory;
   const auto& cpu_engine = CpuEngine::Get()->get_engine();
-  auto s = mkldnn::stream(cpu_engine);
+  auto s                 = mkldnn::stream(cpu_engine);
   // Prepare mkldnn::memorys for weights_layer, weight_iter, and workspace
   if (workspace_ == nullptr)
     workspace_ = mkldnn_shared_mem_t(new memory(fwd_trn_.GetWorkspaceDesc(), cpu_engine));
@@ -607,9 +596,9 @@ void MKLDNNRnnForwardTraining::SetTrnMem(const MKLDNNRnnForward& fwd) {
 
   // insert weights into net_args
   EmplaceNetArgs(&this->net_args_, MKLDNN_ARG_WEIGHTS_LAYER, this->weights_layer_.get());
-  EmplaceNetArgs(&this->net_args_, MKLDNN_ARG_WEIGHTS_ITER,  this->weights_iter_.get());
-  EmplaceNetArgs(&this->net_args_, MKLDNN_ARG_BIAS,          this->bias_);
-  EmplaceNetArgs(&this->net_args_, MKLDNN_ARG_WORKSPACE,     this->workspace_.get());
+  EmplaceNetArgs(&this->net_args_, MKLDNN_ARG_WEIGHTS_ITER, this->weights_iter_.get());
+  EmplaceNetArgs(&this->net_args_, MKLDNN_ARG_BIAS, this->bias_);
+  EmplaceNetArgs(&this->net_args_, MKLDNN_ARG_WORKSPACE, this->workspace_.get());
 }
 
 void MKLDNNRnnForwardTraining::FetchData(const MKLDNNRnnForward& fwd) {
@@ -627,15 +616,14 @@ void MKLDNNRnnForwardTraining::FetchData(const MKLDNNRnnForward& fwd) {
   }
 }
 
-void MKLDNNRnnOp::Init(const OpContext &ctx,
-                       const std::vector<NDArray> &inputs,
-                       const std::vector<OpReqType> &req,
-                       const std::vector<NDArray> &outputs) {
+void MKLDNNRnnOp::Init(
+    const OpContext& ctx, const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+    const std::vector<NDArray>& outputs) {
   using format_tag = mkldnn::memory::format_tag;
 
   // In the `autograd.record()` context, RNNOp is required to run into
   // `forward_training` mode.
-  const bool is_training = (ctx.is_train || ctx.need_grad);
+  const bool is_training  = (ctx.is_train || ctx.need_grad);
   const size_t num_fusion = full_param_.layer_params.size();
   if (fwd_inf_vec_.size() < num_fusion) {
     size_t buffer_size = 0;  // Element number, instead of bytes, in the buffer
@@ -646,8 +634,8 @@ void MKLDNNRnnOp::Init(const OpContext &ctx,
     buffer_size += kMKLDNNAlign * num_fusion * 5;  // Add margin for alignment
 
     for (auto& layer_param : full_param_.layer_params) {
-      fwd_inf_vec_.emplace_back(layer_param,
-          ctx.is_train, inputs[rnn_enum::kData], inputs[rnn_enum::kParams]);
+      fwd_inf_vec_.emplace_back(
+          layer_param, ctx.is_train, inputs[rnn_enum::kData], inputs[rnn_enum::kParams]);
       buffer_size += fwd_inf_vec_.back().GetSize(inputs[rnn_enum::kParams].dtype());
     }
     mgr_.Init(buffer_size, ctx.run_ctx.ctx, inputs[rnn_enum::kParams].dtype());
@@ -655,27 +643,29 @@ void MKLDNNRnnOp::Init(const OpContext &ctx,
 
   if (is_training && fwd_trn_vec_.size() < num_fusion) {
     for (auto& layer_param : full_param_.layer_params) {
-      fwd_trn_vec_.emplace_back(layer_param,
-          true, inputs[rnn_enum::kData], inputs[rnn_enum::kParams]);
+      fwd_trn_vec_.emplace_back(
+          layer_param, true, inputs[rnn_enum::kData], inputs[rnn_enum::kParams]);
     }
   }
 
   // Get the bytes of a real type
-  const NDArray &weights = inputs[rnn_enum::kParams];
-  int dtype = weights.dtype();
-  size_t dtype_bytes = mshadow::mshadow_sizeof(dtype);
+  const NDArray& weights = inputs[rnn_enum::kParams];
+  int dtype              = weights.dtype();
+  size_t dtype_bytes     = mshadow::mshadow_sizeof(dtype);
 
-  const RNNParam &default_param = full_param_.default_param;
-  char *weights_ptr = static_cast<char *>(weights.data().dptr_);
-  char *bias_ptr = weights_ptr + (weights.data().Size() -
-      GetRnnBiasSize(default_param.num_layers, default_param.state_size,
-        default_param.bidirectional + 1, default_param.mode)) * dtype_bytes;
+  const RNNParam& default_param = full_param_.default_param;
+  char* weights_ptr             = static_cast<char*>(weights.data().dptr_);
+  char* bias_ptr                = weights_ptr + (weights.data().Size() -
+                                  GetRnnBiasSize(
+                                      default_param.num_layers, default_param.state_size,
+                                      default_param.bidirectional + 1, default_param.mode)) *
+                                     dtype_bytes;
   for (auto& fwd_layer : fwd_inf_vec_) {
-    size_t single_w_bytes = fwd_layer.GetParam().single_w_size * dtype_bytes;
-    size_t single_b_bytes = fwd_layer.GetParam().native_single_b_size * dtype_bytes;
-    size_t directions = fwd_layer.GetParam().bidirectional ? 2 : 1;
+    size_t single_w_bytes      = fwd_layer.GetParam().single_w_size * dtype_bytes;
+    size_t single_b_bytes      = fwd_layer.GetParam().native_single_b_size * dtype_bytes;
+    size_t directions          = fwd_layer.GetParam().bidirectional ? 2 : 1;
     size_t layer_weights_bytes = single_w_bytes * directions;
-    size_t layer_bias_bytes = single_b_bytes * directions;  // Native MXNet has double bias
+    size_t layer_bias_bytes    = single_b_bytes * directions;  // Native MXNet has double bias
 
     if (!fwd_layer.IsInitialized() || is_training)
       fwd_layer.SetWeightsMem(&(this->mgr_), weights_ptr, bias_ptr, is_training, dtype);
@@ -684,14 +674,14 @@ void MKLDNNRnnOp::Init(const OpContext &ctx,
   }
 
   if (is_training) {
-    CHECK_EQ(fwd_trn_vec_.size(), fwd_inf_vec_.size()) <<
-      "Layers' configurations of forward inference and forward training are disparate.";
+    CHECK_EQ(fwd_trn_vec_.size(), fwd_inf_vec_.size())
+        << "Layers' configurations of forward inference and forward training are disparate.";
     for (size_t lyr = 0; lyr < fwd_inf_vec_.size(); ++lyr)
       fwd_trn_vec_.at(lyr).SetTrnMem(fwd_inf_vec_.at(lyr));
   }
 
-  CHECK_EQ(num_fusion, fwd_inf_vec_.size()) <<
-      "Layer vector's size has a different value than the number of fusion.";
+  CHECK_EQ(num_fusion, fwd_inf_vec_.size())
+      << "Layer vector's size has a different value than the number of fusion.";
   if (dst_.size() < num_fusion - 1) {
     int data_dtype = outputs[rnn_enum::kOut].dtype();
     // Here we need `fwd_inf_vec_.size() - 1` spaces for the intermediate results of the multiple
@@ -699,21 +689,21 @@ void MKLDNNRnnOp::Init(const OpContext &ctx,
     // provide the space. Hence, `forward_inf_vec_.back()` is excluded when allocates the spaces
     // for intermediate results.
     for (std::vector<MKLDNNRnnForward>::const_iterator fwd = fwd_inf_vec_.begin();
-        fwd != fwd_inf_vec_.end() - 1; ++fwd)
-      dst_.push_back(mgr_.Alloc(
-        {fwd->GetParam().dst_dims, get_mkldnn_type(data_dtype), format_tag::tnc}));
+         fwd != fwd_inf_vec_.end() - 1; ++fwd)
+      dst_.push_back(
+          mgr_.Alloc({fwd->GetParam().dst_dims, get_mkldnn_type(data_dtype), format_tag::tnc}));
   }
 
   if (!is_training) initialized_ = true;
 }
 
 void MKLDNNRnnBackward::FetchDataWeightsMem(const MKLDNNRnnForwardTraining& fwd) {
-  using memory = mkldnn::memory;
+  using memory     = mkldnn::memory;
   auto& cpu_engine = CpuEngine::Get()->get_engine();
 
-  if (this->weights_layer_ == nullptr || this-> weights_iter_ == nullptr) {
+  if (this->weights_layer_ == nullptr || this->weights_iter_ == nullptr) {
     this->weights_layer_ = mkldnn_shared_mem_t(new memory(bwd_.weights_layer_desc_, cpu_engine));
-    this->weights_iter_ = mkldnn_shared_mem_t(new memory(bwd_.weights_iter_desc_, cpu_engine));
+    this->weights_iter_  = mkldnn_shared_mem_t(new memory(bwd_.weights_iter_desc_, cpu_engine));
   }
 
   for (auto& kv : fwd.net_args_) {
@@ -746,71 +736,61 @@ void MKLDNNRnnBackward::FetchDataWeightsMem(const MKLDNNRnnForwardTraining& fwd)
 void MKLDNNRnnBackward::SetWeightsGradsMem() {
   using tag = mkldnn::memory::format_tag;
 
-  if (this->diff_weights_layer_ == nullptr
-      || this->diff_weights_iter_ == nullptr
-      || this->diff_bias_ == nullptr) {
-    const auto& cpu_engine = CpuEngine::Get()->get_engine();
+  if (this->diff_weights_layer_ == nullptr || this->diff_weights_iter_ == nullptr ||
+      this->diff_bias_ == nullptr) {
+    const auto& cpu_engine           = CpuEngine::Get()->get_engine();
     const MKLDNNRnnLayerParam& param = fwd_ptr_->GetParam();
-    const auto mkldnn_type = static_cast<mkldnn::memory::data_type>(
-        bwd_.diff_weights_layer_desc_.data.data_type);
+    const auto mkldnn_type =
+        static_cast<mkldnn::memory::data_type>(bwd_.diff_weights_layer_desc_.data.data_type);
 
     auto native_layer_desc = mkldnn::memory::desc(param.weight_layer_dims, mkldnn_type, tag::ldgoi);
-    auto native_iter_desc = mkldnn::memory::desc(param.weight_iter_dims, mkldnn_type, tag::ldgoi);
+    auto native_iter_desc  = mkldnn::memory::desc(param.weight_iter_dims, mkldnn_type, tag::ldgoi);
 
-    this->diff_weights_layer_r_ = std::make_shared<mkldnn::memory>(
-        native_layer_desc, cpu_engine);
-    this->diff_weights_iter_r_ = std::make_shared<mkldnn::memory>(
-        native_iter_desc, cpu_engine);
+    this->diff_weights_layer_r_ = std::make_shared<mkldnn::memory>(native_layer_desc, cpu_engine);
+    this->diff_weights_iter_r_  = std::make_shared<mkldnn::memory>(native_iter_desc, cpu_engine);
 
     if (native_layer_desc == bwd_.diff_weights_layer_desc_) {
       this->diff_weights_layer_ = std::make_shared<mkldnn::memory>(
           bwd_.diff_weights_layer_desc_, cpu_engine, diff_weights_layer_r_->get_data_handle());
     } else {
-      this->diff_weights_layer_ = std::make_shared<mkldnn::memory>(
-          bwd_.diff_weights_layer_desc_, cpu_engine);
+      this->diff_weights_layer_ =
+          std::make_shared<mkldnn::memory>(bwd_.diff_weights_layer_desc_, cpu_engine);
     }
     if (native_iter_desc == bwd_.diff_weights_iter_desc_) {
       this->diff_weights_iter_ = std::make_shared<mkldnn::memory>(
           bwd_.diff_weights_iter_desc_, cpu_engine, diff_weights_iter_r_->get_data_handle());
     } else {
-      this->diff_weights_iter_ = std::make_shared<mkldnn::memory>(
-          bwd_.diff_weights_iter_desc_, cpu_engine);
+      this->diff_weights_iter_ =
+          std::make_shared<mkldnn::memory>(bwd_.diff_weights_iter_desc_, cpu_engine);
     }
-    this->diff_bias_ = std::make_shared<mkldnn::memory>(
-        bwd_.diff_bias_desc_, cpu_engine);
+    this->diff_bias_ = std::make_shared<mkldnn::memory>(bwd_.diff_bias_desc_, cpu_engine);
   }
-  std::memset(this->diff_weights_layer_->get_data_handle(), 0,
-      bwd_.diff_weights_layer_desc_.get_size());
-  std::memset(this->diff_weights_iter_->get_data_handle(), 0,
-      bwd_.diff_weights_iter_desc_.get_size());
-  std::memset(this->diff_bias_->get_data_handle(), 0,
-      bwd_.diff_bias_desc_.get_size());
-  EmplaceNetArgs(&this->net_args_, MKLDNN_ARG_DIFF_WEIGHTS_LAYER,
-      this->diff_weights_layer_.get());
-  EmplaceNetArgs(&this->net_args_, MKLDNN_ARG_DIFF_WEIGHTS_ITER,
-      this->diff_weights_iter_.get());
-  EmplaceNetArgs(&this->net_args_, MKLDNN_ARG_DIFF_BIAS,
-      this->diff_bias_.get());
+  std::memset(
+      this->diff_weights_layer_->get_data_handle(), 0, bwd_.diff_weights_layer_desc_.get_size());
+  std::memset(
+      this->diff_weights_iter_->get_data_handle(), 0, bwd_.diff_weights_iter_desc_.get_size());
+  std::memset(this->diff_bias_->get_data_handle(), 0, bwd_.diff_bias_desc_.get_size());
+  EmplaceNetArgs(&this->net_args_, MKLDNN_ARG_DIFF_WEIGHTS_LAYER, this->diff_weights_layer_.get());
+  EmplaceNetArgs(&this->net_args_, MKLDNN_ARG_DIFF_WEIGHTS_ITER, this->diff_weights_iter_.get());
+  EmplaceNetArgs(&this->net_args_, MKLDNN_ARG_DIFF_BIAS, this->diff_bias_.get());
 }
 
 void MKLDNNRnnBackward::SetDataGradsMem(
-    void* diff_src, void* diff_state, void* diff_statecell,
-    void* diff_dst, void* diff_state_out, void* diff_statecell_out,
-    const int dtype) {
-  using desc = mkldnn::memory::desc;
-  auto& cpu_engine = CpuEngine::Get()->get_engine();
+    void* diff_src, void* diff_state, void* diff_statecell, void* diff_dst, void* diff_state_out,
+    void* diff_statecell_out, const int dtype) {
+  using desc              = mkldnn::memory::desc;
+  auto& cpu_engine        = CpuEngine::Get()->get_engine();
   mkldnn_args_map_t& args = this->net_args_;
 
   RNN_HANDLE_FUNC(RNN_HANDLE_FUNC_NAME);
 
   // Set various diff memory
   auto& fwd_args = fwd_ptr_->GetArgsMap();
-  RNN_BWD_SET(SRC,      fwd_args, diff_src);
+  RNN_BWD_SET(SRC, fwd_args, diff_src);
   RNN_BWD_SET(SRC_ITER, fwd_args, diff_state);
-  RNN_BWD_SET(DST,      fwd_args, diff_dst);
+  RNN_BWD_SET(DST, fwd_args, diff_dst);
 
-  if (fwd_ptr_->GetParam().state_outputs)
-    RNN_BWD_SET(DST_ITER, fwd_args, diff_state_out);
+  if (fwd_ptr_->GetParam().state_outputs) RNN_BWD_SET(DST_ITER, fwd_args, diff_state_out);
 
   if (fwd_ptr_->GetParam().mode == rnn_enum::kLstm) {
     RNN_BWD_SET(SRC_ITER_C, fwd_args, diff_statecell);
@@ -829,42 +809,42 @@ void MKLDNNRnnBackward::SetNativeWeightsGrads() const {
   }
 }
 
-#define OPREQTYPE_SWITCH(ReqType, DType, FWrapper, ...)                     \
-std::function<void(DType*, DType*, size_t)> FWrapper = nullptr;             \
-if (kWriteTo == ReqType || kWriteInplace == ReqType)                        \
-  FWrapper = common::ParallelCopy<DType>;                                   \
-else                                                                        \
-  FWrapper = common::ParallelAdd<DType>;                                    \
-{__VA_ARGS__}
+#define OPREQTYPE_SWITCH(ReqType, DType, FWrapper, ...)           \
+  std::function<void(DType*, DType*, size_t)> FWrapper = nullptr; \
+  if (kWriteTo == ReqType || kWriteInplace == ReqType)            \
+    FWrapper = common::ParallelCopy<DType>;                       \
+  else                                                            \
+    FWrapper = common::ParallelAdd<DType>;                        \
+  { __VA_ARGS__ }
 
-void MKLDNNRnnBackward::CommitWeightsGrads(void* diff_weights, void* diff_bias,
-                                           const OpReqType req, const int dtype) {
+void MKLDNNRnnBackward::CommitWeightsGrads(
+    void* diff_weights, void* diff_bias, const OpReqType req, const int dtype) {
   const MKLDNNRnnLayerParam& param = fwd_ptr_->GetParam();
 
   void* diff_weights_layer_ptr = this->diff_weights_layer_->get_data_handle();
-  void* diff_weights_iter_ptr = this->diff_weights_iter_->get_data_handle();
+  void* diff_weights_iter_ptr  = this->diff_weights_iter_->get_data_handle();
   if (this->diff_weights_layer_->get_desc() != this->diff_weights_layer_r_->get_desc())
     diff_weights_layer_ptr = this->diff_weights_layer_r_->get_data_handle();
   if (this->diff_weights_iter_->get_desc() != this->diff_weights_iter_r_->get_desc())
     diff_weights_iter_ptr = this->diff_weights_iter_r_->get_data_handle();
 
-  const int num_layer = param.num_layer;
-  const int direction = param.bidirectional ? 2 : 1;
-  const int ngates = GetRnnGatesNum(param.mode);
+  const int num_layer   = param.num_layer;
+  const int direction   = param.bidirectional ? 2 : 1;
+  const int ngates      = GetRnnGatesNum(param.mode);
   const size_t wxh_size = param.single_w_size;
-  const size_t wx_size = param.input_size * param.state_size * ngates;
-  const size_t wh_size = param.state_size * param.state_size * ngates;
+  const size_t wx_size  = param.input_size * param.state_size * ngates;
+  const size_t wh_size  = param.state_size * param.state_size * ngates;
 
   /* native weights layout is:
           1st-layer: | wx_lr  | wh_lr  | wx_rl | wh_rl |
           2st-layer: | wx_lr  | wh_lr  | wx_rl | wh_rl |
   size:              |    wxh_bytes    |
-                     |wx_bytes|wh_bytes|      
+                     |wx_bytes|wh_bytes|
   */
   MSHADOW_REAL_TYPE_SWITCH(dtype, DType, {
-    DType* native_weights = static_cast<DType *>(diff_weights);
-    DType* diff_wx_ptr = static_cast<DType *>(diff_weights_layer_ptr);
-    DType* diff_wh_ptr = static_cast<DType *>(diff_weights_iter_ptr);
+    DType* native_weights = static_cast<DType*>(diff_weights);
+    DType* diff_wx_ptr    = static_cast<DType*>(diff_weights_layer_ptr);
+    DType* diff_wh_ptr    = static_cast<DType*>(diff_weights_iter_ptr);
     OPREQTYPE_SWITCH(req, DType, FAccGrad, {
       if (param.mode != rnn_enum::kGru) {
         for (int shift = 0; shift < num_layer * direction; ++shift) {
@@ -879,47 +859,54 @@ void MKLDNNRnnBackward::CommitWeightsGrads(void* diff_weights, void* diff_bias,
         const size_t wx_size_per_gate = param.input_size * param.state_size;
         const size_t wh_size_per_gate = param.state_size * param.state_size;
         for (int shift = 0; shift < num_layer * direction; ++shift) {
-          FAccGrad(native_weights + shift * wxh_size + wx_size_per_gate,
-              diff_wx_ptr + shift * wx_size, wx_size_per_gate);
-          FAccGrad(native_weights + shift * wxh_size,
-              diff_wx_ptr + shift * wx_size + wx_size_per_gate, wx_size_per_gate);
-          FAccGrad(native_weights + shift * wxh_size + 2 * wx_size_per_gate,
+          FAccGrad(
+              native_weights + shift * wxh_size + wx_size_per_gate, diff_wx_ptr + shift * wx_size,
+              wx_size_per_gate);
+          FAccGrad(
+              native_weights + shift * wxh_size, diff_wx_ptr + shift * wx_size + wx_size_per_gate,
+              wx_size_per_gate);
+          FAccGrad(
+              native_weights + shift * wxh_size + 2 * wx_size_per_gate,
               diff_wx_ptr + shift * wx_size + 2 * wx_size_per_gate, wx_size_per_gate);
         }
         // align native_weights to weights_iter memory
         native_weights += wx_size;
         for (int shift = 0; shift < num_layer * direction; ++shift) {
-          FAccGrad(native_weights + shift * wxh_size + wh_size_per_gate,
-              diff_wh_ptr + shift * wh_size, wh_size_per_gate);
-          FAccGrad(native_weights + shift * wxh_size,
-              diff_wh_ptr + shift * wh_size + wh_size_per_gate, wh_size_per_gate);
-          FAccGrad(native_weights + shift * wxh_size + 2 * wh_size_per_gate,
+          FAccGrad(
+              native_weights + shift * wxh_size + wh_size_per_gate, diff_wh_ptr + shift * wh_size,
+              wh_size_per_gate);
+          FAccGrad(
+              native_weights + shift * wxh_size, diff_wh_ptr + shift * wh_size + wh_size_per_gate,
+              wh_size_per_gate);
+          FAccGrad(
+              native_weights + shift * wxh_size + 2 * wh_size_per_gate,
               diff_wh_ptr + shift * wh_size + 2 * wh_size_per_gate, wh_size_per_gate);
         }
       }
     });
   });
 
-  const size_t bias_size = param.single_b_size;
+  const size_t bias_size        = param.single_b_size;
   const size_t native_bias_size = param.native_single_b_size;
   MSHADOW_REAL_TYPE_SWITCH(dtype, DType, {
-    DType* native_bias = static_cast<DType *>(diff_bias);
-    DType* diff_bias_ptr = static_cast<DType *>(this->diff_bias_->get_data_handle());
+    DType* native_bias   = static_cast<DType*>(diff_bias);
+    DType* diff_bias_ptr = static_cast<DType*>(this->diff_bias_->get_data_handle());
     OPREQTYPE_SWITCH(req, DType, FAccGrad, {
       if (param.mode != rnn_enum::kGru) {
         for (int shift = 0; shift < num_layer * direction; ++shift) {
-          FAccGrad(native_bias + shift * native_bias_size,
-              diff_bias_ptr + shift * bias_size, bias_size);
-          FAccGrad(native_bias + shift * native_bias_size + bias_size,
-              diff_bias_ptr + shift * bias_size, bias_size);
+          FAccGrad(
+              native_bias + shift * native_bias_size, diff_bias_ptr + shift * bias_size, bias_size);
+          FAccGrad(
+              native_bias + shift * native_bias_size + bias_size, diff_bias_ptr + shift * bias_size,
+              bias_size);
         }
       } else {
         const size_t bias_size_per_gate = param.state_size;
         for (int shift = 0; shift < num_layer * direction; ++shift) {
-          DType* native_reset = native_bias + shift * native_bias_size;
+          DType* native_reset  = native_bias + shift * native_bias_size;
           DType* native_update = native_reset + bias_size_per_gate;
-          DType* update = diff_bias_ptr + shift * bias_size;
-          DType* reset = update + bias_size_per_gate;
+          DType* update        = diff_bias_ptr + shift * bias_size;
+          DType* reset         = update + bias_size_per_gate;
 
           FAccGrad(native_update, update, bias_size_per_gate);
           FAccGrad(native_reset, reset, bias_size_per_gate);
@@ -928,8 +915,8 @@ void MKLDNNRnnBackward::CommitWeightsGrads(void* diff_weights, void* diff_bias,
 
           DType* native_new_bx = native_update + bias_size_per_gate;
           DType* native_new_bh = native_new_bx + native_bias_size / 2;
-          DType* new_bx = reset + bias_size_per_gate;
-          DType* new_bh = new_bx + bias_size_per_gate;
+          DType* new_bx        = reset + bias_size_per_gate;
+          DType* new_bh        = new_bx + bias_size_per_gate;
           FAccGrad(native_new_bx, new_bx, bias_size_per_gate);
           FAccGrad(native_new_bh, new_bh, bias_size_per_gate);
         }
@@ -949,14 +936,13 @@ inline void RegisterMKLDNNRnn(MKLDNNRnnBackward const& rnn) {
   rnn.SetNativeWeightsGrads();
 }
 
-void MKLDNNRnnOp::Forward(const OpContext &ctx,
-                          const std::vector<NDArray> &inputs,
-                          const std::vector<OpReqType> &req,
-                          const std::vector<NDArray> &outputs) {
+void MKLDNNRnnOp::Forward(
+    const OpContext& ctx, const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+    const std::vector<NDArray>& outputs) {
   TmpMemMgr::Get()->Init(ctx.requested[1]);
   // In the `autograd.record()` context, RNNOp is required to run into
   // forward_training mode.
-  const bool is_training = (ctx.is_train || ctx.need_grad);
+  const bool is_training        = (ctx.is_train || ctx.need_grad);
   const RNNParam& default_param = full_param_.default_param;
 
   // Initialize weights version
@@ -965,8 +951,8 @@ void MKLDNNRnnOp::Forward(const OpContext &ctx,
   }
 
   // Check if weights NDArray was changed. If so, reset initialized_
-  if (!is_training && fwd_inf_vec_.size() > 0
-      && weights_version_ != inputs[rnn_enum::kParams].version()) {
+  if (!is_training && fwd_inf_vec_.size() > 0 &&
+      weights_version_ != inputs[rnn_enum::kParams].version()) {
     initialized_ = false;
     for (auto& fwd : fwd_inf_vec_) fwd.Reset();
     weights_version_ = inputs[rnn_enum::kParams].version();
@@ -984,52 +970,55 @@ void MKLDNNRnnOp::Forward(const OpContext &ctx,
   const int batch_size = default_param.batch_size_;
   const int state_size = default_param.state_size;
   const int directions = default_param.bidirectional ? 2 : 1;
-  mkldnn::memory::desc dst_desc({seq_length, batch_size, directions * state_size},
-      get_mkldnn_type(data_dtype), mkldnn::memory::format_tag::tnc);
-  mkldnn::memory::desc state_desc({num_layers, directions, batch_size, state_size},
-      get_mkldnn_type(data_dtype), mkldnn::memory::format_tag::ldnc);
+  mkldnn::memory::desc dst_desc(
+      {seq_length, batch_size, directions * state_size}, get_mkldnn_type(data_dtype),
+      mkldnn::memory::format_tag::tnc);
+  mkldnn::memory::desc state_desc(
+      {num_layers, directions, batch_size, state_size}, get_mkldnn_type(data_dtype),
+      mkldnn::memory::format_tag::ldnc);
   auto out_mem = CreateMKLDNNMem(outputs[rnn_enum::kOut], dst_desc, req[rnn_enum::kOut]);
   mkldnn_output_t stateout_mem;
   mkldnn_output_t statecellout_mem;
 
   // Get input & output NDArray
-  char *src = static_cast<char *>(inputs[rnn_enum::kData].data().dptr_);
-  char *src_state = static_cast<char *>(inputs[rnn_enum::kState].data().dptr_);
-  char *dst = static_cast<char *>(out_mem.second->get_data_handle());
-  char *dst_state = nullptr;          // Output state
-  char *src_state_cell = nullptr;     // Used in LSTM for cell state
-  char *dst_state_cell = nullptr;     // Used in LSTM for cell state
+  char* src            = static_cast<char*>(inputs[rnn_enum::kData].data().dptr_);
+  char* src_state      = static_cast<char*>(inputs[rnn_enum::kState].data().dptr_);
+  char* dst            = static_cast<char*>(out_mem.second->get_data_handle());
+  char* dst_state      = nullptr;  // Output state
+  char* src_state_cell = nullptr;  // Used in LSTM for cell state
+  char* dst_state_cell = nullptr;  // Used in LSTM for cell state
 
   if (default_param.state_outputs && req[rnn_enum::kStateOut] != kNullOp) {
-    stateout_mem = CreateMKLDNNMem(
-        outputs[rnn_enum::kStateOut], state_desc, req[rnn_enum::kStateOut]);
-    dst_state = static_cast<char *>(stateout_mem.second->get_data_handle());
+    stateout_mem =
+        CreateMKLDNNMem(outputs[rnn_enum::kStateOut], state_desc, req[rnn_enum::kStateOut]);
+    dst_state = static_cast<char*>(stateout_mem.second->get_data_handle());
   }
 
   if (default_param.mode == rnn_enum::kLstm) {
-    src_state_cell = static_cast<char *>(inputs[rnn_enum::kStateCell].data().dptr_);
+    src_state_cell = static_cast<char*>(inputs[rnn_enum::kStateCell].data().dptr_);
     if (default_param.state_outputs && req[rnn_enum::kStateCellOut] != kNullOp) {
       statecellout_mem = CreateMKLDNNMem(
           outputs[rnn_enum::kStateCellOut], state_desc, req[rnn_enum::kStateCellOut]);
-      dst_state_cell = static_cast<char *>(statecellout_mem.second->get_data_handle());
+      dst_state_cell = static_cast<char*>(statecellout_mem.second->get_data_handle());
     }
   }
 
   if (fwd_inf_vec_.size() == 1) {
-    fwd_inf_vec_.front().SetNewDataMem(src, src_state, src_state_cell,
-        dst, dst_state, dst_state_cell, data_dtype);
+    fwd_inf_vec_.front().SetNewDataMem(
+        src, src_state, src_state_cell, dst, dst_state, dst_state_cell, data_dtype);
     if (is_training) {
       fwd_trn_vec_.front().FetchData(fwd_inf_vec_.front());
     }
   } else {
     CHECK_EQ(fwd_inf_vec_.size(), dst_.size() + 1) << "Output memory error.";
     size_t cell_bytes = (default_param.bidirectional + 1) * default_param.batch_size_ *
-        default_param.state_size * mshadow::mshadow_sizeof(data_dtype);
+                        default_param.state_size * mshadow::mshadow_sizeof(data_dtype);
 
     // Set input data memory for the first layer. This stores intermediate output
     // results in this->xxx, used as the source input of the next layer.
-    fwd_inf_vec_.front().SetNewDataMem(src, src_state, src_state_cell,
-        this->dst_.front()->get_data_handle(), dst_state, dst_state_cell, data_dtype);
+    fwd_inf_vec_.front().SetNewDataMem(
+        src, src_state, src_state_cell, this->dst_.front()->get_data_handle(), dst_state,
+        dst_state_cell, data_dtype);
     if (is_training) {
       fwd_trn_vec_.front().FetchData(fwd_inf_vec_.front());
     }
@@ -1039,8 +1028,8 @@ void MKLDNNRnnOp::Forward(const OpContext &ctx,
       if (src_state_cell) src_state_cell += cell_bytes;
       if (dst_state) dst_state += cell_bytes;
       if (dst_state_cell) dst_state_cell += cell_bytes;
-      fwd_inf_vec_.at(lyr).SetNewDataMem(this->dst_.at(lyr - 1)->get_data_handle(),
-          src_state, src_state_cell,
+      fwd_inf_vec_.at(lyr).SetNewDataMem(
+          this->dst_.at(lyr - 1)->get_data_handle(), src_state, src_state_cell,
           this->dst_.at(lyr)->get_data_handle(), dst_state, dst_state_cell, data_dtype);
       if (is_training) {
         fwd_trn_vec_.at(lyr).FetchData(fwd_inf_vec_.at(lyr));
@@ -1051,8 +1040,9 @@ void MKLDNNRnnOp::Forward(const OpContext &ctx,
     if (src_state_cell) src_state_cell += cell_bytes;
     if (dst_state) dst_state += cell_bytes;
     if (dst_state_cell) dst_state_cell += cell_bytes;
-    fwd_inf_vec_.back().SetNewDataMem(this->dst_.back()->get_data_handle(),
-        src_state, src_state_cell, dst, dst_state, dst_state_cell, data_dtype);
+    fwd_inf_vec_.back().SetNewDataMem(
+        this->dst_.back()->get_data_handle(), src_state, src_state_cell, dst, dst_state,
+        dst_state_cell, data_dtype);
     if (is_training) {
       fwd_trn_vec_.back().FetchData(fwd_inf_vec_.back());
     }
@@ -1071,26 +1061,24 @@ void MKLDNNRnnOp::Forward(const OpContext &ctx,
   MKLDNNStream::Get()->Submit();
 }
 
-void MKLDNNRnnOp::Backward(const OpContext& ctx,
-                           const std::vector<NDArray>& inputs,
-                           const std::vector<OpReqType>& req,
-                           const std::vector<NDArray>& outputs) {
+void MKLDNNRnnOp::Backward(
+    const OpContext& ctx, const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+    const std::vector<NDArray>& outputs) {
   using tag = mkldnn::memory::format_tag;
   TmpMemMgr::Get()->Init(ctx.requested[1]);
   const RNNParam& default_param = full_param_.default_param;
-  const int data_dtype = inputs[rnn_enum::kData].dtype();
-  const int w_dtype = inputs[rnn_enum::kParams].dtype();
+  const int data_dtype          = inputs[rnn_enum::kData].dtype();
+  const int w_dtype             = inputs[rnn_enum::kParams].dtype();
 
   // Initialize the bwd_vec_
   if (bwd_vec_.size() != fwd_inf_vec_.size()) {
     bwd_vec_.clear();
     for (size_t lyr = 0; lyr < fwd_inf_vec_.size(); ++lyr)
-      bwd_vec_.emplace_back(fwd_trn_vec_.at(lyr), inputs[rnn_enum::kData],
-          inputs[rnn_enum::kParams]);
+      bwd_vec_.emplace_back(
+          fwd_trn_vec_.at(lyr), inputs[rnn_enum::kData], inputs[rnn_enum::kParams]);
   }
   // Fetch weights, src and dst from Forward layer
-  if (bwd_vec_.size() != fwd_trn_vec_.size())
-    LOG(FATAL) << "MKL-DNN RNN fusion error.";
+  if (bwd_vec_.size() != fwd_trn_vec_.size()) LOG(FATAL) << "MKL-DNN RNN fusion error.";
   for (size_t lyr = 0; lyr < bwd_vec_.size(); ++lyr) {
     bwd_vec_.at(lyr).FetchDataWeightsMem(fwd_trn_vec_.at(lyr));
     bwd_vec_.at(lyr).SetWeightsGradsMem();
@@ -1104,75 +1092,74 @@ void MKLDNNRnnOp::Backward(const OpContext& ctx,
   const int input_size = default_param.input_size_;
   const int state_size = default_param.state_size;
   const int directions = default_param.bidirectional ? 2 : 1;
-  mkldnn::memory::desc src_desc({seq_length, batch_size, input_size},
-      get_mkldnn_type(data_dtype), tag::tnc);
-  mkldnn::memory::desc state_desc({num_layers, directions, batch_size, state_size},
-      get_mkldnn_type(data_dtype), tag::ldnc);
+  mkldnn::memory::desc src_desc(
+      {seq_length, batch_size, input_size}, get_mkldnn_type(data_dtype), tag::tnc);
+  mkldnn::memory::desc state_desc(
+      {num_layers, directions, batch_size, state_size}, get_mkldnn_type(data_dtype), tag::ldnc);
   auto diff_input_mem = CreateMKLDNNMem(outputs[rnn_enum::kData], src_desc, req[rnn_enum::kData]);
   mkldnn_output_t diff_state_mem;
   mkldnn_output_t diff_statecell_mem;
   // index description of outputs NDArray
   //   0    1    2     3
   // | dx | dw | dhx | dcx|
-  char* dx = static_cast<char *>(diff_input_mem.second->get_data_handle());
-  char* dw = static_cast<char *>(outputs[rnn_enum::kParams].data().dptr_);
+  char* dx = static_cast<char*>(diff_input_mem.second->get_data_handle());
+  char* dw = static_cast<char*>(outputs[rnn_enum::kParams].data().dptr_);
   char* db = dw + (inputs[rnn_enum::kParams].data().Size() -
-      GetRnnBiasSize(default_param.num_layers, default_param.state_size,
-        default_param.bidirectional + 1, default_param.mode)) * w_bytes;
-  diff_state_mem = CreateMKLDNNMem(
-      outputs[rnn_enum::kState], state_desc, req[rnn_enum::kState]);
-  char* dhx = static_cast<char *>(diff_state_mem.second->get_data_handle());
-  char* dcx = nullptr;
-  if (full_param_.default_param.mode == rnn_enum::kLstm
-      && req[rnn_enum::kStateCell] != kNullOp) {
-    diff_statecell_mem = CreateMKLDNNMem(
-        outputs[rnn_enum::kStateCell], state_desc, req[rnn_enum::kStateCell]);
-    dcx = static_cast<char *>(diff_statecell_mem.second->get_data_handle());
+                   GetRnnBiasSize(
+                       default_param.num_layers, default_param.state_size,
+                       default_param.bidirectional + 1, default_param.mode)) *
+                      w_bytes;
+  diff_state_mem = CreateMKLDNNMem(outputs[rnn_enum::kState], state_desc, req[rnn_enum::kState]);
+  char* dhx      = static_cast<char*>(diff_state_mem.second->get_data_handle());
+  char* dcx      = nullptr;
+  if (full_param_.default_param.mode == rnn_enum::kLstm && req[rnn_enum::kStateCell] != kNullOp) {
+    diff_statecell_mem =
+        CreateMKLDNNMem(outputs[rnn_enum::kStateCell], state_desc, req[rnn_enum::kStateCell]);
+    dcx = static_cast<char*>(diff_statecell_mem.second->get_data_handle());
   }
 
   // index description of inputs NDArray
   //   0   1   2    3   4    5     6    7    8     9
   // | x | w | hx | y | dy | hy | dhy | cx | cy | dcy |
-  char* dy = static_cast<char *>(inputs[4].data().dptr_);
+  char* dy  = static_cast<char*>(inputs[4].data().dptr_);
   char* dhy = nullptr;
-  if (default_param.state_outputs)
-    dhy = static_cast<char *>(inputs[6].data().dptr_);
+  if (default_param.state_outputs) dhy = static_cast<char*>(inputs[6].data().dptr_);
 
   char* dcy = nullptr;
   if ((default_param.mode == rnn_enum::kLstm) && default_param.state_outputs)
-    dcy = static_cast<char *>(inputs[9].data().dptr_);
+    dcy = static_cast<char*>(inputs[9].data().dptr_);
 
   if (bwd_vec_.size() == 1) {
     bwd_vec_.back().SetDataGradsMem(dx, dhx, dcx, dy, dhy, dcy, data_dtype);
     RegisterMKLDNNRnn(bwd_vec_.back());
   } else {
     const size_t cell_bytes = (default_param.bidirectional + 1) * default_param.batch_size_ *
-        default_param.state_size * mshadow::mshadow_sizeof(data_dtype);
+                              default_param.state_size * mshadow::mshadow_sizeof(data_dtype);
     if (diff_src == nullptr) {
-      auto desc = mkldnn::memory::desc(full_param_.layer_params.back().src_dims,
-          get_mkldnn_type(data_dtype), tag::tnc);
+      auto desc = mkldnn::memory::desc(
+          full_param_.layer_params.back().src_dims, get_mkldnn_type(data_dtype), tag::tnc);
       diff_src = std::make_shared<mkldnn::memory>(desc, CpuEngine::Get()->get_engine());
     }
     // Sets primitives from bottom to top, then submits them in reversed order.
-    bwd_vec_.front().SetDataGradsMem(dx, dhx, dcx,
-        diff_src->get_data_handle(), dhy, dcy, data_dtype);
+    bwd_vec_.front().SetDataGradsMem(
+        dx, dhx, dcx, diff_src->get_data_handle(), dhy, dcy, data_dtype);
     for (size_t lyr = 1; lyr < bwd_vec_.size() - 1; ++lyr) {
       if (dhx) dhx += cell_bytes;
       if (dcx) dcx += cell_bytes;
       if (dhy) dhy += cell_bytes;
       if (dcy) dcy += cell_bytes;
-      bwd_vec_.at(lyr).SetDataGradsMem(diff_src->get_data_handle(), dhx, dcx,
-          diff_src->get_data_handle(), dhy, dcy, data_dtype);
+      bwd_vec_.at(lyr).SetDataGradsMem(
+          diff_src->get_data_handle(), dhx, dcx, diff_src->get_data_handle(), dhy, dcy, data_dtype);
     }
     if (dhx) dhx += cell_bytes;
     if (dcx) dcx += cell_bytes;
     if (dhy) dhy += cell_bytes;
     if (dcy) dcy += cell_bytes;
-    bwd_vec_.back().SetDataGradsMem(diff_src->get_data_handle(), dhx, dcx,
-        dy, dhy, dcy, data_dtype);
+    bwd_vec_.back().SetDataGradsMem(
+        diff_src->get_data_handle(), dhx, dcx, dy, dhy, dcy, data_dtype);
 
     for (std::vector<MKLDNNRnnBackward>::const_reverse_iterator bwd = bwd_vec_.rbegin();
-        bwd != bwd_vec_.rend(); ++bwd) {
+         bwd != bwd_vec_.rend(); ++bwd) {
       RegisterMKLDNNRnn(*bwd);
     }
   }

--- a/src/operator/nn/mkldnn/mkldnn_slice-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_slice-inl.h
@@ -21,7 +21,7 @@
  * \file mkldnn_slice-inl.h
  * \brief
  * \author Zhiyuan Huang
-*/
+ */
 
 #ifndef MXNET_OPERATOR_NN_MKLDNN_MKLDNN_SLICE_INL_H_
 #define MXNET_OPERATOR_NN_MKLDNN_MKLDNN_SLICE_INL_H_
@@ -41,10 +41,8 @@ namespace op {
 
 class MKLDNNSliceFwd {
  public:
-  MKLDNNSliceFwd(const SliceParam &param,
-                 const NDArray &in,
-                 const NDArray &out);
-  void SetNewMem(const mkldnn::memory &input, const mkldnn::memory &output);
+  MKLDNNSliceFwd(const SliceParam& param, const NDArray& in, const NDArray& out);
+  void SetNewMem(const mkldnn::memory& input, const mkldnn::memory& output);
   void Register();
 
  private:
@@ -54,11 +52,12 @@ class MKLDNNSliceFwd {
 };
 
 typedef ParamOpSign<SliceParam> MKLDNNSliceSignature;
-MKLDNNSliceFwd &GetSliceForward(const SliceParam &param, const bool is_train,
-                 const NDArray &in_data, const NDArray &out_data);
+MKLDNNSliceFwd& GetSliceForward(
+    const SliceParam& param, const bool is_train, const NDArray& in_data, const NDArray& out_data);
 
-void MKLDNNSlice(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
-                 const NDArray &in, OpReqType req, const NDArray &out);
+void MKLDNNSlice(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const NDArray& in, OpReqType req,
+    const NDArray& out);
 
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/nn/mkldnn/mkldnn_slice-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_slice-inl.h
@@ -31,7 +31,9 @@
 #include <dmlc/logging.h>
 #include <dmlc/parameter.h>
 #include <mxnet/operator.h>
+
 #include <utility>
+
 #include "../../operator_common.h"
 #include "../../tensor/slice-inl.h"
 #include "./mkldnn_base-inl.h"
@@ -52,11 +54,16 @@ class MKLDNNSliceFwd {
 };
 
 typedef ParamOpSign<SliceParam> MKLDNNSliceSignature;
-MKLDNNSliceFwd& GetSliceForward(const SliceParam& param, const bool is_train,
-                                const NDArray& in_data, const NDArray& out_data);
+MKLDNNSliceFwd& GetSliceForward(const SliceParam& param,
+                                const bool is_train,
+                                const NDArray& in_data,
+                                const NDArray& out_data);
 
-void MKLDNNSlice(const nnvm::NodeAttrs& attrs, const OpContext& ctx, const NDArray& in,
-                 OpReqType req, const NDArray& out);
+void MKLDNNSlice(const nnvm::NodeAttrs& attrs,
+                 const OpContext& ctx,
+                 const NDArray& in,
+                 OpReqType req,
+                 const NDArray& out);
 
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/nn/mkldnn/mkldnn_slice-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_slice-inl.h
@@ -52,12 +52,11 @@ class MKLDNNSliceFwd {
 };
 
 typedef ParamOpSign<SliceParam> MKLDNNSliceSignature;
-MKLDNNSliceFwd& GetSliceForward(
-    const SliceParam& param, const bool is_train, const NDArray& in_data, const NDArray& out_data);
+MKLDNNSliceFwd& GetSliceForward(const SliceParam& param, const bool is_train,
+                                const NDArray& in_data, const NDArray& out_data);
 
-void MKLDNNSlice(
-    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const NDArray& in, OpReqType req,
-    const NDArray& out);
+void MKLDNNSlice(const nnvm::NodeAttrs& attrs, const OpContext& ctx, const NDArray& in,
+                 OpReqType req, const NDArray& out);
 
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/nn/mkldnn/mkldnn_slice.cc
+++ b/src/operator/nn/mkldnn/mkldnn_slice.cc
@@ -25,8 +25,8 @@
 
 #if MXNET_USE_MKLDNN == 1
 
-#include "./mkldnn_ops-inl.h"
 #include "./mkldnn_base-inl.h"
+#include "./mkldnn_ops-inl.h"
 #include "./mkldnn_slice-inl.h"
 
 namespace mxnet {
@@ -68,8 +68,10 @@ void MKLDNNSliceFwd::Register() {
       *fwd_, {{MKLDNN_ARG_FROM, *(this->data_)}, {MKLDNN_ARG_TO, *(this->out_)}});
 }
 
-MKLDNNSliceFwd& GetSliceForward(const SliceParam& param, const bool is_train,
-                                const NDArray& in_data, const NDArray& out_data) {
+MKLDNNSliceFwd& GetSliceForward(const SliceParam& param,
+                                const bool is_train,
+                                const NDArray& in_data,
+                                const NDArray& out_data) {
 #if DMLC_CXX11_THREAD_LOCAL
   static thread_local std::unordered_map<MKLDNNSliceSignature, MKLDNNSliceFwd, OpHash> fwds;
 #else
@@ -88,8 +90,11 @@ MKLDNNSliceFwd& GetSliceForward(const SliceParam& param, const bool is_train,
   return it->second;
 }
 
-void MKLDNNSlice(const nnvm::NodeAttrs& attrs, const OpContext& ctx, const NDArray& in,
-                 OpReqType req, const NDArray& out) {
+void MKLDNNSlice(const nnvm::NodeAttrs& attrs,
+                 const OpContext& ctx,
+                 const NDArray& in,
+                 OpReqType req,
+                 const NDArray& out) {
   const SliceParam& param = nnvm::get<SliceParam>(attrs.parsed);
   MKLDNNSliceFwd& fwd     = GetSliceForward(param, ctx.is_train, in, out);
   auto in_mem             = in.GetMKLDNNData();

--- a/src/operator/nn/mkldnn/mkldnn_slice.cc
+++ b/src/operator/nn/mkldnn/mkldnn_slice.cc
@@ -42,7 +42,8 @@ MKLDNNSliceFwd::MKLDNNSliceFwd(const SliceParam& param, const NDArray& in, const
     dim_t s = 0;
     if (i < param.begin.ndim() && param.begin[i]) {
       s = *param.begin[i];
-      if (s < 0) s += ishape[i];
+      if (s < 0)
+        s += ishape[i];
     }
     dims[i]    = oshape[i];
     offsets[i] = s;

--- a/src/operator/nn/mkldnn/mkldnn_slice.cc
+++ b/src/operator/nn/mkldnn/mkldnn_slice.cc
@@ -68,8 +68,8 @@ void MKLDNNSliceFwd::Register() {
       *fwd_, {{MKLDNN_ARG_FROM, *(this->data_)}, {MKLDNN_ARG_TO, *(this->out_)}});
 }
 
-MKLDNNSliceFwd& GetSliceForward(
-    const SliceParam& param, const bool is_train, const NDArray& in_data, const NDArray& out_data) {
+MKLDNNSliceFwd& GetSliceForward(const SliceParam& param, const bool is_train,
+                                const NDArray& in_data, const NDArray& out_data) {
 #if DMLC_CXX11_THREAD_LOCAL
   static thread_local std::unordered_map<MKLDNNSliceSignature, MKLDNNSliceFwd, OpHash> fwds;
 #else
@@ -88,9 +88,8 @@ MKLDNNSliceFwd& GetSliceForward(
   return it->second;
 }
 
-void MKLDNNSlice(
-    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const NDArray& in, OpReqType req,
-    const NDArray& out) {
+void MKLDNNSlice(const nnvm::NodeAttrs& attrs, const OpContext& ctx, const NDArray& in,
+                 OpReqType req, const NDArray& out) {
   const SliceParam& param = nnvm::get<SliceParam>(attrs.parsed);
   MKLDNNSliceFwd& fwd     = GetSliceForward(param, ctx.is_train, in, out);
   auto in_mem             = in.GetMKLDNNData();

--- a/src/operator/nn/mkldnn/mkldnn_softmax.cc
+++ b/src/operator/nn/mkldnn/mkldnn_softmax.cc
@@ -21,7 +21,7 @@
  * \file mkldnn_softmax.cc
  * \brief
  * \author Da Zheng
-*/
+ */
 
 #include "../softmax-inl.h"
 #include "./mkldnn_ops-inl.h"
@@ -31,45 +31,36 @@
 namespace mxnet {
 namespace op {
 
-static mkldnn::softmax_forward::primitive_desc GetSoftmaxFwdPd(bool is_train,
-                                                               const int axis,
-                                                               const mkldnn::memory &input_mem) {
+static mkldnn::softmax_forward::primitive_desc GetSoftmaxFwdPd(
+    bool is_train, const int axis, const mkldnn::memory& input_mem) {
   mkldnn::memory::desc data_md = input_mem.get_desc();
-  auto cpu_engine = CpuEngine::Get()->get_engine();
-  auto prop = is_train ? mkldnn::prop_kind::forward_training
-                       : mkldnn::prop_kind::forward_scoring;
+  auto cpu_engine              = CpuEngine::Get()->get_engine();
+  auto prop = is_train ? mkldnn::prop_kind::forward_training : mkldnn::prop_kind::forward_scoring;
   auto desc = mkldnn::softmax_forward::desc(prop, data_md, axis);
   return mkldnn::softmax_forward::primitive_desc(desc, cpu_engine);
 }
 
 static mkldnn::softmax_backward::primitive_desc GetSoftmaxBwdPd(
-                                const mkldnn::memory &diff_mem,
-                                const mkldnn::memory &data_mem,
-                                const int axis,
-                                const mkldnn::softmax_forward::primitive_desc &hint_fwd_pd) {
+    const mkldnn::memory& diff_mem, const mkldnn::memory& data_mem, const int axis,
+    const mkldnn::softmax_forward::primitive_desc& hint_fwd_pd) {
   mkldnn::memory::desc diff_md = diff_mem.get_desc();
   mkldnn::memory::desc data_md = data_mem.get_desc();
-  auto cpu_engine = CpuEngine::Get()->get_engine();
-  auto desc = mkldnn::softmax_backward::desc(diff_md, data_md, axis);
+  auto cpu_engine              = CpuEngine::Get()->get_engine();
+  auto desc                    = mkldnn::softmax_backward::desc(diff_md, data_md, axis);
   return mkldnn::softmax_backward::primitive_desc(desc, cpu_engine, hint_fwd_pd);
 }
 
-
-bool SupportMKLDNNSoftmax(const SoftmaxParam &param,
-                          const NDArray &data,
-                          const NDArray &output) {
+bool SupportMKLDNNSoftmax(const SoftmaxParam& param, const NDArray& data, const NDArray& output) {
   // MKLDNN does not support temperature argument in their softmax function
   // now. Need update this once they start to support it.
-  const int ndim = data.shape().ndim();
-  const int in_dtype = data.dtype();
+  const int ndim      = data.shape().ndim();
+  const int in_dtype  = data.dtype();
   const int out_dtype = output.dtype();
-  const int axis = CheckAxis(param.axis, ndim);
+  const int axis      = CheckAxis(param.axis, ndim);
   // MKLDNN does not support temperature argument in their softmax function
   // now. Need update this once they start to support it.
   // Currently, MKLDNN shows bad performance when softmax is not performed on the last dimension
-  if (param.temperature.has_value() ||
-      in_dtype != mshadow::kFloat32 ||
-      in_dtype != out_dtype ||
+  if (param.temperature.has_value() || in_dtype != mshadow::kFloat32 || in_dtype != out_dtype ||
       axis != (ndim - 1)) {
     return false;
   }
@@ -82,15 +73,12 @@ class MKLDNNSoftmaxFwd {
  public:
   mkldnn::softmax_forward::primitive_desc pd;
 
-  MKLDNNSoftmaxFwd(const bool is_train,
-                   const int axis,
-                   const mkldnn::memory &input) : pd(GetSoftmaxFwdPd(is_train, axis, input)) {
+  MKLDNNSoftmaxFwd(const bool is_train, const int axis, const mkldnn::memory& input)
+      : pd(GetSoftmaxFwdPd(is_train, axis, input)) {
     fwd_ = std::make_shared<mkldnn::softmax_forward>(pd);
   }
 
-  const mkldnn::softmax_forward &GetFwd() const {
-    return *fwd_;
-  }
+  const mkldnn::softmax_forward& GetFwd() const { return *fwd_; }
 
  private:
   std::shared_ptr<mkldnn::softmax_forward> fwd_;
@@ -98,11 +86,9 @@ class MKLDNNSoftmaxFwd {
 
 typedef ParamOpSign<SoftmaxParam> MKLDNNSoftmaxSignature;
 
-static MKLDNNSoftmaxFwd &GetSoftmaxFwd(const SoftmaxParam &param,
-                                       const int real_axis,
-                                       const bool is_train,
-                                       const NDArray &data,
-                                       const NDArray &output) {
+static MKLDNNSoftmaxFwd& GetSoftmaxFwd(
+    const SoftmaxParam& param, const int real_axis, const bool is_train, const NDArray& data,
+    const NDArray& output) {
 #if DMLC_CXX11_THREAD_LOCAL
   static thread_local std::unordered_map<MKLDNNSoftmaxSignature, MKLDNNSoftmaxFwd, OpHash> fwds;
 #else
@@ -123,22 +109,20 @@ static MKLDNNSoftmaxFwd &GetSoftmaxFwd(const SoftmaxParam &param,
   return it->second;
 }
 
-void MKLDNNSoftmaxForward(const nnvm::NodeAttrs& attrs,
-                          const OpContext &ctx,
-                          const NDArray &in_data,
-                          const OpReqType &req,
-                          const NDArray &out_data) {
+void MKLDNNSoftmaxForward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const NDArray& in_data,
+    const OpReqType& req, const NDArray& out_data) {
   if (req == kNullOp) return;
   // same as the FCompute path, softmax only supports kWriteTo and kWriteInplace for now.
   CHECK_NE(req, kAddTo);
 
   const SoftmaxParam& param = nnvm::get<SoftmaxParam>(attrs.parsed);
-  int axis = CheckAxis(param.axis, in_data.shape().ndim());
-  auto fwd = GetSoftmaxFwd(param, axis, ctx.is_train, in_data, out_data);
+  int axis                  = CheckAxis(param.axis, in_data.shape().ndim());
+  auto fwd                  = GetSoftmaxFwd(param, axis, ctx.is_train, in_data, out_data);
 
-  auto in_mem = in_data.GetMKLDNNData();
-  auto out_mem = out_data.GetMKLDNNData(fwd.pd.dst_desc());
-  MKLDNNStream *stream = MKLDNNStream::Get();
+  auto in_mem          = in_data.GetMKLDNNData();
+  auto out_mem         = out_data.GetMKLDNNData(fwd.pd.dst_desc());
+  MKLDNNStream* stream = MKLDNNStream::Get();
   stream->RegisterPrimArgs(fwd.GetFwd(), {{MKLDNN_ARG_SRC, *in_mem}, {MKLDNN_ARG_DST, *out_mem}});
   stream->Submit();
 }
@@ -147,26 +131,22 @@ class MKLDNNSoftmaxBwd {
  public:
   mkldnn::softmax_backward::primitive_desc pd;
 
-  MKLDNNSoftmaxBwd(const mkldnn::memory &diff_mem,
-                   const mkldnn::memory &data_mem,
-                   const int axis,
-                   const mkldnn::softmax_forward::primitive_desc &hint_fwd_pd) :
-                                 pd(GetSoftmaxBwdPd(diff_mem, data_mem, axis, hint_fwd_pd)) {
+  MKLDNNSoftmaxBwd(
+      const mkldnn::memory& diff_mem, const mkldnn::memory& data_mem, const int axis,
+      const mkldnn::softmax_forward::primitive_desc& hint_fwd_pd)
+      : pd(GetSoftmaxBwdPd(diff_mem, data_mem, axis, hint_fwd_pd)) {
     bwd_ = std::make_shared<mkldnn::softmax_backward>(pd);
   }
 
-  const mkldnn::softmax_backward &GetBwd() const {
-    return *bwd_;
-  }
+  const mkldnn::softmax_backward& GetBwd() const { return *bwd_; }
 
  private:
   std::shared_ptr<mkldnn::softmax_backward> bwd_;
 };
 
-static MKLDNNSoftmaxBwd &GetSoftmaxBwd(const SoftmaxParam &param,
-                                       const int real_axis,
-                                       const std::vector<NDArray> &data,
-                                       const std::vector<NDArray> &output) {
+static MKLDNNSoftmaxBwd& GetSoftmaxBwd(
+    const SoftmaxParam& param, const int real_axis, const std::vector<NDArray>& data,
+    const std::vector<NDArray>& output) {
 #if DMLC_CXX11_THREAD_LOCAL
   static thread_local std::unordered_map<MKLDNNSoftmaxSignature, MKLDNNSoftmaxBwd, OpHash> bwds;
 #else
@@ -182,39 +162,36 @@ static MKLDNNSoftmaxBwd &GetSoftmaxBwd(const SoftmaxParam &param,
   if (it == bwds.end()) {
     auto diff_mem = data[0].GetMKLDNNData();
     auto data_mem = data[1].GetMKLDNNData();
-    auto fwd_pd = GetSoftmaxFwdPd(true, real_axis, *data_mem);
+    auto fwd_pd   = GetSoftmaxFwdPd(true, real_axis, *data_mem);
     MKLDNNSoftmaxBwd bwd(*diff_mem, *data_mem, real_axis, fwd_pd);
     it = AddToCache(&bwds, key, bwd);
   }
   return it->second;
 }
 
-void MKLDNNSoftmaxBackward(const nnvm::NodeAttrs& attrs,
-                           const OpContext &ctx,
-                           const std::vector<NDArray> &in_data,
-                           const std::vector<OpReqType> &req,
-                           const std::vector<NDArray> &out_data) {
+void MKLDNNSoftmaxBackward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& in_data,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& out_data) {
   if (req[0] == kNullOp) return;
   CHECK_EQ(in_data.size(), 2U);
   const SoftmaxParam& param = nnvm::get<SoftmaxParam>(attrs.parsed);
-  int axis = CheckAxis(param.axis, in_data[1].shape().ndim());
-  auto diff_mem = in_data[0].GetMKLDNNData();
-  auto data_mem = in_data[1].GetMKLDNNData();
-  auto bwd = GetSoftmaxBwd(param, axis, in_data, out_data);
+  int axis                  = CheckAxis(param.axis, in_data[1].shape().ndim());
+  auto diff_mem             = in_data[0].GetMKLDNNData();
+  auto data_mem             = in_data[1].GetMKLDNNData();
+  auto bwd                  = GetSoftmaxBwd(param, axis, in_data, out_data);
 
-  auto out_mem = CreateMKLDNNMem(out_data[0], bwd.pd.diff_src_desc(), req[0]);
-  MKLDNNStream *stream = MKLDNNStream::Get();
+  auto out_mem           = CreateMKLDNNMem(out_data[0], bwd.pd.diff_src_desc(), req[0]);
+  MKLDNNStream* stream   = MKLDNNStream::Get();
   mkldnn_args_map_t args = {
-    { MKLDNN_ARG_DST, *data_mem },
-    { MKLDNN_ARG_DIFF_DST, *diff_mem },
-    { MKLDNN_ARG_DIFF_SRC, *out_mem.second }
-  };
+      {MKLDNN_ARG_DST, *data_mem},
+      {MKLDNN_ARG_DIFF_DST, *diff_mem},
+      {MKLDNN_ARG_DIFF_SRC, *out_mem.second}};
 
   stream->RegisterPrimArgs(bwd.GetBwd(), args);
   CommitOutput(out_data[0], out_mem);
   stream->Submit();
 }
 
-}   // namespace op
-}   // namespace mxnet
+}  // namespace op
+}  // namespace mxnet
 #endif

--- a/src/operator/nn/mkldnn/mkldnn_softmax.cc
+++ b/src/operator/nn/mkldnn/mkldnn_softmax.cc
@@ -62,7 +62,8 @@ bool SupportMKLDNNSoftmax(const SoftmaxParam& param, const NDArray& data, const 
   const int axis      = CheckAxis(param.axis, ndim);
   // MKLDNN does not support temperature argument in their softmax function
   // now. Need update this once they start to support it.
-  // Currently, MKLDNN shows bad performance when softmax is not performed on the last dimension
+  // Currently, MKLDNN shows bad performance when softmax is not performed on
+  // the last dimension
   if (param.temperature.has_value() || in_dtype != mshadow::kFloat32 || in_dtype != out_dtype ||
       axis != (ndim - 1)) {
     return false;
@@ -81,7 +82,9 @@ class MKLDNNSoftmaxFwd {
     fwd_ = std::make_shared<mkldnn::softmax_forward>(pd);
   }
 
-  const mkldnn::softmax_forward& GetFwd() const { return *fwd_; }
+  const mkldnn::softmax_forward& GetFwd() const {
+    return *fwd_;
+  }
 
  private:
   std::shared_ptr<mkldnn::softmax_forward> fwd_;
@@ -119,8 +122,10 @@ void MKLDNNSoftmaxForward(const nnvm::NodeAttrs& attrs,
                           const NDArray& in_data,
                           const OpReqType& req,
                           const NDArray& out_data) {
-  if (req == kNullOp) return;
-  // same as the FCompute path, softmax only supports kWriteTo and kWriteInplace for now.
+  if (req == kNullOp)
+    return;
+  // same as the FCompute path, softmax only supports kWriteTo and kWriteInplace
+  // for now.
   CHECK_NE(req, kAddTo);
 
   const SoftmaxParam& param = nnvm::get<SoftmaxParam>(attrs.parsed);
@@ -146,7 +151,9 @@ class MKLDNNSoftmaxBwd {
     bwd_ = std::make_shared<mkldnn::softmax_backward>(pd);
   }
 
-  const mkldnn::softmax_backward& GetBwd() const { return *bwd_; }
+  const mkldnn::softmax_backward& GetBwd() const {
+    return *bwd_;
+  }
 
  private:
   std::shared_ptr<mkldnn::softmax_backward> bwd_;
@@ -183,7 +190,8 @@ void MKLDNNSoftmaxBackward(const nnvm::NodeAttrs& attrs,
                            const std::vector<NDArray>& in_data,
                            const std::vector<OpReqType>& req,
                            const std::vector<NDArray>& out_data) {
-  if (req[0] == kNullOp) return;
+  if (req[0] == kNullOp)
+    return;
   CHECK_EQ(in_data.size(), 2U);
   const SoftmaxParam& param = nnvm::get<SoftmaxParam>(attrs.parsed);
   int axis                  = CheckAxis(param.axis, in_data[1].shape().ndim());

--- a/src/operator/nn/mkldnn/mkldnn_softmax_output.cc
+++ b/src/operator/nn/mkldnn/mkldnn_softmax_output.cc
@@ -21,7 +21,7 @@
  * \file mkldnn_softmax_output.cc
  * \brief integrate mkldnn softmax to softmax_output forward
  * \author Zhang Rong A
-*/
+ */
 
 #if MXNET_USE_MKLDNN == 1
 #include "../../softmax_output-inl.h"
@@ -31,12 +31,11 @@ namespace mxnet {
 namespace op {
 
 static mkldnn::softmax_forward::primitive_desc GetSoftmaxOutputFwdDescImpl(
-               const SoftmaxOutputParam& param, bool is_train,
-               const int axis, const mkldnn::memory &input_mem) {
+    const SoftmaxOutputParam& param, bool is_train, const int axis,
+    const mkldnn::memory& input_mem) {
   mkldnn::memory::desc data_md = input_mem.get_desc();
-  auto cpu_engine = CpuEngine::Get()->get_engine();
-  auto prop = is_train ? mkldnn::prop_kind::forward_training
-                       : mkldnn::prop_kind::forward_scoring;
+  auto cpu_engine              = CpuEngine::Get()->get_engine();
+  auto prop = is_train ? mkldnn::prop_kind::forward_training : mkldnn::prop_kind::forward_scoring;
   auto desc = mkldnn::softmax_forward::desc(prop, data_md, axis);
   return mkldnn::softmax_forward::primitive_desc(desc, cpu_engine);
 }
@@ -49,26 +48,25 @@ class MKLDNNSoftmaxOutputFwd {
  public:
   const mkldnn::softmax_forward::primitive_desc fwd_pd;
 
-  MKLDNNSoftmaxOutputFwd(const SoftmaxOutputParam& param, bool is_train,
-                         const int axis, const mkldnn::memory &mem): fwd_pd(
-                         GetSoftmaxOutputFwdDescImpl(param, is_train, axis, mem)) {
+  MKLDNNSoftmaxOutputFwd(
+      const SoftmaxOutputParam& param, bool is_train, const int axis, const mkldnn::memory& mem)
+      : fwd_pd(GetSoftmaxOutputFwdDescImpl(param, is_train, axis, mem)) {
     fwd_ = std::make_shared<mkldnn::softmax_forward>(fwd_pd);
   }
 
-  const inline mkldnn::softmax_forward &GetFwd() const {
-    return *fwd_;
-  }
+  const inline mkldnn::softmax_forward& GetFwd() const { return *fwd_; }
 };
 
-static MKLDNNSoftmaxOutputFwd &GetSoftmaxOutputForward(const SoftmaxOutputParam& param,
-                                                       const OpContext &ctx,
-                                                       const NDArray &in_data) {
+static MKLDNNSoftmaxOutputFwd& GetSoftmaxOutputForward(
+    const SoftmaxOutputParam& param, const OpContext& ctx, const NDArray& in_data) {
 #if DMLC_CXX11_THREAD_LOCAL
-  static thread_local
-    std::unordered_map<MKLDNNSoftmaxOuputSignature, MKLDNNSoftmaxOutputFwd, OpHash> fwds;
+  static thread_local std::unordered_map<
+      MKLDNNSoftmaxOuputSignature, MKLDNNSoftmaxOutputFwd, OpHash>
+      fwds;
 #else
   static MX_THREAD_LOCAL
-    std::unordered_map<MKLDNNSoftmaxOuputSignature, MKLDNNSoftmaxOutputFwd, OpHash> fwds;
+      std::unordered_map<MKLDNNSoftmaxOuputSignature, MKLDNNSoftmaxOutputFwd, OpHash>
+          fwds;
 #endif
   MKLDNNSoftmaxOuputSignature key(param);
   key.AddSign(ctx.is_train);
@@ -87,16 +85,14 @@ static MKLDNNSoftmaxOutputFwd &GetSoftmaxOutputForward(const SoftmaxOutputParam&
 }
 
 //  This is only used for forward. For backward ,need double check compatibility
-bool SupportMKLDNNSoftmaxOutput(const SoftmaxOutputParam &param) {
+bool SupportMKLDNNSoftmaxOutput(const SoftmaxOutputParam& param) {
   return param.multi_output ? false : true;
 }
 
-void MKLDNNSoftmaxOutputForward(const nnvm::NodeAttrs& attrs,
-                                const OpContext &ctx,
-                                const std::vector<NDArray> &in_data,
-                                const std::vector<OpReqType> &req,
-                                const std::vector<NDArray> &out_data) {
-  const SoftmaxOutputParam &param = nnvm::get<SoftmaxOutputParam>(attrs.parsed);
+void MKLDNNSoftmaxOutputForward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& in_data,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& out_data) {
+  const SoftmaxOutputParam& param = nnvm::get<SoftmaxOutputParam>(attrs.parsed);
 
   NDArray idata = in_data[softmaxout_enum::kData];
   NDArray odata = out_data[softmaxout_enum::kOut];
@@ -105,18 +101,17 @@ void MKLDNNSoftmaxOutputForward(const nnvm::NodeAttrs& attrs,
   }
 
   auto input_mem = idata.GetMKLDNNData();
-  auto out_mem = CreateMKLDNNMem(out_data[softmaxout_enum::kOut],
-                                 input_mem->get_desc(), req[softmaxout_enum::kOut]);
+  auto out_mem   = CreateMKLDNNMem(
+      out_data[softmaxout_enum::kOut], input_mem->get_desc(), req[softmaxout_enum::kOut]);
 
-  MKLDNNSoftmaxOutputFwd &fwd = GetSoftmaxOutputForward(param, ctx, idata);
+  MKLDNNSoftmaxOutputFwd& fwd = GetSoftmaxOutputForward(param, ctx, idata);
 
-  MKLDNNStream *stream = MKLDNNStream::Get();
-  stream->RegisterPrimArgs(fwd.GetFwd(),
-                           {{MKLDNN_ARG_SRC, *input_mem}, {MKLDNN_ARG_DST, *out_mem.second}});
+  MKLDNNStream* stream = MKLDNNStream::Get();
+  stream->RegisterPrimArgs(
+      fwd.GetFwd(), {{MKLDNN_ARG_SRC, *input_mem}, {MKLDNN_ARG_DST, *out_mem.second}});
   CommitOutput(out_data[softmaxout_enum::kOut], out_mem);
   stream->Submit();
 }
-}   // namespace op
-}   // namespace mxnet
+}  // namespace op
+}  // namespace mxnet
 #endif
-

--- a/src/operator/nn/mkldnn/mkldnn_softmax_output.cc
+++ b/src/operator/nn/mkldnn/mkldnn_softmax_output.cc
@@ -25,13 +25,15 @@
 
 #if MXNET_USE_MKLDNN == 1
 #include "../../softmax_output-inl.h"
-#include "./mkldnn_ops-inl.h"
 #include "./mkldnn_base-inl.h"
+#include "./mkldnn_ops-inl.h"
 namespace mxnet {
 namespace op {
 
 static mkldnn::softmax_forward::primitive_desc GetSoftmaxOutputFwdDescImpl(
-    const SoftmaxOutputParam& param, bool is_train, const int axis,
+    const SoftmaxOutputParam& param,
+    bool is_train,
+    const int axis,
     const mkldnn::memory& input_mem) {
   mkldnn::memory::desc data_md = input_mem.get_desc();
   auto cpu_engine              = CpuEngine::Get()->get_engine();
@@ -48,7 +50,9 @@ class MKLDNNSoftmaxOutputFwd {
  public:
   const mkldnn::softmax_forward::primitive_desc fwd_pd;
 
-  MKLDNNSoftmaxOutputFwd(const SoftmaxOutputParam& param, bool is_train, const int axis,
+  MKLDNNSoftmaxOutputFwd(const SoftmaxOutputParam& param,
+                         bool is_train,
+                         const int axis,
                          const mkldnn::memory& mem)
       : fwd_pd(GetSoftmaxOutputFwdDescImpl(param, is_train, axis, mem)) {
     fwd_ = std::make_shared<mkldnn::softmax_forward>(fwd_pd);
@@ -90,7 +94,8 @@ bool SupportMKLDNNSoftmaxOutput(const SoftmaxOutputParam& param) {
   return param.multi_output ? false : true;
 }
 
-void MKLDNNSoftmaxOutputForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+void MKLDNNSoftmaxOutputForward(const nnvm::NodeAttrs& attrs,
+                                const OpContext& ctx,
                                 const std::vector<NDArray>& in_data,
                                 const std::vector<OpReqType>& req,
                                 const std::vector<NDArray>& out_data) {

--- a/src/operator/nn/mkldnn/mkldnn_softmax_output.cc
+++ b/src/operator/nn/mkldnn/mkldnn_softmax_output.cc
@@ -58,16 +58,18 @@ class MKLDNNSoftmaxOutputFwd {
     fwd_ = std::make_shared<mkldnn::softmax_forward>(fwd_pd);
   }
 
-  const inline mkldnn::softmax_forward& GetFwd() const { return *fwd_; }
+  const inline mkldnn::softmax_forward& GetFwd() const {
+    return *fwd_;
+  }
 };
 
 static MKLDNNSoftmaxOutputFwd& GetSoftmaxOutputForward(const SoftmaxOutputParam& param,
                                                        const OpContext& ctx,
                                                        const NDArray& in_data) {
 #if DMLC_CXX11_THREAD_LOCAL
-  static thread_local std::unordered_map<MKLDNNSoftmaxOuputSignature, MKLDNNSoftmaxOutputFwd,
-                                         OpHash>
-      fwds;
+  static thread_local std::
+      unordered_map<MKLDNNSoftmaxOuputSignature, MKLDNNSoftmaxOutputFwd, OpHash>
+          fwds;
 #else
   static MX_THREAD_LOCAL
       std::unordered_map<MKLDNNSoftmaxOuputSignature, MKLDNNSoftmaxOutputFwd, OpHash>
@@ -108,8 +110,8 @@ void MKLDNNSoftmaxOutputForward(const nnvm::NodeAttrs& attrs,
   }
 
   auto input_mem = idata.GetMKLDNNData();
-  auto out_mem   = CreateMKLDNNMem(out_data[softmaxout_enum::kOut], input_mem->get_desc(),
-                                 req[softmaxout_enum::kOut]);
+  auto out_mem   = CreateMKLDNNMem(
+      out_data[softmaxout_enum::kOut], input_mem->get_desc(), req[softmaxout_enum::kOut]);
 
   MKLDNNSoftmaxOutputFwd& fwd = GetSoftmaxOutputForward(param, ctx, idata);
 

--- a/src/operator/nn/mkldnn/mkldnn_sum.cc
+++ b/src/operator/nn/mkldnn/mkldnn_sum.cc
@@ -21,7 +21,7 @@
  * \file mkldnn_sum.cc
  * \brief
  * \author Da Zheng
-*/
+ */
 #include <iostream>
 
 #include "../../operator_common.h"
@@ -32,17 +32,15 @@ namespace mxnet {
 namespace op {
 
 #if MXNET_USE_MKLDNN == 1
-void MKLDNNSum(const mkldnn::memory &arr1,
-               const mkldnn::memory &arr2,
-               const mkldnn::memory &out) {
+void MKLDNNSum(const mkldnn::memory& arr1, const mkldnn::memory& arr2, const mkldnn::memory& out) {
   std::vector<mkldnn::memory::desc> input_pds(2);
   std::vector<float> scales(2, 1);
   input_pds[0] = arr1.get_desc();
   input_pds[1] = arr2.get_desc();
   CHECK(input_pds[0] == input_pds[0]);
-  const mkldnn::memory *in_mem1 = &arr1;
-  const mkldnn::memory *in_mem2 = &arr2;
-  auto output_pd = out.get_desc();
+  const mkldnn::memory* in_mem1 = &arr1;
+  const mkldnn::memory* in_mem2 = &arr2;
+  auto output_pd                = out.get_desc();
   if (input_pds[0] != output_pd) {
     auto tmp_memory1 = TmpMemMgr::Get()->Alloc(output_pd);
     auto tmp_memory2 = TmpMemMgr::Get()->Alloc(output_pd);
@@ -50,14 +48,14 @@ void MKLDNNSum(const mkldnn::memory &arr1,
     MKLDNNMemoryCopy(arr2, tmp_memory2);
     input_pds[0] = tmp_memory1->get_desc();
     input_pds[1] = tmp_memory2->get_desc();
-    in_mem1 = tmp_memory1;
-    in_mem2 = tmp_memory2;
+    in_mem1      = tmp_memory1;
+    in_mem2      = tmp_memory2;
   }
   mkldnn::sum::primitive_desc sum_pd(output_pd, scales, input_pds, CpuEngine::Get()->get_engine());
   mkldnn_args_map_t args = {
-    { MKLDNN_ARG_MULTIPLE_SRC, *in_mem1 },
-    { MKLDNN_ARG_MULTIPLE_SRC + 1, *in_mem2 },
-    { MKLDNN_ARG_DST, out },
+      {MKLDNN_ARG_MULTIPLE_SRC, *in_mem1},
+      {MKLDNN_ARG_MULTIPLE_SRC + 1, *in_mem2},
+      {MKLDNN_ARG_DST, out},
   };
   MKLDNNStream::Get()->RegisterPrimArgs(mkldnn::sum(sum_pd), args);
 }
@@ -66,21 +64,20 @@ class MKLDNNSumFwd {
  public:
   mkldnn::sum::primitive_desc fwd_pd;
 
-  MKLDNNSumFwd(const std::vector<float> &scales,
-               const std::vector<mkldnn::memory::desc> &data_md)
+  MKLDNNSumFwd(const std::vector<float>& scales, const std::vector<mkldnn::memory::desc>& data_md)
       : fwd_pd(scales, data_md, CpuEngine::Get()->get_engine()) {
     fwd_ = std::make_shared<mkldnn::sum>(fwd_pd);
   }
 
-  const mkldnn::sum &GetFwd() const { return *fwd_; }
+  const mkldnn::sum& GetFwd() const { return *fwd_; }
 
  private:
   std::shared_ptr<mkldnn::sum> fwd_;
 };
 
-static MKLDNNSumFwd &GetSumForward(
-    const std::vector<float> &scales, const std::vector<NDArray> &in_data,
-    const std::vector<mkldnn::memory::desc> &data_md) {
+static MKLDNNSumFwd& GetSumForward(
+    const std::vector<float>& scales, const std::vector<NDArray>& in_data,
+    const std::vector<mkldnn::memory::desc>& data_md) {
 #if DMLC_CXX11_THREAD_LOCAL
   static thread_local std::unordered_map<OpSignature, MKLDNNSumFwd, OpHash> fwds;
 #else
@@ -97,31 +94,29 @@ static MKLDNNSumFwd &GetSumForward(
   return it->second;
 }
 
-void MKLDNNSumForward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
-                      const std::vector<NDArray> &inputs, const std::vector<OpReqType> &req,
-                      const std::vector<NDArray> &outputs) {
+void MKLDNNSumForward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& inputs,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs) {
   TmpMemMgr::Get()->Init(ctx.requested[0]);
-  const int num_inputs = inputs.size();
-  const NDArray &out_data = outputs[0];
+  const int num_inputs    = inputs.size();
+  const NDArray& out_data = outputs[0];
   std::vector<mkldnn::memory::desc> data_md;
-  std::vector<const mkldnn::memory *> data_mem;
+  std::vector<const mkldnn::memory*> data_mem;
   std::vector<float> scales(num_inputs, 1);
 
   data_md.reserve(num_inputs);
   data_mem.reserve(num_inputs);
 
   for (int i = 0; i < num_inputs; ++i) {
-    const mkldnn::memory *in_mem = inputs[i].GetMKLDNNData();
-    mkldnn::memory::desc tmp_md = in_mem->get_desc();
+    const mkldnn::memory* in_mem = inputs[i].GetMKLDNNData();
+    mkldnn::memory::desc tmp_md  = in_mem->get_desc();
     data_md.push_back(tmp_md);
     data_mem.push_back(in_mem);
   }
 
-  MKLDNNSumFwd &fwd = GetSumForward(scales, inputs, data_md);
-  mxnet::mkldnn_output_t out_mem = CreateMKLDNNMem(out_data,
-                                                   fwd.fwd_pd.dst_desc(),
-                                                   req[0],
-                                                   &inputs[0]);
+  MKLDNNSumFwd& fwd = GetSumForward(scales, inputs, data_md);
+  mxnet::mkldnn_output_t out_mem =
+      CreateMKLDNNMem(out_data, fwd.fwd_pd.dst_desc(), req[0], &inputs[0]);
   mkldnn_args_map_t net_args;
   net_args.insert({MKLDNN_ARG_DST, *out_mem.second});
   for (int i = 0; i < num_inputs; ++i) {

--- a/src/operator/nn/mkldnn/mkldnn_sum.cc
+++ b/src/operator/nn/mkldnn/mkldnn_sum.cc
@@ -75,9 +75,9 @@ class MKLDNNSumFwd {
   std::shared_ptr<mkldnn::sum> fwd_;
 };
 
-static MKLDNNSumFwd& GetSumForward(
-    const std::vector<float>& scales, const std::vector<NDArray>& in_data,
-    const std::vector<mkldnn::memory::desc>& data_md) {
+static MKLDNNSumFwd& GetSumForward(const std::vector<float>& scales,
+                                   const std::vector<NDArray>& in_data,
+                                   const std::vector<mkldnn::memory::desc>& data_md) {
 #if DMLC_CXX11_THREAD_LOCAL
   static thread_local std::unordered_map<OpSignature, MKLDNNSumFwd, OpHash> fwds;
 #else
@@ -94,9 +94,9 @@ static MKLDNNSumFwd& GetSumForward(
   return it->second;
 }
 
-void MKLDNNSumForward(
-    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& inputs,
-    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs) {
+void MKLDNNSumForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+                      const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+                      const std::vector<NDArray>& outputs) {
   TmpMemMgr::Get()->Init(ctx.requested[0]);
   const int num_inputs    = inputs.size();
   const NDArray& out_data = outputs[0];

--- a/src/operator/nn/mkldnn/mkldnn_sum.cc
+++ b/src/operator/nn/mkldnn/mkldnn_sum.cc
@@ -25,8 +25,8 @@
 #include <iostream>
 
 #include "../../operator_common.h"
-#include "./mkldnn_ops-inl.h"
 #include "./mkldnn_base-inl.h"
+#include "./mkldnn_ops-inl.h"
 
 namespace mxnet {
 namespace op {
@@ -94,8 +94,10 @@ static MKLDNNSumFwd& GetSumForward(const std::vector<float>& scales,
   return it->second;
 }
 
-void MKLDNNSumForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
-                      const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+void MKLDNNSumForward(const nnvm::NodeAttrs& attrs,
+                      const OpContext& ctx,
+                      const std::vector<NDArray>& inputs,
+                      const std::vector<OpReqType>& req,
                       const std::vector<NDArray>& outputs) {
   TmpMemMgr::Get()->Init(ctx.requested[0]);
   const int num_inputs    = inputs.size();

--- a/src/operator/nn/mkldnn/mkldnn_sum.cc
+++ b/src/operator/nn/mkldnn/mkldnn_sum.cc
@@ -69,7 +69,9 @@ class MKLDNNSumFwd {
     fwd_ = std::make_shared<mkldnn::sum>(fwd_pd);
   }
 
-  const mkldnn::sum& GetFwd() const { return *fwd_; }
+  const mkldnn::sum& GetFwd() const {
+    return *fwd_;
+  }
 
  private:
   std::shared_ptr<mkldnn::sum> fwd_;

--- a/src/operator/nn/mkldnn/mkldnn_transpose.cc
+++ b/src/operator/nn/mkldnn/mkldnn_transpose.cc
@@ -21,7 +21,7 @@
  * \file mkldnn_transpose.cc
  * \brief Implement transpose operator via MKL-DNN reorder primitive
  * \author Tao Lv
-*/
+ */
 
 #if MXNET_USE_MKLDNN == 1
 
@@ -31,8 +31,7 @@
 namespace mxnet {
 namespace op {
 
-bool SupportMKLDNNTranspose(const TransposeParam& param,
-                            const NDArray &data) {
+bool SupportMKLDNNTranspose(const TransposeParam& param, const NDArray& data) {
   auto data_ndim = data.shape().ndim();
 
   if (data_ndim > 4 || data_ndim == 0 || data.shape().Size() == 0 ||
@@ -52,12 +51,11 @@ class MKLDNNTransposeForward {
   std::shared_ptr<mkldnn::reorder> transpose_;
 
  public:
-  MKLDNNTransposeForward(const TransposeParam& param,
-                         const NDArray &data) {
-    auto shape = data.shape();
+  MKLDNNTransposeForward(const TransposeParam& param, const NDArray& data) {
+    auto shape     = data.shape();
     auto data_ndim = shape.ndim();
     auto axes_ndim = param.axes.ndim();
-    auto axes = mxnet::TShape(data_ndim, -1);
+    auto axes      = mxnet::TShape(data_ndim, -1);
     if (axes_ndim == 0) {
       for (int i = 0; i < data_ndim; i++) {
         axes[i] = data_ndim - i - 1;
@@ -69,13 +67,13 @@ class MKLDNNTransposeForward {
     auto engine = CpuEngine::Get()->get_engine();
     auto in_mem = data.GetMKLDNNData();
     auto src_md = in_mem->get_desc();
-    data_ = std::make_shared<mkldnn::memory>(src_md, engine, nullptr);
+    data_       = std::make_shared<mkldnn::memory>(src_md, engine, nullptr);
 
     mkldnn_dims_t strides;
     mkldnn_dims_t sh;
     dim_t total_stride = 1;
     for (int i = data_ndim - 1; i >= 0; i--) {
-      sh[i] = shape[i];
+      sh[i]            = shape[i];
       strides[axes[i]] = total_stride;
       total_stride *= shape[axes[i]];
     }
@@ -84,29 +82,25 @@ class MKLDNNTransposeForward {
     mkldnn_memory_desc_init_by_strides(&dst_fmt, data_ndim, sh, mkldnn_f32, strides);
 
     dst_md_ = std::make_shared<mkldnn::memory::desc>(dst_fmt);
-    out_ = std::make_shared<mkldnn::memory>(*dst_md_, engine, nullptr);
+    out_    = std::make_shared<mkldnn::memory>(*dst_md_, engine, nullptr);
 
     transpose_ = std::make_shared<mkldnn::reorder>(*data_, *out_);
   }
 
-  void SetNewMem(const NDArray &data, const NDArray &output) {
+  void SetNewMem(const NDArray& data, const NDArray& output) {
     if (data.IsMKLDNNData()) {
       this->data_->set_data_handle(data.GetMKLDNNData()->get_data_handle());
     } else {
-      MSHADOW_TYPE_SWITCH(data.dtype(), DTYPE, {
-        this->data_->set_data_handle(data.data().dptr<DTYPE>());
-      });
+      MSHADOW_TYPE_SWITCH(
+          data.dtype(), DTYPE, { this->data_->set_data_handle(data.data().dptr<DTYPE>()); });
     }
 
     CHECK(!output.IsMKLDNNData());
-    MSHADOW_TYPE_SWITCH(output.dtype(), DTYPE, {
-      this->out_->set_data_handle(output.data().dptr<DTYPE>());
-    });
+    MSHADOW_TYPE_SWITCH(
+        output.dtype(), DTYPE, { this->out_->set_data_handle(output.data().dptr<DTYPE>()); });
   }
 
-  const mkldnn::reorder &GetFwd() const {
-    return *transpose_;
-  }
+  const mkldnn::reorder& GetFwd() const { return *transpose_; }
 
   void Execute() const {
     auto stream = MKLDNNStream::Get();
@@ -117,14 +111,15 @@ class MKLDNNTransposeForward {
   }
 };
 
-static MKLDNNTransposeForward &GetTransposeForward(const TransposeParam& param,
-                                                   const NDArray &data) {
+static MKLDNNTransposeForward& GetTransposeForward(
+    const TransposeParam& param, const NDArray& data) {
 #if DMLC_CXX11_THREAD_LOCAL
-  static thread_local std::unordered_map<MKLDNNTransposeSignature,
-                                         MKLDNNTransposeForward, OpHash> fwds;
+  static thread_local std::unordered_map<MKLDNNTransposeSignature, MKLDNNTransposeForward, OpHash>
+      fwds;
 #else
-  static MX_THREAD_LOCAL std::unordered_map<MKLDNNTransposeSignature,
-                                            MKLDNNTransposeForward, OpHash> fwds;
+  static MX_THREAD_LOCAL
+      std::unordered_map<MKLDNNTransposeSignature, MKLDNNTransposeForward, OpHash>
+          fwds;
 #endif
   MKLDNNTransposeSignature key(param);
   key.AddSign(data);
@@ -137,11 +132,9 @@ static MKLDNNTransposeForward &GetTransposeForward(const TransposeParam& param,
   return it->second;
 }
 
-void MKLDNNTransposeForward(const nnvm::NodeAttrs& attrs,
-                            const OpContext &ctx,
-                            const NDArray &data,
-                            const OpReqType &req,
-                            const NDArray &output) {
+void MKLDNNTransposeForward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const NDArray& data, const OpReqType& req,
+    const NDArray& output) {
   const TransposeParam& param = nnvm::get<TransposeParam>(attrs.parsed);
 
   auto fwd = GetTransposeForward(param, data);

--- a/src/operator/nn/mkldnn/mkldnn_transpose.cc
+++ b/src/operator/nn/mkldnn/mkldnn_transpose.cc
@@ -26,6 +26,7 @@
 #if MXNET_USE_MKLDNN == 1
 
 #include <mkldnn.hpp>
+
 #include "../../tensor/matrix_op-inl.h"
 
 namespace mxnet {
@@ -132,8 +133,11 @@ static MKLDNNTransposeForward& GetTransposeForward(const TransposeParam& param,
   return it->second;
 }
 
-void MKLDNNTransposeForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx, const NDArray& data,
-                            const OpReqType& req, const NDArray& output) {
+void MKLDNNTransposeForward(const nnvm::NodeAttrs& attrs,
+                            const OpContext& ctx,
+                            const NDArray& data,
+                            const OpReqType& req,
+                            const NDArray& output) {
   const TransposeParam& param = nnvm::get<TransposeParam>(attrs.parsed);
 
   auto fwd = GetTransposeForward(param, data);

--- a/src/operator/nn/mkldnn/mkldnn_transpose.cc
+++ b/src/operator/nn/mkldnn/mkldnn_transpose.cc
@@ -91,13 +91,13 @@ class MKLDNNTransposeForward {
     if (data.IsMKLDNNData()) {
       this->data_->set_data_handle(data.GetMKLDNNData()->get_data_handle());
     } else {
-      MSHADOW_TYPE_SWITCH(
-          data.dtype(), DTYPE, { this->data_->set_data_handle(data.data().dptr<DTYPE>()); });
+      MSHADOW_TYPE_SWITCH(data.dtype(), DTYPE,
+                          { this->data_->set_data_handle(data.data().dptr<DTYPE>()); });
     }
 
     CHECK(!output.IsMKLDNNData());
-    MSHADOW_TYPE_SWITCH(
-        output.dtype(), DTYPE, { this->out_->set_data_handle(output.data().dptr<DTYPE>()); });
+    MSHADOW_TYPE_SWITCH(output.dtype(), DTYPE,
+                        { this->out_->set_data_handle(output.data().dptr<DTYPE>()); });
   }
 
   const mkldnn::reorder& GetFwd() const { return *transpose_; }
@@ -111,8 +111,8 @@ class MKLDNNTransposeForward {
   }
 };
 
-static MKLDNNTransposeForward& GetTransposeForward(
-    const TransposeParam& param, const NDArray& data) {
+static MKLDNNTransposeForward& GetTransposeForward(const TransposeParam& param,
+                                                   const NDArray& data) {
 #if DMLC_CXX11_THREAD_LOCAL
   static thread_local std::unordered_map<MKLDNNTransposeSignature, MKLDNNTransposeForward, OpHash>
       fwds;
@@ -132,9 +132,8 @@ static MKLDNNTransposeForward& GetTransposeForward(
   return it->second;
 }
 
-void MKLDNNTransposeForward(
-    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const NDArray& data, const OpReqType& req,
-    const NDArray& output) {
+void MKLDNNTransposeForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx, const NDArray& data,
+                            const OpReqType& req, const NDArray& output) {
   const TransposeParam& param = nnvm::get<TransposeParam>(attrs.parsed);
 
   auto fwd = GetTransposeForward(param, data);

--- a/src/operator/nn/mkldnn/mkldnn_transpose.cc
+++ b/src/operator/nn/mkldnn/mkldnn_transpose.cc
@@ -92,16 +92,18 @@ class MKLDNNTransposeForward {
     if (data.IsMKLDNNData()) {
       this->data_->set_data_handle(data.GetMKLDNNData()->get_data_handle());
     } else {
-      MSHADOW_TYPE_SWITCH(data.dtype(), DTYPE,
-                          { this->data_->set_data_handle(data.data().dptr<DTYPE>()); });
+      MSHADOW_TYPE_SWITCH(
+          data.dtype(), DTYPE, { this->data_->set_data_handle(data.data().dptr<DTYPE>()); });
     }
 
     CHECK(!output.IsMKLDNNData());
-    MSHADOW_TYPE_SWITCH(output.dtype(), DTYPE,
-                        { this->out_->set_data_handle(output.data().dptr<DTYPE>()); });
+    MSHADOW_TYPE_SWITCH(
+        output.dtype(), DTYPE, { this->out_->set_data_handle(output.data().dptr<DTYPE>()); });
   }
 
-  const mkldnn::reorder& GetFwd() const { return *transpose_; }
+  const mkldnn::reorder& GetFwd() const {
+    return *transpose_;
+  }
 
   void Execute() const {
     auto stream = MKLDNNStream::Get();

--- a/src/operator/operator_common.h
+++ b/src/operator/operator_common.h
@@ -105,16 +105,24 @@ struct InferStorageTypeError : public dmlc::Error {
 
 /*! \brief check if shape is empty or contains unknown (0) dim.
  * DEPRECATED. */
-inline bool shape_is_none(const mxnet::TShape& x) { return !mxnet::shape_is_known(x); }
+inline bool shape_is_none(const mxnet::TShape& x) {
+  return !mxnet::shape_is_known(x);
+}
 
 /*! \brief check if type is none (-1) */
-inline bool type_is_none(const int& x) { return x == -1; }
+inline bool type_is_none(const int& x) {
+  return x == -1;
+}
 
 /*! \brief check if type is none (-1) */
-inline bool storage_type_is_none(const int& x) { return x == -1; }
+inline bool storage_type_is_none(const int& x) {
+  return x == -1;
+}
 
 /*! \brief check if shape is scalar({1}). */
-inline bool shape_is_scalar(const mxnet::TShape& x) { return x.ndim() == 0; }
+inline bool shape_is_scalar(const mxnet::TShape& x) {
+  return x.ndim() == 0;
+}
 
 /*! \brief get string representation of shape */
 inline std::string shape_string(const mxnet::TShape& x) {
@@ -188,10 +196,9 @@ inline bool type_assign(int* y, const int& x) {
 }
 
 /*!
- * \brief Assign x to y. Checks for compatiblity when y is not DispatchMode::kUndefined.
- * \param y target mode.
- * \param x source mode.
- * \return whether x and y are compatible.
+ * \brief Assign x to y. Checks for compatiblity when y is not
+ * DispatchMode::kUndefined. \param y target mode. \param x source mode. \return
+ * whether x and y are compatible.
  */
 inline bool dispatch_mode_assign(DispatchMode* y, const DispatchMode& x) {
   if (*y == DispatchMode::kUndefined) {
@@ -207,11 +214,10 @@ inline bool dispatch_mode_assign(DispatchMode* y, const DispatchMode& x) {
 #define MXNET_ADD_SPARSE_OP_ALIAS(__name$) .add_alias("_sparse_" #__name$)
 
 /*!
- * \brief macro assign shape to out if out is unknown otherwise check consistency
- *  Use macro so we can see the error file more clearly
- * \param shape_array the shape array to store the result
- * \param index the index of in the array
- * \param shape the inferred shape
+ * \brief macro assign shape to out if out is unknown otherwise check
+ * consistency Use macro so we can see the error file more clearly \param
+ * shape_array the shape array to store the result \param index the index of in
+ * the array \param shape the inferred shape
  */
 #define SHAPE_ASSIGN_CHECK(shape_array, index, shape)                              \
   {                                                                                \
@@ -224,11 +230,10 @@ inline bool dispatch_mode_assign(DispatchMode* y, const DispatchMode& x) {
   }
 
 /*!
- * \brief macro assign type to out if out is unknown (-1) otherwise check consistency
- *  Use macro so we can see the error file more clearly
- * \param type_array the type array to store the result
- * \param index the index of in the array
- * \param type the inferred type
+ * \brief macro assign type to out if out is unknown (-1) otherwise check
+ * consistency Use macro so we can see the error file more clearly \param
+ * type_array the type array to store the result \param index the index of in
+ * the array \param type the inferred type
  */
 #define TYPE_ASSIGN_CHECK(type_array, index, type)                                            \
   {                                                                                           \
@@ -241,11 +246,10 @@ inline bool dispatch_mode_assign(DispatchMode* y, const DispatchMode& x) {
   }
 
 /*!
- * \brief macro assign storage type to out if out is unknown (-1) otherwise check consistency
- *  Use macro so we can see the error file more clearly
- * \param type_array the type array to store the result
- * \param index the index of in the array
- * \param type the inferred storage type
+ * \brief macro assign storage type to out if out is unknown (-1) otherwise
+ * check consistency Use macro so we can see the error file more clearly \param
+ * type_array the type array to store the result \param index the index of in
+ * the array \param type the inferred storage type
  */
 #define STORAGE_TYPE_ASSIGN_CHECK(type_array, index, type)                                        \
   {                                                                                               \
@@ -258,11 +262,10 @@ inline bool dispatch_mode_assign(DispatchMode* y, const DispatchMode& x) {
   }
 
 /*!
- * \brief macro assign type to out if out is unknown (-1) otherwise check consistency
- *  Use macro so we can see the error file more clearly
- * \param type_array the type array to store the result
- * \param index the index of in the array
- * \param type the inferred dispatch type
+ * \brief macro assign type to out if out is unknown (-1) otherwise check
+ * consistency Use macro so we can see the error file more clearly \param
+ * type_array the type array to store the result \param index the index of in
+ * the array \param type the inferred dispatch type
  */
 #define DISPATCH_MODE_ASSIGN_CHECK(type_array, index, type)               \
   {                                                                       \
@@ -340,7 +343,8 @@ inline bool storage_type_assign(StorageTypeVector* stypes,
   return success;
 }
 
-/*! \brief update the stype vector to default storage and dispatch_mode to fallback
+/*! \brief update the stype vector to default storage and dispatch_mode to
+ * fallback
  */
 inline bool dispatch_fallback(StorageTypeVector* stypes, DispatchMode* dispatch) {
   for (auto& stype : *stypes) {
@@ -354,9 +358,11 @@ inline std::vector<nnvm::NodeEntry> CreateNodeEntries(
     nnvm::ObjectPtr pNode,
     const std::vector<nnvm::NodeEntry>* pOgrads = nullptr,
     const std::vector<nnvm::NodeEntry>* pInputs = nullptr) {
-  if (pOgrads) pNode->inputs.insert(pNode->inputs.end(), pOgrads->begin(), pOgrads->end());
+  if (pOgrads)
+    pNode->inputs.insert(pNode->inputs.end(), pOgrads->begin(), pOgrads->end());
 
-  if (pInputs) pNode->inputs.insert(pNode->inputs.end(), pInputs->begin(), pInputs->end());
+  if (pInputs)
+    pNode->inputs.insert(pNode->inputs.end(), pInputs->begin(), pInputs->end());
 
   if (!pNode->is_variable()) {
     CHECK_EQ(pNode->num_inputs(), pNode->inputs.size())
@@ -381,8 +387,10 @@ inline nnvm::ObjectPtr MakeNode(const char* op_name,
   auto p        = nnvm::Node::Create();
   p->attrs.op   = nnvm::Op::Get(op_name);
   p->attrs.name = name;
-  if (dict != nullptr) p->attrs.dict = *dict;
-  if (inputs != nullptr) p->inputs = *inputs;
+  if (dict != nullptr)
+    p->attrs.dict = *dict;
+  if (inputs != nullptr)
+    p->inputs = *inputs;
   if (fwd_node != nullptr) {
     p->control_deps.emplace_back(*fwd_node);
   }
@@ -417,7 +425,8 @@ inline std::vector<nnvm::NodeEntry> MakeGradNode(
   return CreateNodeEntries(p);
 }
 
-// quick helper to make gradient nodes that simply pass back zero. could be used in output ops.
+// quick helper to make gradient nodes that simply pass back zero. could be used
+// in output ops.
 inline std::vector<nnvm::NodeEntry> MakeZeroGradNodes(const nnvm::ObjectPtr& n,
                                                       const std::vector<nnvm::NodeEntry>& ograds) {
   std::vector<nnvm::NodeEntry> ret;
@@ -437,10 +446,13 @@ inline std::vector<nnvm::NodeEntry> MakeZeroGradNodes(const nnvm::ObjectPtr& n,
 inline bool CheckGradAllZero(const std::vector<nnvm::NodeEntry>& ograds) {
   static const auto zero_op      = nnvm::Op::Get("_zeros");
   static const auto zero_like_op = nnvm::Op::Get("zeros_like");
-  if (ograds.empty()) return false;
+  if (ograds.empty())
+    return false;
   for (const auto& grad : ograds) {
-    if (!grad.node) return false;
-    if (grad.node->op() != zero_op && grad.node->op() != zero_like_op) return false;
+    if (!grad.node)
+      return false;
+    if (grad.node->op() != zero_op && grad.node->op() != zero_like_op)
+      return false;
   }
   return true;
 }
@@ -453,7 +465,8 @@ inline std::vector<nnvm::NodeEntry> MakeNonlossGradNode(
     const std::vector<nnvm::NodeEntry>& ograds,
     const std::vector<nnvm::NodeEntry>& inputs,
     const std::unordered_map<std::string, std::string>& dict) {
-  if (CheckGradAllZero(ograds)) return MakeZeroGradNodes(n, ograds);
+  if (CheckGradAllZero(ograds))
+    return MakeZeroGradNodes(n, ograds);
   auto p = MakeNode(op_name, n->attrs.name + "_backward", nullptr, &dict, &n);
 
   return CreateNodeEntries(p, &ograds, &inputs);
@@ -507,14 +520,20 @@ class OpSignature {
   uint64_t hash;
 
  public:
-  OpSignature() { hash = 0; }
+  OpSignature() {
+    hash = 0;
+  }
 
-  explicit OpSignature(uint64_t hash) { this->hash = hash; }
+  explicit OpSignature(uint64_t hash) {
+    this->hash = hash;
+  }
 
   /*
    * This is to reserve space for the vector.
    */
-  void Reserve(size_t num) { eles.reserve(num); }
+  void Reserve(size_t num) {
+    eles.reserve(num);
+  }
 
   /*
    * We provide different methods to add signature to an op.
@@ -630,18 +649,25 @@ class OpSignature {
   }
 
   bool operator==(const OpSignature& sign) const {
-    if (hash != sign.hash) return false;
-    if (eles.size() != sign.eles.size()) return false;
+    if (hash != sign.hash)
+      return false;
+    if (eles.size() != sign.eles.size())
+      return false;
     for (size_t i = 0; i < eles.size(); i++)
-      if (eles[i] != sign.eles[i]) return false;
+      if (eles[i] != sign.eles[i])
+        return false;
     return true;
   }
 
-  uint64_t GetHash() const { return hash; }
+  uint64_t GetHash() const {
+    return hash;
+  }
 };
 
 struct OpHash {
-  size_t operator()(const OpSignature& sign) const { return sign.GetHash(); }
+  size_t operator()(const OpSignature& sign) const {
+    return sign.GetHash();
+  }
 };
 
 template <typename ParamType>

--- a/src/operator/operator_common.h
+++ b/src/operator/operator_common.h
@@ -307,9 +307,8 @@ inline bool dispatch_mode_assign(DispatchMode* y, const DispatchMode& x) {
 /*! \brief assign stype to target_stype, if successful,
  *         assign dispatch_mode to target_dispatch
  */
-inline bool storage_type_assign(
-    int* stype, const NDArrayStorageType target_stype, DispatchMode* dispatch,
-    const DispatchMode target_dispatch) {
+inline bool storage_type_assign(int* stype, const NDArrayStorageType target_stype,
+                                DispatchMode* dispatch, const DispatchMode target_dispatch) {
   if (type_assign(stype, target_stype)) {
     DISPATCH_MODE_ASSIGN_CHECK(dispatch, 0, target_dispatch);
     return true;
@@ -320,9 +319,8 @@ inline bool storage_type_assign(
 /*! \brief assign the stype vector to target_stype, if successful,
  *         assign dispatch_mode to target_dispatch
  */
-inline bool storage_type_assign(
-    StorageTypeVector* stypes, const NDArrayStorageType target_stype, DispatchMode* dispatch,
-    const DispatchMode target_dispatch) {
+inline bool storage_type_assign(StorageTypeVector* stypes, const NDArrayStorageType target_stype,
+                                DispatchMode* dispatch, const DispatchMode target_dispatch) {
   CHECK_GT(stypes->size(), 0);
   bool success = true;
   for (int& stype : *stypes) {
@@ -368,11 +366,10 @@ inline std::vector<nnvm::NodeEntry> CreateNodeEntries(
 }
 
 // make a new node with operator op_name. Inputs are not filled.
-inline nnvm::ObjectPtr MakeNode(
-    const char* op_name, const std::string& name,
-    std::vector<nnvm::NodeEntry> const* inputs               = nullptr,
-    std::unordered_map<std::string, std::string> const* dict = nullptr,
-    nnvm::ObjectPtr const* fwd_node                          = nullptr) {
+inline nnvm::ObjectPtr MakeNode(const char* op_name, const std::string& name,
+                                std::vector<nnvm::NodeEntry> const* inputs               = nullptr,
+                                std::unordered_map<std::string, std::string> const* dict = nullptr,
+                                nnvm::ObjectPtr const* fwd_node = nullptr) {
   auto p        = nnvm::Node::Create();
   p->attrs.op   = nnvm::Op::Get(op_name);
   p->attrs.name = name;
@@ -393,9 +390,10 @@ inline nnvm::ObjectPtr MakeNode(
   return p;
 }
 
-inline nnvm::ObjectPtr MakeNode(
-    const char* op_name, const std::string& name, const std::vector<nnvm::NodeEntry>& inputs,
-    std::unordered_map<std::string, std::string> const* dict, nnvm::ObjectPtr const* fwd_node) {
+inline nnvm::ObjectPtr MakeNode(const char* op_name, const std::string& name,
+                                const std::vector<nnvm::NodeEntry>& inputs,
+                                std::unordered_map<std::string, std::string> const* dict,
+                                nnvm::ObjectPtr const* fwd_node) {
   return MakeNode(op_name, name, &inputs, dict, fwd_node);
 }
 
@@ -409,8 +407,8 @@ inline std::vector<nnvm::NodeEntry> MakeGradNode(
 }
 
 // quick helper to make gradient nodes that simply pass back zero. could be used in output ops.
-inline std::vector<nnvm::NodeEntry> MakeZeroGradNodes(
-    const nnvm::ObjectPtr& n, const std::vector<nnvm::NodeEntry>& ograds) {
+inline std::vector<nnvm::NodeEntry> MakeZeroGradNodes(const nnvm::ObjectPtr& n,
+                                                      const std::vector<nnvm::NodeEntry>& ograds) {
   std::vector<nnvm::NodeEntry> ret;
   for (uint32_t i = 0; i < n->num_inputs(); ++i) {
     std::ostringstream os;
@@ -468,8 +466,8 @@ inline void ParamParser(nnvm::NodeAttrs* attrs) {
   attrs->parsed = std::move(param);
 }
 
-inline void CheckAllRowsPresent(
-    const NDArray& arr, const std::string& func, const std::string& param) {
+inline void CheckAllRowsPresent(const NDArray& arr, const std::string& func,
+                                const std::string& param) {
   if (arr.storage_type() == kRowSparseStorage) {
     CHECK(arr.storage_shape()[0] == arr.shape()[0])
         << func << " for RowSparse " << param << " is only implemented for "
@@ -481,9 +479,10 @@ inline void CheckAllRowsPresent(
   }
 }
 
-inline void LogUnimplementedOp(
-    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& inputs,
-    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs) {
+inline void LogUnimplementedOp(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+                               const std::vector<NDArray>& inputs,
+                               const std::vector<OpReqType>& req,
+                               const std::vector<NDArray>& outputs) {
   using common::operator_string;
   LOG(FATAL) << "Not implemented: " << operator_string(attrs, ctx, inputs, req, outputs);
 }

--- a/src/operator/operator_common.h
+++ b/src/operator/operator_common.h
@@ -30,15 +30,17 @@
 #include <dmlc/json.h>
 #include <dmlc/logging.h>
 #include <dmlc/thread_local.h>
-#include <mxnet/operator.h>
+#include <mxnet/base.h>
 #include <mxnet/ndarray.h>
 #include <mxnet/op_attr_types.h>
-#include <mxnet/base.h>
+#include <mxnet/operator.h>
+
+#include <algorithm>
 #include <istream>
 #include <ostream>
 #include <string>
 #include <vector>
-#include <algorithm>
+
 #include "../common/cuda_utils.h"
 #include "../common/utils.h"
 
@@ -307,8 +309,10 @@ inline bool dispatch_mode_assign(DispatchMode* y, const DispatchMode& x) {
 /*! \brief assign stype to target_stype, if successful,
  *         assign dispatch_mode to target_dispatch
  */
-inline bool storage_type_assign(int* stype, const NDArrayStorageType target_stype,
-                                DispatchMode* dispatch, const DispatchMode target_dispatch) {
+inline bool storage_type_assign(int* stype,
+                                const NDArrayStorageType target_stype,
+                                DispatchMode* dispatch,
+                                const DispatchMode target_dispatch) {
   if (type_assign(stype, target_stype)) {
     DISPATCH_MODE_ASSIGN_CHECK(dispatch, 0, target_dispatch);
     return true;
@@ -319,8 +323,10 @@ inline bool storage_type_assign(int* stype, const NDArrayStorageType target_styp
 /*! \brief assign the stype vector to target_stype, if successful,
  *         assign dispatch_mode to target_dispatch
  */
-inline bool storage_type_assign(StorageTypeVector* stypes, const NDArrayStorageType target_stype,
-                                DispatchMode* dispatch, const DispatchMode target_dispatch) {
+inline bool storage_type_assign(StorageTypeVector* stypes,
+                                const NDArrayStorageType target_stype,
+                                DispatchMode* dispatch,
+                                const DispatchMode target_dispatch) {
   CHECK_GT(stypes->size(), 0);
   bool success = true;
   for (int& stype : *stypes) {
@@ -345,7 +351,8 @@ inline bool dispatch_fallback(StorageTypeVector* stypes, DispatchMode* dispatch)
 }
 
 inline std::vector<nnvm::NodeEntry> CreateNodeEntries(
-    nnvm::ObjectPtr pNode, const std::vector<nnvm::NodeEntry>* pOgrads = nullptr,
+    nnvm::ObjectPtr pNode,
+    const std::vector<nnvm::NodeEntry>* pOgrads = nullptr,
     const std::vector<nnvm::NodeEntry>* pInputs = nullptr) {
   if (pOgrads) pNode->inputs.insert(pNode->inputs.end(), pOgrads->begin(), pOgrads->end());
 
@@ -366,7 +373,8 @@ inline std::vector<nnvm::NodeEntry> CreateNodeEntries(
 }
 
 // make a new node with operator op_name. Inputs are not filled.
-inline nnvm::ObjectPtr MakeNode(const char* op_name, const std::string& name,
+inline nnvm::ObjectPtr MakeNode(const char* op_name,
+                                const std::string& name,
                                 std::vector<nnvm::NodeEntry> const* inputs               = nullptr,
                                 std::unordered_map<std::string, std::string> const* dict = nullptr,
                                 nnvm::ObjectPtr const* fwd_node = nullptr) {
@@ -390,7 +398,8 @@ inline nnvm::ObjectPtr MakeNode(const char* op_name, const std::string& name,
   return p;
 }
 
-inline nnvm::ObjectPtr MakeNode(const char* op_name, const std::string& name,
+inline nnvm::ObjectPtr MakeNode(const char* op_name,
+                                const std::string& name,
                                 const std::vector<nnvm::NodeEntry>& inputs,
                                 std::unordered_map<std::string, std::string> const* dict,
                                 nnvm::ObjectPtr const* fwd_node) {
@@ -399,7 +408,9 @@ inline nnvm::ObjectPtr MakeNode(const char* op_name, const std::string& name,
 
 // quick helper to make node
 inline std::vector<nnvm::NodeEntry> MakeGradNode(
-    const char* op_name, const nnvm::ObjectPtr& n, const std::vector<nnvm::NodeEntry>& inputs,
+    const char* op_name,
+    const nnvm::ObjectPtr& n,
+    const std::vector<nnvm::NodeEntry>& inputs,
     const std::unordered_map<std::string, std::string>& dict) {
   auto p = MakeNode(op_name, n->attrs.name + "_backward", &inputs, &dict, &n);
 
@@ -437,7 +448,9 @@ inline bool CheckGradAllZero(const std::vector<nnvm::NodeEntry>& ograds) {
 // make gradient node that doesn't add to objective.
 // i.e. igrads are always zero when ograds are zero.
 inline std::vector<nnvm::NodeEntry> MakeNonlossGradNode(
-    const char* op_name, const nnvm::ObjectPtr& n, const std::vector<nnvm::NodeEntry>& ograds,
+    const char* op_name,
+    const nnvm::ObjectPtr& n,
+    const std::vector<nnvm::NodeEntry>& ograds,
     const std::vector<nnvm::NodeEntry>& inputs,
     const std::unordered_map<std::string, std::string>& dict) {
   if (CheckGradAllZero(ograds)) return MakeZeroGradNodes(n, ograds);
@@ -466,7 +479,8 @@ inline void ParamParser(nnvm::NodeAttrs* attrs) {
   attrs->parsed = std::move(param);
 }
 
-inline void CheckAllRowsPresent(const NDArray& arr, const std::string& func,
+inline void CheckAllRowsPresent(const NDArray& arr,
+                                const std::string& func,
                                 const std::string& param) {
   if (arr.storage_type() == kRowSparseStorage) {
     CHECK(arr.storage_shape()[0] == arr.shape()[0])
@@ -479,7 +493,8 @@ inline void CheckAllRowsPresent(const NDArray& arr, const std::string& func,
   }
 }
 
-inline void LogUnimplementedOp(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+inline void LogUnimplementedOp(const nnvm::NodeAttrs& attrs,
+                               const OpContext& ctx,
                                const std::vector<NDArray>& inputs,
                                const std::vector<OpReqType>& req,
                                const std::vector<NDArray>& outputs) {

--- a/src/operator/operator_common.h
+++ b/src/operator/operator_common.h
@@ -23,7 +23,7 @@
  * \brief common internal header of most operators
  *   this header includes utility functions operator can use
  * \author Bing Xu
-*/
+ */
 #ifndef MXNET_OPERATOR_OPERATOR_COMMON_H_
 #define MXNET_OPERATOR_OPERATOR_COMMON_H_
 
@@ -52,23 +52,22 @@ namespace op {
  * \tparam OType output type
  * \tparam Exp expression type
  */
-#define Assign(out, req, exp)           \
-  {                                     \
-    switch (req) {                      \
-      case kNullOp:                     \
-        break;                          \
-      case kWriteTo:                    \
-      case kWriteInplace:               \
-        (out) = (exp);                  \
-        break;                          \
-      case kAddTo:                      \
-        (out) += (exp);                 \
-        break;                          \
-      default:                          \
-        LOG(FATAL) << "not reached";    \
-    }                                   \
+#define Assign(out, req, exp)        \
+  {                                  \
+    switch (req) {                   \
+      case kNullOp:                  \
+        break;                       \
+      case kWriteTo:                 \
+      case kWriteInplace:            \
+        (out) = (exp);               \
+        break;                       \
+      case kAddTo:                   \
+        (out) += (exp);              \
+        break;                       \
+      default:                       \
+        LOG(FATAL) << "not reached"; \
+    }                                \
   }
-
 
 /*! \brief exception throwed by InferShape error */
 struct InferShapeError : public dmlc::Error {
@@ -78,7 +77,7 @@ struct InferShapeError : public dmlc::Error {
   int index;
   // constructor
   InferShapeError(const std::string& msg_, int index)
-    : dmlc::Error(msg_), msg(msg_), index(index) {}
+      : dmlc::Error(msg_), msg(msg_), index(index) {}
 };
 
 /*! \brief exception throwed by InferShape error */
@@ -88,8 +87,7 @@ struct InferTypeError : public dmlc::Error {
   /*! \brief corresponding input index */
   int index;
   // constructor
-  InferTypeError(const std::string& msg_, int index)
-    : dmlc::Error(msg_), msg(msg_), index(index) {}
+  InferTypeError(const std::string& msg_, int index) : dmlc::Error(msg_), msg(msg_), index(index) {}
 };
 
 /*! \brief exception throwed by InferStorageType error */
@@ -100,29 +98,21 @@ struct InferStorageTypeError : public dmlc::Error {
   int index;
   // constructor
   InferStorageTypeError(const std::string& msg_, int index)
-    : dmlc::Error(msg_), msg(msg_), index(index) {}
+      : dmlc::Error(msg_), msg(msg_), index(index) {}
 };
 
 /*! \brief check if shape is empty or contains unknown (0) dim.
  * DEPRECATED. */
-inline bool shape_is_none(const mxnet::TShape& x) {
-  return !mxnet::shape_is_known(x);
-}
+inline bool shape_is_none(const mxnet::TShape& x) { return !mxnet::shape_is_known(x); }
 
 /*! \brief check if type is none (-1) */
-inline bool type_is_none(const int& x) {
-  return x == -1;
-}
+inline bool type_is_none(const int& x) { return x == -1; }
 
 /*! \brief check if type is none (-1) */
-inline bool storage_type_is_none(const int& x) {
-  return x == -1;
-}
+inline bool storage_type_is_none(const int& x) { return x == -1; }
 
 /*! \brief check if shape is scalar({1}). */
-inline bool shape_is_scalar(const mxnet::TShape& x) {
-  return x.ndim() == 0;
-}
+inline bool shape_is_scalar(const mxnet::TShape& x) { return x.ndim() == 0; }
 
 /*! \brief get string representation of shape */
 inline std::string shape_string(const mxnet::TShape& x) {
@@ -161,7 +151,7 @@ inline std::string type_string(const int& x) {
  * \param x source shape.
  * \return whether x and y are compatible.
  */
-inline bool shape_assign(mxnet::TShape *y, const mxnet::TShape& x) {
+inline bool shape_assign(mxnet::TShape* y, const mxnet::TShape& x) {
   if (!mxnet::ndim_is_known(*y)) {
     *y = x;
     return true;
@@ -185,7 +175,7 @@ inline bool shape_assign(mxnet::TShape *y, const mxnet::TShape& x) {
  * \param x source type.
  * \return whether x and y are compatible.
  */
-inline bool type_assign(int *y, const int& x) {
+inline bool type_assign(int* y, const int& x) {
   if (*y == -1) {
     *y = x;
     return true;
@@ -201,7 +191,7 @@ inline bool type_assign(int *y, const int& x) {
  * \param x source mode.
  * \return whether x and y are compatible.
  */
-inline bool dispatch_mode_assign(DispatchMode *y, const DispatchMode& x) {
+inline bool dispatch_mode_assign(DispatchMode* y, const DispatchMode& x) {
   if (*y == DispatchMode::kUndefined) {
     *y = x;
     return true;
@@ -212,8 +202,7 @@ inline bool dispatch_mode_assign(DispatchMode *y, const DispatchMode& x) {
 }
 
 /*! \brief Register op name as an alias */
-#define MXNET_ADD_SPARSE_OP_ALIAS(__name$) \
-  .add_alias("_sparse_" #__name$)
+#define MXNET_ADD_SPARSE_OP_ALIAS(__name$) .add_alias("_sparse_" #__name$)
 
 /*!
  * \brief macro assign shape to out if out is unknown otherwise check consistency
@@ -222,14 +211,14 @@ inline bool dispatch_mode_assign(DispatchMode *y, const DispatchMode& x) {
  * \param index the index of in the array
  * \param shape the inferred shape
  */
-#define SHAPE_ASSIGN_CHECK(shape_array, index, shape)                       \
-  {                                                                         \
+#define SHAPE_ASSIGN_CHECK(shape_array, index, shape)                              \
+  {                                                                                \
     if (!::mxnet::op::shape_assign(&(shape_array)[index], mxnet::TShape(shape))) { \
-      std::ostringstream os;                                                \
-      os << "Shape inconsistent, Provided = " << (shape_array)[index] << ','\
-         << " inferred shape=" << shape;                                    \
-      throw ::mxnet::op::InferShapeError(os.str(), index);                  \
-    }                                                                       \
+      std::ostringstream os;                                                       \
+      os << "Shape inconsistent, Provided = " << (shape_array)[index] << ','       \
+         << " inferred shape=" << shape;                                           \
+      throw ::mxnet::op::InferShapeError(os.str(), index);                         \
+    }                                                                              \
   }
 
 /*!
@@ -239,15 +228,14 @@ inline bool dispatch_mode_assign(DispatchMode *y, const DispatchMode& x) {
  * \param index the index of in the array
  * \param type the inferred type
  */
-#define TYPE_ASSIGN_CHECK(type_array, index, type)                          \
-  {                                                                         \
-    if (!::mxnet::op::type_assign(&(type_array)[index], type)) {            \
-      std::ostringstream os;                                                \
-      os << "Type inconsistent, Provided = "                                \
-         << ::mxnet::op::type_string((type_array)[index]) << ','            \
-         << " inferred type = " << ::mxnet::op::type_string(type);          \
-      throw ::mxnet::op::InferTypeError(os.str(), index);                   \
-    }                                                                       \
+#define TYPE_ASSIGN_CHECK(type_array, index, type)                                            \
+  {                                                                                           \
+    if (!::mxnet::op::type_assign(&(type_array)[index], type)) {                              \
+      std::ostringstream os;                                                                  \
+      os << "Type inconsistent, Provided = " << ::mxnet::op::type_string((type_array)[index]) \
+         << ',' << " inferred type = " << ::mxnet::op::type_string(type);                     \
+      throw ::mxnet::op::InferTypeError(os.str(), index);                                     \
+    }                                                                                         \
   }
 
 /*!
@@ -257,15 +245,14 @@ inline bool dispatch_mode_assign(DispatchMode *y, const DispatchMode& x) {
  * \param index the index of in the array
  * \param type the inferred storage type
  */
-#define STORAGE_TYPE_ASSIGN_CHECK(type_array, index, type)                  \
-  {                                                                         \
-    if (!::mxnet::op::type_assign(&(type_array)[index], type)) {            \
-      std::ostringstream os;                                                \
-      os << "Storage type inconsistent, Provided = "                        \
-         << common::stype_string((type_array)[index]) << ','                \
-         << " inferred storage type = " << common::stype_string(type);      \
-      throw ::mxnet::op::InferStorageTypeError(os.str(), index);            \
-    }                                                                       \
+#define STORAGE_TYPE_ASSIGN_CHECK(type_array, index, type)                                        \
+  {                                                                                               \
+    if (!::mxnet::op::type_assign(&(type_array)[index], type)) {                                  \
+      std::ostringstream os;                                                                      \
+      os << "Storage type inconsistent, Provided = " << common::stype_string((type_array)[index]) \
+         << ',' << " inferred storage type = " << common::stype_string(type);                     \
+      throw ::mxnet::op::InferStorageTypeError(os.str(), index);                                  \
+    }                                                                                             \
   }
 
 /*!
@@ -275,15 +262,15 @@ inline bool dispatch_mode_assign(DispatchMode *y, const DispatchMode& x) {
  * \param index the index of in the array
  * \param type the inferred dispatch type
  */
-#define DISPATCH_MODE_ASSIGN_CHECK(type_array, index, type)                 \
-  {                                                                         \
-    if (!::mxnet::op::dispatch_mode_assign(&(type_array)[index], type)) {   \
-      std::ostringstream os;                                                \
-      os << "Dispatch mode inconsistent, Provided = "                       \
-         << common::dispatch_mode_string((type_array)[index]) << ','        \
-         << " inferred mode = " << common::dispatch_mode_string(type);      \
-      throw ::mxnet::op::InferStorageTypeError(os.str(), index);            \
-    }                                                                       \
+#define DISPATCH_MODE_ASSIGN_CHECK(type_array, index, type)               \
+  {                                                                       \
+    if (!::mxnet::op::dispatch_mode_assign(&(type_array)[index], type)) { \
+      std::ostringstream os;                                              \
+      os << "Dispatch mode inconsistent, Provided = "                     \
+         << common::dispatch_mode_string((type_array)[index]) << ','      \
+         << " inferred mode = " << common::dispatch_mode_string(type);    \
+      throw ::mxnet::op::InferStorageTypeError(os.str(), index);          \
+    }                                                                     \
   }
 
 /*!
@@ -291,39 +278,38 @@ inline bool dispatch_mode_assign(DispatchMode *y, const DispatchMode& x) {
  * \param type the type to be checked
  * \param expected the expected type
  */
-#define UNIFORM_TYPE_CHECK(type, expected, arg)                         \
-  {                                                                     \
-    CHECK_EQ(type, expected) << "This layer requires uniform type. "    \
-                             << "Expected '" << ::mxnet::op::type_string(expected)   \
-                             << "' v.s. given '" << ::mxnet::op::type_string(type)   \
-                             << "' at '" << arg << "'";                 \
+#define UNIFORM_TYPE_CHECK(type, expected, arg)                                                \
+  {                                                                                            \
+    CHECK_EQ(type, expected) << "This layer requires uniform type. "                           \
+                             << "Expected '" << ::mxnet::op::type_string(expected)             \
+                             << "' v.s. given '" << ::mxnet::op::type_string(type) << "' at '" \
+                             << arg << "'";                                                    \
   }
 
 // helper macro to implement bind dispatch
 #if MXNET_USE_CUDA
-#define DO_BIND_DISPATCH(Method, ...)                                \
-  if (ctx.dev_mask() == cpu::kDevMask) {                             \
-      return Method<cpu>(__VA_ARGS__);                               \
-    } else {                                                         \
-      return Method<gpu>(__VA_ARGS__);                               \
-    }
+#define DO_BIND_DISPATCH(Method, ...)    \
+  if (ctx.dev_mask() == cpu::kDevMask) { \
+    return Method<cpu>(__VA_ARGS__);     \
+  } else {                               \
+    return Method<gpu>(__VA_ARGS__);     \
+  }
 #else
-#define DO_BIND_DISPATCH(Method, ...)                                \
-  if (ctx.dev_mask() == cpu::kDevMask) {                             \
-    return Method<cpu>(__VA_ARGS__);                                 \
-  } else {                                                           \
-    LOG(FATAL) << "GPU is not enabled";                              \
-    return nullptr;                                                  \
+#define DO_BIND_DISPATCH(Method, ...)    \
+  if (ctx.dev_mask() == cpu::kDevMask) { \
+    return Method<cpu>(__VA_ARGS__);     \
+  } else {                               \
+    LOG(FATAL) << "GPU is not enabled";  \
+    return nullptr;                      \
   }
 #endif
 
 /*! \brief assign stype to target_stype, if successful,
  *         assign dispatch_mode to target_dispatch
  */
-inline bool storage_type_assign(int* stype,
-                                const NDArrayStorageType target_stype,
-                                DispatchMode* dispatch,
-                                const DispatchMode target_dispatch) {
+inline bool storage_type_assign(
+    int* stype, const NDArrayStorageType target_stype, DispatchMode* dispatch,
+    const DispatchMode target_dispatch) {
   if (type_assign(stype, target_stype)) {
     DISPATCH_MODE_ASSIGN_CHECK(dispatch, 0, target_dispatch);
     return true;
@@ -334,10 +320,9 @@ inline bool storage_type_assign(int* stype,
 /*! \brief assign the stype vector to target_stype, if successful,
  *         assign dispatch_mode to target_dispatch
  */
-inline bool storage_type_assign(StorageTypeVector* stypes,
-                                const NDArrayStorageType target_stype,
-                                DispatchMode* dispatch,
-                                const DispatchMode target_dispatch) {
+inline bool storage_type_assign(
+    StorageTypeVector* stypes, const NDArrayStorageType target_stype, DispatchMode* dispatch,
+    const DispatchMode target_dispatch) {
   CHECK_GT(stypes->size(), 0);
   bool success = true;
   for (int& stype : *stypes) {
@@ -361,21 +346,18 @@ inline bool dispatch_fallback(StorageTypeVector* stypes, DispatchMode* dispatch)
   return true;
 }
 
-inline std::vector<nnvm::NodeEntry>CreateNodeEntries(
-  nnvm::ObjectPtr pNode,
-  const std::vector<nnvm::NodeEntry>* pOgrads = nullptr,
-  const std::vector<nnvm::NodeEntry>* pInputs = nullptr) {
-  if (pOgrads)
-    pNode->inputs.insert(pNode->inputs.end(), pOgrads->begin(), pOgrads->end());
+inline std::vector<nnvm::NodeEntry> CreateNodeEntries(
+    nnvm::ObjectPtr pNode, const std::vector<nnvm::NodeEntry>* pOgrads = nullptr,
+    const std::vector<nnvm::NodeEntry>* pInputs = nullptr) {
+  if (pOgrads) pNode->inputs.insert(pNode->inputs.end(), pOgrads->begin(), pOgrads->end());
 
-  if (pInputs)
-    pNode->inputs.insert(pNode->inputs.end(), pInputs->begin(), pInputs->end());
+  if (pInputs) pNode->inputs.insert(pNode->inputs.end(), pInputs->begin(), pInputs->end());
 
   if (!pNode->is_variable()) {
     CHECK_EQ(pNode->num_inputs(), pNode->inputs.size())
-      << "Number of inputs to operator " << pNode->op()->name << " (" << pNode->num_inputs()
-      << ") does not match the actual number of inputs provided to operator "
-      << pNode->attrs.name << " (" << pNode->inputs.size() << ").";
+        << "Number of inputs to operator " << pNode->op()->name << " (" << pNode->num_inputs()
+        << ") does not match the actual number of inputs provided to operator " << pNode->attrs.name
+        << " (" << pNode->inputs.size() << ").";
   }
 
   std::vector<nnvm::NodeEntry> ret;
@@ -388,11 +370,11 @@ inline std::vector<nnvm::NodeEntry>CreateNodeEntries(
 // make a new node with operator op_name. Inputs are not filled.
 inline nnvm::ObjectPtr MakeNode(
     const char* op_name, const std::string& name,
-    std::vector<nnvm::NodeEntry> const * inputs = nullptr,
-    std::unordered_map<std::string, std::string> const * dict = nullptr,
-    nnvm::ObjectPtr const * fwd_node = nullptr) {
-  auto p = nnvm::Node::Create();
-  p->attrs.op = nnvm::Op::Get(op_name);
+    std::vector<nnvm::NodeEntry> const* inputs               = nullptr,
+    std::unordered_map<std::string, std::string> const* dict = nullptr,
+    nnvm::ObjectPtr const* fwd_node                          = nullptr) {
+  auto p        = nnvm::Node::Create();
+  p->attrs.op   = nnvm::Op::Get(op_name);
   p->attrs.name = name;
   if (dict != nullptr) p->attrs.dict = *dict;
   if (inputs != nullptr) p->inputs = *inputs;
@@ -404,37 +386,31 @@ inline nnvm::ObjectPtr MakeNode(
   }
   if (inputs != nullptr) {
     CHECK_EQ(p->num_inputs(), p->inputs.size())
-      << "Number of inputs to operator " << op_name << " (" << p->num_inputs()
-      << ") does not match the actual number of inputs provided to operator "
-      << name << " (" << p->inputs.size() << ").";
+        << "Number of inputs to operator " << op_name << " (" << p->num_inputs()
+        << ") does not match the actual number of inputs provided to operator " << name << " ("
+        << p->inputs.size() << ").";
   }
   return p;
 }
 
 inline nnvm::ObjectPtr MakeNode(
-    const char* op_name, const std::string& name,
-    const std::vector<nnvm::NodeEntry>& inputs,
-    std::unordered_map<std::string, std::string> const * dict,
-    nnvm::ObjectPtr const * fwd_node) {
+    const char* op_name, const std::string& name, const std::vector<nnvm::NodeEntry>& inputs,
+    std::unordered_map<std::string, std::string> const* dict, nnvm::ObjectPtr const* fwd_node) {
   return MakeNode(op_name, name, &inputs, dict, fwd_node);
 }
 
-
 // quick helper to make node
 inline std::vector<nnvm::NodeEntry> MakeGradNode(
-    const char* op_name, const nnvm::ObjectPtr& n,
-    const std::vector<nnvm::NodeEntry>& inputs,
+    const char* op_name, const nnvm::ObjectPtr& n, const std::vector<nnvm::NodeEntry>& inputs,
     const std::unordered_map<std::string, std::string>& dict) {
-  auto p = MakeNode(op_name, n->attrs.name + "_backward",
-                    &inputs, &dict, &n);
+  auto p = MakeNode(op_name, n->attrs.name + "_backward", &inputs, &dict, &n);
 
   return CreateNodeEntries(p);
 }
 
 // quick helper to make gradient nodes that simply pass back zero. could be used in output ops.
 inline std::vector<nnvm::NodeEntry> MakeZeroGradNodes(
-    const nnvm::ObjectPtr& n,
-    const std::vector<nnvm::NodeEntry>& ograds) {
+    const nnvm::ObjectPtr& n, const std::vector<nnvm::NodeEntry>& ograds) {
   std::vector<nnvm::NodeEntry> ret;
   for (uint32_t i = 0; i < n->num_inputs(); ++i) {
     std::ostringstream os;
@@ -448,18 +424,14 @@ inline std::vector<nnvm::NodeEntry> MakeZeroGradNodes(
   return ret;
 }
 
-
 // check whether all output grads are zero.
 inline bool CheckGradAllZero(const std::vector<nnvm::NodeEntry>& ograds) {
-  static const auto zero_op = nnvm::Op::Get("_zeros");
+  static const auto zero_op      = nnvm::Op::Get("_zeros");
   static const auto zero_like_op = nnvm::Op::Get("zeros_like");
-  if (ograds.empty())
-    return false;
+  if (ograds.empty()) return false;
   for (const auto& grad : ograds) {
-    if (!grad.node)
-      return false;
-    if (grad.node->op() != zero_op && grad.node->op() != zero_like_op )
-      return false;
+    if (!grad.node) return false;
+    if (grad.node->op() != zero_op && grad.node->op() != zero_like_op) return false;
   }
   return true;
 }
@@ -467,20 +439,17 @@ inline bool CheckGradAllZero(const std::vector<nnvm::NodeEntry>& ograds) {
 // make gradient node that doesn't add to objective.
 // i.e. igrads are always zero when ograds are zero.
 inline std::vector<nnvm::NodeEntry> MakeNonlossGradNode(
-    const char* op_name, const nnvm::ObjectPtr& n,
-    const std::vector<nnvm::NodeEntry>& ograds,
+    const char* op_name, const nnvm::ObjectPtr& n, const std::vector<nnvm::NodeEntry>& ograds,
     const std::vector<nnvm::NodeEntry>& inputs,
     const std::unordered_map<std::string, std::string>& dict) {
-  if (CheckGradAllZero(ograds))
-    return MakeZeroGradNodes(n, ograds);
-  auto p = MakeNode(op_name, n->attrs.name + "_backward",
-                    nullptr, &dict, &n);
+  if (CheckGradAllZero(ograds)) return MakeZeroGradNodes(n, ograds);
+  auto p = MakeNode(op_name, n->attrs.name + "_backward", nullptr, &dict, &n);
 
   return CreateNodeEntries(p, &ograds, &inputs);
 }
 
 /*! \brief Parse keyword arguments as PType arguments and save to parsed */
-template<typename PType>
+template <typename PType>
 inline void ParamParser(nnvm::NodeAttrs* attrs) {
   PType param;
   try {
@@ -499,26 +468,24 @@ inline void ParamParser(nnvm::NodeAttrs* attrs) {
   attrs->parsed = std::move(param);
 }
 
-inline void CheckAllRowsPresent(const NDArray& arr, const std::string& func,
-                                const std::string& param) {
+inline void CheckAllRowsPresent(
+    const NDArray& arr, const std::string& func, const std::string& param) {
   if (arr.storage_type() == kRowSparseStorage) {
-    CHECK(arr.storage_shape()[0] == arr.shape()[0]) << func
-          << " for RowSparse " << param << " is only implemented for "
-          << "RowSparse " << param << " with all rows containing non-zeros. "
-          << "Expects " << param << ".data.shape[0] (" << arr.storage_shape()[0]
-          << ") == " << param << ".shape[0] (" << arr.shape()[0] << ").";
+    CHECK(arr.storage_shape()[0] == arr.shape()[0])
+        << func << " for RowSparse " << param << " is only implemented for "
+        << "RowSparse " << param << " with all rows containing non-zeros. "
+        << "Expects " << param << ".data.shape[0] (" << arr.storage_shape()[0] << ") == " << param
+        << ".shape[0] (" << arr.shape()[0] << ").";
   } else {
     CHECK(arr.storage_type() == kDefaultStorage);
   }
 }
 
-inline void LogUnimplementedOp(const nnvm::NodeAttrs& attrs,
-                               const OpContext &ctx,
-                               const std::vector<NDArray> &inputs,
-                               const std::vector<OpReqType> &req,
-                               const std::vector<NDArray> &outputs) {
-    using common::operator_string;
-    LOG(FATAL) << "Not implemented: " << operator_string(attrs, ctx, inputs, req, outputs);
+inline void LogUnimplementedOp(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& inputs,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs) {
+  using common::operator_string;
+  LOG(FATAL) << "Not implemented: " << operator_string(attrs, ctx, inputs, req, outputs);
 }
 
 class OpSignature {
@@ -526,20 +493,14 @@ class OpSignature {
   uint64_t hash;
 
  public:
-  OpSignature() {
-    hash = 0;
-  }
+  OpSignature() { hash = 0; }
 
-  explicit OpSignature(uint64_t hash) {
-    this->hash = hash;
-  }
+  explicit OpSignature(uint64_t hash) { this->hash = hash; }
 
   /*
    * This is to reserve space for the vector.
    */
-  void Reserve(size_t num) {
-    eles.reserve(num);
-  }
+  void Reserve(size_t num) { eles.reserve(num); }
 
   /*
    * We provide different methods to add signature to an op.
@@ -551,9 +512,9 @@ class OpSignature {
    */
 
 #if MXNET_USE_MKLDNN == 1
-  void AddSign(const mkldnn::memory &mem) {
+  void AddSign(const mkldnn::memory& mem) {
     auto desc = mem.get_desc();
-    hash = hash * 2 + desc.data.format_kind;
+    hash      = hash * 2 + desc.data.format_kind;
     eles.push_back(desc.data.format_kind);
     hash = hash * 2 + desc.data.data_type;
     eles.push_back(desc.data.data_type);
@@ -605,19 +566,19 @@ class OpSignature {
         eles.push_back(desc.data.format_desc.rnn_packed_desc.size);
         break;
       default:
-      // nothing need to add
+        // nothing need to add
         break;
     }
   }
 #endif
 
-  void AddSign(const std::vector<NDArray> &arrs) {
-    for (auto &arr : arrs) {
+  void AddSign(const std::vector<NDArray>& arrs) {
+    for (auto& arr : arrs) {
       AddSign(arr);
     }
   }
 
-  void AddSign(const NDArray &arr) {
+  void AddSign(const NDArray& arr) {
 #if MXNET_USE_MKLDNN == 1
     if (arr.IsMKLDNNData()) {
       AddSign(*(arr.GetMKLDNNData()));
@@ -631,13 +592,13 @@ class OpSignature {
 #endif
   }
 
-  void AddSign(const mxnet::ShapeVector &shapes) {
-    for (auto &shape : shapes) {
+  void AddSign(const mxnet::ShapeVector& shapes) {
+    for (auto& shape : shapes) {
       AddSign(shape);
     }
   }
 
-  void AddSign(const mxnet::TShape &shape) {
+  void AddSign(const mxnet::TShape& shape) {
     for (int i = 0; i < shape.ndim(); i++) {
       hash = hash * 2 + shape[i];
       eles.push_back(shape[i]);
@@ -654,45 +615,36 @@ class OpSignature {
     eles.push_back(val);
   }
 
-  bool operator==(const OpSignature &sign) const {
-    if (hash != sign.hash)
-      return false;
-    if (eles.size() != sign.eles.size())
-      return false;
+  bool operator==(const OpSignature& sign) const {
+    if (hash != sign.hash) return false;
+    if (eles.size() != sign.eles.size()) return false;
     for (size_t i = 0; i < eles.size(); i++)
-      if (eles[i] != sign.eles[i])
-        return false;
+      if (eles[i] != sign.eles[i]) return false;
     return true;
   }
 
-  uint64_t GetHash() const {
-    return hash;
-  }
+  uint64_t GetHash() const { return hash; }
 };
 
 struct OpHash {
-  size_t operator()(const OpSignature &sign) const {
-    return sign.GetHash();
-  }
+  size_t operator()(const OpSignature& sign) const { return sign.GetHash(); }
 };
 
-template<typename ParamType>
-class ParamOpSign: public OpSignature {
+template <typename ParamType>
+class ParamOpSign : public OpSignature {
   const ParamType param;
 
-  static size_t hash(const ParamType &param) {
+  static size_t hash(const ParamType& param) {
     std::hash<ParamType> fn;
     return fn(param);
   }
 
  public:
-  explicit ParamOpSign(const ParamType &_param): OpSignature(
-      hash(_param)), param(_param) {
-  }
+  explicit ParamOpSign(const ParamType& _param) : OpSignature(hash(_param)), param(_param) {}
 
-  bool operator==(const ParamOpSign<ParamType> &sign) const {
-    const OpSignature &this_upper = *this;
-    const OpSignature &other_upper = sign;
+  bool operator==(const ParamOpSign<ParamType>& sign) const {
+    const OpSignature& this_upper  = *this;
+    const OpSignature& other_upper = sign;
     return this_upper == other_upper && param == sign.param;
   }
 };

--- a/src/operator/quantization/mkldnn/mkldnn_dequantize-inl.h
+++ b/src/operator/quantization/mkldnn/mkldnn_dequantize-inl.h
@@ -34,14 +34,14 @@
 namespace mxnet {
 namespace op {
 
-
 class SgMKLDNNDequantizeOperator {
  public:
-  explicit SgMKLDNNDequantizeOperator(const nnvm::NodeAttrs &attrs)
+  explicit SgMKLDNNDequantizeOperator(const nnvm::NodeAttrs& attrs)
       : param_(nnvm::get<DequantizeParam>(attrs.parsed)) {}
 
-  void Forward(const OpContext &ctx, const std::vector<NDArray> &inputs,
-               const std::vector<OpReqType> &req, const std::vector<NDArray> &outputs);
+  void Forward(
+      const OpContext& ctx, const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+      const std::vector<NDArray>& outputs);
 
  private:
   bool initialized_{false};
@@ -53,12 +53,12 @@ class SgMKLDNNDequantizeOperator {
   std::shared_ptr<mkldnn::reorder> fwd_pd_;
 };
 
-void SgMKLDNNDequantizeOperator::Forward(const OpContext &ctx, const std::vector<NDArray> &inputs,
-                                         const std::vector<OpReqType> &req,
-                                         const std::vector<NDArray> &outputs) {
+void SgMKLDNNDequantizeOperator::Forward(
+    const OpContext& ctx, const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+    const std::vector<NDArray>& outputs) {
   NDArray in_buffer = inputs[0];
   if (inputs[0].IsView() && inputs[0].IsMKLDNNData()) in_buffer = inputs[0].Reorder2Default();
-  auto i_mem = in_buffer.GetMKLDNNData();
+  auto i_mem     = in_buffer.GetMKLDNNData();
   float data_min = *inputs[1].data().dptr<float>();
   float data_max = *inputs[2].data().dptr<float>();
 
@@ -66,56 +66,53 @@ void SgMKLDNNDequantizeOperator::Forward(const OpContext &ctx, const std::vector
     initialized_ = false;
 
   if (!initialized_) {
-    cached_data_min_ = data_min;
-    cached_data_max_ = data_max;
-    float real_range = MaxAbs(cached_data_min_, cached_data_max_);
+    cached_data_min_      = data_min;
+    cached_data_max_      = data_max;
+    float real_range      = MaxAbs(cached_data_min_, cached_data_max_);
     float quantized_range = 0.0;
     if (inputs[0].dtype() == mshadow::kUint8) {
       quantized_range = kUint8Range;
     } else if (inputs[0].dtype() == mshadow::kInt8) {
       quantized_range = kInt8Range;
-      real_range = MaxAbs(*inputs[1].data().dptr<float>(), *inputs[2].data().dptr<float>());
+      real_range      = MaxAbs(*inputs[1].data().dptr<float>(), *inputs[2].data().dptr<float>());
     } else {
       LOG(FATAL) << "mkldnn dequantize op only supports int8 and uint8 as output type";
     }
     float scale = real_range / quantized_range;
     mkldnn::primitive_attr attr;
-    const int mask = 0;
+    const int mask            = 0;
     std::vector<float> scales = {scale};
     attr.set_output_scales(mask, scales);
     mkldnn::engine cpu_engine = mxnet::CpuEngine::Get()->get_engine();
-    auto i_desc = i_mem->get_desc();
-    size_t i_ndim = in_buffer.shape().ndim();
+    auto i_desc               = i_mem->get_desc();
+    size_t i_ndim             = in_buffer.shape().ndim();
     if (i_ndim == 4) {
       mkldnn::memory::format_tag o_fmt = mkldnn::memory::format_tag::nchw;
       mkldnn::memory::dims o_dims(i_desc.data.dims, i_desc.data.dims + i_desc.data.ndims);
       o_desc_ = mkldnn::memory::desc(o_dims, get_mkldnn_type<float>(), o_fmt);
     } else {
-      o_desc_ = i_desc;
+      o_desc_                = i_desc;
       o_desc_.data.data_type = get_mkldnn_type_t<float>();
     }
     auto reorder_pd =
         mkldnn::reorder::primitive_desc(cpu_engine, i_desc, cpu_engine, o_desc_, attr);
-    fwd_pd_ = std::make_shared<mkldnn::reorder>(reorder_pd);
+    fwd_pd_      = std::make_shared<mkldnn::reorder>(reorder_pd);
     initialized_ = true;
   }
-  auto o_mem = CreateMKLDNNMem(outputs[0], o_desc_, req[0]);
+  auto o_mem             = CreateMKLDNNMem(outputs[0], o_desc_, req[0]);
   args_[MKLDNN_ARG_FROM] = *i_mem;
-  args_[MKLDNN_ARG_TO] = *o_mem.second;
+  args_[MKLDNN_ARG_TO]   = *o_mem.second;
   MKLDNNStream::Get()->RegisterPrimArgs(*fwd_pd_, args_);
   CommitOutput(outputs[0], o_mem);
   MKLDNNStream::Get()->Submit();
 }
 
-static void SgMKLDNNDequantizeForward(const OpStatePtr &state_ptr, const OpContext &ctx,
-                                      const std::vector<NDArray> &inputs,
-                                      const std::vector<OpReqType> &req,
-                                      const std::vector<NDArray> &outputs) {
-  SgMKLDNNDequantizeOperator &op = state_ptr.get_state<SgMKLDNNDequantizeOperator>();
+static void SgMKLDNNDequantizeForward(
+    const OpStatePtr& state_ptr, const OpContext& ctx, const std::vector<NDArray>& inputs,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs) {
+  SgMKLDNNDequantizeOperator& op = state_ptr.get_state<SgMKLDNNDequantizeOperator>();
   op.Forward(ctx, inputs, req, outputs);
 }
-
-
 
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/quantization/mkldnn/mkldnn_dequantize-inl.h
+++ b/src/operator/quantization/mkldnn/mkldnn_dequantize-inl.h
@@ -39,9 +39,8 @@ class SgMKLDNNDequantizeOperator {
   explicit SgMKLDNNDequantizeOperator(const nnvm::NodeAttrs& attrs)
       : param_(nnvm::get<DequantizeParam>(attrs.parsed)) {}
 
-  void Forward(
-      const OpContext& ctx, const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
-      const std::vector<NDArray>& outputs);
+  void Forward(const OpContext& ctx, const std::vector<NDArray>& inputs,
+               const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs);
 
  private:
   bool initialized_{false};
@@ -53,9 +52,9 @@ class SgMKLDNNDequantizeOperator {
   std::shared_ptr<mkldnn::reorder> fwd_pd_;
 };
 
-void SgMKLDNNDequantizeOperator::Forward(
-    const OpContext& ctx, const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
-    const std::vector<NDArray>& outputs) {
+void SgMKLDNNDequantizeOperator::Forward(const OpContext& ctx, const std::vector<NDArray>& inputs,
+                                         const std::vector<OpReqType>& req,
+                                         const std::vector<NDArray>& outputs) {
   NDArray in_buffer = inputs[0];
   if (inputs[0].IsView() && inputs[0].IsMKLDNNData()) in_buffer = inputs[0].Reorder2Default();
   auto i_mem     = in_buffer.GetMKLDNNData();
@@ -107,9 +106,10 @@ void SgMKLDNNDequantizeOperator::Forward(
   MKLDNNStream::Get()->Submit();
 }
 
-static void SgMKLDNNDequantizeForward(
-    const OpStatePtr& state_ptr, const OpContext& ctx, const std::vector<NDArray>& inputs,
-    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs) {
+static void SgMKLDNNDequantizeForward(const OpStatePtr& state_ptr, const OpContext& ctx,
+                                      const std::vector<NDArray>& inputs,
+                                      const std::vector<OpReqType>& req,
+                                      const std::vector<NDArray>& outputs) {
   SgMKLDNNDequantizeOperator& op = state_ptr.get_state<SgMKLDNNDequantizeOperator>();
   op.Forward(ctx, inputs, req, outputs);
 }

--- a/src/operator/quantization/mkldnn/mkldnn_dequantize-inl.h
+++ b/src/operator/quantization/mkldnn/mkldnn_dequantize-inl.h
@@ -60,7 +60,8 @@ void SgMKLDNNDequantizeOperator::Forward(const OpContext& ctx,
                                          const std::vector<OpReqType>& req,
                                          const std::vector<NDArray>& outputs) {
   NDArray in_buffer = inputs[0];
-  if (inputs[0].IsView() && inputs[0].IsMKLDNNData()) in_buffer = inputs[0].Reorder2Default();
+  if (inputs[0].IsView() && inputs[0].IsMKLDNNData())
+    in_buffer = inputs[0].Reorder2Default();
   auto i_mem     = in_buffer.GetMKLDNNData();
   float data_min = *inputs[1].data().dptr<float>();
   float data_max = *inputs[2].data().dptr<float>();

--- a/src/operator/quantization/mkldnn/mkldnn_dequantize-inl.h
+++ b/src/operator/quantization/mkldnn/mkldnn_dequantize-inl.h
@@ -29,6 +29,7 @@
 #include <algorithm>
 #include <string>
 #include <vector>
+
 #include "../../nn/mkldnn/mkldnn_base-inl.h"
 
 namespace mxnet {
@@ -39,8 +40,10 @@ class SgMKLDNNDequantizeOperator {
   explicit SgMKLDNNDequantizeOperator(const nnvm::NodeAttrs& attrs)
       : param_(nnvm::get<DequantizeParam>(attrs.parsed)) {}
 
-  void Forward(const OpContext& ctx, const std::vector<NDArray>& inputs,
-               const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs);
+  void Forward(const OpContext& ctx,
+               const std::vector<NDArray>& inputs,
+               const std::vector<OpReqType>& req,
+               const std::vector<NDArray>& outputs);
 
  private:
   bool initialized_{false};
@@ -52,7 +55,8 @@ class SgMKLDNNDequantizeOperator {
   std::shared_ptr<mkldnn::reorder> fwd_pd_;
 };
 
-void SgMKLDNNDequantizeOperator::Forward(const OpContext& ctx, const std::vector<NDArray>& inputs,
+void SgMKLDNNDequantizeOperator::Forward(const OpContext& ctx,
+                                         const std::vector<NDArray>& inputs,
                                          const std::vector<OpReqType>& req,
                                          const std::vector<NDArray>& outputs) {
   NDArray in_buffer = inputs[0];
@@ -106,7 +110,8 @@ void SgMKLDNNDequantizeOperator::Forward(const OpContext& ctx, const std::vector
   MKLDNNStream::Get()->Submit();
 }
 
-static void SgMKLDNNDequantizeForward(const OpStatePtr& state_ptr, const OpContext& ctx,
+static void SgMKLDNNDequantizeForward(const OpStatePtr& state_ptr,
+                                      const OpContext& ctx,
                                       const std::vector<NDArray>& inputs,
                                       const std::vector<OpReqType>& req,
                                       const std::vector<NDArray>& outputs) {

--- a/src/operator/quantization/mkldnn/mkldnn_quantize-inl.h
+++ b/src/operator/quantization/mkldnn/mkldnn_quantize-inl.h
@@ -67,7 +67,8 @@ static void MKLDNNQuantizeComputeKer(const std::vector<NDArray>& inputs,
   attr.set_output_scales(mask, scales);
   mkldnn::engine cpu_engine = mxnet::CpuEngine::Get()->get_engine();
   NDArray in_buffer         = inputs[0];
-  if (inputs[0].IsView() && inputs[0].IsMKLDNNData()) in_buffer = inputs[0].Reorder2Default();
+  if (inputs[0].IsView() && inputs[0].IsMKLDNNData())
+    in_buffer = inputs[0].Reorder2Default();
 
   auto i_mem    = in_buffer.GetMKLDNNData();
   auto i_desc   = i_mem->get_desc();

--- a/src/operator/quantization/mkldnn/mkldnn_quantize-inl.h
+++ b/src/operator/quantization/mkldnn/mkldnn_quantize-inl.h
@@ -36,23 +36,22 @@ namespace mxnet {
 namespace op {
 
 template <typename SrcType, typename DstType>
-static void MKLDNNQuantizeComputeKer(const std::vector<NDArray>& inputs,
-                                     const std::vector<NDArray>& outputs,
-                                     const QuantizeParam& param,
-                                     const std::vector<OpReqType>& req) {
+static void MKLDNNQuantizeComputeKer(
+    const std::vector<NDArray>& inputs, const std::vector<NDArray>& outputs,
+    const QuantizeParam& param, const std::vector<OpReqType>& req) {
   using namespace mshadow;
   using namespace mxnet_op;
   using red::limits::MaxValue;
   using red::limits::MinValue;
-  float real_range = 0.0;
+  float real_range      = 0.0;
   float quantized_range = 0.0;
   if (param.out_type == mshadow::kUint8) {
-    real_range = MaxAbs(*inputs[1].data().dptr<float>(), *inputs[2].data().dptr<float>());
+    real_range      = MaxAbs(*inputs[1].data().dptr<float>(), *inputs[2].data().dptr<float>());
     quantized_range = MaxAbs(MaxValue<DstType>(), MinValue<DstType>());
     *outputs[1].data().dptr<float>() = *inputs[1].data().dptr<float>();
     *outputs[2].data().dptr<float>() = *inputs[2].data().dptr<float>();
   } else if (param.out_type == mshadow::kInt8) {
-    real_range = MaxAbs(*inputs[1].data().dptr<float>(), *inputs[2].data().dptr<float>());
+    real_range      = MaxAbs(*inputs[1].data().dptr<float>(), *inputs[2].data().dptr<float>());
     quantized_range = MinAbs(MaxValue<DstType>(), MinValue<DstType>());
     *outputs[1].data().dptr<float>() = -real_range;
     *outputs[2].data().dptr<float>() = real_range;
@@ -61,15 +60,15 @@ static void MKLDNNQuantizeComputeKer(const std::vector<NDArray>& inputs,
   }
   float scale = quantized_range / real_range;
   mkldnn::primitive_attr attr;
-  const int mask = 0;
+  const int mask            = 0;
   std::vector<float> scales = {scale};
   attr.set_output_scales(mask, scales);
   mkldnn::engine cpu_engine = mxnet::CpuEngine::Get()->get_engine();
-  NDArray in_buffer = inputs[0];
+  NDArray in_buffer         = inputs[0];
   if (inputs[0].IsView() && inputs[0].IsMKLDNNData()) in_buffer = inputs[0].Reorder2Default();
 
-  auto i_mem = in_buffer.GetMKLDNNData();
-  auto i_desc = i_mem->get_desc();
+  auto i_mem    = in_buffer.GetMKLDNNData();
+  auto i_desc   = i_mem->get_desc();
   size_t i_ndim = in_buffer.shape().ndim();
   mkldnn::memory::desc o_desc;
   if (i_ndim == 4) {
@@ -77,21 +76,20 @@ static void MKLDNNQuantizeComputeKer(const std::vector<NDArray>& inputs,
     mkldnn::memory::dims o_dims(i_desc.data.dims, i_desc.data.dims + i_desc.data.ndims);
     o_desc = mkldnn::memory::desc(o_dims, get_mkldnn_type<DstType>(), o_fmt);
   } else {
-    o_desc = i_desc;
+    o_desc                = i_desc;
     o_desc.data.data_type = get_mkldnn_type_t<DstType>();
   }
   auto reorder_pd = mkldnn::reorder::primitive_desc(cpu_engine, i_desc, cpu_engine, o_desc, attr);
-  auto o_mem = CreateMKLDNNMem(outputs[0], o_desc, req[0]);
+  auto o_mem      = CreateMKLDNNMem(outputs[0], o_desc, req[0]);
   MKLDNNStream::Get()->RegisterPrimArgs(
       mkldnn::reorder(reorder_pd), {{MKLDNN_ARG_FROM, *i_mem}, {MKLDNN_ARG_TO, *o_mem.second}});
   CommitOutput(outputs[0], o_mem);
   MKLDNNStream::Get()->Submit();
 }
 
-static void MKLDNNQuantizeCompute(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
-                                  const std::vector<NDArray> &inputs,
-                                  const std::vector<OpReqType> &req,
-                                  const std::vector<NDArray> &outputs) {
+static void MKLDNNQuantizeCompute(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& inputs,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs) {
   const QuantizeParam& param = nnvm::get<QuantizeParam>(attrs.parsed);
   if (param.out_type == mshadow::kUint8) {
     MKLDNNQuantizeComputeKer<float, uint8_t>(inputs, outputs, param, req);

--- a/src/operator/quantization/mkldnn/mkldnn_quantize-inl.h
+++ b/src/operator/quantization/mkldnn/mkldnn_quantize-inl.h
@@ -26,11 +26,12 @@
 #ifndef MXNET_OPERATOR_QUANTIZATION_MKLDNN_MKLDNN_QUANTIZE_INL_H_
 #define MXNET_OPERATOR_QUANTIZATION_MKLDNN_MKLDNN_QUANTIZE_INL_H_
 #if MXNET_USE_MKLDNN == 1
-#include <string>
 #include <algorithm>
+#include <string>
 #include <vector>
-#include "../quantize-inl.h"
+
 #include "../../nn/mkldnn/mkldnn_base-inl.h"
+#include "../quantize-inl.h"
 
 namespace mxnet {
 namespace op {
@@ -88,7 +89,8 @@ static void MKLDNNQuantizeComputeKer(const std::vector<NDArray>& inputs,
   MKLDNNStream::Get()->Submit();
 }
 
-static void MKLDNNQuantizeCompute(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+static void MKLDNNQuantizeCompute(const nnvm::NodeAttrs& attrs,
+                                  const OpContext& ctx,
                                   const std::vector<NDArray>& inputs,
                                   const std::vector<OpReqType>& req,
                                   const std::vector<NDArray>& outputs) {

--- a/src/operator/quantization/mkldnn/mkldnn_quantize-inl.h
+++ b/src/operator/quantization/mkldnn/mkldnn_quantize-inl.h
@@ -36,9 +36,10 @@ namespace mxnet {
 namespace op {
 
 template <typename SrcType, typename DstType>
-static void MKLDNNQuantizeComputeKer(
-    const std::vector<NDArray>& inputs, const std::vector<NDArray>& outputs,
-    const QuantizeParam& param, const std::vector<OpReqType>& req) {
+static void MKLDNNQuantizeComputeKer(const std::vector<NDArray>& inputs,
+                                     const std::vector<NDArray>& outputs,
+                                     const QuantizeParam& param,
+                                     const std::vector<OpReqType>& req) {
   using namespace mshadow;
   using namespace mxnet_op;
   using red::limits::MaxValue;
@@ -87,9 +88,10 @@ static void MKLDNNQuantizeComputeKer(
   MKLDNNStream::Get()->Submit();
 }
 
-static void MKLDNNQuantizeCompute(
-    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& inputs,
-    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs) {
+static void MKLDNNQuantizeCompute(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+                                  const std::vector<NDArray>& inputs,
+                                  const std::vector<OpReqType>& req,
+                                  const std::vector<NDArray>& outputs) {
   const QuantizeParam& param = nnvm::get<QuantizeParam>(attrs.parsed);
   if (param.out_type == mshadow::kUint8) {
     MKLDNNQuantizeComputeKer<float, uint8_t>(inputs, outputs, param, req);

--- a/src/operator/quantization/mkldnn/mkldnn_quantize_v2-inl.h
+++ b/src/operator/quantization/mkldnn/mkldnn_quantize_v2-inl.h
@@ -40,9 +40,8 @@ class SgMKLDNNQuantizeOperator {
   explicit SgMKLDNNQuantizeOperator(const nnvm::NodeAttrs& attrs)
       : param_(nnvm::get<QuantizeV2Param>(attrs.parsed)) {}
 
-  void Forward(
-      const OpContext& ctx, const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
-      const std::vector<NDArray>& outputs);
+  void Forward(const OpContext& ctx, const std::vector<NDArray>& inputs,
+               const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs);
 
  private:
   bool initalized_{false};
@@ -180,9 +179,10 @@ void SgMKLDNNQuantizeOperator::Forward(const OpContext &ctx, const std::vector<N
   }
 }
 
-static void SgMKLDNNQuantizeForward(
-    const OpStatePtr& state_ptr, const OpContext& ctx, const std::vector<NDArray>& inputs,
-    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs) {
+static void SgMKLDNNQuantizeForward(const OpStatePtr& state_ptr, const OpContext& ctx,
+                                    const std::vector<NDArray>& inputs,
+                                    const std::vector<OpReqType>& req,
+                                    const std::vector<NDArray>& outputs) {
   SgMKLDNNQuantizeOperator& op = state_ptr.get_state<SgMKLDNNQuantizeOperator>();
   op.Forward(ctx, inputs, req, outputs);
 }

--- a/src/operator/quantization/mkldnn/mkldnn_quantize_v2-inl.h
+++ b/src/operator/quantization/mkldnn/mkldnn_quantize_v2-inl.h
@@ -85,7 +85,8 @@ void SgMKLDNNQuantizeOperator::Forward(const OpContext& ctx,
       MKLDNNStream::Get()->Submit();
     }
   } else {
-    if (in_buffer.IsView() && in_buffer.IsMKLDNNData()) in_buffer = inputs[0].Reorder2Default();
+    if (in_buffer.IsView() && in_buffer.IsMKLDNNData())
+      in_buffer = inputs[0].Reorder2Default();
     auto i_mem = in_buffer.GetMKLDNNData();
 
     if (param_.min_calib_range.has_value() && param_.max_calib_range.has_value()) {
@@ -101,12 +102,16 @@ void SgMKLDNNQuantizeOperator::Forward(const OpContext& ctx,
 #pragma omp parallel for num_threads(nthreads)
       for (index_t i = 0; i < static_cast<index_t>(in_buffer.shape().Size()); i++) {
         int tid = omp_get_thread_num();
-        if (in_ptr[i] > data_maxs[tid]) data_maxs[tid] = in_ptr[i];
-        if (in_ptr[i] < data_mins[tid]) data_mins[tid] = in_ptr[i];
+        if (in_ptr[i] > data_maxs[tid])
+          data_maxs[tid] = in_ptr[i];
+        if (in_ptr[i] < data_mins[tid])
+          data_mins[tid] = in_ptr[i];
       }
       for (index_t i = 0; i < nthreads; i++) {
-        if (data_maxs[i] > data_max) data_max = data_maxs[i];
-        if (data_mins[i] < data_min) data_min = data_mins[i];
+        if (data_maxs[i] > data_max)
+          data_max = data_maxs[i];
+        if (data_mins[i] < data_min)
+          data_min = data_mins[i];
       }
 
       if (initalized_ && (cached_data_min_ != data_min || cached_data_max_ != data_max))

--- a/src/operator/quantization/mkldnn/mkldnn_quantized_act.cc
+++ b/src/operator/quantization/mkldnn/mkldnn_quantized_act.cc
@@ -30,9 +30,10 @@
 namespace mxnet {
 namespace op {
 
-static void MKLDNNQuantizedActForward(
-    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& in_data,
-    const std::vector<OpReqType>& req, const std::vector<NDArray>& out_data) {
+static void MKLDNNQuantizedActForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+                                      const std::vector<NDArray>& in_data,
+                                      const std::vector<OpReqType>& req,
+                                      const std::vector<NDArray>& out_data) {
   CHECK(in_data[0].dtype() == mshadow::kUint8 || in_data[0].dtype() == mshadow::kInt8)
       << "_contrib_quantized_act op only supports uint8 and int8 as input "
          "type";

--- a/src/operator/quantization/mkldnn/mkldnn_quantized_act.cc
+++ b/src/operator/quantization/mkldnn/mkldnn_quantized_act.cc
@@ -21,7 +21,7 @@
  * \file mkldnn_quantized_act.cc
  * \brief MKLDNN(Quantized) Activation operator based on subgraph
  * /author Zhiyuan Huang
-*/
+ */
 #if MXNET_USE_MKLDNN == 1
 
 #include "../../nn/mkldnn/mkldnn_ops-inl.h"
@@ -30,13 +30,10 @@
 namespace mxnet {
 namespace op {
 
-static void MKLDNNQuantizedActForward(const nnvm::NodeAttrs& attrs,
-                                      const OpContext& ctx,
-                                      const std::vector<NDArray>& in_data,
-                                      const std::vector<OpReqType>& req,
-                                      const std::vector<NDArray>& out_data) {
-  CHECK(in_data[0].dtype() == mshadow::kUint8 ||
-        in_data[0].dtype() == mshadow::kInt8)
+static void MKLDNNQuantizedActForward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& in_data,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& out_data) {
+  CHECK(in_data[0].dtype() == mshadow::kUint8 || in_data[0].dtype() == mshadow::kInt8)
       << "_contrib_quantized_act op only supports uint8 and int8 as input "
          "type";
 
@@ -46,8 +43,8 @@ static void MKLDNNQuantizedActForward(const nnvm::NodeAttrs& attrs,
 }
 
 NNVM_REGISTER_OP(_contrib_quantized_act)
-.set_attr<bool>("TIsMKLDNN", true)
-.set_attr<FComputeEx>("FComputeEx<cpu>", MKLDNNQuantizedActForward);
+    .set_attr<bool>("TIsMKLDNN", true)
+    .set_attr<FComputeEx>("FComputeEx<cpu>", MKLDNNQuantizedActForward);
 
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/quantization/mkldnn/mkldnn_quantized_act.cc
+++ b/src/operator/quantization/mkldnn/mkldnn_quantized_act.cc
@@ -30,7 +30,8 @@
 namespace mxnet {
 namespace op {
 
-static void MKLDNNQuantizedActForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+static void MKLDNNQuantizedActForward(const nnvm::NodeAttrs& attrs,
+                                      const OpContext& ctx,
                                       const std::vector<NDArray>& in_data,
                                       const std::vector<OpReqType>& req,
                                       const std::vector<NDArray>& out_data) {

--- a/src/operator/quantization/mkldnn/mkldnn_quantized_batch_norm.cc
+++ b/src/operator/quantization/mkldnn/mkldnn_quantized_batch_norm.cc
@@ -30,7 +30,8 @@
 namespace mxnet {
 namespace op {
 
-static void MKLDNNQuantizedBatchNormForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+static void MKLDNNQuantizedBatchNormForward(const nnvm::NodeAttrs& attrs,
+                                            const OpContext& ctx,
                                             const std::vector<NDArray>& in_data,
                                             const std::vector<OpReqType>& req,
                                             const std::vector<NDArray>& outputs) {
@@ -125,7 +126,8 @@ static void MKLDNNQuantizedBatchNormForward(const nnvm::NodeAttrs& attrs, const 
   MKLDNNStream::Get()->Submit();
 }
 
-inline static bool QuantizedBatchNormStorageType(const nnvm::NodeAttrs& attrs, const int dev_mask,
+inline static bool QuantizedBatchNormStorageType(const nnvm::NodeAttrs& attrs,
+                                                 const int dev_mask,
                                                  DispatchMode* dispatch_mode,
                                                  std::vector<int>* in_attrs,
                                                  std::vector<int>* out_attrs) {

--- a/src/operator/quantization/mkldnn/mkldnn_quantized_batch_norm.cc
+++ b/src/operator/quantization/mkldnn/mkldnn_quantized_batch_norm.cc
@@ -30,9 +30,10 @@
 namespace mxnet {
 namespace op {
 
-static void MKLDNNQuantizedBatchNormForward(
-    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& in_data,
-    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs) {
+static void MKLDNNQuantizedBatchNormForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+                                            const std::vector<NDArray>& in_data,
+                                            const std::vector<OpReqType>& req,
+                                            const std::vector<NDArray>& outputs) {
   CHECK_EQ(in_data.size(), 7U);
   CHECK_EQ(outputs.size(), 3U);
 
@@ -124,9 +125,10 @@ static void MKLDNNQuantizedBatchNormForward(
   MKLDNNStream::Get()->Submit();
 }
 
-inline static bool QuantizedBatchNormStorageType(
-    const nnvm::NodeAttrs& attrs, const int dev_mask, DispatchMode* dispatch_mode,
-    std::vector<int>* in_attrs, std::vector<int>* out_attrs) {
+inline static bool QuantizedBatchNormStorageType(const nnvm::NodeAttrs& attrs, const int dev_mask,
+                                                 DispatchMode* dispatch_mode,
+                                                 std::vector<int>* in_attrs,
+                                                 std::vector<int>* out_attrs) {
   bool dispatched = false;
   if (!dispatched) {
     dispatched = MKLDNNStorageType(attrs, dev_mask, true, dispatch_mode, in_attrs, out_attrs);
@@ -137,11 +139,10 @@ inline static bool QuantizedBatchNormStorageType(
 NNVM_REGISTER_OP(_contrib_quantized_batch_norm)
     .set_attr<FInferStorageType>("FInferStorageType", QuantizedBatchNormStorageType)
     .set_attr<FComputeEx>("FComputeEx<cpu>", MKLDNNQuantizedBatchNormForward)
-    .set_attr<FResourceRequest>(
-        "FResourceRequest",
-        [](const NodeAttrs& n) {
-          return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
-        })
+    .set_attr<FResourceRequest>("FResourceRequest",
+                                [](const NodeAttrs& n) {
+                                  return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
+                                })
     .set_attr<bool>("TIsMKLDNN", true);
 
 }  // namespace op

--- a/src/operator/quantization/mkldnn/mkldnn_quantized_batch_norm.cc
+++ b/src/operator/quantization/mkldnn/mkldnn_quantized_batch_norm.cc
@@ -21,7 +21,7 @@
  * \file mkldnn_quantized_batch_norm.cc
  * \brief
  * \author Yixin Bao
-*/
+ */
 
 #if MXNET_USE_MKLDNN == 1
 #include "../../nn/mkldnn/mkldnn_batch_norm-inl.h"
@@ -30,23 +30,22 @@
 namespace mxnet {
 namespace op {
 
-static void MKLDNNQuantizedBatchNormForward(const nnvm::NodeAttrs &attrs, const OpContext &ctx,
-                                            const std::vector<NDArray> &in_data,
-                                            const std::vector<OpReqType> &req,
-                                            const std::vector<NDArray> &outputs) {
+static void MKLDNNQuantizedBatchNormForward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& in_data,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs) {
   CHECK_EQ(in_data.size(), 7U);
   CHECK_EQ(outputs.size(), 3U);
 
   TmpMemMgr::Get()->Init(ctx.requested[batchnorm::kTempSpace]);
-  const BatchNormParam &param = nnvm::get<BatchNormParam>(attrs.parsed);
-  const NDArray &data = in_data[quantized_batchnorm::kData];
-  auto data_mem = data.GetMKLDNNData();
+  const BatchNormParam& param = nnvm::get<BatchNormParam>(attrs.parsed);
+  const NDArray& data         = in_data[quantized_batchnorm::kData];
+  auto data_mem               = data.GetMKLDNNData();
 
   // reorder if data type = uint8
   if (in_data[quantized_batchnorm::kData].dtype() == mshadow::kUint8) {
-    auto u8_md = data_mem->get_desc();
-    auto s8_md = u8_md;
-    s8_md.data.data_type = static_cast<mkldnn_data_type_t>(mkldnn::memory::data_type::s8);
+    auto u8_md            = data_mem->get_desc();
+    auto s8_md            = u8_md;
+    s8_md.data.data_type  = static_cast<mkldnn_data_type_t>(mkldnn::memory::data_type::s8);
     auto data_reorder_mem = TmpMemMgr::Get()->Alloc(s8_md);
 
     std::vector<float> reorder_scale;
@@ -64,13 +63,13 @@ static void MKLDNNQuantizedBatchNormForward(const nnvm::NodeAttrs &attrs, const 
   }
   const size_t channelAxis = static_cast<size_t>(
       param.axis < 0 ? static_cast<int>(data.shape().ndim()) + param.axis : param.axis);
-  const int channel_count = data.shape()[channelAxis];
-  const float min_data = in_data[quantized_batchnorm::kDataMin].data().dptr<float>()[0];
-  const float max_data = in_data[quantized_batchnorm::kDataMax].data().dptr<float>()[0];
+  const int channel_count  = data.shape()[channelAxis];
+  const float min_data     = in_data[quantized_batchnorm::kDataMin].data().dptr<float>()[0];
+  const float max_data     = in_data[quantized_batchnorm::kDataMax].data().dptr<float>()[0];
   const float max_abs_data = std::max(std::abs(min_data), std::abs(max_data));
 
-  float *min_output_ptr = outputs[quantized_batchnorm::kOutMin].data().dptr<float>();
-  float *max_output_ptr = outputs[quantized_batchnorm::kOutMax].data().dptr<float>();
+  float* min_output_ptr = outputs[quantized_batchnorm::kOutMin].data().dptr<float>();
+  float* max_output_ptr = outputs[quantized_batchnorm::kOutMax].data().dptr<float>();
   if (param.min_calib_range.has_value() && param.max_calib_range.has_value()) {
     *max_output_ptr = param.max_calib_range.value();
     *min_output_ptr = param.min_calib_range.value();
@@ -82,53 +81,52 @@ static void MKLDNNQuantizedBatchNormForward(const nnvm::NodeAttrs &attrs, const 
 
   mkldnn::normalization_flags flags =
       mkldnn::normalization_flags::use_global_stats | mkldnn::normalization_flags::use_scale_shift;
-  auto &fwd = GetBNForward<float>(param, ctx, data_mem, flags);
-  const mkldnn::memory &weight_mem = fwd.GetWeight();
+  auto& fwd                        = GetBNForward<float>(param, ctx, data_mem, flags);
+  const mkldnn::memory& weight_mem = fwd.GetWeight();
   CHECK_EQ(weight_mem.get_desc().get_size(), channel_count * sizeof(float) * 2);
-  float *weight_buf = reinterpret_cast<float *>(weight_mem.get_data_handle());
+  float* weight_buf = reinterpret_cast<float*>(weight_mem.get_data_handle());
 
-  float *gamma_ptr = in_data[quantized_batchnorm::kGamma].data().dptr<float>();
-  float *beta_ptr = in_data[quantized_batchnorm::kBeta].data().dptr<float>();
+  float* gamma_ptr = in_data[quantized_batchnorm::kGamma].data().dptr<float>();
+  float* beta_ptr  = in_data[quantized_batchnorm::kBeta].data().dptr<float>();
 
-  const NDArray &moving_mean = in_data[quantized_batchnorm::kInMovingMean];
-  const NDArray &moving_var = in_data[quantized_batchnorm::kInMovingVar];
-  float *moving_mean_ptr = moving_mean.data().dptr<float>();
-  float *moving_var_ptr = moving_var.data().dptr<float>();
+  const NDArray& moving_mean = in_data[quantized_batchnorm::kInMovingMean];
+  const NDArray& moving_var  = in_data[quantized_batchnorm::kInMovingVar];
+  float* moving_mean_ptr     = moving_mean.data().dptr<float>();
+  float* moving_var_ptr      = moving_var.data().dptr<float>();
 
   // rescale gamma and beta, to make mean=0 and var=1
-  auto rescaled_mean_mem = TmpMemMgr::Get()->Alloc(moving_mean.GetMKLDNNData()->get_desc());
-  auto rescaled_var_mem = TmpMemMgr::Get()->Alloc(moving_var.GetMKLDNNData()->get_desc());
-  float *rescaled_mean_ptr = reinterpret_cast<float *>(rescaled_mean_mem->get_data_handle());
-  float *rescaled_var_ptr = reinterpret_cast<float *>(rescaled_var_mem->get_data_handle());
+  auto rescaled_mean_mem   = TmpMemMgr::Get()->Alloc(moving_mean.GetMKLDNNData()->get_desc());
+  auto rescaled_var_mem    = TmpMemMgr::Get()->Alloc(moving_var.GetMKLDNNData()->get_desc());
+  float* rescaled_mean_ptr = reinterpret_cast<float*>(rescaled_mean_mem->get_data_handle());
+  float* rescaled_var_ptr  = reinterpret_cast<float*>(rescaled_var_mem->get_data_handle());
 
 #pragma omp parallel for num_threads(engine::OpenMP::Get()->GetRecommendedOMPThreadCount())
   for (int channel = 0; channel < channel_count; ++channel) {
-    float invstd = 1.0 / std::sqrt(moving_var_ptr[channel] + param.eps);
+    float invstd        = 1.0 / std::sqrt(moving_var_ptr[channel] + param.eps);
     weight_buf[channel] = gamma_ptr[channel] * invstd * max_abs_data / max_abs_output;
     weight_buf[channel_count + channel] =
         (beta_ptr[channel] - moving_mean_ptr[channel] * gamma_ptr[channel] * invstd) * kInt8Range /
         max_abs_output;
     rescaled_mean_ptr[channel] = 0.0f;
-    rescaled_var_ptr[channel] = 1.0f;
+    rescaled_var_ptr[channel]  = 1.0f;
   }
 
-  const NDArray &out = outputs[batchnorm::kOut];
-  auto out_mem = const_cast<NDArray &>(out).CreateMKLDNNData(fwd.GetPd().dst_desc());
+  const NDArray& out = outputs[batchnorm::kOut];
+  auto out_mem       = const_cast<NDArray&>(out).CreateMKLDNNData(fwd.GetPd().dst_desc());
   mkldnn_args_map_t net_args;
-  net_args[MKLDNN_ARG_SRC] = *data_mem;
+  net_args[MKLDNN_ARG_SRC]         = *data_mem;
   net_args[MKLDNN_ARG_SCALE_SHIFT] = weight_mem;
-  net_args[MKLDNN_ARG_DST] = *out_mem;
-  net_args[MKLDNN_ARG_MEAN] = *rescaled_mean_mem;
-  net_args[MKLDNN_ARG_VARIANCE] = *rescaled_var_mem;
+  net_args[MKLDNN_ARG_DST]         = *out_mem;
+  net_args[MKLDNN_ARG_MEAN]        = *rescaled_mean_mem;
+  net_args[MKLDNN_ARG_VARIANCE]    = *rescaled_var_mem;
 
   MKLDNNStream::Get()->RegisterPrimArgs(fwd.GetFwd(), net_args);
   MKLDNNStream::Get()->Submit();
 }
 
-inline static bool QuantizedBatchNormStorageType(const nnvm::NodeAttrs &attrs, const int dev_mask,
-                                                 DispatchMode *dispatch_mode,
-                                                 std::vector<int> *in_attrs,
-                                                 std::vector<int> *out_attrs) {
+inline static bool QuantizedBatchNormStorageType(
+    const nnvm::NodeAttrs& attrs, const int dev_mask, DispatchMode* dispatch_mode,
+    std::vector<int>* in_attrs, std::vector<int>* out_attrs) {
   bool dispatched = false;
   if (!dispatched) {
     dispatched = MKLDNNStorageType(attrs, dev_mask, true, dispatch_mode, in_attrs, out_attrs);
@@ -137,12 +135,14 @@ inline static bool QuantizedBatchNormStorageType(const nnvm::NodeAttrs &attrs, c
 }
 
 NNVM_REGISTER_OP(_contrib_quantized_batch_norm)
-.set_attr<FInferStorageType>("FInferStorageType", QuantizedBatchNormStorageType)
-.set_attr<FComputeEx>("FComputeEx<cpu>", MKLDNNQuantizedBatchNormForward)
-.set_attr<FResourceRequest>("FResourceRequest", [](const NodeAttrs& n) {
-  return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
-})
-.set_attr<bool>("TIsMKLDNN", true);
+    .set_attr<FInferStorageType>("FInferStorageType", QuantizedBatchNormStorageType)
+    .set_attr<FComputeEx>("FComputeEx<cpu>", MKLDNNQuantizedBatchNormForward)
+    .set_attr<FResourceRequest>(
+        "FResourceRequest",
+        [](const NodeAttrs& n) {
+          return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
+        })
+    .set_attr<bool>("TIsMKLDNN", true);
 
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/quantization/mkldnn/mkldnn_quantized_batch_norm.cc
+++ b/src/operator/quantization/mkldnn/mkldnn_quantized_batch_norm.cc
@@ -76,7 +76,8 @@ static void MKLDNNQuantizedBatchNormForward(const nnvm::NodeAttrs& attrs,
     *max_output_ptr = param.max_calib_range.value();
     *min_output_ptr = param.min_calib_range.value();
   } else {
-    LOG(FATAL) << "min_calib_range or max_calib_range is not available. Quantized BN currently "
+    LOG(FATAL) << "min_calib_range or max_calib_range is not available. "
+                  "Quantized BN currently "
                   "don't support calib_mode=None";
   }
   const float max_abs_output = std::max(std::abs(*min_output_ptr), std::abs(*max_output_ptr));

--- a/src/operator/quantization/mkldnn/mkldnn_quantized_concat.cc
+++ b/src/operator/quantization/mkldnn/mkldnn_quantized_concat.cc
@@ -54,9 +54,11 @@ static void MKLDNNQuantizedConcatForward(const nnvm::NodeAttrs& attrs,
   float output_pos_max = 0.f;  // 0.f is the minimum for output_pos_max
   for (int i = 0; i < param_.num_args; ++i) {
     data_min[i] = in_data[param_.num_args + 2 * i].data().dptr<float>()[0];
-    if (data_min[i] < output_neg_min) output_neg_min = data_min[i];
+    if (data_min[i] < output_neg_min)
+      output_neg_min = data_min[i];
     data_max[i] = in_data[param_.num_args + 2 * i + 1].data().dptr<float>()[0];
-    if (data_max[i] > output_pos_max) output_pos_max = data_max[i];
+    if (data_max[i] > output_pos_max)
+      output_pos_max = data_max[i];
   }
   out_data[quantized_concat_enum::kMin].data().dptr<float>()[0] = output_neg_min;
   out_data[quantized_concat_enum::kMax].data().dptr<float>()[0] = output_pos_max;
@@ -95,8 +97,8 @@ static void MKLDNNQuantizedConcatForward(const nnvm::NodeAttrs& attrs,
     }
   }
   MKLDNNConcatFwd& fwd           = GetConcatForward(param_.dim, in_data, data_md);
-  mxnet::mkldnn_output_t out_mem = CreateMKLDNNMem(out_data[quantized_concat_enum::kOut],
-                                                   fwd.fwd_pd.dst_desc(), req[concat_enum::kOut]);
+  mxnet::mkldnn_output_t out_mem = CreateMKLDNNMem(
+      out_data[quantized_concat_enum::kOut], fwd.fwd_pd.dst_desc(), req[concat_enum::kOut]);
   mkldnn_args_map_t net_args;
   net_args[MKLDNN_ARG_DST] = *out_mem.second;
   for (int i = 0; i < param_.num_args; i++) {

--- a/src/operator/quantization/mkldnn/mkldnn_quantized_concat.cc
+++ b/src/operator/quantization/mkldnn/mkldnn_quantized_concat.cc
@@ -39,7 +39,8 @@ static float GetScale(const NDArray& data, float min, float max) {
   return data_range / MaxAbs(min, max);
 }
 
-static void MKLDNNQuantizedConcatForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+static void MKLDNNQuantizedConcatForward(const nnvm::NodeAttrs& attrs,
+                                         const OpContext& ctx,
                                          const std::vector<NDArray>& in_data,
                                          const std::vector<OpReqType>& req,
                                          const std::vector<NDArray>& out_data) {
@@ -106,8 +107,10 @@ static void MKLDNNQuantizedConcatForward(const nnvm::NodeAttrs& attrs, const OpC
   MKLDNNStream::Get()->Submit();
 }
 
-inline static bool ConcatStorageType(const nnvm::NodeAttrs& attrs, const int dev_mask,
-                                     DispatchMode* dispatch_mode, std::vector<int>* in_attrs,
+inline static bool ConcatStorageType(const nnvm::NodeAttrs& attrs,
+                                     const int dev_mask,
+                                     DispatchMode* dispatch_mode,
+                                     std::vector<int>* in_attrs,
                                      std::vector<int>* out_attrs) {
   const ConcatParam& param_ = nnvm::get<ConcatParam>(attrs.parsed);
   CHECK_EQ(in_attrs->size(), static_cast<size_t>(param_.num_args * 3));

--- a/src/operator/quantization/mkldnn/mkldnn_quantized_concat.cc
+++ b/src/operator/quantization/mkldnn/mkldnn_quantized_concat.cc
@@ -39,9 +39,10 @@ static float GetScale(const NDArray& data, float min, float max) {
   return data_range / MaxAbs(min, max);
 }
 
-static void MKLDNNQuantizedConcatForward(
-    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& in_data,
-    const std::vector<OpReqType>& req, const std::vector<NDArray>& out_data) {
+static void MKLDNNQuantizedConcatForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+                                         const std::vector<NDArray>& in_data,
+                                         const std::vector<OpReqType>& req,
+                                         const std::vector<NDArray>& out_data) {
   const ConcatParam& param_ = nnvm::get<ConcatParam>(attrs.parsed);
   CHECK_EQ(in_data.size(), static_cast<size_t>(param_.num_args * 3));
   CHECK_EQ(out_data.size(), 3U);
@@ -93,8 +94,8 @@ static void MKLDNNQuantizedConcatForward(
     }
   }
   MKLDNNConcatFwd& fwd           = GetConcatForward(param_.dim, in_data, data_md);
-  mxnet::mkldnn_output_t out_mem = CreateMKLDNNMem(
-      out_data[quantized_concat_enum::kOut], fwd.fwd_pd.dst_desc(), req[concat_enum::kOut]);
+  mxnet::mkldnn_output_t out_mem = CreateMKLDNNMem(out_data[quantized_concat_enum::kOut],
+                                                   fwd.fwd_pd.dst_desc(), req[concat_enum::kOut]);
   mkldnn_args_map_t net_args;
   net_args[MKLDNN_ARG_DST] = *out_mem.second;
   for (int i = 0; i < param_.num_args; i++) {
@@ -105,9 +106,9 @@ static void MKLDNNQuantizedConcatForward(
   MKLDNNStream::Get()->Submit();
 }
 
-inline static bool ConcatStorageType(
-    const nnvm::NodeAttrs& attrs, const int dev_mask, DispatchMode* dispatch_mode,
-    std::vector<int>* in_attrs, std::vector<int>* out_attrs) {
+inline static bool ConcatStorageType(const nnvm::NodeAttrs& attrs, const int dev_mask,
+                                     DispatchMode* dispatch_mode, std::vector<int>* in_attrs,
+                                     std::vector<int>* out_attrs) {
   const ConcatParam& param_ = nnvm::get<ConcatParam>(attrs.parsed);
   CHECK_EQ(in_attrs->size(), static_cast<size_t>(param_.num_args * 3));
   CHECK_EQ(out_attrs->size(), 3U);
@@ -118,11 +119,10 @@ inline static bool ConcatStorageType(
 NNVM_REGISTER_OP(_contrib_quantized_concat)
     .set_attr<FInferStorageType>("FInferStorageType", ConcatStorageType)
     .set_attr<FComputeEx>("FComputeEx<cpu>", MKLDNNQuantizedConcatForward)
-    .set_attr<FResourceRequest>(
-        "FResourceRequest",
-        [](const NodeAttrs& n) {
-          return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
-        })
+    .set_attr<FResourceRequest>("FResourceRequest",
+                                [](const NodeAttrs& n) {
+                                  return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
+                                })
     .set_attr<bool>("TIsMKLDNN", true);
 
 }  // namespace op

--- a/src/operator/quantization/mkldnn/mkldnn_quantized_conv.cc
+++ b/src/operator/quantization/mkldnn/mkldnn_quantized_conv.cc
@@ -33,9 +33,10 @@
 namespace mxnet {
 namespace op {
 
-static void MKLDNNQuantizedConvForward(
-    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& in_data,
-    const std::vector<OpReqType>& req, const std::vector<NDArray>& out_data) {
+static void MKLDNNQuantizedConvForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+                                       const std::vector<NDArray>& in_data,
+                                       const std::vector<OpReqType>& req,
+                                       const std::vector<NDArray>& out_data) {
   CHECK_EQ(in_data[0].dtype(), mshadow::kUint8)
       << "mkldnn_quantized_conv op only supports uint8 as input type";
   TmpMemMgr::Get()->Init(ctx.requested[conv::kTempSpace]);
@@ -44,9 +45,8 @@ static void MKLDNNQuantizedConvForward(
   MKLDNNConvFullParam full_param;
   full_param.conv_param = param;
   full_param.mkldnn_param.Init(std::unordered_map<std::string, std::string>());
-  auto& fwd = GetConvFwd(
-      full_param, ctx.is_train, in_data[conv::kData], in_data[conv::kWeight],
-      param.no_bias ? nullptr : &in_data[conv::kBias], out_data[conv::kOut]);
+  auto& fwd     = GetConvFwd(full_param, ctx.is_train, in_data[conv::kData], in_data[conv::kWeight],
+                         param.no_bias ? nullptr : &in_data[conv::kBias], out_data[conv::kOut]);
   auto data_mem = in_data[conv::kData].GetMKLDNNDataReorder(fwd.GetPd().src_desc());
   const mkldnn::memory* weight_mem;
   // For inference, we want to reorder the weight array so we don't need to

--- a/src/operator/quantization/mkldnn/mkldnn_quantized_conv.cc
+++ b/src/operator/quantization/mkldnn/mkldnn_quantized_conv.cc
@@ -21,7 +21,7 @@
  * \file mkldnn_quantized_conv.cc
  * \brief
  * \author Wenting Jiang, Xinyu Chen
-*/
+ */
 
 #if MXNET_USE_MKLDNN == 1
 #include "../../nn/mkldnn/mkldnn_base-inl.h"
@@ -33,23 +33,22 @@
 namespace mxnet {
 namespace op {
 
-static void MKLDNNQuantizedConvForward(const nnvm::NodeAttrs& attrs,
-                                       const OpContext &ctx,
-                                       const std::vector<NDArray> &in_data,
-                                       const std::vector<OpReqType> &req,
-                                       const std::vector<NDArray> &out_data) {
+static void MKLDNNQuantizedConvForward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& in_data,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& out_data) {
   CHECK_EQ(in_data[0].dtype(), mshadow::kUint8)
-    << "mkldnn_quantized_conv op only supports uint8 as input type";
+      << "mkldnn_quantized_conv op only supports uint8 as input type";
   TmpMemMgr::Get()->Init(ctx.requested[conv::kTempSpace]);
-  NDArray weight = in_data[conv::kWeight];
+  NDArray weight         = in_data[conv::kWeight];
   ConvolutionParam param = nnvm::get<ConvolutionParam>(attrs.parsed);
   MKLDNNConvFullParam full_param;
   full_param.conv_param = param;
   full_param.mkldnn_param.Init(std::unordered_map<std::string, std::string>());
-  auto &fwd = GetConvFwd(full_param, ctx.is_train, in_data[conv::kData], in_data[conv::kWeight],
-                         param.no_bias ? nullptr : &in_data[conv::kBias], out_data[conv::kOut]);
+  auto& fwd = GetConvFwd(
+      full_param, ctx.is_train, in_data[conv::kData], in_data[conv::kWeight],
+      param.no_bias ? nullptr : &in_data[conv::kBias], out_data[conv::kOut]);
   auto data_mem = in_data[conv::kData].GetMKLDNNDataReorder(fwd.GetPd().src_desc());
-  const mkldnn::memory *weight_mem;
+  const mkldnn::memory* weight_mem;
   // For inference, we want to reorder the weight array so we don't need to
   // reorder data every time.
   if (weight.IsDefaultData()) {
@@ -61,11 +60,10 @@ static void MKLDNNQuantizedConvForward(const nnvm::NodeAttrs& attrs,
   } else {
     weight_mem = weight.GetMKLDNNData();
   }
-  auto out_mem = CreateMKLDNNMem(out_data[conv::kOut], fwd.GetPd().dst_desc(),
-                                 req[conv::kOut]);
+  auto out_mem = CreateMKLDNNMem(out_data[conv::kOut], fwd.GetPd().dst_desc(), req[conv::kOut]);
   mkldnn_args_map_t net_args;
   if (!param.no_bias) {
-    const mkldnn::memory *bias_mem =
+    const mkldnn::memory* bias_mem =
         in_data[conv::kBias].GetMKLDNNDataReorder(fwd.GetPd().bias_desc());
     net_args.insert({MKLDNN_ARG_BIAS, *bias_mem});
   }
@@ -75,18 +73,16 @@ static void MKLDNNQuantizedConvForward(const nnvm::NodeAttrs& attrs,
   MKLDNNStream::Get()->RegisterPrimArgs(fwd.GetFwd(), net_args);
   CommitOutput(out_data[conv::kOut], out_mem);
   MKLDNNStream::Get()->Submit();
-  Stream<cpu> *s = ctx.get_stream<cpu>();
+  Stream<cpu>* s          = ctx.get_stream<cpu>();
   const size_t num_inputs = param.no_bias ? 2 : 3;
-  mxnet_op::Kernel<QuantizationRangeForS8S8MultiplicationStruct, cpu>::Launch(s, 1,
-           out_data[1].data().dptr<float>(), out_data[2].data().dptr<float>(),
-           in_data[num_inputs].data().dptr<float>(),
-           in_data[num_inputs+1].data().dptr<float>(),
-           in_data[num_inputs+2].data().dptr<float>(),
-           in_data[num_inputs+3].data().dptr<float>());
+  mxnet_op::Kernel<QuantizationRangeForS8S8MultiplicationStruct, cpu>::Launch(
+      s, 1, out_data[1].data().dptr<float>(), out_data[2].data().dptr<float>(),
+      in_data[num_inputs].data().dptr<float>(), in_data[num_inputs + 1].data().dptr<float>(),
+      in_data[num_inputs + 2].data().dptr<float>(), in_data[num_inputs + 3].data().dptr<float>());
 }
 
 NNVM_REGISTER_OP(_contrib_quantized_conv)
-.set_attr<FComputeEx>("FComputeEx<cpu>", MKLDNNQuantizedConvForward);
+    .set_attr<FComputeEx>("FComputeEx<cpu>", MKLDNNQuantizedConvForward);
 
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/quantization/mkldnn/mkldnn_quantized_conv.cc
+++ b/src/operator/quantization/mkldnn/mkldnn_quantized_conv.cc
@@ -46,8 +46,12 @@ static void MKLDNNQuantizedConvForward(const nnvm::NodeAttrs& attrs,
   MKLDNNConvFullParam full_param;
   full_param.conv_param = param;
   full_param.mkldnn_param.Init(std::unordered_map<std::string, std::string>());
-  auto& fwd     = GetConvFwd(full_param, ctx.is_train, in_data[conv::kData], in_data[conv::kWeight],
-                         param.no_bias ? nullptr : &in_data[conv::kBias], out_data[conv::kOut]);
+  auto& fwd     = GetConvFwd(full_param,
+                         ctx.is_train,
+                         in_data[conv::kData],
+                         in_data[conv::kWeight],
+                         param.no_bias ? nullptr : &in_data[conv::kBias],
+                         out_data[conv::kOut]);
   auto data_mem = in_data[conv::kData].GetMKLDNNDataReorder(fwd.GetPd().src_desc());
   const mkldnn::memory* weight_mem;
   // For inference, we want to reorder the weight array so we don't need to
@@ -77,9 +81,14 @@ static void MKLDNNQuantizedConvForward(const nnvm::NodeAttrs& attrs,
   Stream<cpu>* s          = ctx.get_stream<cpu>();
   const size_t num_inputs = param.no_bias ? 2 : 3;
   mxnet_op::Kernel<QuantizationRangeForS8S8MultiplicationStruct, cpu>::Launch(
-      s, 1, out_data[1].data().dptr<float>(), out_data[2].data().dptr<float>(),
-      in_data[num_inputs].data().dptr<float>(), in_data[num_inputs + 1].data().dptr<float>(),
-      in_data[num_inputs + 2].data().dptr<float>(), in_data[num_inputs + 3].data().dptr<float>());
+      s,
+      1,
+      out_data[1].data().dptr<float>(),
+      out_data[2].data().dptr<float>(),
+      in_data[num_inputs].data().dptr<float>(),
+      in_data[num_inputs + 1].data().dptr<float>(),
+      in_data[num_inputs + 2].data().dptr<float>(),
+      in_data[num_inputs + 3].data().dptr<float>());
 }
 
 NNVM_REGISTER_OP(_contrib_quantized_conv)

--- a/src/operator/quantization/mkldnn/mkldnn_quantized_conv.cc
+++ b/src/operator/quantization/mkldnn/mkldnn_quantized_conv.cc
@@ -24,16 +24,17 @@
  */
 
 #if MXNET_USE_MKLDNN == 1
+#include "../../elemwise_op_common.h"
+#include "../../nn/convolution-inl.h"
 #include "../../nn/mkldnn/mkldnn_base-inl.h"
 #include "../../nn/mkldnn/mkldnn_convolution-inl.h"
-#include "../../nn/convolution-inl.h"
-#include "../quantization_utils.h"
 #include "../../tensor/matrix_op-inl.h"
-#include "../../elemwise_op_common.h"
+#include "../quantization_utils.h"
 namespace mxnet {
 namespace op {
 
-static void MKLDNNQuantizedConvForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+static void MKLDNNQuantizedConvForward(const nnvm::NodeAttrs& attrs,
+                                       const OpContext& ctx,
                                        const std::vector<NDArray>& in_data,
                                        const std::vector<OpReqType>& req,
                                        const std::vector<NDArray>& out_data) {

--- a/src/operator/quantization/mkldnn/mkldnn_quantized_elemwise_add.cc
+++ b/src/operator/quantization/mkldnn/mkldnn_quantized_elemwise_add.cc
@@ -24,10 +24,10 @@
  */
 
 #if MXNET_USE_MKLDNN == 1
-#include "../quantized_elemwise_add-inl.h"
-#include "../../nn/mkldnn/mkldnn_ops-inl.h"
 #include "../../nn/mkldnn/mkldnn_base-inl.h"
+#include "../../nn/mkldnn/mkldnn_ops-inl.h"
 #include "../quantization_utils.h"
+#include "../quantized_elemwise_add-inl.h"
 
 namespace mxnet {
 namespace op {
@@ -60,8 +60,10 @@ class MKLDNNQuantizedElemwiseAddFwd {
 };
 
 static MKLDNNQuantizedElemwiseAddFwd& GetQuantizedElemwiseAddForward(
-    const mkldnn::memory::desc& output_desc, const std::vector<float>& scales,
-    const std::vector<NDArray>& in_data, const std::vector<NDArray>& out_data,
+    const mkldnn::memory::desc& output_desc,
+    const std::vector<float>& scales,
+    const std::vector<NDArray>& in_data,
+    const std::vector<NDArray>& out_data,
     const std::vector<mkldnn::memory::desc>& data_md) {
 #if DMLC_CXX11_THREAD_LOCAL
   static thread_local std::unordered_map<OpSignature, MKLDNNQuantizedElemwiseAddFwd, OpHash> fwds;
@@ -87,7 +89,8 @@ static MKLDNNQuantizedElemwiseAddFwd& GetQuantizedElemwiseAddForward(
   return it->second;
 }
 
-static void MKLDNNQuantizedElemwiseAddForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+static void MKLDNNQuantizedElemwiseAddForward(const nnvm::NodeAttrs& attrs,
+                                              const OpContext& ctx,
                                               const std::vector<NDArray>& in_data,
                                               const std::vector<OpReqType>& req,
                                               const std::vector<NDArray>& out_data) {
@@ -221,8 +224,10 @@ static void MKLDNNQuantizedElemwiseAddForward(const nnvm::NodeAttrs& attrs, cons
   out_data[quantized_elemwise_add_enum::kMax].data().dptr<float>()[0] = output_max;
 }
 
-inline static bool ElemwiseAddStorageType(const nnvm::NodeAttrs& attrs, const int dev_mask,
-                                          DispatchMode* dispatch_mode, std::vector<int>* in_attrs,
+inline static bool ElemwiseAddStorageType(const nnvm::NodeAttrs& attrs,
+                                          const int dev_mask,
+                                          DispatchMode* dispatch_mode,
+                                          std::vector<int>* in_attrs,
                                           std::vector<int>* out_attrs) {
   // Check num of inputs: A, B, A_min, A_max, B_min, B_max
   CHECK_EQ(in_attrs->size(), 6U);

--- a/src/operator/quantization/mkldnn/mkldnn_quantized_elemwise_add.cc
+++ b/src/operator/quantization/mkldnn/mkldnn_quantized_elemwise_add.cc
@@ -51,7 +51,9 @@ class MKLDNNQuantizedElemwiseAddFwd {
     data_.resize(data_md.size());
   }
 
-  const mkldnn::sum& GetFwd() const { return *fwd_; }
+  const mkldnn::sum& GetFwd() const {
+    return *fwd_;
+  }
 
  private:
   std::shared_ptr<mkldnn::sum> fwd_;
@@ -210,8 +212,8 @@ static void MKLDNNQuantizedElemwiseAddForward(const nnvm::NodeAttrs& attrs,
       mkldnn::memory::desc(i_dims, output_data_type, mkldnn::memory::format_tag::any);
   MKLDNNQuantizedElemwiseAddFwd& fwd =
       GetQuantizedElemwiseAddForward(output_desc, scales, in_data, out_data, in_desc);
-  auto mem = CreateMKLDNNMem(out_data[quantized_elemwise_add_enum::kOut], fwd.fwd_pd.dst_desc(),
-                             req[0], &in_data[0]);
+  auto mem = CreateMKLDNNMem(
+      out_data[quantized_elemwise_add_enum::kOut], fwd.fwd_pd.dst_desc(), req[0], &in_data[0]);
   mkldnn_args_map_t args({{MKLDNN_ARG_MULTIPLE_SRC, *dataA_mem},
                           {MKLDNN_ARG_MULTIPLE_SRC + 1, *dataB_mem},
                           {MKLDNN_ARG_DST, *mem.second}});

--- a/src/operator/quantization/mkldnn/mkldnn_quantized_elemwise_add.cc
+++ b/src/operator/quantization/mkldnn/mkldnn_quantized_elemwise_add.cc
@@ -44,15 +44,14 @@ class MKLDNNQuantizedElemwiseAddFwd {
   mkldnn::sum::primitive_desc fwd_pd;
 
   MKLDNNQuantizedElemwiseAddFwd(
-               const mkldnn::memory::desc &output_desc,
-               const std::vector<float> &scales,
-               const std::vector<mkldnn::memory::desc> &data_md)
+      const mkldnn::memory::desc& output_desc, const std::vector<float>& scales,
+      const std::vector<mkldnn::memory::desc>& data_md)
       : fwd_pd(output_desc, scales, data_md, CpuEngine::Get()->get_engine()) {
     fwd_ = std::make_shared<mkldnn::sum>(fwd_pd);
     data_.resize(data_md.size());
   }
 
-  const mkldnn::sum &GetFwd() const { return *fwd_; }
+  const mkldnn::sum& GetFwd() const { return *fwd_; }
 
  private:
   std::shared_ptr<mkldnn::sum> fwd_;
@@ -60,16 +59,15 @@ class MKLDNNQuantizedElemwiseAddFwd {
   std::shared_ptr<mkldnn::memory> out_;
 };
 
-static MKLDNNQuantizedElemwiseAddFwd &GetQuantizedElemwiseAddForward(
-    const mkldnn::memory::desc &output_desc, const std::vector<float> &scales,
-    const std::vector<NDArray> &in_data, const std::vector<NDArray> &out_data,
-    const std::vector<mkldnn::memory::desc> &data_md) {
+static MKLDNNQuantizedElemwiseAddFwd& GetQuantizedElemwiseAddForward(
+    const mkldnn::memory::desc& output_desc, const std::vector<float>& scales,
+    const std::vector<NDArray>& in_data, const std::vector<NDArray>& out_data,
+    const std::vector<mkldnn::memory::desc>& data_md) {
 #if DMLC_CXX11_THREAD_LOCAL
-  static thread_local std::unordered_map<OpSignature,
-              MKLDNNQuantizedElemwiseAddFwd, OpHash> fwds;
+  static thread_local std::unordered_map<OpSignature, MKLDNNQuantizedElemwiseAddFwd, OpHash> fwds;
 #else
-  static MX_THREAD_LOCAL std::unordered_map<OpSignature,
-              MKLDNNQuantizedElemwiseAddFwd, OpHash> fwds;
+  static MX_THREAD_LOCAL std::unordered_map<OpSignature, MKLDNNQuantizedElemwiseAddFwd, OpHash>
+      fwds;
 #endif
   OpSignature key;
   key.AddSign(in_data);
@@ -89,60 +87,56 @@ static MKLDNNQuantizedElemwiseAddFwd &GetQuantizedElemwiseAddForward(
   return it->second;
 }
 
-
-static void MKLDNNQuantizedElemwiseAddForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
-                                              const std::vector<NDArray>& in_data,
-                                              const std::vector<OpReqType>& req,
-                                              const std::vector<NDArray>& out_data) {
+static void MKLDNNQuantizedElemwiseAddForward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& in_data,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& out_data) {
   const QuantizeElemwiseAddParam& params = nnvm::get<QuantizeElemwiseAddParam>(attrs.parsed);
   // A, B, A_min, A_max, B_min, B_max
   CHECK_EQ(in_data.size(), 6U) << "should be A, B, A_min, A_max, B_min, B_max";
   // C, C_min, C_max
   CHECK_EQ(out_data.size(), 3U) << "should be C, C_min, C_max";
   // Collect data min,max,absmax
-  const float dataA_min = in_data[quantized_elemwise_add_enum::kAMin].data().dptr<float>()[0];
-  const float dataB_min = in_data[quantized_elemwise_add_enum::kBMin].data().dptr<float>()[0];
-  const float dataA_max = in_data[quantized_elemwise_add_enum::kAMax].data().dptr<float>()[0];
-  const float dataB_max = in_data[quantized_elemwise_add_enum::kBMax].data().dptr<float>()[0];
+  const float dataA_min    = in_data[quantized_elemwise_add_enum::kAMin].data().dptr<float>()[0];
+  const float dataB_min    = in_data[quantized_elemwise_add_enum::kBMin].data().dptr<float>()[0];
+  const float dataA_max    = in_data[quantized_elemwise_add_enum::kAMax].data().dptr<float>()[0];
+  const float dataB_max    = in_data[quantized_elemwise_add_enum::kBMax].data().dptr<float>()[0];
   const float dataA_absmax = MaxAbs(dataA_min, dataA_max);
   const float dataB_absmax = MaxAbs(dataB_min, dataB_max);
 
-  auto dataA_mem  = in_data[quantized_elemwise_add_enum::kDataA].GetMKLDNNData();
-  auto dataB_mem  = in_data[quantized_elemwise_add_enum::kDataB].GetMKLDNNData();
-  const bool is_dataA_int8 = (in_data[quantized_elemwise_add_enum::kDataA].dtype()
-                              == mshadow::kInt8);
+  auto dataA_mem = in_data[quantized_elemwise_add_enum::kDataA].GetMKLDNNData();
+  auto dataB_mem = in_data[quantized_elemwise_add_enum::kDataB].GetMKLDNNData();
+  const bool is_dataA_int8 =
+      (in_data[quantized_elemwise_add_enum::kDataA].dtype() == mshadow::kInt8);
   const float dataA_range = is_dataA_int8 ? kInt8Range : kUint8Range;
 
-  const float A_scale = GetScale(in_data[quantized_elemwise_add_enum::kDataA],
-                                 dataA_min,
-                                 dataA_max);
-  const float B_scale = GetScale(in_data[quantized_elemwise_add_enum::kDataB],
-                                 dataB_min,
-                                 dataB_max);
+  const float A_scale =
+      GetScale(in_data[quantized_elemwise_add_enum::kDataA], dataA_min, dataA_max);
+  const float B_scale =
+      GetScale(in_data[quantized_elemwise_add_enum::kDataB], dataB_min, dataB_max);
   // rescaled_mem is for reorder mkldnn memory
-  mkldnn::memory *rescaled_mem;
+  mkldnn::memory* rescaled_mem;
 
   // output default set as int32
   float output_data_range = kInt32Range;
-  auto output_data_type = mkldnn::memory::data_type::s32;
+  auto output_data_type   = mkldnn::memory::data_type::s32;
   // dataA && dataB are uint8
   if (out_data[quantized_elemwise_add_enum::kOut].dtype() == mshadow::kInt8) {
     output_data_range = kInt8Range;
-    output_data_type = mkldnn::memory::data_type::s8;
+    output_data_type  = mkldnn::memory::data_type::s8;
   } else if (out_data[quantized_elemwise_add_enum::kOut].dtype() == mshadow::kUint8) {
     output_data_range = kUint8Range;
-    output_data_type = mkldnn::memory::data_type::u8;
+    output_data_type  = mkldnn::memory::data_type::u8;
   } else {
     output_data_range = kInt32Range;
-    output_data_type = mkldnn::memory::data_type::s32;
+    output_data_type  = mkldnn::memory::data_type::s32;
   }
 
-  float output_min = 0;
-  float output_max = 0;
+  float output_min     = 0;
+  float output_max     = 0;
   float out_data_scale = 0;
   if (params.max_calib_range.has_value() && params.min_calib_range.has_value()) {
-    output_min = params.min_calib_range.value();
-    output_max = params.max_calib_range.value();
+    output_min     = params.min_calib_range.value();
+    output_max     = params.max_calib_range.value();
     out_data_scale = output_data_range / MaxAbs(output_min, output_max);
   } else {
     output_max = dataA_absmax + dataB_absmax;
@@ -152,45 +146,39 @@ static void MKLDNNQuantizedElemwiseAddForward(const nnvm::NodeAttrs& attrs, cons
   const int scales_num = 2;
   std::vector<float> scales(scales_num, 1);
   auto engine = CpuEngine::Get()->get_engine();
-  if (in_data[quantized_elemwise_add_enum::kDataA].dtype()
-      != in_data[quantized_elemwise_add_enum::kDataB].dtype()) {
-    auto s8_desc = (is_dataA_int8 == true)
-                 ? dataA_mem->get_desc()
-                 : dataB_mem->get_desc();
+  if (in_data[quantized_elemwise_add_enum::kDataA].dtype() !=
+      in_data[quantized_elemwise_add_enum::kDataB].dtype()) {
+    auto s8_desc = (is_dataA_int8 == true) ? dataA_mem->get_desc() : dataB_mem->get_desc();
     rescaled_mem = TmpMemMgr::Get()->Alloc(s8_desc);
     float u8_reorder_scale = 0;
     if (params.max_calib_range.has_value() && params.min_calib_range.has_value()) {
       if (is_dataA_int8 == true) {
         u8_reorder_scale = out_data_scale / B_scale;
-        scales[0] = out_data_scale / A_scale;
+        scales[0]        = out_data_scale / A_scale;
       } else {
         u8_reorder_scale = out_data_scale / A_scale;
-        scales[1] = out_data_scale / B_scale;
+        scales[1]        = out_data_scale / B_scale;
       }
     } else {
       // x*dataA_absmax/dataA_range = y*(dataA_absmax+dataB_absmax)/output_range
       if (is_dataA_int8 == true) {
-        u8_reorder_scale = dataB_absmax * output_data_range
-                           / ((dataA_absmax + dataB_absmax) * kUint8Range);
-        scales[0] = dataA_absmax * output_data_range
-                         / ((dataA_absmax + dataB_absmax) * dataA_range);
+        u8_reorder_scale =
+            dataB_absmax * output_data_range / ((dataA_absmax + dataB_absmax) * kUint8Range);
+        scales[0] =
+            dataA_absmax * output_data_range / ((dataA_absmax + dataB_absmax) * dataA_range);
       } else {
-        u8_reorder_scale = dataA_absmax * output_data_range
-                           / ((dataA_absmax + dataB_absmax) * dataA_range);
-        scales[1] = dataB_absmax * output_data_range
-                         / ((dataA_absmax + dataB_absmax) * kInt8Range);
+        u8_reorder_scale =
+            dataA_absmax * output_data_range / ((dataA_absmax + dataB_absmax) * dataA_range);
+        scales[1] = dataB_absmax * output_data_range / ((dataA_absmax + dataB_absmax) * kInt8Range);
       }
     }
     std::vector<float> reorder_scale = {u8_reorder_scale};
     mkldnn::primitive_attr reorder_attr;
     reorder_attr.set_output_scales(0, reorder_scale);
     auto u8_mem = (is_dataA_int8 == true) ? dataB_mem : dataA_mem;
-    const auto reorder_pd = mkldnn::reorder::primitive_desc(engine,
-                                                            u8_mem->get_desc(),
-                                                            engine,
-                                                            s8_desc,
-                                                            reorder_attr);
-    mkldnn_args_map_t args({{MKLDNN_ARG_FROM, *u8_mem }, {MKLDNN_ARG_TO, *rescaled_mem}});
+    const auto reorder_pd =
+        mkldnn::reorder::primitive_desc(engine, u8_mem->get_desc(), engine, s8_desc, reorder_attr);
+    mkldnn_args_map_t args({{MKLDNN_ARG_FROM, *u8_mem}, {MKLDNN_ARG_TO, *rescaled_mem}});
     MKLDNNStream::Get()->RegisterPrimArgs(mkldnn::reorder(reorder_pd), args);
 
     if (is_dataA_int8 == true) {
@@ -214,19 +202,17 @@ static void MKLDNNQuantizedElemwiseAddForward(const nnvm::NodeAttrs& attrs, cons
   in_desc.push_back(dataB_mem->get_desc());
   const auto in_shape = in_data[quantized_elemwise_add_enum::kDataA].shape();
   mkldnn::memory::dims i_dims(in_shape.begin(), in_shape.end());
-  auto output_desc = mkldnn::memory::desc(i_dims,
-                                          output_data_type,
-                                          mkldnn::memory::format_tag::any);
-  MKLDNNQuantizedElemwiseAddFwd &fwd = GetQuantizedElemwiseAddForward(output_desc, scales,
-                                                                      in_data, out_data, in_desc);
-  auto mem = CreateMKLDNNMem(out_data[quantized_elemwise_add_enum::kOut],
-                             fwd.fwd_pd.dst_desc(),
-                             req[0],
-                             &in_data[0]);
-  mkldnn_args_map_t args({{MKLDNN_ARG_MULTIPLE_SRC,  *dataA_mem},
-                          {MKLDNN_ARG_MULTIPLE_SRC + 1,  *dataB_mem},
-                          {MKLDNN_ARG_DST, *mem.second}});
-  MKLDNNStream *stream = MKLDNNStream::Get();
+  auto output_desc =
+      mkldnn::memory::desc(i_dims, output_data_type, mkldnn::memory::format_tag::any);
+  MKLDNNQuantizedElemwiseAddFwd& fwd =
+      GetQuantizedElemwiseAddForward(output_desc, scales, in_data, out_data, in_desc);
+  auto mem = CreateMKLDNNMem(
+      out_data[quantized_elemwise_add_enum::kOut], fwd.fwd_pd.dst_desc(), req[0], &in_data[0]);
+  mkldnn_args_map_t args(
+      {{MKLDNN_ARG_MULTIPLE_SRC, *dataA_mem},
+       {MKLDNN_ARG_MULTIPLE_SRC + 1, *dataB_mem},
+       {MKLDNN_ARG_DST, *mem.second}});
+  MKLDNNStream* stream = MKLDNNStream::Get();
   stream->RegisterPrimArgs(fwd.GetFwd(), args);
   CommitOutput(out_data[quantized_elemwise_add_enum::kOut], mem);
   stream->Submit();
@@ -235,9 +221,9 @@ static void MKLDNNQuantizedElemwiseAddForward(const nnvm::NodeAttrs& attrs, cons
   out_data[quantized_elemwise_add_enum::kMax].data().dptr<float>()[0] = output_max;
 }
 
-inline static bool ElemwiseAddStorageType(const nnvm::NodeAttrs& attrs, const int dev_mask,
-                                          DispatchMode* dispatch_mode, std::vector<int>* in_attrs,
-                                          std::vector<int>* out_attrs) {
+inline static bool ElemwiseAddStorageType(
+    const nnvm::NodeAttrs& attrs, const int dev_mask, DispatchMode* dispatch_mode,
+    std::vector<int>* in_attrs, std::vector<int>* out_attrs) {
   // Check num of inputs: A, B, A_min, A_max, B_min, B_max
   CHECK_EQ(in_attrs->size(), 6U);
   // Check num of outputs: C, C_min, C_max
@@ -247,11 +233,11 @@ inline static bool ElemwiseAddStorageType(const nnvm::NodeAttrs& attrs, const in
 }
 
 NNVM_REGISTER_OP(_contrib_quantized_elemwise_add)
-.set_attr<FInferStorageType>("FInferStorageType", ElemwiseAddStorageType)
-.set_attr<FComputeEx>("FComputeEx<cpu>", MKLDNNQuantizedElemwiseAddForward)
-.set_attr<bool>("TIsMKLDNN", true)
-.set_attr_parser(ParamParser<QuantizeElemwiseAddParam>)
-.add_arguments(QuantizeElemwiseAddParam::__FIELDS__());
+    .set_attr<FInferStorageType>("FInferStorageType", ElemwiseAddStorageType)
+    .set_attr<FComputeEx>("FComputeEx<cpu>", MKLDNNQuantizedElemwiseAddForward)
+    .set_attr<bool>("TIsMKLDNN", true)
+    .set_attr_parser(ParamParser<QuantizeElemwiseAddParam>)
+    .add_arguments(QuantizeElemwiseAddParam::__FIELDS__());
 }  // namespace op
 }  // namespace mxnet
 

--- a/src/operator/quantization/mkldnn/mkldnn_quantized_flatten.cc
+++ b/src/operator/quantization/mkldnn/mkldnn_quantized_flatten.cc
@@ -30,17 +30,18 @@
 namespace mxnet {
 namespace op {
 
-inline static bool FlattenStorageType(
-    const nnvm::NodeAttrs& attrs, const int dev_mask, DispatchMode* dispatch_mode,
-    std::vector<int>* in_attrs, std::vector<int>* out_attrs) {
+inline static bool FlattenStorageType(const nnvm::NodeAttrs& attrs, const int dev_mask,
+                                      DispatchMode* dispatch_mode, std::vector<int>* in_attrs,
+                                      std::vector<int>* out_attrs) {
   CHECK_EQ(in_attrs->size(), 3U);
   CHECK_EQ(out_attrs->size(), 3U);
   return MKLDNNStorageType(attrs, dev_mask, true, dispatch_mode, in_attrs, out_attrs);
 }
 
-static void MKLDNNQuantizedFlattenForward(
-    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& inputs,
-    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs) {
+static void MKLDNNQuantizedFlattenForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+                                          const std::vector<NDArray>& inputs,
+                                          const std::vector<OpReqType>& req,
+                                          const std::vector<NDArray>& outputs) {
   MKLDNNRun(MKLDNNReshapeForward, attrs, ctx, inputs[0], req[0], outputs[0]);
   outputs[1].data().dptr<float>()[0] = inputs[1].data().dptr<float>()[0];
   outputs[2].data().dptr<float>()[0] = inputs[2].data().dptr<float>()[0];
@@ -49,11 +50,10 @@ static void MKLDNNQuantizedFlattenForward(
 NNVM_REGISTER_OP(_contrib_quantized_flatten)
     .set_attr<FInferStorageType>("FInferStorageType", FlattenStorageType)
     .set_attr<FComputeEx>("FComputeEx<cpu>", MKLDNNQuantizedFlattenForward)
-    .set_attr<FResourceRequest>(
-        "FResourceRequest",
-        [](const NodeAttrs& n) {
-          return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
-        })
+    .set_attr<FResourceRequest>("FResourceRequest",
+                                [](const NodeAttrs& n) {
+                                  return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
+                                })
     .set_attr<bool>("TIsMKLDNN", true);
 
 }  // namespace op

--- a/src/operator/quantization/mkldnn/mkldnn_quantized_flatten.cc
+++ b/src/operator/quantization/mkldnn/mkldnn_quantized_flatten.cc
@@ -30,30 +30,31 @@
 namespace mxnet {
 namespace op {
 
-inline static bool FlattenStorageType(const nnvm::NodeAttrs& attrs, const int dev_mask,
-                                     DispatchMode* dispatch_mode, std::vector<int>* in_attrs,
-                                     std::vector<int>* out_attrs) {
+inline static bool FlattenStorageType(
+    const nnvm::NodeAttrs& attrs, const int dev_mask, DispatchMode* dispatch_mode,
+    std::vector<int>* in_attrs, std::vector<int>* out_attrs) {
   CHECK_EQ(in_attrs->size(), 3U);
   CHECK_EQ(out_attrs->size(), 3U);
   return MKLDNNStorageType(attrs, dev_mask, true, dispatch_mode, in_attrs, out_attrs);
 }
 
-static void MKLDNNQuantizedFlattenForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
-                                          const std::vector<NDArray>& inputs,
-                                          const std::vector<OpReqType>& req,
-                                          const std::vector<NDArray>& outputs) {
+static void MKLDNNQuantizedFlattenForward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& inputs,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs) {
   MKLDNNRun(MKLDNNReshapeForward, attrs, ctx, inputs[0], req[0], outputs[0]);
   outputs[1].data().dptr<float>()[0] = inputs[1].data().dptr<float>()[0];
   outputs[2].data().dptr<float>()[0] = inputs[2].data().dptr<float>()[0];
 }
 
 NNVM_REGISTER_OP(_contrib_quantized_flatten)
-.set_attr<FInferStorageType>("FInferStorageType", FlattenStorageType)
-.set_attr<FComputeEx>("FComputeEx<cpu>", MKLDNNQuantizedFlattenForward)
-.set_attr<FResourceRequest>("FResourceRequest", [](const NodeAttrs& n) {
-  return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
-})
-.set_attr<bool>("TIsMKLDNN", true);
+    .set_attr<FInferStorageType>("FInferStorageType", FlattenStorageType)
+    .set_attr<FComputeEx>("FComputeEx<cpu>", MKLDNNQuantizedFlattenForward)
+    .set_attr<FResourceRequest>(
+        "FResourceRequest",
+        [](const NodeAttrs& n) {
+          return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
+        })
+    .set_attr<bool>("TIsMKLDNN", true);
 
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/quantization/mkldnn/mkldnn_quantized_flatten.cc
+++ b/src/operator/quantization/mkldnn/mkldnn_quantized_flatten.cc
@@ -30,15 +30,18 @@
 namespace mxnet {
 namespace op {
 
-inline static bool FlattenStorageType(const nnvm::NodeAttrs& attrs, const int dev_mask,
-                                      DispatchMode* dispatch_mode, std::vector<int>* in_attrs,
+inline static bool FlattenStorageType(const nnvm::NodeAttrs& attrs,
+                                      const int dev_mask,
+                                      DispatchMode* dispatch_mode,
+                                      std::vector<int>* in_attrs,
                                       std::vector<int>* out_attrs) {
   CHECK_EQ(in_attrs->size(), 3U);
   CHECK_EQ(out_attrs->size(), 3U);
   return MKLDNNStorageType(attrs, dev_mask, true, dispatch_mode, in_attrs, out_attrs);
 }
 
-static void MKLDNNQuantizedFlattenForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+static void MKLDNNQuantizedFlattenForward(const nnvm::NodeAttrs& attrs,
+                                          const OpContext& ctx,
                                           const std::vector<NDArray>& inputs,
                                           const std::vector<OpReqType>& req,
                                           const std::vector<NDArray>& outputs) {

--- a/src/operator/quantization/mkldnn/mkldnn_quantized_fully_connected.cc
+++ b/src/operator/quantization/mkldnn/mkldnn_quantized_fully_connected.cc
@@ -31,9 +31,10 @@
 namespace mxnet {
 namespace op {
 
-void MKLDNNQuantizedFullyConnectedForward(
-    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& in_data,
-    const std::vector<OpReqType>& req, const std::vector<NDArray>& out_data) {
+void MKLDNNQuantizedFullyConnectedForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+                                          const std::vector<NDArray>& in_data,
+                                          const std::vector<OpReqType>& req,
+                                          const std::vector<NDArray>& out_data) {
   TmpMemMgr::Get()->Init(ctx.requested[fullc::kTempSpace]);
   FullyConnectedParam param = nnvm::get<FullyConnectedParam>(attrs.parsed);
   const size_t num_inputs   = param.no_bias ? 2 : 3;

--- a/src/operator/quantization/mkldnn/mkldnn_quantized_fully_connected.cc
+++ b/src/operator/quantization/mkldnn/mkldnn_quantized_fully_connected.cc
@@ -31,55 +31,50 @@
 namespace mxnet {
 namespace op {
 
-void MKLDNNQuantizedFullyConnectedForward(const nnvm::NodeAttrs &attrs,
-                                          const OpContext &ctx,
-                                          const std::vector<NDArray> &in_data,
-                                          const std::vector<OpReqType> &req,
-                                          const std::vector<NDArray> &out_data) {
+void MKLDNNQuantizedFullyConnectedForward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& in_data,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& out_data) {
   TmpMemMgr::Get()->Init(ctx.requested[fullc::kTempSpace]);
   FullyConnectedParam param = nnvm::get<FullyConnectedParam>(attrs.parsed);
-  const size_t num_inputs = param.no_bias ? 2 : 3;
+  const size_t num_inputs   = param.no_bias ? 2 : 3;
 
   CHECK_EQ(in_data.size(), static_cast<size_t>(num_inputs * 3));
   CHECK_EQ(out_data.size(), 3U);
 
-  NDArray data = in_data[fullc::kData];
+  NDArray data   = in_data[fullc::kData];
   NDArray weight = in_data[fullc::kWeight];
 
-  const float min_data =
-    in_data[num_inputs + quantized_fullc::kDataMin].data().dptr<float>()[0];
-  const float max_data =
-    in_data[num_inputs + quantized_fullc::kDataMax].data().dptr<float>()[0];
+  const float min_data = in_data[num_inputs + quantized_fullc::kDataMin].data().dptr<float>()[0];
+  const float max_data = in_data[num_inputs + quantized_fullc::kDataMax].data().dptr<float>()[0];
   const float min_weight =
-    in_data[num_inputs + quantized_fullc::kWeightMin].data().dptr<float>()[0];
+      in_data[num_inputs + quantized_fullc::kWeightMin].data().dptr<float>()[0];
   const float max_weight =
-    in_data[num_inputs + quantized_fullc::kWeightMax].data().dptr<float>()[0];
-  float *min_output_ptr = out_data[quantized_fullc::kOutMin].data().dptr<float>();
-  float *max_output_ptr = out_data[quantized_fullc::kOutMax].data().dptr<float>();
+      in_data[num_inputs + quantized_fullc::kWeightMax].data().dptr<float>()[0];
+  float* min_output_ptr = out_data[quantized_fullc::kOutMin].data().dptr<float>();
+  float* max_output_ptr = out_data[quantized_fullc::kOutMax].data().dptr<float>();
 
-  auto data_range = (data.dtype() == mshadow::kInt8) ? kInt8Range : kUint8Range;
-  float data_scale = data_range / MaxAbs(min_data, max_data);
+  auto data_range    = (data.dtype() == mshadow::kInt8) ? kInt8Range : kUint8Range;
+  float data_scale   = data_range / MaxAbs(min_data, max_data);
   float weight_scale = kInt8Range / MaxAbs(min_weight, max_weight);
 
   NDArray quantized_bias;
   if (!param.no_bias) {
-    NDArray bias = in_data[fullc::kBias];
+    NDArray bias   = in_data[fullc::kBias];
     float min_bias = in_data[num_inputs + quantized_fullc::kBiasMin].data().dptr<float>()[0];
     float max_bias = in_data[num_inputs + quantized_fullc::kBiasMax].data().dptr<float>()[0];
     float bias_int32_rescale = data_scale * weight_scale * MaxAbs(min_bias, max_bias) / kInt8Range;
 
-    quantized_bias = NDArray(bias.storage_type(), bias.shape(),
-                             bias.ctx(), true, mshadow::kInt32);
-    int8_t *bias_ptr = bias.data().dptr<int8_t>();
-    int32_t *quantized_bias_ptr = quantized_bias.data().dptr<int32_t>();
-    size_t bias_size = bias.shape().Size();
-    #pragma omp parallel for num_threads(engine::OpenMP::Get()->GetRecommendedOMPThreadCount())
+    quantized_bias = NDArray(bias.storage_type(), bias.shape(), bias.ctx(), true, mshadow::kInt32);
+    int8_t* bias_ptr            = bias.data().dptr<int8_t>();
+    int32_t* quantized_bias_ptr = quantized_bias.data().dptr<int32_t>();
+    size_t bias_size            = bias.shape().Size();
+#pragma omp parallel for num_threads(engine::OpenMP::Get()->GetRecommendedOMPThreadCount())
     for (index_t i = 0; i < static_cast<index_t>(bias_size); ++i) {
       quantized_bias_ptr[i] = bias_ptr[i] * bias_int32_rescale;
     }
   }
 
-  Stream<cpu> *s = ctx.get_stream<cpu>();
+  Stream<cpu>* s = ctx.get_stream<cpu>();
   if (data.dtype() == mshadow::kInt8) {
     mxnet_op::Kernel<QuantizationRangeForS8S8MultiplicationStruct, cpu>::Launch(
         s, 1, min_output_ptr, max_output_ptr, &min_data, &max_data, &min_weight, &max_weight);
@@ -88,14 +83,14 @@ void MKLDNNQuantizedFullyConnectedForward(const nnvm::NodeAttrs &attrs,
         s, 1, min_output_ptr, max_output_ptr, &min_data, &max_data, &min_weight, &max_weight);
   }
 
-  bool is_train = false;
+  bool is_train               = false;
   mkldnn::memory::desc out_md = GetMemDesc(out_data[fullc::kOut]);
   MKLDNNFCFlattenData(param, out_data[fullc::kOut], &data, &out_md);
-  auto &fwd = GetFCFwd(param, is_train, data, weight,
-      param.no_bias ? nullptr : &quantized_bias, out_md);
+  auto& fwd =
+      GetFCFwd(param, is_train, data, weight, param.no_bias ? nullptr : &quantized_bias, out_md);
 
   auto data_mem = in_data[fullc::kData].GetMKLDNNDataReorder(fwd.fwd_pd.src_desc());
-  const mkldnn::memory *weight_mem = nullptr;
+  const mkldnn::memory* weight_mem = nullptr;
 
   if (weight.IsDefaultData()) {
     // We also need to modify the layout on the original weight array.
@@ -107,8 +102,7 @@ void MKLDNNQuantizedFullyConnectedForward(const nnvm::NodeAttrs &attrs,
     weight_mem = weight.GetMKLDNNData();
     CHECK(weight_mem->get_desc() == fwd.fwd_pd.weights_desc());
   }
-  auto out_mem = CreateMKLDNNMem(out_data[fullc::kOut], fwd.fwd_pd.dst_desc(),
-                                 req[fullc::kOut]);
+  auto out_mem = CreateMKLDNNMem(out_data[fullc::kOut], fwd.fwd_pd.dst_desc(), req[fullc::kOut]);
 
   mkldnn_args_map_t args = {
       {MKLDNN_ARG_SRC, *data_mem},
@@ -116,9 +110,9 @@ void MKLDNNQuantizedFullyConnectedForward(const nnvm::NodeAttrs &attrs,
       {MKLDNN_ARG_DST, *out_mem.second},
   };
 
-  const mkldnn::memory *bias_mem = nullptr;
+  const mkldnn::memory* bias_mem = nullptr;
   if (!param.no_bias) {
-    bias_mem = quantized_bias.GetMKLDNNDataReorder(fwd.fwd_pd.bias_desc());
+    bias_mem              = quantized_bias.GetMKLDNNDataReorder(fwd.fwd_pd.bias_desc());
     args[MKLDNN_ARG_BIAS] = *bias_mem;
   }
 

--- a/src/operator/quantization/mkldnn/mkldnn_quantized_fully_connected.cc
+++ b/src/operator/quantization/mkldnn/mkldnn_quantized_fully_connected.cc
@@ -31,7 +31,8 @@
 namespace mxnet {
 namespace op {
 
-void MKLDNNQuantizedFullyConnectedForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+void MKLDNNQuantizedFullyConnectedForward(const nnvm::NodeAttrs& attrs,
+                                          const OpContext& ctx,
                                           const std::vector<NDArray>& in_data,
                                           const std::vector<OpReqType>& req,
                                           const std::vector<NDArray>& out_data) {

--- a/src/operator/quantization/mkldnn/mkldnn_quantized_ops-inl.h
+++ b/src/operator/quantization/mkldnn/mkldnn_quantized_ops-inl.h
@@ -35,9 +35,10 @@
 namespace mxnet {
 namespace op {
 
-void MKLDNNQuantizedFullyConnectedForward(
-    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& in_data,
-    const std::vector<OpReqType>& req, const std::vector<NDArray>& out_data);
+void MKLDNNQuantizedFullyConnectedForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+                                          const std::vector<NDArray>& in_data,
+                                          const std::vector<OpReqType>& req,
+                                          const std::vector<NDArray>& out_data);
 
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/quantization/mkldnn/mkldnn_quantized_ops-inl.h
+++ b/src/operator/quantization/mkldnn/mkldnn_quantized_ops-inl.h
@@ -35,11 +35,9 @@
 namespace mxnet {
 namespace op {
 
-void MKLDNNQuantizedFullyConnectedForward(const nnvm::NodeAttrs &attrs,
-                                          const OpContext &ctx,
-                                          const std::vector<NDArray> &in_data,
-                                          const std::vector<OpReqType> &req,
-                                          const std::vector<NDArray> &out_data);
+void MKLDNNQuantizedFullyConnectedForward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& in_data,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& out_data);
 
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/quantization/mkldnn/mkldnn_quantized_ops-inl.h
+++ b/src/operator/quantization/mkldnn/mkldnn_quantized_ops-inl.h
@@ -30,12 +30,14 @@
 #if MXNET_USE_MKLDNN == 1
 
 #include <mxnet/ndarray.h>
+
 #include <vector>
 
 namespace mxnet {
 namespace op {
 
-void MKLDNNQuantizedFullyConnectedForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+void MKLDNNQuantizedFullyConnectedForward(const nnvm::NodeAttrs& attrs,
+                                          const OpContext& ctx,
                                           const std::vector<NDArray>& in_data,
                                           const std::vector<OpReqType>& req,
                                           const std::vector<NDArray>& out_data);

--- a/src/operator/quantization/mkldnn/mkldnn_quantized_pooling.cc
+++ b/src/operator/quantization/mkldnn/mkldnn_quantized_pooling.cc
@@ -30,7 +30,8 @@
 namespace mxnet {
 namespace op {
 
-static void MKLDNNQuantizedPoolingForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+static void MKLDNNQuantizedPoolingForward(const nnvm::NodeAttrs& attrs,
+                                          const OpContext& ctx,
                                           const std::vector<NDArray>& in_data,
                                           const std::vector<OpReqType>& req,
                                           const std::vector<NDArray>& out_data) {

--- a/src/operator/quantization/mkldnn/mkldnn_quantized_pooling.cc
+++ b/src/operator/quantization/mkldnn/mkldnn_quantized_pooling.cc
@@ -36,7 +36,8 @@ static void MKLDNNQuantizedPoolingForward(const nnvm::NodeAttrs& attrs,
                                           const std::vector<OpReqType>& req,
                                           const std::vector<NDArray>& out_data) {
   CHECK(in_data[0].dtype() == mshadow::kUint8 || in_data[0].dtype() == mshadow::kInt8)
-      << "mkldnn_quantized_pooling op only supports uint8 and int8 as input type";
+      << "mkldnn_quantized_pooling op only supports uint8 and int8 as input "
+         "type";
   const PoolingParam& param = nnvm::get<PoolingParam>(attrs.parsed);
   MKLDNNPoolingCompute(ctx, param, in_data[0], req[0], out_data[0], nullptr);
   out_data[1].data().dptr<float>()[0] = in_data[1].data().dptr<float>()[0];

--- a/src/operator/quantization/mkldnn/mkldnn_quantized_pooling.cc
+++ b/src/operator/quantization/mkldnn/mkldnn_quantized_pooling.cc
@@ -30,9 +30,10 @@
 namespace mxnet {
 namespace op {
 
-static void MKLDNNQuantizedPoolingForward(
-    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& in_data,
-    const std::vector<OpReqType>& req, const std::vector<NDArray>& out_data) {
+static void MKLDNNQuantizedPoolingForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+                                          const std::vector<NDArray>& in_data,
+                                          const std::vector<OpReqType>& req,
+                                          const std::vector<NDArray>& out_data) {
   CHECK(in_data[0].dtype() == mshadow::kUint8 || in_data[0].dtype() == mshadow::kInt8)
       << "mkldnn_quantized_pooling op only supports uint8 and int8 as input type";
   const PoolingParam& param = nnvm::get<PoolingParam>(attrs.parsed);

--- a/src/operator/quantization/mkldnn/mkldnn_quantized_pooling.cc
+++ b/src/operator/quantization/mkldnn/mkldnn_quantized_pooling.cc
@@ -21,7 +21,7 @@
  * \file mkldnn_quantized_pooling.cc
  * \brief
  * \author Tao Lv, Xinyu Chen
-*/
+ */
 
 #if MXNET_USE_MKLDNN == 1
 
@@ -30,13 +30,11 @@
 namespace mxnet {
 namespace op {
 
-static void MKLDNNQuantizedPoolingForward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
-                                          const std::vector<NDArray> &in_data,
-                                          const std::vector<OpReqType> &req,
-                                          const std::vector<NDArray> &out_data) {
-  CHECK(in_data[0].dtype() == mshadow::kUint8
-        || in_data[0].dtype() == mshadow::kInt8)
-        << "mkldnn_quantized_pooling op only supports uint8 and int8 as input type";
+static void MKLDNNQuantizedPoolingForward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& in_data,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& out_data) {
+  CHECK(in_data[0].dtype() == mshadow::kUint8 || in_data[0].dtype() == mshadow::kInt8)
+      << "mkldnn_quantized_pooling op only supports uint8 and int8 as input type";
   const PoolingParam& param = nnvm::get<PoolingParam>(attrs.parsed);
   MKLDNNPoolingCompute(ctx, param, in_data[0], req[0], out_data[0], nullptr);
   out_data[1].data().dptr<float>()[0] = in_data[1].data().dptr<float>()[0];
@@ -44,8 +42,8 @@ static void MKLDNNQuantizedPoolingForward(const nnvm::NodeAttrs& attrs, const Op
 }
 
 NNVM_REGISTER_OP(_contrib_quantized_pooling)
-.set_attr<bool>("TIsMKLDNN", true)
-.set_attr<FComputeEx>("FComputeEx<cpu>", MKLDNNQuantizedPoolingForward);
+    .set_attr<bool>("TIsMKLDNN", true)
+    .set_attr<FComputeEx>("FComputeEx<cpu>", MKLDNNQuantizedPoolingForward);
 
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/quantization/mkldnn/mkldnn_requantize-inl.h
+++ b/src/operator/quantization/mkldnn/mkldnn_requantize-inl.h
@@ -77,7 +77,8 @@ static void MKLDNNRequantizeForwardKer(const nnvm::NodeAttrs& attrs,
   mkldnn::engine cpu_engine = mxnet::CpuEngine::Get()->get_engine();
 
   NDArray in_buffer = inputs[0];
-  if (inputs[0].IsView() && inputs[0].IsMKLDNNData()) in_buffer = inputs[0].Reorder2Default();
+  if (inputs[0].IsView() && inputs[0].IsMKLDNNData())
+    in_buffer = inputs[0].Reorder2Default();
 
   auto i_mem            = in_buffer.GetMKLDNNData();
   auto i_desc           = i_mem->get_desc();
@@ -119,12 +120,16 @@ static void MKLDNNRequantizeForward(const nnvm::NodeAttrs& attrs,
 #pragma omp parallel for num_threads(nthreads)
     for (index_t i = 0; i < static_cast<index_t>(in_buffer.shape().Size()); i++) {
       int tid = omp_get_thread_num();
-      if (in_ptr[i] > data_maxs[tid]) data_maxs[tid] = in_ptr[i];
-      if (in_ptr[i] < data_mins[tid]) data_mins[tid] = in_ptr[i];
+      if (in_ptr[i] > data_maxs[tid])
+        data_maxs[tid] = in_ptr[i];
+      if (in_ptr[i] < data_mins[tid])
+        data_mins[tid] = in_ptr[i];
     }
     for (index_t i = 0; i < nthreads; i++) {
-      if (data_maxs[i] > data_max) data_max = data_maxs[i];
-      if (data_mins[i] < data_min) data_min = data_mins[i];
+      if (data_maxs[i] > data_max)
+        data_max = data_maxs[i];
+      if (data_mins[i] < data_min)
+        data_min = data_mins[i];
     }
     float src_range     = MinAbs(MinValue<SrcDType>(), MaxValue<SrcDType>());
     SrcDType data_range = MaxAbs(data_min, data_max);

--- a/src/operator/quantization/mkldnn/mkldnn_requantize-inl.h
+++ b/src/operator/quantization/mkldnn/mkldnn_requantize-inl.h
@@ -35,12 +35,10 @@ namespace mxnet {
 namespace op {
 
 template <typename DstType>
-static void MKLDNNRequantizeForwardKer(const nnvm::NodeAttrs& attrs,
-                                       const OpContext& ctx,
-                                       const std::vector<NDArray>& inputs,
-                                       const std::vector<OpReqType>& req,
-                                       const std::vector<NDArray>& outputs,
-                                       const float real_range) {
+static void MKLDNNRequantizeForwardKer(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& inputs,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs,
+    const float real_range) {
   using namespace mshadow;
   using namespace mxnet_op;
   using red::limits::MaxValue;
@@ -50,71 +48,65 @@ static void MKLDNNRequantizeForwardKer(const nnvm::NodeAttrs& attrs,
   size_t i_dim = inputs[0].shape().ndim();
   size_t o_dim = outputs[0].shape().ndim();
   CHECK_EQ(i_dim, o_dim);
-  float first_quantized_range = MinAbs(MinValue<SrcDType>(),
-                                       MaxValue<SrcDType>());
-  float first_real_range = MaxAbs(*inputs[1].data().dptr<float>(),
-                                  *inputs[2].data().dptr<float>());
-  float first_scale = first_real_range / first_quantized_range;
-  float second_real_range = real_range;
+  float first_quantized_range = MinAbs(MinValue<SrcDType>(), MaxValue<SrcDType>());
+  float first_real_range = MaxAbs(*inputs[1].data().dptr<float>(), *inputs[2].data().dptr<float>());
+  float first_scale      = first_real_range / first_quantized_range;
+  float second_real_range      = real_range;
   float second_quantized_range = 0.f;
   if (std::is_same<DstType, int8_t>::value) {
-    second_quantized_range = MinAbs(MaxValue<DstType>(), MinValue<DstType>());
+    second_quantized_range           = MinAbs(MaxValue<DstType>(), MinValue<DstType>());
     *outputs[1].data().dptr<float>() = -second_real_range;
     *outputs[2].data().dptr<float>() = second_real_range;
   } else if (std::is_same<DstType, uint8_t>::value) {
-    second_quantized_range = MaxValue<DstType>();
+    second_quantized_range           = MaxValue<DstType>();
     *outputs[1].data().dptr<float>() = 0.f;
     *outputs[2].data().dptr<float>() = second_real_range;
   } else {
     LOG(FATAL) << "Unsupported requantize output type";
   }
   float second_scale = second_quantized_range / second_real_range;
-  float scale = first_scale * second_scale;
+  float scale        = first_scale * second_scale;
 
   mkldnn::primitive_attr attr;
-  const int mask = 0;
+  const int mask            = 0;
   std::vector<float> scales = {scale};
   attr.set_output_scales(mask, scales);
   mkldnn::engine cpu_engine = mxnet::CpuEngine::Get()->get_engine();
 
   NDArray in_buffer = inputs[0];
-  if (inputs[0].IsView() && inputs[0].IsMKLDNNData())
-    in_buffer = inputs[0].Reorder2Default();
+  if (inputs[0].IsView() && inputs[0].IsMKLDNNData()) in_buffer = inputs[0].Reorder2Default();
 
-  auto i_mem = in_buffer.GetMKLDNNData();
-  auto i_desc = i_mem->get_desc();
-  auto o_desc = i_desc;
+  auto i_mem            = in_buffer.GetMKLDNNData();
+  auto i_desc           = i_mem->get_desc();
+  auto o_desc           = i_desc;
   o_desc.data.data_type = get_mkldnn_type_t<DstType>();
-  auto reorder_pd  = mkldnn::reorder::primitive_desc(cpu_engine, i_desc, cpu_engine, o_desc, attr);
-  auto o_mem = CreateMKLDNNMem(outputs[0], o_desc, req[0]);
+  auto reorder_pd = mkldnn::reorder::primitive_desc(cpu_engine, i_desc, cpu_engine, o_desc, attr);
+  auto o_mem      = CreateMKLDNNMem(outputs[0], o_desc, req[0]);
   MKLDNNStream::Get()->RegisterPrimArgs(
       mkldnn::reorder(reorder_pd), {{MKLDNN_ARG_FROM, *i_mem}, {MKLDNN_ARG_TO, *o_mem.second}});
   CommitOutput(outputs[0], o_mem);
   MKLDNNStream::Get()->Submit();
 }
 
-static void MKLDNNRequantizeForward(const nnvm::NodeAttrs& attrs,
-                                    const OpContext& ctx,
-                                    const std::vector<NDArray>& inputs,
-                                    const std::vector<OpReqType>& req,
-                                    const std::vector<NDArray>& outputs) {
+static void MKLDNNRequantizeForward(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& inputs,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs) {
   using namespace mshadow;
   using namespace mxnet_op;
   using red::limits::MaxValue;
   using red::limits::MinValue;
   typedef int32_t SrcDType;
-  typedef int8_t  DstDType;
+  typedef int8_t DstDType;
   const RequantizeParam& param = nnvm::get<RequantizeParam>(attrs.parsed);
   float real_range;
   // Model is calibrated
   if (param.min_calib_range.has_value() && param.max_calib_range.has_value()) {
-    real_range =
-          MaxAbs(param.min_calib_range.value(), param.max_calib_range.value());
-  // Model is not calibrated
+    real_range = MaxAbs(param.min_calib_range.value(), param.max_calib_range.value());
+    // Model is not calibrated
   } else {
     NDArray in_buffer = inputs[0].Reorder2Default();
-    auto in_ptr = in_buffer.data().dptr<SrcDType>();
-    auto nthreads = engine::OpenMP::Get()->GetRecommendedOMPThreadCount();
+    auto in_ptr       = in_buffer.data().dptr<SrcDType>();
+    auto nthreads     = engine::OpenMP::Get()->GetRecommendedOMPThreadCount();
     SrcDType data_min = MaxValue<SrcDType>();
     SrcDType data_max = MinValue<SrcDType>();
     std::vector<SrcDType> data_maxs(nthreads, data_max);
@@ -129,10 +121,10 @@ static void MKLDNNRequantizeForward(const nnvm::NodeAttrs& attrs,
       if (data_maxs[i] > data_max) data_max = data_maxs[i];
       if (data_mins[i] < data_min) data_min = data_mins[i];
     }
-    float src_range = MinAbs(MinValue<SrcDType>(), MaxValue<SrcDType>());
+    float src_range     = MinAbs(MinValue<SrcDType>(), MaxValue<SrcDType>());
     SrcDType data_range = MaxAbs(data_min, data_max);
-    float data_scale = MaxAbs(*inputs[1].data().dptr<float>(), *inputs[2].data().dptr<float>());
-    real_range = data_range * data_scale / src_range;
+    float data_scale    = MaxAbs(*inputs[1].data().dptr<float>(), *inputs[2].data().dptr<float>());
+    real_range          = data_range * data_scale / src_range;
   }
   auto out_type = GetQuantizeOutputType(param);
   if (out_type == mshadow::kUint8) {

--- a/src/operator/quantization/mkldnn/mkldnn_requantize-inl.h
+++ b/src/operator/quantization/mkldnn/mkldnn_requantize-inl.h
@@ -25,17 +25,19 @@
 #ifndef MXNET_OPERATOR_QUANTIZATION_MKLDNN_MKLDNN_REQUANTIZE_INL_H_
 #define MXNET_OPERATOR_QUANTIZATION_MKLDNN_MKLDNN_REQUANTIZE_INL_H_
 #if MXNET_USE_MKLDNN == 1
-#include <string>
 #include <algorithm>
+#include <string>
 #include <vector>
-#include "../requantize-inl.h"
+
 #include "../../nn/mkldnn/mkldnn_base-inl.h"
+#include "../requantize-inl.h"
 
 namespace mxnet {
 namespace op {
 
 template <typename DstType>
-static void MKLDNNRequantizeForwardKer(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+static void MKLDNNRequantizeForwardKer(const nnvm::NodeAttrs& attrs,
+                                       const OpContext& ctx,
                                        const std::vector<NDArray>& inputs,
                                        const std::vector<OpReqType>& req,
                                        const std::vector<NDArray>& outputs,
@@ -89,7 +91,8 @@ static void MKLDNNRequantizeForwardKer(const nnvm::NodeAttrs& attrs, const OpCon
   MKLDNNStream::Get()->Submit();
 }
 
-static void MKLDNNRequantizeForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+static void MKLDNNRequantizeForward(const nnvm::NodeAttrs& attrs,
+                                    const OpContext& ctx,
                                     const std::vector<NDArray>& inputs,
                                     const std::vector<OpReqType>& req,
                                     const std::vector<NDArray>& outputs) {

--- a/src/operator/quantization/mkldnn/mkldnn_requantize-inl.h
+++ b/src/operator/quantization/mkldnn/mkldnn_requantize-inl.h
@@ -35,10 +35,11 @@ namespace mxnet {
 namespace op {
 
 template <typename DstType>
-static void MKLDNNRequantizeForwardKer(
-    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& inputs,
-    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs,
-    const float real_range) {
+static void MKLDNNRequantizeForwardKer(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+                                       const std::vector<NDArray>& inputs,
+                                       const std::vector<OpReqType>& req,
+                                       const std::vector<NDArray>& outputs,
+                                       const float real_range) {
   using namespace mshadow;
   using namespace mxnet_op;
   using red::limits::MaxValue;
@@ -88,9 +89,10 @@ static void MKLDNNRequantizeForwardKer(
   MKLDNNStream::Get()->Submit();
 }
 
-static void MKLDNNRequantizeForward(
-    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& inputs,
-    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs) {
+static void MKLDNNRequantizeForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+                                    const std::vector<NDArray>& inputs,
+                                    const std::vector<OpReqType>& req,
+                                    const std::vector<NDArray>& outputs) {
   using namespace mshadow;
   using namespace mxnet_op;
   using red::limits::MaxValue;

--- a/src/operator/subgraph/mkldnn/mkldnn_common.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_common.h
@@ -33,9 +33,8 @@ namespace mxnet {
 namespace op {
 
 template <typename DType>
-static std::vector<float> GetWeightScales(
-    const NDArray& weight, const NDArray* bias, const float data_scale,
-    bool weight_channelwise_scale) {
+static std::vector<float> GetWeightScales(const NDArray& weight, const NDArray* bias,
+                                          const float data_scale, bool weight_channelwise_scale) {
   auto nthreads = engine::OpenMP::Get()->GetRecommendedOMPThreadCount();
   std::vector<float> weight_scales;
   const DType* weight_ptr = weight.data().dptr<DType>();
@@ -85,10 +84,11 @@ static std::vector<float> GetWeightScales(
   return weight_scales;
 }
 
-static void ConvertWeightBias2MKLDNN(
-    NDArray* weight, NDArray* bias, bool has_bias, const mkldnn::memory::desc& weight_md,
-    const mkldnn::memory::desc* bias_md, const int num_group, float data_scale,
-    const std::vector<float>& weight_scales, const bool submit = true) {
+static void ConvertWeightBias2MKLDNN(NDArray* weight, NDArray* bias, bool has_bias,
+                                     const mkldnn::memory::desc& weight_md,
+                                     const mkldnn::memory::desc* bias_md, const int num_group,
+                                     float data_scale, const std::vector<float>& weight_scales,
+                                     const bool submit = true) {
   MKLDNNStream* stream           = MKLDNNStream::Get();
   const auto new_weight          = NDArray(weight_md);
   const auto conv_weights_memory = new_weight.GetMKLDNNData();

--- a/src/operator/subgraph/mkldnn/mkldnn_common.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_common.h
@@ -22,7 +22,7 @@
  * \file mkldnn_common.h
  * \brief Common header file for MKLDNN backend subgraph
  * \author Ciyong Chen
-*/
+ */
 
 #ifndef MXNET_OPERATOR_SUBGRAPH_MKLDNN_MKLDNN_COMMON_H_
 #define MXNET_OPERATOR_SUBGRAPH_MKLDNN_MKLDNN_COMMON_H_
@@ -33,31 +33,30 @@ namespace mxnet {
 namespace op {
 
 template <typename DType>
-static std::vector<float> GetWeightScales(const NDArray &weight, const NDArray *bias,
-                                          const float data_scale, bool weight_channelwise_scale) {
+static std::vector<float> GetWeightScales(
+    const NDArray& weight, const NDArray* bias, const float data_scale,
+    bool weight_channelwise_scale) {
   auto nthreads = engine::OpenMP::Get()->GetRecommendedOMPThreadCount();
   std::vector<float> weight_scales;
-  const DType *weight_ptr = weight.data().dptr<DType>();
-  const DType *bias_ptr = bias? bias->data().dptr<DType>() : nullptr;
-  const auto wshape = weight.shape();
-  size_t channel = wshape[0];
+  const DType* weight_ptr = weight.data().dptr<DType>();
+  const DType* bias_ptr   = bias ? bias->data().dptr<DType>() : nullptr;
+  const auto wshape       = weight.shape();
+  size_t channel          = wshape[0];
 
   size_t offset = wshape.ProdShape(1, wshape.ndim());
   std::vector<DType> weight_c_min(channel, MaxValue<DType>());
   std::vector<DType> weight_c_max(channel, MinValue<DType>());
   for (int c = 0; c < static_cast<int>(channel); ++c) {
-    const DType *p1 = weight_ptr + c * offset;
+    const DType* p1 = weight_ptr + c * offset;
     for (size_t k = 0; k < offset; ++k) {
-      if (weight_c_min[c] > p1[k])
-        weight_c_min[c] = p1[k];
-      if (weight_c_max[c] < p1[k])
-        weight_c_max[c] = p1[k];
+      if (weight_c_min[c] > p1[k]) weight_c_min[c] = p1[k];
+      if (weight_c_max[c] < p1[k]) weight_c_max[c] = p1[k];
     }
   }
 
   if (weight_channelwise_scale) {
     weight_scales.resize(channel);
-    #pragma omp parallel for num_threads(nthreads)
+#pragma omp parallel for num_threads(nthreads)
     for (int c = 0; c < static_cast<int>(channel); ++c) {
       float scale = GetQuantizeScale(mshadow::kInt8, weight_c_min[c], weight_c_max[c]);
       if (bias_ptr && bias_ptr[c]) {
@@ -86,14 +85,12 @@ static std::vector<float> GetWeightScales(const NDArray &weight, const NDArray *
   return weight_scales;
 }
 
-static void ConvertWeightBias2MKLDNN(NDArray *weight, NDArray *bias, bool has_bias,
-                                     const mkldnn::memory::desc &weight_md,
-                                     const mkldnn::memory::desc *bias_md,
-                                     const int num_group, float data_scale,
-                                     const std::vector<float> &weight_scales,
-                                     const bool submit = true) {
-  MKLDNNStream *stream = MKLDNNStream::Get();
-  const auto new_weight = NDArray(weight_md);
+static void ConvertWeightBias2MKLDNN(
+    NDArray* weight, NDArray* bias, bool has_bias, const mkldnn::memory::desc& weight_md,
+    const mkldnn::memory::desc* bias_md, const int num_group, float data_scale,
+    const std::vector<float>& weight_scales, const bool submit = true) {
+  MKLDNNStream* stream           = MKLDNNStream::Get();
+  const auto new_weight          = NDArray(weight_md);
   const auto conv_weights_memory = new_weight.GetMKLDNNData();
   mkldnn::primitive_attr weight_attr;
   if (weight_scales.size()) {
@@ -113,9 +110,9 @@ static void ConvertWeightBias2MKLDNN(NDArray *weight, NDArray *bias, bool has_bi
     for (size_t c = 0; c < weight_scales.size(); ++c) {
       bias_scales[c] = weight_scales[c] * data_scale;
     }
-    new_bias = NDArray(*bias_md);
+    new_bias                    = NDArray(*bias_md);
     const auto conv_bias_memory = new_bias.GetMKLDNNData();
-    const int bias_mask = (bias_scales.size()) == 1 ? 0 : 1;
+    const int bias_mask         = (bias_scales.size()) == 1 ? 0 : 1;
     mkldnn::primitive_attr bias_attr;
     bias_attr.set_output_scales(bias_mask, bias_scales);
     auto bias_weights_memory = bias->GetMKLDNNData();
@@ -125,8 +122,7 @@ static void ConvertWeightBias2MKLDNN(NDArray *weight, NDArray *bias, bool has_bi
         mkldnn::reorder(bias_reorder_pd),
         {{MKLDNN_ARG_FROM, *bias_weights_memory}, {MKLDNN_ARG_TO, *conv_bias_memory}});
   }
-  if (submit)
-    stream->Submit();
+  if (submit) stream->Submit();
   *weight = new_weight;
   if (has_bias && data_scale) *bias = new_bias;
 }

--- a/src/operator/subgraph/mkldnn/mkldnn_common.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_common.h
@@ -50,8 +50,10 @@ static std::vector<float> GetWeightScales(const NDArray& weight,
   for (int c = 0; c < static_cast<int>(channel); ++c) {
     const DType* p1 = weight_ptr + c * offset;
     for (size_t k = 0; k < offset; ++k) {
-      if (weight_c_min[c] > p1[k]) weight_c_min[c] = p1[k];
-      if (weight_c_max[c] < p1[k]) weight_c_max[c] = p1[k];
+      if (weight_c_min[c] > p1[k])
+        weight_c_min[c] = p1[k];
+      if (weight_c_max[c] < p1[k])
+        weight_c_max[c] = p1[k];
     }
   }
 
@@ -62,8 +64,8 @@ static std::vector<float> GetWeightScales(const NDArray& weight,
       float scale = GetQuantizeScale(mshadow::kInt8, weight_c_min[c], weight_c_max[c]);
       if (bias_ptr && bias_ptr[c]) {
         // avoid overflow on bias
-        // TODO(zhennan): mkldnn has bug to handle INT_MAX in bias, so set the maximum value of bias
-        // to INT_MAX / 2.
+        // TODO(zhennan): mkldnn has bug to handle INT_MAX in bias, so set the
+        // maximum value of bias to INT_MAX / 2.
         float scale_max =
             static_cast<float>(bias_ptr[c] > 0 ? MaxValue<int32_t>() : MinValue<int32_t>()) / 2 /
             bias_ptr[c] / data_scale;
@@ -75,8 +77,10 @@ static std::vector<float> GetWeightScales(const NDArray& weight,
     DType total_min = weight_c_min[0];
     DType total_max = weight_c_max[0];
     for (size_t c = 0; c < channel; ++c) {
-      if (total_min > weight_c_min[c]) total_min = weight_c_min[c];
-      if (total_max < weight_c_max[c]) total_max = weight_c_max[c];
+      if (total_min > weight_c_min[c])
+        total_min = weight_c_min[c];
+      if (total_max < weight_c_max[c])
+        total_max = weight_c_max[c];
     }
     weight_scales.resize(3);
     weight_scales[0] = GetQuantizeScale(mshadow::kInt8, total_min, total_max);
@@ -104,7 +108,8 @@ static void ConvertWeightBias2MKLDNN(NDArray* weight,
     weight_attr.set_output_scales(weight_mask, weight_scales);
   }
   auto default_weights_memory = GetWeights(*weight, num_group);
-  if (default_weights_memory == nullptr) default_weights_memory = weight->GetMKLDNNData();
+  if (default_weights_memory == nullptr)
+    default_weights_memory = weight->GetMKLDNNData();
   const auto weight_reorder_pd =
       mkldnn::reorder::primitive_desc(*default_weights_memory, *conv_weights_memory, weight_attr);
   MKLDNNStream::Get()->RegisterPrimArgs(
@@ -128,9 +133,11 @@ static void ConvertWeightBias2MKLDNN(NDArray* weight,
         mkldnn::reorder(bias_reorder_pd),
         {{MKLDNN_ARG_FROM, *bias_weights_memory}, {MKLDNN_ARG_TO, *conv_bias_memory}});
   }
-  if (submit) stream->Submit();
+  if (submit)
+    stream->Submit();
   *weight = new_weight;
-  if (has_bias && data_scale) *bias = new_bias;
+  if (has_bias && data_scale)
+    *bias = new_bias;
 }
 
 }  // namespace op

--- a/src/operator/subgraph/mkldnn/mkldnn_common.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_common.h
@@ -33,8 +33,10 @@ namespace mxnet {
 namespace op {
 
 template <typename DType>
-static std::vector<float> GetWeightScales(const NDArray& weight, const NDArray* bias,
-                                          const float data_scale, bool weight_channelwise_scale) {
+static std::vector<float> GetWeightScales(const NDArray& weight,
+                                          const NDArray* bias,
+                                          const float data_scale,
+                                          bool weight_channelwise_scale) {
   auto nthreads = engine::OpenMP::Get()->GetRecommendedOMPThreadCount();
   std::vector<float> weight_scales;
   const DType* weight_ptr = weight.data().dptr<DType>();
@@ -84,10 +86,14 @@ static std::vector<float> GetWeightScales(const NDArray& weight, const NDArray* 
   return weight_scales;
 }
 
-static void ConvertWeightBias2MKLDNN(NDArray* weight, NDArray* bias, bool has_bias,
+static void ConvertWeightBias2MKLDNN(NDArray* weight,
+                                     NDArray* bias,
+                                     bool has_bias,
                                      const mkldnn::memory::desc& weight_md,
-                                     const mkldnn::memory::desc* bias_md, const int num_group,
-                                     float data_scale, const std::vector<float>& weight_scales,
+                                     const mkldnn::memory::desc* bias_md,
+                                     const int num_group,
+                                     float data_scale,
+                                     const std::vector<float>& weight_scales,
                                      const bool submit = true) {
   MKLDNNStream* stream           = MKLDNNStream::Get();
   const auto new_weight          = NDArray(weight_md);

--- a/src/operator/subgraph/mkldnn/mkldnn_conv-inl.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_conv-inl.h
@@ -41,11 +41,10 @@ static inline bool IsOutputUInt8(const MKLDNNConvFusionParam& param) {
   bool result              = false;
   const auto& mkldnn_param = param.full_conv_param.mkldnn_param;
   auto IsOutputUInt8Helper = [](const MKLDNNPostEltwiseParam& param) {
-    return (
-        (param.alg == mkldnn::algorithm::eltwise_relu && param.alpha == 0.f) ||
-        param.alg == mkldnn::algorithm::eltwise_logistic ||
-        param.alg == mkldnn::algorithm::eltwise_soft_relu ||
-        param.alg == mkldnn::algorithm::eltwise_bounded_relu);
+    return ((param.alg == mkldnn::algorithm::eltwise_relu && param.alpha == 0.f) ||
+            param.alg == mkldnn::algorithm::eltwise_logistic ||
+            param.alg == mkldnn::algorithm::eltwise_soft_relu ||
+            param.alg == mkldnn::algorithm::eltwise_bounded_relu);
   };
   if ((!mkldnn_param.with_sum) && mkldnn_param.with_act) {
     CHECK(param.full_conv_param.act_param.alg != mkldnn::algorithm::undef);

--- a/src/operator/subgraph/mkldnn/mkldnn_conv-inl.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_conv-inl.h
@@ -24,6 +24,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+
 #include "../../nn/activation-inl.h"
 #include "../../nn/batch_norm-inl.h"
 #include "../../nn/convolution-inl.h"

--- a/src/operator/subgraph/mkldnn/mkldnn_conv-inl.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_conv-inl.h
@@ -38,13 +38,14 @@ struct MKLDNNConvFusionParam {
 };
 
 static inline bool IsOutputUInt8(const MKLDNNConvFusionParam& param) {
-  bool result = false;
+  bool result              = false;
   const auto& mkldnn_param = param.full_conv_param.mkldnn_param;
-  auto IsOutputUInt8Helper = [](const MKLDNNPostEltwiseParam &param) {
-    return ((param.alg == mkldnn::algorithm::eltwise_relu && param.alpha == 0.f) ||
-            param.alg == mkldnn::algorithm::eltwise_logistic ||
-            param.alg == mkldnn::algorithm::eltwise_soft_relu ||
-            param.alg == mkldnn::algorithm::eltwise_bounded_relu);
+  auto IsOutputUInt8Helper = [](const MKLDNNPostEltwiseParam& param) {
+    return (
+        (param.alg == mkldnn::algorithm::eltwise_relu && param.alpha == 0.f) ||
+        param.alg == mkldnn::algorithm::eltwise_logistic ||
+        param.alg == mkldnn::algorithm::eltwise_soft_relu ||
+        param.alg == mkldnn::algorithm::eltwise_bounded_relu);
   };
   if ((!mkldnn_param.with_sum) && mkldnn_param.with_act) {
     CHECK(param.full_conv_param.act_param.alg != mkldnn::algorithm::undef);

--- a/src/operator/subgraph/mkldnn/mkldnn_conv.cc
+++ b/src/operator/subgraph/mkldnn/mkldnn_conv.cc
@@ -1,21 +1,21 @@
 /*
-* Licensed to the Apache Software Foundation (ASF) under one
-* or more contributor license agreements.  See the NOTICE file
-* distributed with this work for additional information
-* regarding copyright ownership.  The ASF licenses this file
-* to you under the Apache License, Version 2.0 (the
-* "License"); you may not use this file except in compliance
-* with the License.  You may obtain a copy of the License at
-*
-*   http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing,
-* software distributed under the License is distributed on an
-* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied.  See the License for the
-* specific language governing permissions and limitations
-* under the License.
-*/
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 #if MXNET_USE_MKLDNN == 1
 
@@ -38,30 +38,29 @@ using red::limits::MaxValue;
 using red::limits::MinValue;
 
 template <typename DType>
-static void UpdateConvWeightBias(NDArray *weight, NDArray *bias, bool no_bias,
-                                 const NDArray &gamma, const NDArray &beta,
-                                 const NDArray &mean, const NDArray &variance,
-                                 const BatchNormParam *param) {
-  NDArray update_weight = NDArray(weight->storage_type(), weight->shape(),
-                                  weight->ctx(), true, weight->dtype());
-  NDArray update_bias = NDArray(beta.storage_type(), beta.shape(), beta.ctx(),
-                                true, weight->dtype());
-  const DType *weight_ptr = weight->data().dptr<DType>();
-  const DType *bias_ptr = no_bias ? nullptr : bias->data().dptr<DType>();
-  const float *gamma_ptr = gamma.data().dptr<float>();
-  const float *beta_ptr = beta.data().dptr<float>();
-  const float *mean_ptr = mean.data().dptr<float>();
-  const float *var_ptr = variance.data().dptr<float>();
-  DType *update_weight_ptr = update_weight.data().dptr<DType>();
-  DType *update_bias_ptr = update_bias.data().dptr<DType>();
-  size_t channel = gamma.shape()[0];
-  const auto wshape = weight->shape();
-  size_t offset = wshape.ProdShape(1, wshape.ndim());
+static void UpdateConvWeightBias(
+    NDArray* weight, NDArray* bias, bool no_bias, const NDArray& gamma, const NDArray& beta,
+    const NDArray& mean, const NDArray& variance, const BatchNormParam* param) {
+  NDArray update_weight =
+      NDArray(weight->storage_type(), weight->shape(), weight->ctx(), true, weight->dtype());
+  NDArray update_bias =
+      NDArray(beta.storage_type(), beta.shape(), beta.ctx(), true, weight->dtype());
+  const DType* weight_ptr  = weight->data().dptr<DType>();
+  const DType* bias_ptr    = no_bias ? nullptr : bias->data().dptr<DType>();
+  const float* gamma_ptr   = gamma.data().dptr<float>();
+  const float* beta_ptr    = beta.data().dptr<float>();
+  const float* mean_ptr    = mean.data().dptr<float>();
+  const float* var_ptr     = variance.data().dptr<float>();
+  DType* update_weight_ptr = update_weight.data().dptr<DType>();
+  DType* update_bias_ptr   = update_bias.data().dptr<DType>();
+  size_t channel           = gamma.shape()[0];
+  const auto wshape        = weight->shape();
+  size_t offset            = wshape.ProdShape(1, wshape.ndim());
 #pragma omp parallel for num_threads(engine::OpenMP::Get()->GetRecommendedOMPThreadCount())
   for (int c = 0; c < static_cast<int>(channel); ++c) {
-    const DType *p1 = weight_ptr + c * offset;
-    DType *p2 = update_weight_ptr + c * offset;
-    float alpha = (param->fix_gamma ? 1.0f : gamma_ptr[c]) / sqrt(var_ptr[c] + param->eps);
+    const DType* p1 = weight_ptr + c * offset;
+    DType* p2       = update_weight_ptr + c * offset;
+    float alpha     = (param->fix_gamma ? 1.0f : gamma_ptr[c]) / sqrt(var_ptr[c] + param->eps);
 
     if (bias_ptr)
       update_bias_ptr[c] =
@@ -74,24 +73,23 @@ static void UpdateConvWeightBias(NDArray *weight, NDArray *bias, bool no_bias,
     }
   }
   *weight = update_weight;
-  *bias = update_bias;
+  *bias   = update_bias;
 }
 
-static inline size_t GetInSumIndex(const MKLDNNConvFusionParam &param) {
+static inline size_t GetInSumIndex(const MKLDNNConvFusionParam& param) {
   return 2 + (param.full_conv_param.conv_param.no_bias ? 0 : 1) +
          (param.full_conv_param.mkldnn_param.with_bn ? 4 : 0);
 }
 
 class SgMKLDNNConvOperator {
  public:
-  explicit SgMKLDNNConvOperator(const nnvm::NodeAttrs &attrs)
+  explicit SgMKLDNNConvOperator(const nnvm::NodeAttrs& attrs)
       : subgraph_sym_(*attrs.subgraphs[0]),
         param_(nnvm::get<MKLDNNConvFusionParam>(attrs.parsed)) {}
 
-  void Forward(const OpContext &ctx,
-               const std::vector<NDArray> &inputs,
-               const std::vector<OpReqType> &req,
-               const std::vector<NDArray> &outputs);
+  void Forward(
+      const OpContext& ctx, const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+      const std::vector<NDArray>& outputs);
 
  private:
   bool initialized_{false};
@@ -115,14 +113,13 @@ class SgMKLDNNConvOperator {
   std::vector<float> weight_scales_;
 };
 
-void SgMKLDNNConvOperator::Forward(const OpContext &ctx,
-                                   const std::vector<NDArray> &inputs,
-                                   const std::vector<OpReqType> &req,
-                                   const std::vector<NDArray> &outputs) {
-  auto &full_conv_param = param_.full_conv_param;
-  auto &mkldnn_param = param_.full_conv_param.mkldnn_param;
-  auto &conv_param = param_.full_conv_param.conv_param;
-  auto bn_param = param_.bn_param.get();
+void SgMKLDNNConvOperator::Forward(
+    const OpContext& ctx, const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+    const std::vector<NDArray>& outputs) {
+  auto& full_conv_param = param_.full_conv_param;
+  auto& mkldnn_param    = param_.full_conv_param.mkldnn_param;
+  auto& conv_param      = param_.full_conv_param.conv_param;
+  auto bn_param         = param_.bn_param.get();
   size_t input_size =
       2 + (conv_param.no_bias ? 0 : 1) + (mkldnn_param.with_bn ? 4 : 0) +
       (mkldnn_param.with_sum ? 1 : 0) +
@@ -130,27 +127,25 @@ void SgMKLDNNConvOperator::Forward(const OpContext &ctx,
   CHECK_EQ(inputs.size(), input_size);
   size_t idx = 0;
 
-  auto in_data = idx++;
+  auto in_data   = idx++;
   auto in_weight = idx++;
-  auto in_bias = conv_param.no_bias ? 0 : (idx++);
-  auto in_gamma = mkldnn_param.with_bn ? (idx++) : 0;
-  auto in_beta = mkldnn_param.with_bn ? (idx++) : 0;
-  auto in_mean = mkldnn_param.with_bn ? (idx++) : 0;
-  auto in_var = mkldnn_param.with_bn ? (idx++) : 0;
-  auto in_sum = mkldnn_param.with_sum ? (idx++) : 0;
-  float data_min =
-      mkldnn_param.quantized ? inputs[idx++].data().dptr<float>()[0] : 0.0;
-  float data_max =
-      mkldnn_param.quantized ? inputs[idx++].data().dptr<float>()[0] : 0.0;
-  float sum_min = (mkldnn_param.with_sum && mkldnn_param.quantized)
-                      ? inputs[idx++].data().dptr<float>()[0]
-                      : 0.0;
-  float sum_max = (mkldnn_param.with_sum && mkldnn_param.quantized)
-                      ? inputs[idx++].data().dptr<float>()[0]
-                      : 0.0;
+  auto in_bias   = conv_param.no_bias ? 0 : (idx++);
+  auto in_gamma  = mkldnn_param.with_bn ? (idx++) : 0;
+  auto in_beta   = mkldnn_param.with_bn ? (idx++) : 0;
+  auto in_mean   = mkldnn_param.with_bn ? (idx++) : 0;
+  auto in_var    = mkldnn_param.with_bn ? (idx++) : 0;
+  auto in_sum    = mkldnn_param.with_sum ? (idx++) : 0;
+  float data_min = mkldnn_param.quantized ? inputs[idx++].data().dptr<float>()[0] : 0.0;
+  float data_max = mkldnn_param.quantized ? inputs[idx++].data().dptr<float>()[0] : 0.0;
+  float sum_min  = (mkldnn_param.with_sum && mkldnn_param.quantized)
+                       ? inputs[idx++].data().dptr<float>()[0]
+                       : 0.0;
+  float sum_max  = (mkldnn_param.with_sum && mkldnn_param.quantized)
+                       ? inputs[idx++].data().dptr<float>()[0]
+                       : 0.0;
   CHECK_EQ(input_size, idx);
-  bool has_bias = mkldnn_param.with_bn || !conv_param.no_bias;
-  NDArray data = inputs[in_data];
+  bool has_bias  = mkldnn_param.with_bn || !conv_param.no_bias;
+  NDArray data   = inputs[in_data];
   NDArray output = mkldnn_param.with_sum ? inputs[in_sum] : outputs[kOut];
 
   // Copy inputs[in_sum] into outputs[kOut] in case inplace optimization failed.
@@ -158,31 +153,31 @@ void SgMKLDNNConvOperator::Forward(const OpContext &ctx,
     if (!initialized_) {
       // TODO(zhennan): Currently, mkldnn fallback mechanism will break inplace option,
       // which make check (req[kOut] == kWriteInplace) useless.
-      auto in_mkl_mem = inputs[in_sum].GetMKLDNNData();
+      auto in_mkl_mem  = inputs[in_sum].GetMKLDNNData();
       auto out_mkl_mem = outputs[kOut].GetMKLDNNData();
       if (in_mkl_mem->get_data_handle() == out_mkl_mem->get_data_handle()) {
         inplace_ = true;
       }
     }
     if (!inplace_) {
-      auto in_mkl_mem = inputs[in_sum].GetMKLDNNData();
+      auto in_mkl_mem  = inputs[in_sum].GetMKLDNNData();
       auto out_mkl_mem = outputs[kOut].GetMKLDNNData();
       if (outputs[kOut].dtype() == mshadow::kInt32) {
-        const auto& mem_desc = in_mkl_mem->get_desc();
+        const auto& mem_desc  = in_mkl_mem->get_desc();
         const auto this_dtype = get_mkldnn_type(mshadow::kInt32);
-        auto omd = mem_desc;
-        omd.data.data_type = static_cast<mkldnn_data_type_t>(this_dtype);
-        mkldnn_mem_ptr tmp_mem(new mkldnn::memory(omd, CpuEngine::Get()->get_engine(),
-                                                  out_mkl_mem->get_data_handle()));
+        auto omd              = mem_desc;
+        omd.data.data_type    = static_cast<mkldnn_data_type_t>(this_dtype);
+        mkldnn_mem_ptr tmp_mem(new mkldnn::memory(
+            omd, CpuEngine::Get()->get_engine(), out_mkl_mem->get_data_handle()));
         MKLDNNStream::Get()->RegisterMem(tmp_mem);
         MKLDNNStream::Get()->RegisterPrimArgs(
             mkldnn::reorder(*in_mkl_mem, *tmp_mem),
             {{MKLDNN_ARG_FROM, *in_mkl_mem}, {MKLDNN_ARG_TO, *tmp_mem}});
         output = NDArray(tmp_mem);
       } else {
-        mkldnn_mem_ptr tmp_mem(new mkldnn::memory(in_mkl_mem->get_desc(),
-                                                  CpuEngine::Get()->get_engine(),
-                                                  out_mkl_mem->get_data_handle()));
+        mkldnn_mem_ptr tmp_mem(new mkldnn::memory(
+            in_mkl_mem->get_desc(), CpuEngine::Get()->get_engine(),
+            out_mkl_mem->get_data_handle()));
         MKLDNNStream::Get()->RegisterMem(tmp_mem);
         MKLDNNMemoryCopy(*in_mkl_mem, tmp_mem.get());
         output = NDArray(tmp_mem);
@@ -211,13 +206,13 @@ void SgMKLDNNConvOperator::Forward(const OpContext &ctx,
   if (!initialized_) {
     cached_data_min_ = data_min;
     cached_data_max_ = data_max;
-    cached_sum_min_ = sum_min;
-    cached_sum_max_ = sum_max;
-    cached_weight_ = inputs[in_weight].Reorder2Default();
-    weight_ver_ = inputs[in_weight].version();
+    cached_sum_min_  = sum_min;
+    cached_sum_max_  = sum_max;
+    cached_weight_   = inputs[in_weight].Reorder2Default();
+    weight_ver_      = inputs[in_weight].version();
     if (!conv_param.no_bias) {
       cached_bias_ = inputs[in_bias];
-      bias_ver_ = inputs[in_bias].version();
+      bias_ver_    = inputs[in_bias].version();
     } else {
       cached_bias_ = NDArray();
     }
@@ -225,10 +220,9 @@ void SgMKLDNNConvOperator::Forward(const OpContext &ctx,
     // Update weight and bias after bn fusion.
     if (mkldnn_param.with_bn) {
       MKLDNN_REAL_TYPE_SWITCH(inputs[in_weight].dtype(), DType, {
-        UpdateConvWeightBias<DType>(&cached_weight_, &cached_bias_,
-                                    conv_param.no_bias, inputs[in_gamma],
-                                    inputs[in_beta], inputs[in_mean],
-                                    inputs[in_var], bn_param);
+        UpdateConvWeightBias<DType>(
+            &cached_weight_, &cached_bias_, conv_param.no_bias, inputs[in_gamma], inputs[in_beta],
+            inputs[in_mean], inputs[in_var], bn_param);
       });
     }
     // Quantize weight and bias.
@@ -240,32 +234,34 @@ void SgMKLDNNConvOperator::Forward(const OpContext &ctx,
       }
       auto weight_channelwise_scale = false;
       if (mkldnn_param.min_calib_range.has_value() && mkldnn_param.max_calib_range.has_value()) {
-        cached_output_min_ = mkldnn_param.min_calib_range.value();
-        cached_output_max_ = mkldnn_param.max_calib_range.value();
-        post_requantize_ = true;
+        cached_output_min_       = mkldnn_param.min_calib_range.value();
+        cached_output_max_       = mkldnn_param.max_calib_range.value();
+        post_requantize_         = true;
         weight_channelwise_scale = true;
       }
       data_scale_ = GetQuantizeScale(data.dtype(), cached_data_min_, cached_data_max_);
       MKLDNN_REAL_TYPE_SWITCH(cached_weight_.dtype(), DType, {
-        weight_scales_ = GetWeightScales<DType>(cached_weight_, has_bias ? &cached_bias_ : nullptr,
-                                                data_scale_, weight_channelwise_scale);
+        weight_scales_ = GetWeightScales<DType>(
+            cached_weight_, has_bias ? &cached_bias_ : nullptr, data_scale_,
+            weight_channelwise_scale);
       });
       // Collect scale.
-      size_t channel = cached_weight_.shape()[0];
+      size_t channel     = cached_weight_.shape()[0];
       float sum_in_scale = 1.0;
       float output_scale;
       if (mkldnn_param.with_sum) {
         sum_in_scale = GetQuantizeScale(inputs[in_sum].dtype(), cached_sum_min_, cached_sum_max_);
       }
       if (post_requantize_) {
-        output_scale = GetQuantizeScale(IsOutputUInt8(param_) ? mshadow::kUint8 : mshadow::kInt8,
-                                        cached_output_min_, cached_output_max_);
+        output_scale = GetQuantizeScale(
+            IsOutputUInt8(param_) ? mshadow::kUint8 : mshadow::kInt8, cached_output_min_,
+            cached_output_max_);
         full_conv_param.requantize_scales.resize(weight_channelwise_scale ? channel : 1);
         for (size_t c = 0; c < full_conv_param.requantize_scales.size(); c++) {
           full_conv_param.requantize_scales[c] = output_scale / data_scale_ / weight_scales_[c];
         }
       } else {
-        Stream<cpu> *s = ctx.get_stream<cpu>();
+        Stream<cpu>* s = ctx.get_stream<cpu>();
         if (data.dtype() == mshadow::kInt8) {
           mxnet_op::Kernel<QuantizationRangeForS8S8MultiplicationStruct, cpu>::Launch(
               s, 1, &cached_output_min_, &cached_output_max_, &weight_scales_[1],
@@ -297,32 +293,31 @@ void SgMKLDNNConvOperator::Forward(const OpContext &ctx,
       }
     }
     fwd_.reset(new MKLDNNConvForward(
-        full_conv_param, ctx.is_train, data, cached_weight_,
-        has_bias ? &cached_bias_ : nullptr, output));
+        full_conv_param, ctx.is_train, data, cached_weight_, has_bias ? &cached_bias_ : nullptr,
+        output));
     mkldnn::memory::desc bias_md;
     if (has_bias) bias_md = fwd_->GetPd().bias_desc();
-    ConvertWeightBias2MKLDNN(&cached_weight_, &cached_bias_, has_bias,
-                             fwd_->GetPd().weights_desc(),
-                             has_bias ? & bias_md : nullptr,
-                             full_conv_param.conv_param.num_group,
-                             data_scale_, weight_scales_);
-    args_[MKLDNN_ARG_SRC] = *data.GetMKLDNNData();
+    ConvertWeightBias2MKLDNN(
+        &cached_weight_, &cached_bias_, has_bias, fwd_->GetPd().weights_desc(),
+        has_bias ? &bias_md : nullptr, full_conv_param.conv_param.num_group, data_scale_,
+        weight_scales_);
+    args_[MKLDNN_ARG_SRC]     = *data.GetMKLDNNData();
     args_[MKLDNN_ARG_WEIGHTS] = *cached_weight_.GetMKLDNNData();
     if (has_bias) args_[MKLDNN_ARG_BIAS] = *cached_bias_.GetMKLDNNData();
     args_[MKLDNN_ARG_DST] = *output.GetMKLDNNData();
-    initialized_ = true;
+    initialized_          = true;
   }
 
   if (mkldnn_param.with_sum) {
-    const auto& output_mem = output.GetMKLDNNData();
+    const auto& output_mem   = output.GetMKLDNNData();
     const auto& out_mem_desc = output_mem->get_desc();
     const auto& dst_mem_desc = fwd_->GetPd().dst_desc();
     if (out_mem_desc != dst_mem_desc) {
-      auto tmp_out_mem = output.GetMKLDNNDataReorder(fwd_->GetPd().dst_desc());
-      auto data_md = dst_mem_desc;
+      auto tmp_out_mem       = output.GetMKLDNNDataReorder(fwd_->GetPd().dst_desc());
+      auto data_md           = dst_mem_desc;
       data_md.data.data_type = static_cast<mkldnn_data_type_t>(out_mem_desc.data.data_type);
-      mkldnn_mem_ptr new_out_mem(new mkldnn::memory(data_md, CpuEngine::Get()->get_engine(),
-                                                    output_mem->get_data_handle()));
+      mkldnn_mem_ptr new_out_mem(new mkldnn::memory(
+          data_md, CpuEngine::Get()->get_engine(), output_mem->get_data_handle()));
       MKLDNNStream::Get()->RegisterMem(new_out_mem);
       MKLDNNMemoryCopy(*tmp_out_mem, new_out_mem.get());
       output = NDArray(new_out_mem);
@@ -330,8 +325,8 @@ void SgMKLDNNConvOperator::Forward(const OpContext &ctx,
   }
 
   if (mkldnn_param.quantized) {
-    auto data_mem = data.GetMKLDNNDataReorder(fwd_->GetPd().src_desc());
-    mkldnn::memory *mem = output.CreateMKLDNNData(fwd_->GetPd().dst_desc());
+    auto data_mem         = data.GetMKLDNNDataReorder(fwd_->GetPd().src_desc());
+    mkldnn::memory* mem   = output.CreateMKLDNNData(fwd_->GetPd().dst_desc());
     args_[MKLDNN_ARG_SRC] = *data_mem;
     args_[MKLDNN_ARG_DST] = *mem;
     MKLDNNStream::Get()->RegisterPrimArgs(fwd_->GetFwd(), args_);
@@ -343,8 +338,8 @@ void SgMKLDNNConvOperator::Forward(const OpContext &ctx,
     } else {
       new_inputs = {data, cached_weight_};
     }
-    MKLDNNConvolutionForwardFullFeature(full_conv_param, ctx, fwd_.get(), new_inputs, req,
-                                        {output});
+    MKLDNNConvolutionForwardFullFeature(
+        full_conv_param, ctx, fwd_.get(), new_inputs, req, {output});
   }
 
   if (mkldnn_param.quantized) {
@@ -352,30 +347,28 @@ void SgMKLDNNConvOperator::Forward(const OpContext &ctx,
     *outputs[kMax].data().dptr<float>() = cached_output_max_;
   }
   if (mkldnn_param.with_sum) {
-    auto out = const_cast<NDArray &>(outputs[kOut]);
+    auto out = const_cast<NDArray&>(outputs[kOut]);
     out.UpdateMKLDNNMemDesc(fwd_->GetPd().dst_desc());
   }
 }
 
-static void SgMKLDNNConvOpForward(const OpStatePtr &state_ptr,
-                                  const OpContext &ctx,
-                                  const std::vector<NDArray> &inputs,
-                                  const std::vector<OpReqType> &req,
-                                  const std::vector<NDArray> &outputs) {
-  SgMKLDNNConvOperator &op = state_ptr.get_state<SgMKLDNNConvOperator>();
+static void SgMKLDNNConvOpForward(
+    const OpStatePtr& state_ptr, const OpContext& ctx, const std::vector<NDArray>& inputs,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs) {
+  SgMKLDNNConvOperator& op = state_ptr.get_state<SgMKLDNNConvOperator>();
   op.Forward(ctx, inputs, req, outputs);
 }
 
-static uint32_t SgMKLDNNConvNumInputs(const NodeAttrs &attrs) {
-  auto const &param = nnvm::get<MKLDNNConvFusionParam>(attrs.parsed);
-  auto num_input = DefaultSubgraphOpNumInputs(attrs);
+static uint32_t SgMKLDNNConvNumInputs(const NodeAttrs& attrs) {
+  auto const& param = nnvm::get<MKLDNNConvFusionParam>(attrs.parsed);
+  auto num_input    = DefaultSubgraphOpNumInputs(attrs);
   if (param.full_conv_param.mkldnn_param.quantized)
     return num_input + 2 + (param.full_conv_param.mkldnn_param.with_sum ? 2 : 0);
   else
     return num_input;
 }
 
-static void SgMKLDNNConvParamParser(nnvm::NodeAttrs *attrs) {
+static void SgMKLDNNConvParamParser(nnvm::NodeAttrs* attrs) {
   MKLDNNConvFusionParam param_;
 
   // For back-compatible, rename
@@ -396,12 +389,12 @@ static void SgMKLDNNConvParamParser(nnvm::NodeAttrs *attrs) {
 
   try {
     param_.full_conv_param.mkldnn_param.Init(attrs->dict);
-  } catch (const dmlc::ParamError &e) {
+  } catch (const dmlc::ParamError& e) {
     std::ostringstream os;
     os << e.what();
     os << ", in operator " << attrs->op->name << "("
        << "name=\"" << attrs->name << "\"";
-    for (const auto &k : attrs->dict) {
+    for (const auto& k : attrs->dict) {
       os << ", " << k.first << "=\"" << k.second << "\"";
     }
     os << ")";
@@ -409,43 +402,41 @@ static void SgMKLDNNConvParamParser(nnvm::NodeAttrs *attrs) {
   }
   CHECK_EQ(attrs->subgraphs.size(), 1);
   auto subgraph_sym = attrs->subgraphs[0];
-  bool with_act = false;
-  DFSVisit(subgraph_sym->outputs, [&](const nnvm::ObjectPtr &node) {
+  bool with_act     = false;
+  DFSVisit(subgraph_sym->outputs, [&](const nnvm::ObjectPtr& node) {
     if (node->is_variable()) return;
-    auto &node_name = node->op()->name;
+    auto& node_name = node->op()->name;
     if (node_name == "BatchNorm") {
       CHECK_EQ(param_.full_conv_param.mkldnn_param.with_bn, true);
       CHECK(param_.bn_param.get() == nullptr);
-      param_.bn_param = std::make_shared<BatchNormParam>(
-          nnvm::get<BatchNormParam>(node->attrs.parsed));
+      param_.bn_param =
+          std::make_shared<BatchNormParam>(nnvm::get<BatchNormParam>(node->attrs.parsed));
     } else if (node_name == "Convolution") {
-      param_.full_conv_param.conv_param =
-          nnvm::get<ConvolutionParam>(node->attrs.parsed);
+      param_.full_conv_param.conv_param = nnvm::get<ConvolutionParam>(node->attrs.parsed);
     } else if (node_name == "Activation" || node_name == "LeakyReLU" || node_name == "clip") {
-      auto &post_act_param =
-          (param_.full_conv_param.mkldnn_param.with_act && !with_act)
-              ? param_.full_conv_param.act_param
-              : param_.full_conv_param.postsum_act_param;
-      with_act = true;
+      auto& post_act_param = (param_.full_conv_param.mkldnn_param.with_act && !with_act)
+                                 ? param_.full_conv_param.act_param
+                                 : param_.full_conv_param.postsum_act_param;
+      with_act             = true;
       if (node_name == "Activation") {
         const auto act_param = nnvm::get<ActivationParam>(node->attrs.parsed);
-        post_act_param.alg = GetMKLDNNActAlgo(act_param);
+        post_act_param.alg   = GetMKLDNNActAlgo(act_param);
       } else if (node_name == "LeakyReLU") {
         const auto act_param = nnvm::get<LeakyReLUParam>(node->attrs.parsed);
         post_act_param.alpha = act_param.slope;
-        post_act_param.alg = GetMKLDNNActAlgo(act_param);
+        post_act_param.alg   = GetMKLDNNActAlgo(act_param);
       } else {
         const auto clip_param = nnvm::get<ClipParam>(node->attrs.parsed);
-        post_act_param.alg = mkldnn::algorithm::eltwise_bounded_relu;
-        post_act_param.alpha = clip_param.a_max;
+        post_act_param.alg    = mkldnn::algorithm::eltwise_bounded_relu;
+        post_act_param.alpha  = clip_param.a_max;
       }
     }
   });
   attrs->parsed = std::move(param_);
 }
 
-static std::vector<std::string> SgMKLDNNConvListInputNames(const NodeAttrs &attrs) {
-  auto const &param = nnvm::get<MKLDNNConvFusionParam>(attrs.parsed);
+static std::vector<std::string> SgMKLDNNConvListInputNames(const NodeAttrs& attrs) {
+  auto const& param = nnvm::get<MKLDNNConvFusionParam>(attrs.parsed);
   std::vector<std::string> input_names;
   input_names.emplace_back("data");
   input_names.emplace_back("weight");
@@ -473,29 +464,25 @@ static std::vector<std::string> SgMKLDNNConvListInputNames(const NodeAttrs &attr
   return input_names;
 }
 
-static std::vector<std::string> SgMKLDNNConvListOutputNames(
-    const NodeAttrs &attrs) {
-  auto const &param = nnvm::get<MKLDNNConvFusionParam>(attrs.parsed);
+static std::vector<std::string> SgMKLDNNConvListOutputNames(const NodeAttrs& attrs) {
+  auto const& param = nnvm::get<MKLDNNConvFusionParam>(attrs.parsed);
   if (param.full_conv_param.mkldnn_param.quantized)
     return std::vector<std::string>{"output", "output_min", "output_max"};
   else
     return std::vector<std::string>{"output"};
 }
 
-static OpStatePtr CreateSgMKLDNNConvState(const nnvm::NodeAttrs &attrs,
-                                          Context ctx,
-                                          const mxnet::ShapeVector &in_shapes,
-                                          const std::vector<int> &in_types) {
+static OpStatePtr CreateSgMKLDNNConvState(
+    const nnvm::NodeAttrs& attrs, Context ctx, const mxnet::ShapeVector& in_shapes,
+    const std::vector<int>& in_types) {
   return OpStatePtr::Create<SgMKLDNNConvOperator>(attrs);
 }
 
 template <typename DType>
-static void FilterMinMaxIndice(const MKLDNNConvParam &mkldnn_param,
-                               std::vector<DType> *in_shapes,
-                               std::vector<DType> *out_shapes,
-                               std::vector<DType> *base_in_shapes,
-                               std::vector<DType> *base_out_shapes,
-                               std::unordered_set<size_t> *minmax_indice) {
+static void FilterMinMaxIndice(
+    const MKLDNNConvParam& mkldnn_param, std::vector<DType>* in_shapes,
+    std::vector<DType>* out_shapes, std::vector<DType>* base_in_shapes,
+    std::vector<DType>* base_out_shapes, std::unordered_set<size_t>* minmax_indice) {
   base_out_shapes->push_back(out_shapes->at(0));
   size_t last = in_shapes->size() - 1;
   if (mkldnn_param.with_sum) {
@@ -503,30 +490,26 @@ static void FilterMinMaxIndice(const MKLDNNConvParam &mkldnn_param,
     minmax_indice->insert(last - 1);
     minmax_indice->insert(last - 2);
     minmax_indice->insert(last - 3);
-    *base_in_shapes =
-        std::vector<DType>(in_shapes->begin(), in_shapes->end() - 4);
+    *base_in_shapes = std::vector<DType>(in_shapes->begin(), in_shapes->end() - 4);
   } else {
     minmax_indice->insert(last);
     minmax_indice->insert(last - 1);
-    *base_in_shapes =
-        std::vector<DType>(in_shapes->begin(), in_shapes->end() - 2);
+    *base_in_shapes = std::vector<DType>(in_shapes->begin(), in_shapes->end() - 2);
   }
 }
 
-static bool SgMKLDNNConvInferShape(const nnvm::NodeAttrs &attrs,
-                                   mxnet::ShapeVector *in_shapes,
-                                   mxnet::ShapeVector *out_shapes) {
-  auto const &param = nnvm::get<MKLDNNConvFusionParam>(attrs.parsed);
+static bool SgMKLDNNConvInferShape(
+    const nnvm::NodeAttrs& attrs, mxnet::ShapeVector* in_shapes, mxnet::ShapeVector* out_shapes) {
+  auto const& param = nnvm::get<MKLDNNConvFusionParam>(attrs.parsed);
   if (param.full_conv_param.mkldnn_param.quantized) {
     std::unordered_set<size_t> minmax_indice;
     mxnet::ShapeVector base_in_shapes;
     mxnet::ShapeVector base_out_shapes;
 
-    FilterMinMaxIndice<mxnet::TShape>(param.full_conv_param.mkldnn_param, in_shapes,
-                               out_shapes, &base_in_shapes, &base_out_shapes,
-                               &minmax_indice);
-    bool result =
-        DefaultSubgraphOpShape(attrs, &base_in_shapes, &base_out_shapes);
+    FilterMinMaxIndice<mxnet::TShape>(
+        param.full_conv_param.mkldnn_param, in_shapes, out_shapes, &base_in_shapes,
+        &base_out_shapes, &minmax_indice);
+    bool result     = DefaultSubgraphOpShape(attrs, &base_in_shapes, &base_out_shapes);
     size_t base_idx = 0;
     for (size_t i = 0; i < in_shapes->size(); ++i) {
       if (minmax_indice.count(i)) {
@@ -544,31 +527,30 @@ static bool SgMKLDNNConvInferShape(const nnvm::NodeAttrs &attrs,
   }
 }
 
-static bool SgMKLDNNConvInferType(const nnvm::NodeAttrs &attrs,
-                                  std::vector<int> *in_types,
-                                  std::vector<int> *out_types) {
-  auto const &param = nnvm::get<MKLDNNConvFusionParam>(attrs.parsed);
+static bool SgMKLDNNConvInferType(
+    const nnvm::NodeAttrs& attrs, std::vector<int>* in_types, std::vector<int>* out_types) {
+  auto const& param = nnvm::get<MKLDNNConvFusionParam>(attrs.parsed);
   if (param.full_conv_param.mkldnn_param.quantized) {
     std::unordered_set<size_t> minmax_indice;
     std::vector<int> base_in_types;
     std::vector<int> base_out_types;
-    FilterMinMaxIndice<int>(param.full_conv_param.mkldnn_param, in_types,
-                            out_types, &base_in_types, &base_out_types,
-                            &minmax_indice);
+    FilterMinMaxIndice<int>(
+        param.full_conv_param.mkldnn_param, in_types, out_types, &base_in_types, &base_out_types,
+        &minmax_indice);
     // Override data type to fp32 for default infer type as bn doesn't support
     // uint8.
-    int orig_data = base_in_types[0];
+    int orig_data    = base_in_types[0];
     base_in_types[0] = mshadow::kFloat32;
-    int orig_sum = base_in_types[0];
+    int orig_sum     = base_in_types[0];
     if (param.full_conv_param.mkldnn_param.with_sum) {
-      auto sum_index = GetInSumIndex(param);
-      orig_sum = base_in_types[sum_index];
+      auto sum_index           = GetInSumIndex(param);
+      orig_sum                 = base_in_types[sum_index];
       base_in_types[sum_index] = mshadow::kFloat32;
     }
-    bool result = DefaultSubgraphOpType(attrs, &base_in_types, &base_out_types);
+    bool result      = DefaultSubgraphOpType(attrs, &base_in_types, &base_out_types);
     base_in_types[0] = orig_data;
     if (param.full_conv_param.mkldnn_param.with_sum) {
-      auto sum_index = GetInSumIndex(param);
+      auto sum_index           = GetInSumIndex(param);
       base_in_types[sum_index] = orig_sum;
     }
     size_t base_idx = 0;
@@ -598,19 +580,17 @@ static bool SgMKLDNNConvInferType(const nnvm::NodeAttrs &attrs,
   }
 }
 
-static bool SgMKLDNNConvOpStorageType(const nnvm::NodeAttrs &attrs,
-                                      const int dev_mask,
-                                      DispatchMode *dispatch_mode,
-                                      std::vector<int> *in_stypes,
-                                      std::vector<int> *out_stypes) {
-  auto const &param = nnvm::get<MKLDNNConvFusionParam>(attrs.parsed);
+static bool SgMKLDNNConvOpStorageType(
+    const nnvm::NodeAttrs& attrs, const int dev_mask, DispatchMode* dispatch_mode,
+    std::vector<int>* in_stypes, std::vector<int>* out_stypes) {
+  auto const& param = nnvm::get<MKLDNNConvFusionParam>(attrs.parsed);
   if (param.full_conv_param.mkldnn_param.quantized) {
     std::unordered_set<size_t> minmax_indice;
     std::vector<int> base_in_stypes;
     std::vector<int> base_out_stypes;
-    FilterMinMaxIndice<int>(param.full_conv_param.mkldnn_param, in_stypes,
-                            out_stypes, &base_in_stypes, &base_out_stypes,
-                            &minmax_indice);
+    FilterMinMaxIndice<int>(
+        param.full_conv_param.mkldnn_param, in_stypes, out_stypes, &base_in_stypes,
+        &base_out_stypes, &minmax_indice);
     bool result = DefaultSubgraphOpStorageType(
         attrs, dev_mask, dispatch_mode, &base_in_stypes, &base_out_stypes);
     size_t base_idx = 0;
@@ -626,14 +606,12 @@ static bool SgMKLDNNConvOpStorageType(const nnvm::NodeAttrs &attrs,
     type_assign(&out_stypes->at(2), mxnet::kDefaultStorage);
     return result;
   } else {
-    return DefaultSubgraphOpStorageType(attrs, dev_mask, dispatch_mode,
-                                        in_stypes, out_stypes);
+    return DefaultSubgraphOpStorageType(attrs, dev_mask, dispatch_mode, in_stypes, out_stypes);
   }
 }
 
-std::vector<std::pair<int, int>> SgMKLDNNConvInplaceOption(
-    const NodeAttrs &attrs) {
-  auto const &param = nnvm::get<MKLDNNConvFusionParam>(attrs.parsed);
+std::vector<std::pair<int, int>> SgMKLDNNConvInplaceOption(const NodeAttrs& attrs) {
+  auto const& param = nnvm::get<MKLDNNConvFusionParam>(attrs.parsed);
   if (param.full_conv_param.mkldnn_param.with_sum) {
     return std::vector<std::pair<int, int>>{{GetInSumIndex(param), 0}};
   } else {
@@ -642,15 +620,15 @@ std::vector<std::pair<int, int>> SgMKLDNNConvInplaceOption(
 }
 
 nnvm::ObjectPtr SgMKLDNNConvQuantizedOp(const NodeAttrs& attrs) {
-  auto const &param = nnvm::get<MKLDNNConvFusionParam>(attrs.parsed);
+  auto const& param    = nnvm::get<MKLDNNConvFusionParam>(attrs.parsed);
   nnvm::ObjectPtr node = nnvm::Node::Create();
-  node->attrs.op = Op::Get("_sg_mkldnn_conv");
-  const int k_ndims = param.full_conv_param.conv_param.kernel.ndim();
+  node->attrs.op       = Op::Get("_sg_mkldnn_conv");
+  const int k_ndims    = param.full_conv_param.conv_param.kernel.ndim();
   CHECK(k_ndims == 2U || k_ndims == 3U)
       << "Quantized Convolution of MKL-DNN supports 2D/3D kernel currently."
-      <<  "Please exclude this layer from the quantized model.";
-  node->attrs.name = "quantized_" + attrs.name;
-  node->attrs.dict = attrs.dict;
+      << "Please exclude this layer from the quantized model.";
+  node->attrs.name              = "quantized_" + attrs.name;
+  node->attrs.dict              = attrs.dict;
   node->attrs.dict["quantized"] = "true";
   node->attrs.subgraphs.reserve(attrs.subgraphs.size());
   for (auto sub : attrs.subgraphs) {
@@ -660,13 +638,13 @@ nnvm::ObjectPtr SgMKLDNNConvQuantizedOp(const NodeAttrs& attrs) {
   return node;
 }
 
-bool SgMKLDNNAvoidConvQuantizeInput(const NodeAttrs &attrs, const size_t index,
-                                    const std::string quantize_granularity) {
-  auto const &param = nnvm::get<MKLDNNConvFusionParam>(attrs.parsed);
+bool SgMKLDNNAvoidConvQuantizeInput(
+    const NodeAttrs& attrs, const size_t index, const std::string quantize_granularity) {
+  auto const& param = nnvm::get<MKLDNNConvFusionParam>(attrs.parsed);
   std::unordered_set<size_t> avoid_indice;
   size_t idx = 0;
-  idx++;                         // data
-  avoid_indice.insert(idx++);    // weight
+  idx++;                       // data
+  avoid_indice.insert(idx++);  // weight
   if (!param.full_conv_param.conv_param.no_bias) {
     avoid_indice.insert(idx++);  // bias
   }
@@ -680,37 +658,37 @@ bool SgMKLDNNAvoidConvQuantizeInput(const NodeAttrs &attrs, const size_t index,
 }
 
 NNVM_REGISTER_OP(_sg_mkldnn_conv)
-.describe(R"code(_sg_mkldnn_conv)code" ADD_FILELINE)
-.set_num_inputs(SgMKLDNNConvNumInputs)
-.set_num_outputs([](const NodeAttrs& attrs) {
-  auto const &param = nnvm::get<MKLDNNConvFusionParam>(attrs.parsed);
-  return param.full_conv_param.mkldnn_param.quantized ? 3 : 1;
-})
-.set_attr_parser(SgMKLDNNConvParamParser)
-.set_attr<nnvm::FListInputNames>("FListInputNames", SgMKLDNNConvListInputNames)
-.set_attr<nnvm::FListOutputNames>("FListOutputNames", SgMKLDNNConvListOutputNames)
-.set_attr<FCreateOpState>("FCreateOpState", CreateSgMKLDNNConvState)
-.set_attr<mxnet::FInferShape>("FInferShape", SgMKLDNNConvInferShape)
-.set_attr<nnvm::FInferType>("FInferType", SgMKLDNNConvInferType)
-.set_attr<FInferStorageType>("FInferStorageType", SgMKLDNNConvOpStorageType)
-.set_attr<FStatefulComputeEx>("FStatefulComputeEx<cpu>", SgMKLDNNConvOpForward)
-.set_attr<bool>("TIsMKLDNN", true)
-// TODO(Xinyu): a temp solution to enable GluonCV INT8 flow,
-// will be reverted after the improvement of CachedOP is done.
-.set_attr<nnvm::FGradient>("FGradient", MakeZeroGradNodes)
-.set_attr<FResourceRequest>("FResourceRequest", [](const NodeAttrs& n) {
-  return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
-})
-.set_attr<nnvm::FMutateInputs>("FMutateInputs",
-                                DefaultSubgraphOpMutableInputs)
-.set_attr<std::string>("key_var_num_args", "num_args")
-.set_attr<nnvm::FInplaceOption>("FInplaceOption", SgMKLDNNConvInplaceOption)
-.set_attr<FQuantizable>("FQuantizable", [](const NodeAttrs& attrs) {
-    return QuantizeType::kMust;
-})
-.set_attr<FQuantizedOp>("FQuantizedOp", SgMKLDNNConvQuantizedOp)
-.set_attr<FNeedRequantize>("FNeedRequantize", [](const NodeAttrs& attrs) { return true; })
-.set_attr<FAvoidQuantizeInput>("FAvoidQuantizeInput", SgMKLDNNAvoidConvQuantizeInput);
+    .describe(R"code(_sg_mkldnn_conv)code" ADD_FILELINE)
+    .set_num_inputs(SgMKLDNNConvNumInputs)
+    .set_num_outputs([](const NodeAttrs& attrs) {
+      auto const& param = nnvm::get<MKLDNNConvFusionParam>(attrs.parsed);
+      return param.full_conv_param.mkldnn_param.quantized ? 3 : 1;
+    })
+    .set_attr_parser(SgMKLDNNConvParamParser)
+    .set_attr<nnvm::FListInputNames>("FListInputNames", SgMKLDNNConvListInputNames)
+    .set_attr<nnvm::FListOutputNames>("FListOutputNames", SgMKLDNNConvListOutputNames)
+    .set_attr<FCreateOpState>("FCreateOpState", CreateSgMKLDNNConvState)
+    .set_attr<mxnet::FInferShape>("FInferShape", SgMKLDNNConvInferShape)
+    .set_attr<nnvm::FInferType>("FInferType", SgMKLDNNConvInferType)
+    .set_attr<FInferStorageType>("FInferStorageType", SgMKLDNNConvOpStorageType)
+    .set_attr<FStatefulComputeEx>("FStatefulComputeEx<cpu>", SgMKLDNNConvOpForward)
+    .set_attr<bool>("TIsMKLDNN", true)
+    // TODO(Xinyu): a temp solution to enable GluonCV INT8 flow,
+    // will be reverted after the improvement of CachedOP is done.
+    .set_attr<nnvm::FGradient>("FGradient", MakeZeroGradNodes)
+    .set_attr<FResourceRequest>(
+        "FResourceRequest",
+        [](const NodeAttrs& n) {
+          return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
+        })
+    .set_attr<nnvm::FMutateInputs>("FMutateInputs", DefaultSubgraphOpMutableInputs)
+    .set_attr<std::string>("key_var_num_args", "num_args")
+    .set_attr<nnvm::FInplaceOption>("FInplaceOption", SgMKLDNNConvInplaceOption)
+    .set_attr<FQuantizable>(
+        "FQuantizable", [](const NodeAttrs& attrs) { return QuantizeType::kMust; })
+    .set_attr<FQuantizedOp>("FQuantizedOp", SgMKLDNNConvQuantizedOp)
+    .set_attr<FNeedRequantize>("FNeedRequantize", [](const NodeAttrs& attrs) { return true; })
+    .set_attr<FAvoidQuantizeInput>("FAvoidQuantizeInput", SgMKLDNNAvoidConvQuantizeInput);
 
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/subgraph/mkldnn/mkldnn_conv.cc
+++ b/src/operator/subgraph/mkldnn/mkldnn_conv.cc
@@ -19,17 +19,18 @@
 
 #if MXNET_USE_MKLDNN == 1
 
+#include <string>
 #include <utility>
 #include <vector>
-#include <string>
-#include "../common.h"
+
+#include "../../nn/mkldnn/mkldnn_act-inl.h"
 #include "../../nn/mkldnn/mkldnn_base-inl.h"
 #include "../../nn/mkldnn/mkldnn_ops-inl.h"
 #include "../../quantization/quantization_utils.h"
-#include "mkldnn_conv-inl.h"
-#include "../../nn/mkldnn/mkldnn_act-inl.h"
 #include "../../tensor/matrix_op-inl.h"
+#include "../common.h"
 #include "mkldnn_common.h"
+#include "mkldnn_conv-inl.h"
 
 namespace mxnet {
 namespace op {
@@ -38,8 +39,13 @@ using red::limits::MaxValue;
 using red::limits::MinValue;
 
 template <typename DType>
-static void UpdateConvWeightBias(NDArray* weight, NDArray* bias, bool no_bias, const NDArray& gamma,
-                                 const NDArray& beta, const NDArray& mean, const NDArray& variance,
+static void UpdateConvWeightBias(NDArray* weight,
+                                 NDArray* bias,
+                                 bool no_bias,
+                                 const NDArray& gamma,
+                                 const NDArray& beta,
+                                 const NDArray& mean,
+                                 const NDArray& variance,
                                  const BatchNormParam* param) {
   NDArray update_weight =
       NDArray(weight->storage_type(), weight->shape(), weight->ctx(), true, weight->dtype());
@@ -87,8 +93,10 @@ class SgMKLDNNConvOperator {
       : subgraph_sym_(*attrs.subgraphs[0]),
         param_(nnvm::get<MKLDNNConvFusionParam>(attrs.parsed)) {}
 
-  void Forward(const OpContext& ctx, const std::vector<NDArray>& inputs,
-               const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs);
+  void Forward(const OpContext& ctx,
+               const std::vector<NDArray>& inputs,
+               const std::vector<OpReqType>& req,
+               const std::vector<NDArray>& outputs);
 
  private:
   bool initialized_{false};
@@ -112,7 +120,8 @@ class SgMKLDNNConvOperator {
   std::vector<float> weight_scales_;
 };
 
-void SgMKLDNNConvOperator::Forward(const OpContext& ctx, const std::vector<NDArray>& inputs,
+void SgMKLDNNConvOperator::Forward(const OpContext& ctx,
+                                   const std::vector<NDArray>& inputs,
                                    const std::vector<OpReqType>& req,
                                    const std::vector<NDArray>& outputs) {
   auto& full_conv_param = param_.full_conv_param;
@@ -347,7 +356,8 @@ void SgMKLDNNConvOperator::Forward(const OpContext& ctx, const std::vector<NDArr
   }
 }
 
-static void SgMKLDNNConvOpForward(const OpStatePtr& state_ptr, const OpContext& ctx,
+static void SgMKLDNNConvOpForward(const OpStatePtr& state_ptr,
+                                  const OpContext& ctx,
                                   const std::vector<NDArray>& inputs,
                                   const std::vector<OpReqType>& req,
                                   const std::vector<NDArray>& outputs) {
@@ -468,15 +478,18 @@ static std::vector<std::string> SgMKLDNNConvListOutputNames(const NodeAttrs& att
     return std::vector<std::string>{"output"};
 }
 
-static OpStatePtr CreateSgMKLDNNConvState(const nnvm::NodeAttrs& attrs, Context ctx,
+static OpStatePtr CreateSgMKLDNNConvState(const nnvm::NodeAttrs& attrs,
+                                          Context ctx,
                                           const mxnet::ShapeVector& in_shapes,
                                           const std::vector<int>& in_types) {
   return OpStatePtr::Create<SgMKLDNNConvOperator>(attrs);
 }
 
 template <typename DType>
-static void FilterMinMaxIndice(const MKLDNNConvParam& mkldnn_param, std::vector<DType>* in_shapes,
-                               std::vector<DType>* out_shapes, std::vector<DType>* base_in_shapes,
+static void FilterMinMaxIndice(const MKLDNNConvParam& mkldnn_param,
+                               std::vector<DType>* in_shapes,
+                               std::vector<DType>* out_shapes,
+                               std::vector<DType>* base_in_shapes,
                                std::vector<DType>* base_out_shapes,
                                std::unordered_set<size_t>* minmax_indice) {
   base_out_shapes->push_back(out_shapes->at(0));
@@ -494,7 +507,8 @@ static void FilterMinMaxIndice(const MKLDNNConvParam& mkldnn_param, std::vector<
   }
 }
 
-static bool SgMKLDNNConvInferShape(const nnvm::NodeAttrs& attrs, mxnet::ShapeVector* in_shapes,
+static bool SgMKLDNNConvInferShape(const nnvm::NodeAttrs& attrs,
+                                   mxnet::ShapeVector* in_shapes,
                                    mxnet::ShapeVector* out_shapes) {
   auto const& param = nnvm::get<MKLDNNConvFusionParam>(attrs.parsed);
   if (param.full_conv_param.mkldnn_param.quantized) {
@@ -522,7 +536,8 @@ static bool SgMKLDNNConvInferShape(const nnvm::NodeAttrs& attrs, mxnet::ShapeVec
   }
 }
 
-static bool SgMKLDNNConvInferType(const nnvm::NodeAttrs& attrs, std::vector<int>* in_types,
+static bool SgMKLDNNConvInferType(const nnvm::NodeAttrs& attrs,
+                                  std::vector<int>* in_types,
                                   std::vector<int>* out_types) {
   auto const& param = nnvm::get<MKLDNNConvFusionParam>(attrs.parsed);
   if (param.full_conv_param.mkldnn_param.quantized) {
@@ -574,8 +589,10 @@ static bool SgMKLDNNConvInferType(const nnvm::NodeAttrs& attrs, std::vector<int>
   }
 }
 
-static bool SgMKLDNNConvOpStorageType(const nnvm::NodeAttrs& attrs, const int dev_mask,
-                                      DispatchMode* dispatch_mode, std::vector<int>* in_stypes,
+static bool SgMKLDNNConvOpStorageType(const nnvm::NodeAttrs& attrs,
+                                      const int dev_mask,
+                                      DispatchMode* dispatch_mode,
+                                      std::vector<int>* in_stypes,
                                       std::vector<int>* out_stypes) {
   auto const& param = nnvm::get<MKLDNNConvFusionParam>(attrs.parsed);
   if (param.full_conv_param.mkldnn_param.quantized) {
@@ -631,7 +648,8 @@ nnvm::ObjectPtr SgMKLDNNConvQuantizedOp(const NodeAttrs& attrs) {
   return node;
 }
 
-bool SgMKLDNNAvoidConvQuantizeInput(const NodeAttrs& attrs, const size_t index,
+bool SgMKLDNNAvoidConvQuantizeInput(const NodeAttrs& attrs,
+                                    const size_t index,
                                     const std::string quantize_granularity) {
   auto const& param = nnvm::get<MKLDNNConvFusionParam>(attrs.parsed);
   std::unordered_set<size_t> avoid_indice;

--- a/src/operator/subgraph/mkldnn/mkldnn_conv_property.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_conv_property.h
@@ -23,8 +23,9 @@
 
 #include <string>
 #include <vector>
-#include "../../nn/activation-inl.h"
+
 #include "../../leaky_relu-inl.h"
+#include "../../nn/activation-inl.h"
 #include "../../nn/convolution-inl.h"
 #include "../../nn/mkldnn/mkldnn_ops-inl.h"
 #include "../../tensor/matrix_op-inl.h"
@@ -54,8 +55,8 @@ class SgMKLDNNConvSelector : public SubgraphSelector {
   std::vector<const nnvm::Node*> matched_list_;
 
  public:
-  SgMKLDNNConvSelector(int dis_all, int dis_conv_bn, int dis_conv_act, int dis_conv_sum,
-                       int quantize)
+  SgMKLDNNConvSelector(
+      int dis_all, int dis_conv_bn, int dis_conv_act, int dis_conv_sum, int quantize)
       : disable_all_(dis_all),
         disable_conv_bn_(dis_conv_bn),
         disable_conv_act_(dis_conv_act),
@@ -243,7 +244,8 @@ class SgMKLDNNConvProperty : public SubgraphProperty {
     }
   }
 
-  void ConnectSubgraphInputs(const nnvm::ObjectPtr n, std::vector<nnvm::NodeEntry*>* input_entries,
+  void ConnectSubgraphInputs(const nnvm::ObjectPtr n,
+                             std::vector<nnvm::NodeEntry*>* input_entries,
                              std::vector<nnvm::NodeEntry>* orig_input_entries) const override {
     auto sym = n->attrs.subgraphs[0];
     std::unordered_set<const nnvm::Node*> node_sets;

--- a/src/operator/subgraph/mkldnn/mkldnn_conv_property.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_conv_property.h
@@ -54,8 +54,8 @@ class SgMKLDNNConvSelector : public SubgraphSelector {
   std::vector<const nnvm::Node*> matched_list_;
 
  public:
-  SgMKLDNNConvSelector(
-      int dis_all, int dis_conv_bn, int dis_conv_act, int dis_conv_sum, int quantize)
+  SgMKLDNNConvSelector(int dis_all, int dis_conv_bn, int dis_conv_act, int dis_conv_sum,
+                       int quantize)
       : disable_all_(dis_all),
         disable_conv_bn_(dis_conv_bn),
         disable_conv_act_(dis_conv_act),
@@ -161,8 +161,8 @@ class SgMKLDNNConvSelector : public SubgraphSelector {
 
   void Reset() override {
     CHECK_GE(matched_list_.size(), 1);
-    auto new_selector = SgMKLDNNConvSelector(
-        disable_all_, disable_conv_bn_, disable_conv_act_, disable_conv_sum_, quantize_);
+    auto new_selector = SgMKLDNNConvSelector(disable_all_, disable_conv_bn_, disable_conv_act_,
+                                             disable_conv_sum_, quantize_);
     new_selector.Select(*matched_list_[0], nullptr);
     *this = new_selector;
   }
@@ -187,8 +187,8 @@ class SgMKLDNNConvProperty : public SubgraphProperty {
     }
     return property;
   }
-  nnvm::ObjectPtr CreateSubgraphNode(
-      const nnvm::Symbol& sym, const int subgraph_id = 0) const override {
+  nnvm::ObjectPtr CreateSubgraphNode(const nnvm::Symbol& sym,
+                                     const int subgraph_id = 0) const override {
     nnvm::ObjectPtr n = nnvm::Node::Create();
     // This op has single output, remove duplicated.
     auto last_node = sym.outputs[0].node;
@@ -235,17 +235,16 @@ class SgMKLDNNConvProperty : public SubgraphProperty {
     return selector;
   }
 
-  void ConnectSubgraphOutputs(
-      const nnvm::ObjectPtr n, std::vector<nnvm::NodeEntry*>* output_entries) const override {
+  void ConnectSubgraphOutputs(const nnvm::ObjectPtr n,
+                              std::vector<nnvm::NodeEntry*>* output_entries) const override {
     // Connect all extern output entries to output[0]
     for (size_t i = 0; i < output_entries->size(); ++i) {
       *output_entries->at(i) = nnvm::NodeEntry{n, 0, 0};
     }
   }
 
-  void ConnectSubgraphInputs(
-      const nnvm::ObjectPtr n, std::vector<nnvm::NodeEntry*>* input_entries,
-      std::vector<nnvm::NodeEntry>* orig_input_entries) const override {
+  void ConnectSubgraphInputs(const nnvm::ObjectPtr n, std::vector<nnvm::NodeEntry*>* input_entries,
+                             std::vector<nnvm::NodeEntry>* orig_input_entries) const override {
     auto sym = n->attrs.subgraphs[0];
     std::unordered_set<const nnvm::Node*> node_sets;
     DFSVisit(sym->outputs, [&](const nnvm::ObjectPtr& node) {
@@ -260,9 +259,8 @@ class SgMKLDNNConvProperty : public SubgraphProperty {
           node->inputs[1] = node->inputs[0];
           node->inputs[0] = tmp;
           std::rotate(input_entries->begin(), input_entries->begin() + 1, input_entries->end());
-          std::rotate(
-              orig_input_entries->begin(), orig_input_entries->begin() + 1,
-              orig_input_entries->end());
+          std::rotate(orig_input_entries->begin(), orig_input_entries->begin() + 1,
+                      orig_input_entries->end());
         }
       }
     });

--- a/src/operator/subgraph/mkldnn/mkldnn_conv_property.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_conv_property.h
@@ -51,11 +51,11 @@ class SgMKLDNNConvSelector : public SubgraphSelector {
   bool disable_conv_sum_;
   bool quantize_;
   SelectStatus status_;
-  std::vector<const nnvm::Node *> matched_list_;
+  std::vector<const nnvm::Node*> matched_list_;
 
  public:
-  SgMKLDNNConvSelector(int dis_all, int dis_conv_bn, int dis_conv_act, int dis_conv_sum,
-                       int quantize)
+  SgMKLDNNConvSelector(
+      int dis_all, int dis_conv_bn, int dis_conv_act, int dis_conv_sum, int quantize)
       : disable_all_(dis_all),
         disable_conv_bn_(dis_conv_bn),
         disable_conv_act_(dis_conv_act),
@@ -64,28 +64,24 @@ class SgMKLDNNConvSelector : public SubgraphSelector {
 
   bool Select(const nnvm::Node& n, const std::shared_ptr<NodeAttr>& node_attr) override {
     if (n.op() && n.op()->name == "Convolution") {
-      const auto &param = nnvm::get<ConvolutionParam>(n.attrs.parsed);
-      if ((param.kernel.ndim() == 2 || param.kernel.ndim() == 3) &&
-           SupportMKLDNNAttr(node_attr)) {
+      const auto& param = nnvm::get<ConvolutionParam>(n.attrs.parsed);
+      if ((param.kernel.ndim() == 2 || param.kernel.ndim() == 3) && SupportMKLDNNAttr(node_attr)) {
         status_ = disable_all_ ? kSuccess : kStart;
         matched_list_.clear();
         matched_list_.push_back(&n);
         return true;
-        }
+      }
     }
     return false;
   }
 
-  bool SelectInput(const nnvm::Node &n, const nnvm::Node &new_node) override {
-    return false;
-  }
+  bool SelectInput(const nnvm::Node& n, const nnvm::Node& new_node) override { return false; }
 
-  bool SelectOutput(const nnvm::Node &n, const nnvm::Node &new_node) override {
+  bool SelectOutput(const nnvm::Node& n, const nnvm::Node& new_node) override {
     // If n isn't the last matched node, then we encoutered a internal
     // branch, we should pop out the node behind n and stop fusion.
     if (matched_list_.back() != &n) {
-      if (std::find(matched_list_.begin(), matched_list_.end(), &n) !=
-          matched_list_.end()) {
+      if (std::find(matched_list_.begin(), matched_list_.end(), &n) != matched_list_.end()) {
         while (matched_list_.back() != &n) {
           matched_list_.pop_back();
         }
@@ -93,8 +89,7 @@ class SgMKLDNNConvSelector : public SubgraphSelector {
       status_ = kSuccess;
       return false;
     }
-    if (status_ == kFail || status_ == kSuccess || new_node.is_variable())
-      return false;
+    if (status_ == kFail || status_ == kSuccess || new_node.is_variable()) return false;
 
     // Use status_ machine to do selection. The status_ change is
     // kStart -> kBN -> kSum -> kSuccess
@@ -114,8 +109,7 @@ class SgMKLDNNConvSelector : public SubgraphSelector {
       case kSum:
       default:
         if ((!disable_conv_act_) && new_node.op()->name == "Activation") {
-          const ActivationParam &param =
-              nnvm::get<ActivationParam>(new_node.attrs.parsed);
+          const ActivationParam& param = nnvm::get<ActivationParam>(new_node.attrs.parsed);
           if ((quantize_ && SupportQuantizedMKLDNNAct(param)) ||
               (!quantize_ && SupportMKLDNNAct(param))) {
             matched_list_.push_back(&new_node);
@@ -124,10 +118,8 @@ class SgMKLDNNConvSelector : public SubgraphSelector {
             return true;
           }
         } else if ((!disable_conv_act_) && new_node.op()->name == "LeakyReLU") {
-          const LeakyReLUParam &param =
-              nnvm::get<LeakyReLUParam>(new_node.attrs.parsed);
-          if (param.act_type == leakyrelu::kLeakyReLU ||
-              param.act_type == leakyrelu::kGELU) {
+          const LeakyReLUParam& param = nnvm::get<LeakyReLUParam>(new_node.attrs.parsed);
+          if (param.act_type == leakyrelu::kLeakyReLU || param.act_type == leakyrelu::kGELU) {
             matched_list_.push_back(&new_node);
             // not support conv+relu+sum yet.
             status_ = kSuccess;
@@ -138,7 +130,7 @@ class SgMKLDNNConvSelector : public SubgraphSelector {
             // TODO(zhennan): doesn't support int8 conv+sum+relu6 at moment. To support this, we
             // need to fuse conv+sum first, and calibrate with it. Then fuse int8 relu6 into fused
             // conv.
-            const ClipParam &param = nnvm::get<ClipParam>(new_node.attrs.parsed);
+            const ClipParam& param = nnvm::get<ClipParam>(new_node.attrs.parsed);
             if (param.a_min == 0.f) {
               matched_list_.push_back(&new_node);
               // not support conv+relu+sum yet.
@@ -152,16 +144,14 @@ class SgMKLDNNConvSelector : public SubgraphSelector {
     }
   }
 
-  std::vector<nnvm::Node *> Filter(
-      const std::vector<nnvm::Node *> &candidates) override {
+  std::vector<nnvm::Node*> Filter(const std::vector<nnvm::Node*>& candidates) override {
     if (status_ == kFail) {
-      return std::vector<nnvm::Node *>(0);
+      return std::vector<nnvm::Node*>(0);
     } else {
-      std::vector<nnvm::Node *> ret;
+      std::vector<nnvm::Node*> ret;
       for (auto i : matched_list_) {
-        auto non_const_i = const_cast<nnvm::Node *>(i);
-        if (std::find(candidates.begin(), candidates.end(), non_const_i) !=
-            candidates.end()) {
+        auto non_const_i = const_cast<nnvm::Node*>(i);
+        if (std::find(candidates.begin(), candidates.end(), non_const_i) != candidates.end()) {
           ret.push_back(non_const_i);
         }
       }
@@ -171,8 +161,8 @@ class SgMKLDNNConvSelector : public SubgraphSelector {
 
   void Reset() override {
     CHECK_GE(matched_list_.size(), 1);
-    auto new_selector = SgMKLDNNConvSelector(disable_all_, disable_conv_bn_, disable_conv_act_,
-                                             disable_conv_sum_, quantize_);
+    auto new_selector = SgMKLDNNConvSelector(
+        disable_all_, disable_conv_bn_, disable_conv_act_, disable_conv_sum_, quantize_);
     new_selector.Select(*matched_list_[0], nullptr);
     *this = new_selector;
   }
@@ -181,15 +171,15 @@ class SgMKLDNNConvSelector : public SubgraphSelector {
 class SgMKLDNNConvProperty : public SubgraphProperty {
  public:
   SgMKLDNNConvProperty() {
-    disable_conv_bn_ = dmlc::GetEnv("MXNET_DISABLE_MKLDNN_FUSE_CONV_BN", 0);
+    disable_conv_bn_  = dmlc::GetEnv("MXNET_DISABLE_MKLDNN_FUSE_CONV_BN", 0);
     disable_conv_act_ = dmlc::GetEnv("MXNET_DISABLE_MKLDNN_FUSE_CONV_RELU", 0);
     disable_conv_sum_ = dmlc::GetEnv("MXNET_DISABLE_MKLDNN_FUSE_CONV_SUM", 0);
 
     disable_all_ = disable_conv_bn_ && disable_conv_act_ && disable_conv_sum_;
   }
   static SubgraphPropertyPtr Create() {
-    static const std::string &name = "MKLDNN convolution optimization pass";
-    auto property = std::make_shared<SgMKLDNNConvProperty>();
+    static const std::string& name = "MKLDNN convolution optimization pass";
+    auto property                  = std::make_shared<SgMKLDNNConvProperty>();
     property->SetAttr<std::string>("property_name", name);
     property->SetAttr<bool>("inference_only", true);
     if (dmlc::GetEnv("MXNET_DISABLE_MKLDNN_CONV_OPT", 0)) {
@@ -197,8 +187,8 @@ class SgMKLDNNConvProperty : public SubgraphProperty {
     }
     return property;
   }
-  nnvm::ObjectPtr CreateSubgraphNode(const nnvm::Symbol &sym,
-                                   const int subgraph_id = 0) const override {
+  nnvm::ObjectPtr CreateSubgraphNode(
+      const nnvm::Symbol& sym, const int subgraph_id = 0) const override {
     nnvm::ObjectPtr n = nnvm::Node::Create();
     // This op has single output, remove duplicated.
     auto last_node = sym.outputs[0].node;
@@ -207,9 +197,9 @@ class SgMKLDNNConvProperty : public SubgraphProperty {
     std::ostringstream node_name;
     node_name << "sg_mkldnn_";
     bool _with_sum = false;
-    DFSVisit(new_sym.outputs, [&](const nnvm::ObjectPtr &node) {
+    DFSVisit(new_sym.outputs, [&](const nnvm::ObjectPtr& node) {
       if (node->is_variable()) return;
-      auto &sub_name = node->op()->name;
+      auto& sub_name = node->op()->name;
       if (sub_name == "Convolution") {
         node_name << "conv_";
       } else if (sub_name == "BatchNorm") {
@@ -218,7 +208,7 @@ class SgMKLDNNConvProperty : public SubgraphProperty {
       } else if (sub_name == "elemwise_add") {
         node_name << "add_";
         n->attrs.dict["with_sum"] = "true";
-        _with_sum = true;
+        _with_sum                 = true;
 
       } else if (sub_name == "Activation" || sub_name == "LeakyReLU" || sub_name == "clip") {
         node_name << "act_";
@@ -231,7 +221,7 @@ class SgMKLDNNConvProperty : public SubgraphProperty {
     });
     node_name << std::to_string(subgraph_id);
     n->attrs.name = node_name.str();
-    n->attrs.op = Op::Get("_sg_mkldnn_conv");
+    n->attrs.op   = Op::Get("_sg_mkldnn_conv");
     CHECK(n->attrs.op);
     n->attrs.subgraphs.emplace_back(std::make_shared<nnvm::Symbol>(new_sym));
     n->op()->attr_parser(&(n->attrs));
@@ -246,8 +236,7 @@ class SgMKLDNNConvProperty : public SubgraphProperty {
   }
 
   void ConnectSubgraphOutputs(
-      const nnvm::ObjectPtr n,
-      std::vector<nnvm::NodeEntry *> *output_entries) const override {
+      const nnvm::ObjectPtr n, std::vector<nnvm::NodeEntry*>* output_entries) const override {
     // Connect all extern output entries to output[0]
     for (size_t i = 0; i < output_entries->size(); ++i) {
       *output_entries->at(i) = nnvm::NodeEntry{n, 0, 0};
@@ -255,11 +244,11 @@ class SgMKLDNNConvProperty : public SubgraphProperty {
   }
 
   void ConnectSubgraphInputs(
-      const nnvm::ObjectPtr n, std::vector<nnvm::NodeEntry *> *input_entries,
-      std::vector<nnvm::NodeEntry> *orig_input_entries) const override {
+      const nnvm::ObjectPtr n, std::vector<nnvm::NodeEntry*>* input_entries,
+      std::vector<nnvm::NodeEntry>* orig_input_entries) const override {
     auto sym = n->attrs.subgraphs[0];
-    std::unordered_set<const nnvm::Node *> node_sets;
-    DFSVisit(sym->outputs, [&](const nnvm::ObjectPtr &node) {
+    std::unordered_set<const nnvm::Node*> node_sets;
+    DFSVisit(sym->outputs, [&](const nnvm::ObjectPtr& node) {
       if (node->is_variable()) return;
       node_sets.insert(node.get());
       if (node->op()->name == "elemwise_add") {
@@ -267,14 +256,13 @@ class SgMKLDNNConvProperty : public SubgraphProperty {
         // switch sum operands sequence to ensure that
         // the extra sum operand stays in the last of inputs.
         if (node_sets.count(node->inputs[1].node.get())) {
-          auto tmp = node->inputs[1];
+          auto tmp        = node->inputs[1];
           node->inputs[1] = node->inputs[0];
           node->inputs[0] = tmp;
-          std::rotate(input_entries->begin(), input_entries->begin() + 1,
-                      input_entries->end());
-          std::rotate(orig_input_entries->begin(),
-                      orig_input_entries->begin() + 1,
-                      orig_input_entries->end());
+          std::rotate(input_entries->begin(), input_entries->begin() + 1, input_entries->end());
+          std::rotate(
+              orig_input_entries->begin(), orig_input_entries->begin() + 1,
+              orig_input_entries->end());
         }
       }
     });

--- a/src/operator/subgraph/mkldnn/mkldnn_elemwisemul_post_quantize_property.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_elemwisemul_post_quantize_property.h
@@ -30,8 +30,9 @@
 
 #include <string>
 #include <vector>
-#include "../../tensor/elemwise_binary_op-inl.h"
+
 #include "../../quantization/requantize-inl.h"
+#include "../../tensor/elemwise_binary_op-inl.h"
 #include "../common.h"
 #include "mkldnn_subgraph_base-inl.h"
 

--- a/src/operator/subgraph/mkldnn/mkldnn_elemwisemul_post_quantize_property.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_elemwisemul_post_quantize_property.h
@@ -71,10 +71,13 @@ class ElemwiseMulPostQuantizeSelector : public SubgraphSelector {
     return false;
   }
 
-  bool SelectInput(const nnvm::Node& n, const nnvm::Node& new_node) override { return false; }
+  bool SelectInput(const nnvm::Node& n, const nnvm::Node& new_node) override {
+    return false;
+  }
 
   bool SelectOutput(const nnvm::Node& n, const nnvm::Node& new_node) override {
-    if (status == kFail || status == kSuccess || new_node.is_variable()) return false;
+    if (status == kFail || status == kSuccess || new_node.is_variable())
+      return false;
     // If n isn't the last matched node, then we encoutered a internal
     // branch, we should pop out the node behind n and stop fusion.
     if (matched_list.back() != &n) {
@@ -155,7 +158,8 @@ class ElemwiseMulPostQuantizeProperty : public SubgraphProperty {
     nnvm::ObjectPtr dequantize_node = nullptr;
 
     DFSVisit(sym.outputs, [&](const nnvm::ObjectPtr& node) {
-      if (node->is_variable()) return;
+      if (node->is_variable())
+        return;
       if (node->op() == Op::Get(QUANTIZED_ElemwiseMul_NAME)) {
         em_node = node;
       } else if (node->op() == Op::Get("_contrib_requantize")) {
@@ -171,8 +175,9 @@ class ElemwiseMulPostQuantizeProperty : public SubgraphProperty {
     CHECK(requantize_param.min_calib_range.has_value());
     CHECK(requantize_param.max_calib_range.has_value());
 
-    // When only fused quantized_elemwise_mul and requantize, set min/max_cablib_range,
-    // When fused quantized_elemwise_mul + requantize + dequantize, set dequantize flag to true.
+    // When only fused quantized_elemwise_mul and requantize, set
+    // min/max_cablib_range, When fused quantized_elemwise_mul + requantize +
+    // dequantize, set dequantize flag to true.
     if (dequantize_node != nullptr) {
       em_node->attrs.dict["enable_float_output"] = "True";
     } else {

--- a/src/operator/subgraph/mkldnn/mkldnn_elemwisemul_post_quantize_property.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_elemwisemul_post_quantize_property.h
@@ -147,8 +147,8 @@ class ElemwiseMulPostQuantizeProperty : public SubgraphProperty {
     return property;
   }
 
-  nnvm::ObjectPtr CreateSubgraphNode(
-      const nnvm::Symbol& sym, const int subgraph_id = 0) const override {
+  nnvm::ObjectPtr CreateSubgraphNode(const nnvm::Symbol& sym,
+                                     const int subgraph_id = 0) const override {
     nnvm::ObjectPtr em_node         = nullptr;
     nnvm::ObjectPtr requantize_node = nullptr;
     nnvm::ObjectPtr dequantize_node = nullptr;
@@ -190,8 +190,8 @@ class ElemwiseMulPostQuantizeProperty : public SubgraphProperty {
     return selector;
   }
 
-  void ConnectSubgraphOutputs(
-      const nnvm::ObjectPtr n, std::vector<nnvm::NodeEntry*>* output_entries) const override {
+  void ConnectSubgraphOutputs(const nnvm::ObjectPtr n,
+                              std::vector<nnvm::NodeEntry*>* output_entries) const override {
     for (size_t i = 0; i < output_entries->size(); ++i) {
       auto entry_ptr = output_entries->at(i);
       *entry_ptr     = nnvm::NodeEntry{n, entry_ptr->index, 0};

--- a/src/operator/subgraph/mkldnn/mkldnn_fc-inl.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_fc-inl.h
@@ -24,8 +24,9 @@
 #include <string>
 #include <utility>
 #include <vector>
-#include "mkldnn.hpp"
+
 #include "../../nn/mkldnn/mkldnn_fully_connected-inl.h"
+#include "mkldnn.hpp"
 
 namespace mxnet {
 namespace op {

--- a/src/operator/subgraph/mkldnn/mkldnn_fc-inl.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_fc-inl.h
@@ -31,13 +31,8 @@ namespace mxnet {
 namespace op {
 
 static inline bool SupportMKLDNNFCEltwiseFusion(const std::string op_name) {
-  if (op_name == "Activation" ||
-      op_name == "square" ||
-      op_name == "sqrt" ||
-      op_name == "exp" ||
-      op_name == "abs" ||
-      op_name == "clip" ||
-      op_name == "LeakyReLU") {
+  if (op_name == "Activation" || op_name == "square" || op_name == "sqrt" || op_name == "exp" ||
+      op_name == "abs" || op_name == "clip" || op_name == "LeakyReLU") {
     return true;
   } else {
     return false;
@@ -63,13 +58,10 @@ static inline bool IsOutputUint8(const MKLDNNFCFullParam& full_param) {
   auto alg = full_param.eltwise_param.alg;
   // TODO(ciyong): some alg doesn't support int8 so far.
   if (full_param.mkldnn_param.with_eltwise &&
-      (alg == mkldnn::algorithm::eltwise_relu ||
-       alg == mkldnn::algorithm::eltwise_logistic ||
+      (alg == mkldnn::algorithm::eltwise_relu || alg == mkldnn::algorithm::eltwise_logistic ||
        alg == mkldnn::algorithm::eltwise_soft_relu ||
-       alg == mkldnn::algorithm::eltwise_bounded_relu ||
-       alg == mkldnn::algorithm::eltwise_square ||
-       alg == mkldnn::algorithm::eltwise_sqrt ||
-       alg == mkldnn::algorithm::eltwise_exp ||
+       alg == mkldnn::algorithm::eltwise_bounded_relu || alg == mkldnn::algorithm::eltwise_square ||
+       alg == mkldnn::algorithm::eltwise_sqrt || alg == mkldnn::algorithm::eltwise_exp ||
        alg == mkldnn::algorithm::eltwise_abs)) {
     return true;
   }

--- a/src/operator/subgraph/mkldnn/mkldnn_fc.cc
+++ b/src/operator/subgraph/mkldnn/mkldnn_fc.cc
@@ -1,28 +1,28 @@
 /*
-* Licensed to the Apache Software Foundation (ASF) under one
-* or more contributor license agreements.  See the NOTICE file
-* distributed with this work for additional information
-* regarding copyright ownership.  The ASF licenses this file
-* to you under the Apache License, Version 2.0 (the
-* "License"); you may not use this file except in compliance
-* with the License.  You may obtain a copy of the License at
-*
-*   http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing,
-* software distributed under the License is distributed on an
-* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied.  See the License for the
-* specific language governing permissions and limitations
-* under the License.
-*/
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 /*!
  * Copyright (c) 2019 by Contributors
  * \file mkldnn_fc.cc
  * \brief MKLDNN (Quantized) FullyConnected operator based on subgraph
  * \author Ciyong Chen
-*/
+ */
 
 #if MXNET_USE_MKLDNN == 1
 
@@ -114,19 +114,17 @@ class FCInputIndex {
 
 class SgMKLDNNFCOp {
  public:
-  explicit SgMKLDNNFCOp(const nnvm::NodeAttrs &attrs)
-    : subgraph_sym_(*attrs.subgraphs[0]),
-      full_param_(nnvm::get<MKLDNNFCFullParam>(attrs.parsed)) {}
+  explicit SgMKLDNNFCOp(const nnvm::NodeAttrs& attrs)
+      : subgraph_sym_(*attrs.subgraphs[0]),
+        full_param_(nnvm::get<MKLDNNFCFullParam>(attrs.parsed)) {}
 
-  void Forward(const OpContext &ctx,
-               const std::vector<NDArray> &inputs,
-               const std::vector<OpReqType> &req,
-               const std::vector<NDArray> &outputs);
+  void Forward(
+      const OpContext& ctx, const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+      const std::vector<NDArray>& outputs);
 
-  void Backward(const OpContext &ctx,
-                const std::vector<NDArray> &inputs,
-                const std::vector<OpReqType> &req,
-                const std::vector<NDArray> &outputs) {
+  void Backward(
+      const OpContext& ctx, const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+      const std::vector<NDArray>& outputs) {
     LOG(FATAL) << "Not implemented: subgraph mkldnn fully connected only supports "
                   "inference computation.";
   }
@@ -287,10 +285,10 @@ void SgMKLDNNFCOp::Forward(const OpContext &ctx,
       cached_bias_ = NDArray();
     }
     const mxnet::TShape ishape = data.shape();
-    const auto data_ndim = ishape.ndim();
+    const auto data_ndim       = ishape.ndim();
     if (data.IsMKLDNNData()) {
       reorder_data_ = true;
-      data = data.Reorder2Default();
+      data          = data.Reorder2Default();
     }
     if (data_ndim != 2) {
       if (!default_param.flatten) {
@@ -309,15 +307,16 @@ void SgMKLDNNFCOp::Forward(const OpContext &ctx,
       out_dims[1] = static_cast<int>(oshape[1]);
     } else {
       if (!default_param.flatten) {
-        out_dims[0] = static_cast<int>(oshape.ProdShape(0, oshape.ndim()-1));
-        out_dims[1] = static_cast<int>(oshape[oshape.ndim()-1]);
+        out_dims[0] = static_cast<int>(oshape.ProdShape(0, oshape.ndim() - 1));
+        out_dims[1] = static_cast<int>(oshape[oshape.ndim() - 1]);
       } else {
         out_dims[0] = static_cast<int>(static_cast<int>(oshape[0]));
         out_dims[1] = static_cast<int>(oshape.ProdShape(1, oshape.ndim()));
       }
     }
-    mkldnn::memory::desc out_md = mkldnn::memory::desc(out_dims, get_mkldnn_type(output.dtype()),
-      static_cast<mkldnn::memory::format_tag>(GetDefaultFormat(2)));
+    mkldnn::memory::desc out_md = mkldnn::memory::desc(
+        out_dims, get_mkldnn_type(output.dtype()),
+        static_cast<mkldnn::memory::format_tag>(GetDefaultFormat(2)));
     cached_out_mem_ = std::make_shared<mkldnn::memory>(out_md, engine);
 
     bool support_channelwise_scale = false;
@@ -327,12 +326,11 @@ void SgMKLDNNFCOp::Forward(const OpContext &ctx,
 
       bool fuse_requantize = false;
       // Channelwise scaling is only supported when fusion is enabled (requantize or dequantize).
-      if (mkldnn_param.min_calib_range.has_value() &&
-          mkldnn_param.max_calib_range.has_value()) {
-        cached_min_output_ = mkldnn_param.min_calib_range.value();
-        cached_max_output_ = mkldnn_param.max_calib_range.value();
+      if (mkldnn_param.min_calib_range.has_value() && mkldnn_param.max_calib_range.has_value()) {
+        cached_min_output_        = mkldnn_param.min_calib_range.value();
+        cached_max_output_        = mkldnn_param.max_calib_range.value();
         support_channelwise_scale = true;
-        fuse_requantize = true;
+        fuse_requantize           = true;
       }
       if (mkldnn_param.enable_float_output) {
         support_channelwise_scale = true;
@@ -343,24 +341,25 @@ void SgMKLDNNFCOp::Forward(const OpContext &ctx,
       // False         True/False                 False
       if (channel_wise && !support_channelwise_scale) {
         LOG(FATAL)
-          << "Currently, channel-wise quantization requires fuse requantize or dequantize."
-          << " Please make sure the `min_calib_range` and `max_calib_range` are set when only"
-          << " fuse requantize (outputs of FullyConnected are collected during calibration phase),"
-          << " or the env var of `MXNET_DISABLE_MKLDNN_QFC_FLOAT_OUTPUT` and "
-          << " `MXNET_DISABLE_MKLDNN_QFC_FUSE_ALL` are not set to true (default is false)";
+            << "Currently, channel-wise quantization requires fuse requantize or dequantize."
+            << " Please make sure the `min_calib_range` and `max_calib_range` are set when only"
+            << " fuse requantize (outputs of FullyConnected are collected during calibration "
+               "phase),"
+            << " or the env var of `MXNET_DISABLE_MKLDNN_QFC_FLOAT_OUTPUT` and "
+            << " `MXNET_DISABLE_MKLDNN_QFC_FUSE_ALL` are not set to true (default is false)";
       }
       support_channelwise_scale = support_channelwise_scale && channel_wise;
 
       if (support_channelwise_scale) {
         MSHADOW_REAL_TYPE_SWITCH(cached_weight_.dtype(), DType, {
-          weight_scales_ =
-            GetWeightScales<DType>(cached_weight_, has_bias ? &cached_bias_ : nullptr,
-                                   data_scale_, support_channelwise_scale);
+          weight_scales_ = GetWeightScales<DType>(
+              cached_weight_, has_bias ? &cached_bias_ : nullptr, data_scale_,
+              support_channelwise_scale);
         });
       } else {
         weight_scales_.resize(1);
         weight_scales_[0] =
-          GetQuantizeScale(cached_weight_.dtype(), cached_min_weight_, cached_max_weight_);
+            GetQuantizeScale(cached_weight_.dtype(), cached_min_weight_, cached_max_weight_);
         if (has_bias) {
           if (cached_bias_.dtype() == mshadow::kInt8) {
             float bias_scale = GetQuantizeScale(mshadow::kInt8, cached_min_bias_, cached_max_bias_);
@@ -406,7 +405,7 @@ void SgMKLDNNFCOp::Forward(const OpContext &ctx,
           if (mkldnn_param.with_eltwise) {
             tmp_scale_ = 1.0 / data_scale_;
             full_param_.eltwise_param.scale =
-              GetQuantizeScale(output.dtype(), cached_min_output_, cached_max_output_);
+                GetQuantizeScale(output.dtype(), cached_min_output_, cached_max_output_);
           } else {
           out_scale = GetQuantizeScale(output.dtype(), cached_min_output_, cached_max_output_);
           tmp_scale_ = out_scale / data_scale_;
@@ -417,7 +416,7 @@ void SgMKLDNNFCOp::Forward(const OpContext &ctx,
 
         if (support_channelwise_scale) {
           full_param_.output_scales.resize(num_channel);
-          #pragma omp parallel for num_threads(nthreads)
+#pragma omp parallel for num_threads(nthreads)
           for (index_t i = 0; i < static_cast<index_t>(num_channel); ++i) {
             full_param_.output_scales[i] = tmp_scale_ / weight_scales_[i];
           }
@@ -426,7 +425,7 @@ void SgMKLDNNFCOp::Forward(const OpContext &ctx,
           full_param_.output_scales[0] = tmp_scale_ / weight_scales_[0];
         }
       } else {
-        Stream<cpu> *s = ctx.get_stream<cpu>();
+        Stream<cpu>* s = ctx.get_stream<cpu>();
         if (data.dtype() == mshadow::kInt8) {
           mxnet_op::Kernel<QuantizationRangeForS8S8MultiplicationStruct, cpu>::Launch(
               s, 1, &cached_min_output_, &cached_max_output_, &min_data, &max_data, &min_weight,
@@ -447,39 +446,37 @@ void SgMKLDNNFCOp::Forward(const OpContext &ctx,
       }
     }   // if (mkldnn_param.quantized)
 
-    fwd_.reset(new MKLDNNFullyConnectedForward(full_param_, ctx.is_train, data, cached_weight_,
-      (has_bias ? &cached_bias_ : nullptr), out_md));
+    fwd_.reset(new MKLDNNFullyConnectedForward(
+        full_param_, ctx.is_train, data, cached_weight_, (has_bias ? &cached_bias_ : nullptr),
+        out_md));
 
     // convert weight and bias to the format that MKL-DNN requires
     if (!mkldnn_param.quantized || support_channelwise_scale) {
       mkldnn::memory::desc bias_md;
       if (has_bias) bias_md = fwd_->fwd_pd.bias_desc();
-      ConvertWeightBias2MKLDNN(&cached_weight_, &cached_bias_, has_bias,
-                              fwd_->fwd_pd.weights_desc(),
-                              has_bias ? &bias_md : nullptr,
-                              1, data_scale_, weight_scales_, false);
+      ConvertWeightBias2MKLDNN(
+          &cached_weight_, &cached_bias_, has_bias, fwd_->fwd_pd.weights_desc(),
+          has_bias ? &bias_md : nullptr, 1, data_scale_, weight_scales_, false);
     } else {
       const auto def_weight_mem = weight.GetMKLDNNData();
       if (def_weight_mem->get_desc() != fwd_->fwd_pd.weights_desc()) {
-        cached_weight_ = NDArray(fwd_->fwd_pd.weights_desc());
+        cached_weight_         = NDArray(fwd_->fwd_pd.weights_desc());
         auto cached_weight_mem = cached_weight_.GetMKLDNNData();
         std::unordered_map<int, mkldnn::memory> args(
-          {{MKLDNN_ARG_FROM, *def_weight_mem},
-          {MKLDNN_ARG_TO, *cached_weight_mem}});
+            {{MKLDNN_ARG_FROM, *def_weight_mem}, {MKLDNN_ARG_TO, *cached_weight_mem}});
         MKLDNNStream::Get()->RegisterPrimArgs(
-          mkldnn::reorder(*def_weight_mem, *cached_weight_mem), args);
+            mkldnn::reorder(*def_weight_mem, *cached_weight_mem), args);
       }
     }
 
     const auto data_mem = data.GetMKLDNNData();
-    cached_data_mem_ = std::make_shared<mkldnn::memory>(data_mem->get_desc(), engine);
+    cached_data_mem_    = std::make_shared<mkldnn::memory>(data_mem->get_desc(), engine);
 
-    args_[MKLDNN_ARG_SRC] = *cached_data_mem_;
+    args_[MKLDNN_ARG_SRC]     = *cached_data_mem_;
     args_[MKLDNN_ARG_WEIGHTS] = *cached_weight_.GetMKLDNNData();
-    if (has_bias)
-      args_[MKLDNN_ARG_BIAS] = *cached_bias_.GetMKLDNNData();
+    if (has_bias) args_[MKLDNN_ARG_BIAS] = *cached_bias_.GetMKLDNNData();
     args_[MKLDNN_ARG_DST] = *cached_out_mem_;
-    initialized_ = true;
+    initialized_          = true;
   }
 
   if (mkldnn_param.with_sum) {
@@ -501,10 +498,10 @@ void SgMKLDNNFCOp::Forward(const OpContext &ctx,
     data = data.Reorder2Default();
   }
   MSHADOW_TYPE_SWITCH(data.dtype(), DType, {
-    cached_data_mem_->set_data_handle(reinterpret_cast<void *>(data.data().dptr<DType>()));
+    cached_data_mem_->set_data_handle(reinterpret_cast<void*>(data.data().dptr<DType>()));
   });
   MSHADOW_TYPE_SWITCH(output.dtype(), DType, {
-    cached_out_mem_->set_data_handle(reinterpret_cast<void *>(output.data().dptr<DType>()));
+    cached_out_mem_->set_data_handle(reinterpret_cast<void*>(output.data().dptr<DType>()));
   });
   MKLDNNStream::Get()->RegisterPrimArgs(fwd_->GetFwd(), args_);
   MKLDNNStream::Get()->Submit();
@@ -517,7 +514,7 @@ void SgMKLDNNFCOp::Forward(const OpContext &ctx,
   }
 }
 
-static void SgMKLDNNFCParamParser(nnvm::NodeAttrs *attrs) {
+static void SgMKLDNNFCParamParser(nnvm::NodeAttrs* attrs) {
   // For backward compatible, with_relu->with_eltwise
   auto legacy = attrs->dict.find("with_relu");
   if (legacy != attrs->dict.end()) {
@@ -528,35 +525,34 @@ static void SgMKLDNNFCParamParser(nnvm::NodeAttrs *attrs) {
   MKLDNNFCFullParam full_param;
   try {
     full_param.mkldnn_param.Init(attrs->dict);
-  } catch (const dmlc::ParamError &e) {
+  } catch (const dmlc::ParamError& e) {
     std::ostringstream os;
     os << e.what();
     os << ", in operator " << attrs->op->name << "("
        << "name=\"" << attrs->name << "\"";
-    for (const auto &k : attrs->dict) {
+    for (const auto& k : attrs->dict) {
       os << ", " << k.first << "=\"" << k.second << "\"";
     }
     os << ")";
     throw dmlc::ParamError(os.str());
   }
   auto subgraph_sym = attrs->subgraphs[0];
-  DFSVisit(subgraph_sym->outputs, [&](const nnvm::ObjectPtr &node) {
+  DFSVisit(subgraph_sym->outputs, [&](const nnvm::ObjectPtr& node) {
     if (node->is_variable()) return;
-    auto &op_name = node->op()->name;
+    auto& op_name = node->op()->name;
     if (op_name == "FullyConnected") {
-      full_param.default_param =
-          nnvm::get<FullyConnectedParam>(node->attrs.parsed);
+      full_param.default_param = nnvm::get<FullyConnectedParam>(node->attrs.parsed);
     } else if (SupportMKLDNNFCEltwiseFusion(op_name)) {
       if (op_name == "Activation") {
         const ActivationParam act_param = nnvm::get<ActivationParam>(node->attrs.parsed);
-        full_param.eltwise_param.alg = GetMKLDNNActAlgo(act_param);
+        full_param.eltwise_param.alg    = GetMKLDNNActAlgo(act_param);
       } else if (op_name == "LeakyReLU") {
-        const auto act_param = nnvm::get<LeakyReLUParam>(node->attrs.parsed);
+        const auto act_param           = nnvm::get<LeakyReLUParam>(node->attrs.parsed);
         full_param.eltwise_param.alpha = act_param.slope;
-        full_param.eltwise_param.alg = GetMKLDNNActAlgo(act_param);
+        full_param.eltwise_param.alg   = GetMKLDNNActAlgo(act_param);
       } else if (op_name == "clip") {
-        const ClipParam clip_param = nnvm::get<ClipParam>(node->attrs.parsed);
-        full_param.eltwise_param.alg = mkldnn::algorithm::eltwise_bounded_relu;
+        const ClipParam clip_param     = nnvm::get<ClipParam>(node->attrs.parsed);
+        full_param.eltwise_param.alg   = mkldnn::algorithm::eltwise_bounded_relu;
         full_param.eltwise_param.alpha = clip_param.a_max;
       } else {
         full_param.eltwise_param.alg = GetMKLDNNEltwiseAlgo(op_name);
@@ -566,8 +562,8 @@ static void SgMKLDNNFCParamParser(nnvm::NodeAttrs *attrs) {
   attrs->parsed = std::move(full_param);
 }
 
-static std::vector<std::string> SgMKLDNNFCListInputNames(const NodeAttrs &attrs) {
-  auto const &full_param = nnvm::get<MKLDNNFCFullParam>(attrs.parsed);
+static std::vector<std::string> SgMKLDNNFCListInputNames(const NodeAttrs& attrs) {
+  auto const& full_param               = nnvm::get<MKLDNNFCFullParam>(attrs.parsed);
   std::vector<std::string> input_names = DefaultSubgraphOpListInputs(attrs);
   if (full_param.mkldnn_param.quantized) {
     bool channel_wise = false;
@@ -593,8 +589,8 @@ static std::vector<std::string> SgMKLDNNFCListInputNames(const NodeAttrs &attrs)
   return input_names;
 }
 
-static std::vector<std::string> SgMKLDNNFCListOutputNames(const NodeAttrs &attrs) {
-  auto const &full_param = nnvm::get<MKLDNNFCFullParam>(attrs.parsed);
+static std::vector<std::string> SgMKLDNNFCListOutputNames(const NodeAttrs& attrs) {
+  auto const& full_param = nnvm::get<MKLDNNFCFullParam>(attrs.parsed);
   if (full_param.mkldnn_param.quantized) {
     if (full_param.mkldnn_param.enable_float_output)
       return std::vector<std::string>{"output"};
@@ -619,10 +615,9 @@ static inline void FillBaseInputOutputInfo(const MKLDNNFCFullParam &param,
   }
 }
 
-static bool SgMKLDNNFCInferShape(const nnvm::NodeAttrs &attrs,
-                                 mxnet::ShapeVector *in_shapes,
-                                 mxnet::ShapeVector *out_shapes) {
-  auto const &full_param = nnvm::get<MKLDNNFCFullParam>(attrs.parsed);
+static bool SgMKLDNNFCInferShape(
+    const nnvm::NodeAttrs& attrs, mxnet::ShapeVector* in_shapes, mxnet::ShapeVector* out_shapes) {
+  auto const& full_param = nnvm::get<MKLDNNFCFullParam>(attrs.parsed);
   if (full_param.mkldnn_param.quantized) {
     mxnet::ShapeVector base_in_shapes;
     mxnet::ShapeVector base_out_shapes;
@@ -648,10 +643,9 @@ static bool SgMKLDNNFCInferShape(const nnvm::NodeAttrs &attrs,
   }
 }
 
-static bool SgMKLDNNFCInferType(const nnvm::NodeAttrs &attrs,
-                                std::vector<int> *in_types,
-                                std::vector<int> *out_types) {
-  auto const &full_param = nnvm::get<MKLDNNFCFullParam>(attrs.parsed);
+static bool SgMKLDNNFCInferType(
+    const nnvm::NodeAttrs& attrs, std::vector<int>* in_types, std::vector<int>* out_types) {
+  auto const& full_param = nnvm::get<MKLDNNFCFullParam>(attrs.parsed);
   if (full_param.mkldnn_param.quantized) {
     bool channel_wise = false;
     if (full_param.mkldnn_param.channel_wise_quantize.has_value() &&
@@ -707,12 +701,10 @@ static bool SgMKLDNNFCInferType(const nnvm::NodeAttrs &attrs,
   }
 }
 
-static bool SgMKLDNNFCStorageType(const nnvm::NodeAttrs &attrs,
-                                  const int dev_mask,
-                                  DispatchMode *dispatch_mode,
-                                  std::vector<int> *in_attrs,
-                                  std::vector<int> *out_attrs) {
-  auto const &full_param = nnvm::get<MKLDNNFCFullParam>(attrs.parsed);
+static bool SgMKLDNNFCStorageType(
+    const nnvm::NodeAttrs& attrs, const int dev_mask, DispatchMode* dispatch_mode,
+    std::vector<int>* in_attrs, std::vector<int>* out_attrs) {
+  auto const& full_param = nnvm::get<MKLDNNFCFullParam>(attrs.parsed);
   if (full_param.mkldnn_param.quantized) {
     std::vector<int> base_in_attrs;
     std::vector<int> base_out_attrs;
@@ -735,8 +727,7 @@ static bool SgMKLDNNFCStorageType(const nnvm::NodeAttrs &attrs,
     }
     return ret;
   } else {
-    return DefaultSubgraphOpStorageType(attrs, dev_mask, dispatch_mode,
-                                        in_attrs, out_attrs);
+    return DefaultSubgraphOpStorageType(attrs, dev_mask, dispatch_mode, in_attrs, out_attrs);
   }
 }
 
@@ -759,20 +750,18 @@ static OpStatePtr CreateSgMKLDNNFCState(const nnvm::NodeAttrs &attrs,
   return OpStatePtr::Create<SgMKLDNNFCOp>(attrs);
 }
 
-static void SgMKLDNNFCForward(const OpStatePtr &state_pointer,
-                              const OpContext &ctx,
-                              const std::vector<NDArray> &inputs,
-                              const std::vector<OpReqType> &req,
-                              const std::vector<NDArray> &outputs) {
-  SgMKLDNNFCOp &op = state_pointer.get_state<SgMKLDNNFCOp>();
+static void SgMKLDNNFCForward(
+    const OpStatePtr& state_pointer, const OpContext& ctx, const std::vector<NDArray>& inputs,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs) {
+  SgMKLDNNFCOp& op = state_pointer.get_state<SgMKLDNNFCOp>();
   op.Forward(ctx, inputs, req, outputs);
 }
 
 nnvm::ObjectPtr SgMKLDNNFCQuantizedOp(const NodeAttrs& attrs) {
-  nnvm::ObjectPtr node = nnvm::Node::Create();
-  node->attrs.op = Op::Get("_sg_mkldnn_fully_connected");
-  node->attrs.name = "quantized_" + attrs.name;
-  node->attrs.dict = attrs.dict;
+  nnvm::ObjectPtr node          = nnvm::Node::Create();
+  node->attrs.op                = Op::Get("_sg_mkldnn_fully_connected");
+  node->attrs.name              = "quantized_" + attrs.name;
+  node->attrs.dict              = attrs.dict;
   node->attrs.dict["quantized"] = "True";
   node->attrs.subgraphs.reserve(attrs.subgraphs.size());
   for (auto sub : attrs.subgraphs) {
@@ -782,15 +771,15 @@ nnvm::ObjectPtr SgMKLDNNFCQuantizedOp(const NodeAttrs& attrs) {
   return node;
 }
 
-static bool SgMKLDNNAvoidFCQuantizeInput(const NodeAttrs& attrs, const size_t index_to_check,
-                                         const std::string quantize_granularity) {
-  auto const &full_param = nnvm::get<MKLDNNFCFullParam>(attrs.parsed);
+static bool SgMKLDNNAvoidFCQuantizeInput(
+    const NodeAttrs& attrs, const size_t index_to_check, const std::string quantize_granularity) {
+  auto const& full_param = nnvm::get<MKLDNNFCFullParam>(attrs.parsed);
   std::unordered_set<size_t> avoid_indexes;
   FCInputIndex idx(full_param);
   if (quantize_granularity == "channel-wise") {
-    avoid_indexes.insert(fullc::kWeight);   // weight
+    avoid_indexes.insert(fullc::kWeight);  // weight
     if (!full_param.default_param.no_bias) {
-      avoid_indexes.insert(fullc::kBias);   // bias
+      avoid_indexes.insert(fullc::kBias);  // bias
     }
   }
   if (idx.IsSumInputFloat()) {

--- a/src/operator/subgraph/mkldnn/mkldnn_fc.cc
+++ b/src/operator/subgraph/mkldnn/mkldnn_fc.cc
@@ -32,6 +32,7 @@
 #include <unordered_set>
 #include <utility>
 #include <vector>
+
 #include "../../nn/mkldnn/mkldnn_act-inl.h"
 #include "../../nn/mkldnn/mkldnn_base-inl.h"
 #include "../../nn/mkldnn/mkldnn_fully_connected-inl.h"
@@ -45,21 +46,19 @@
 namespace mxnet {
 namespace op {
 
-
-static inline size_t GetInSumIndex(const MKLDNNFCFullParam &param) {
+static inline size_t GetInSumIndex(const MKLDNNFCFullParam& param) {
   assert(param.mkldnn_param.with_sum);
   return fullc::kWeight + 1 + (param.default_param.no_bias ? 0 : 1);
 }
 
-
 class FCInputIndex {
  public:
   explicit FCInputIndex(const MKLDNNFCFullParam full_param) {
-    auto &mkldnn_param = full_param.mkldnn_param;
-    const bool has_bias = !full_param.default_param.no_bias;
+    auto& mkldnn_param   = full_param.mkldnn_param;
+    const bool has_bias  = !full_param.default_param.no_bias;
     const bool quantized = mkldnn_param.quantized;
-    const bool sum_input_quantized = quantized && mkldnn_param.with_sum &&
-                                     !mkldnn_param.enable_float_output;
+    const bool sum_input_quantized =
+        quantized && mkldnn_param.with_sum && !mkldnn_param.enable_float_output;
     const bool channel_wise = quantized && mkldnn_param.channel_wise_quantize.has_value() &&
                               mkldnn_param.channel_wise_quantize.value();
 
@@ -69,18 +68,18 @@ class FCInputIndex {
     weight        = index++;
     bias          = has_bias ? index++ : 0;
     num_quantized = index + (sum_input_quantized ? 1 : 0);
-    sum           = mkldnn_param.with_sum ? index++: 0;
+    sum           = mkldnn_param.with_sum ? index++ : 0;
     num_base      = index;
 
-    data_min      = quantized ? index++ : 0;
-    data_max      = quantized ? index++ : 0;
-    weight_min    = (quantized && !channel_wise) ? index++ : 0;
-    weight_max    = (quantized && !channel_wise) ? index++ : 0;
-    bias_min      = (quantized && !channel_wise && has_bias) ? index++ : 0;
-    bias_max      = (quantized && !channel_wise && has_bias) ? index++ : 0;
-    sum_min       = sum_input_quantized ? index++ : 0;
-    sum_max       = sum_input_quantized ? index++ : 0;
-    num_total     = index;
+    data_min   = quantized ? index++ : 0;
+    data_max   = quantized ? index++ : 0;
+    weight_min = (quantized && !channel_wise) ? index++ : 0;
+    weight_max = (quantized && !channel_wise) ? index++ : 0;
+    bias_min   = (quantized && !channel_wise && has_bias) ? index++ : 0;
+    bias_max   = (quantized && !channel_wise && has_bias) ? index++ : 0;
+    sum_min    = sum_input_quantized ? index++ : 0;
+    sum_max    = sum_input_quantized ? index++ : 0;
+    num_total  = index;
   }
 
   // true if sum input is used and it is float number
@@ -89,7 +88,7 @@ class FCInputIndex {
   int GetBase() const { return num_base; }
 
   // return number of standard inputs which are quantized (represented as integer)
-  int GetQuantized() const { return num_quantized;}
+  int GetQuantized() const { return num_quantized; }
 
   // Represent index of particular input in the input vector:
   int data;
@@ -111,18 +110,21 @@ class FCInputIndex {
   int num_quantized;  // Number of standard inputs which are quantized
 };
 
-
 class SgMKLDNNFCOp {
  public:
   explicit SgMKLDNNFCOp(const nnvm::NodeAttrs& attrs)
       : subgraph_sym_(*attrs.subgraphs[0]),
         full_param_(nnvm::get<MKLDNNFCFullParam>(attrs.parsed)) {}
 
-  void Forward(const OpContext& ctx, const std::vector<NDArray>& inputs,
-               const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs);
+  void Forward(const OpContext& ctx,
+               const std::vector<NDArray>& inputs,
+               const std::vector<OpReqType>& req,
+               const std::vector<NDArray>& outputs);
 
-  void Backward(const OpContext& ctx, const std::vector<NDArray>& inputs,
-                const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs) {
+  void Backward(const OpContext& ctx,
+                const std::vector<NDArray>& inputs,
+                const std::vector<OpReqType>& req,
+                const std::vector<NDArray>& outputs) {
     LOG(FATAL) << "Not implemented: subgraph mkldnn fully connected only supports "
                   "inference computation.";
   }
@@ -155,47 +157,47 @@ class SgMKLDNNFCOp {
   std::vector<float> weight_scales_;
 };
 
-void SgMKLDNNFCOp::Forward(const OpContext &ctx,
-                           const std::vector<NDArray> &in_data,
-                           const std::vector<OpReqType> &req,
-                           const std::vector<NDArray> &out_data) {
-  auto &mkldnn_param        = full_param_.mkldnn_param;
-  auto &default_param       = full_param_.default_param;
-  const bool has_bias       = !default_param.no_bias;
-  const bool quantized      = mkldnn_param.quantized;
-  const bool out_quantized  = mkldnn_param.quantized && !mkldnn_param.enable_float_output;
-  const bool channel_wise   = quantized && mkldnn_param.channel_wise_quantize.has_value() &&
-                              mkldnn_param.channel_wise_quantize.value();
+void SgMKLDNNFCOp::Forward(const OpContext& ctx,
+                           const std::vector<NDArray>& in_data,
+                           const std::vector<OpReqType>& req,
+                           const std::vector<NDArray>& out_data) {
+  auto& mkldnn_param       = full_param_.mkldnn_param;
+  auto& default_param      = full_param_.default_param;
+  const bool has_bias      = !default_param.no_bias;
+  const bool quantized     = mkldnn_param.quantized;
+  const bool out_quantized = mkldnn_param.quantized && !mkldnn_param.enable_float_output;
+  const bool channel_wise  = quantized && mkldnn_param.channel_wise_quantize.has_value() &&
+                            mkldnn_param.channel_wise_quantize.value();
 
   const FCInputIndex idx(full_param_);
 
   CHECK_EQ(in_data.size(), idx.GetTotal());
 
-  int index = 0;
-  const int out_index = index++;
+  int index               = 0;
+  const int out_index     = index++;
   const int out_min_index = out_quantized ? index++ : 0;
   const int out_max_index = out_quantized ? index++ : 0;
-  CHECK_EQ(out_data.size(), index);   // index is equal to total number of outpits
+  CHECK_EQ(out_data.size(), index);  // index is equal to total number of outpits
 
-  float min_data    = 0.0f;
-  float max_data    = 0.0f;
-  float min_weight  = 0.0f;
-  float max_weight  = 0.0f;
-  float min_bias    = 0.0f;
-  float max_bias    = 0.0f;
+  float min_data   = 0.0f;
+  float max_data   = 0.0f;
+  float min_weight = 0.0f;
+  float max_weight = 0.0f;
+  float min_bias   = 0.0f;
+  float max_bias   = 0.0f;
 
   const float sum_min = idx.sum_min ? in_data[idx.sum_min].data().dptr<float>()[0] : 0.0;
   const float sum_max = idx.sum_max ? in_data[idx.sum_max].data().dptr<float>()[0] : 0.0;
 
-  NDArray data = in_data[idx.data];
-  const NDArray &weight = in_data[idx.weight];
+  NDArray data          = in_data[idx.data];
+  const NDArray& weight = in_data[idx.weight];
   NDArray output;
 
   if (mkldnn_param.with_sum) {
     if (!initialized_) {
       // TODO(zhennan): Currently, mkldnn fallback mechanism will break inplace option,
       // which make check (req[out_index] == kWriteInplace) useless.
-      auto in_mkl_mem = in_data[idx.sum].GetMKLDNNData();
+      auto in_mkl_mem  = in_data[idx.sum].GetMKLDNNData();
       auto out_mkl_mem = out_data[out_index].GetMKLDNNData();
       if (in_mkl_mem->get_data_handle() == out_mkl_mem->get_data_handle()) {
         inplace_ = true;
@@ -205,11 +207,11 @@ void SgMKLDNNFCOp::Forward(const OpContext &ctx,
       output = in_data[idx.sum];
     } else {
       // Not in place: copy in_data[idx.sum] into outputs[out_index].
-      auto in_mkl_mem = in_data[idx.sum].GetMKLDNNData();
+      auto in_mkl_mem  = in_data[idx.sum].GetMKLDNNData();
       auto out_mkl_mem = out_data[out_index].GetMKLDNNData();
       if (out_data[out_index].dtype() == mshadow::kInt32) {
-        auto mem_desc = in_mkl_mem->get_desc();
-        auto this_dtype = get_mkldnn_type(mshadow::kInt32);
+        auto mem_desc           = in_mkl_mem->get_desc();
+        auto this_dtype         = get_mkldnn_type(mshadow::kInt32);
         mem_desc.data.data_type = static_cast<mkldnn_data_type_t>(this_dtype);
         mkldnn_mem_ptr tmp_mem(new mkldnn::memory(mem_desc, CpuEngine::Get()->get_engine(),
                                                   out_mkl_mem->get_data_handle()));
@@ -265,20 +267,20 @@ void SgMKLDNNFCOp::Forward(const OpContext &ctx,
 
   if (!initialized_) {
     const auto nthreads = engine::OpenMP::Get()->GetRecommendedOMPThreadCount();
-    const auto engine = CpuEngine::Get()->get_engine();
-    cached_min_data_ = min_data;
-    cached_max_data_ = max_data;
-    cached_min_weight_ = min_weight;
-    cached_max_weight_ = max_weight;
-    weight_ver_ = weight.version();
-    cached_weight_ = weight;
-    cached_sum_min_ = sum_min;
-    cached_sum_max_ = sum_max;
+    const auto engine   = CpuEngine::Get()->get_engine();
+    cached_min_data_    = min_data;
+    cached_max_data_    = max_data;
+    cached_min_weight_  = min_weight;
+    cached_max_weight_  = max_weight;
+    weight_ver_         = weight.version();
+    cached_weight_      = weight;
+    cached_sum_min_     = sum_min;
+    cached_sum_max_     = sum_max;
     if (has_bias) {
       cached_min_bias_ = min_bias;
       cached_max_bias_ = max_bias;
-      bias_ver_ = in_data[idx.bias].version();
-      cached_bias_ = in_data[idx.bias];
+      bias_ver_        = in_data[idx.bias].version();
+      cached_bias_     = in_data[idx.bias];
     } else {
       cached_bias_ = NDArray();
     }
@@ -371,10 +373,10 @@ void SgMKLDNNFCOp::Forward(const OpContext &ctx,
               // avoid overflow on bias
               bias_int32_rescale = bias_max_rescale;
               float weight_rescale =
-                bias_int32_rescale * bias_scale / data_scale_ / weight_scales_[0];
-              int8_t *weight_ptr = weight.data().dptr<int8_t>();
+                  bias_int32_rescale * bias_scale / data_scale_ / weight_scales_[0];
+              int8_t* weight_ptr = weight.data().dptr<int8_t>();
               size_t weight_size = weight.shape().Size();
-              #pragma omp parallel for num_threads(nthreads)
+#pragma omp parallel for num_threads(nthreads)
               for (index_t i = 0; i < static_cast<index_t>(weight_size); ++i) {
                 weight_ptr[i] = std::round(weight_ptr[i] * weight_rescale);
               }
@@ -383,11 +385,11 @@ void SgMKLDNNFCOp::Forward(const OpContext &ctx,
             NDArray bias = in_data[fullc::kBias];
             cached_bias_ =
                 NDArray(bias.storage_type(), bias.shape(), bias.ctx(), true, mshadow::kInt32);
-            int8_t *bias_ptr = bias.data().dptr<int8_t>();
-            int32_t *quantized_bias_ptr = cached_bias_.data().dptr<int32_t>();
-            size_t bias_size = bias.shape().Size();
+            int8_t* bias_ptr            = bias.data().dptr<int8_t>();
+            int32_t* quantized_bias_ptr = cached_bias_.data().dptr<int32_t>();
+            size_t bias_size            = bias.shape().Size();
 
-            #pragma omp parallel for num_threads(nthreads)
+#pragma omp parallel for num_threads(nthreads)
             for (index_t i = 0; i < static_cast<index_t>(bias_size); ++i) {
               quantized_bias_ptr[i] = std::round(bias_ptr[i] * bias_int32_rescale);
             }
@@ -396,7 +398,7 @@ void SgMKLDNNFCOp::Forward(const OpContext &ctx,
       }
 
       size_t num_channel = cached_weight_.shape()[0];
-      float out_scale = 1.0f;
+      float out_scale    = 1.0f;
       if (fuse_requantize || mkldnn_param.enable_float_output) {
         float tmp_scale_ = 1.0f;
         if (fuse_requantize) {
@@ -405,8 +407,8 @@ void SgMKLDNNFCOp::Forward(const OpContext &ctx,
             full_param_.eltwise_param.scale =
                 GetQuantizeScale(output.dtype(), cached_min_output_, cached_max_output_);
           } else {
-          out_scale = GetQuantizeScale(output.dtype(), cached_min_output_, cached_max_output_);
-          tmp_scale_ = out_scale / data_scale_;
+            out_scale  = GetQuantizeScale(output.dtype(), cached_min_output_, cached_max_output_);
+            tmp_scale_ = out_scale / data_scale_;
           }
         } else {
           tmp_scale_ = 1.0 / data_scale_;
@@ -439,10 +441,10 @@ void SgMKLDNNFCOp::Forward(const OpContext &ctx,
 
       if (mkldnn_param.with_sum && !mkldnn_param.enable_float_output) {
         float sum_in_scale =
-          GetQuantizeScale(in_data[idx.sum].dtype(), cached_sum_min_, cached_sum_max_);
+            GetQuantizeScale(in_data[idx.sum].dtype(), cached_sum_min_, cached_sum_max_);
         mkldnn_param.sum_scale = out_scale / sum_in_scale;
       }
-    }   // if (mkldnn_param.quantized)
+    }  // if (mkldnn_param.quantized)
 
     fwd_.reset(new MKLDNNFullyConnectedForward(full_param_, ctx.is_train, data, cached_weight_,
                                                (has_bias ? &cached_bias_ : nullptr), out_md));
@@ -477,11 +479,11 @@ void SgMKLDNNFCOp::Forward(const OpContext &ctx,
   }
 
   if (mkldnn_param.with_sum) {
-    const auto& output_mem = output.GetMKLDNNData();
+    const auto& output_mem   = output.GetMKLDNNData();
     const auto& out_mem_desc = output_mem->get_desc();
-    auto dst_mem_desc = fwd_->fwd_pd.dst_desc();
+    auto dst_mem_desc        = fwd_->fwd_pd.dst_desc();
     if (out_mem_desc != dst_mem_desc) {
-      auto tmp_out_mem = output.GetMKLDNNDataReorder(dst_mem_desc);
+      auto tmp_out_mem            = output.GetMKLDNNDataReorder(dst_mem_desc);
       dst_mem_desc.data.data_type = out_mem_desc.data.data_type;
       mkldnn_mem_ptr new_out_mem(new mkldnn::memory(dst_mem_desc, CpuEngine::Get()->get_engine(),
                                                     output_mem->get_data_handle()));
@@ -504,10 +506,10 @@ void SgMKLDNNFCOp::Forward(const OpContext &ctx,
   MKLDNNStream::Get()->Submit();
 
   if (mkldnn_param.quantized && !mkldnn_param.enable_float_output) {
-    float *min_output_ptr = out_data[out_min_index].data().dptr<float>();
-    float *max_output_ptr = out_data[out_max_index].data().dptr<float>();
-    *min_output_ptr = cached_min_output_;
-    *max_output_ptr = cached_max_output_;
+    float* min_output_ptr = out_data[out_min_index].data().dptr<float>();
+    float* max_output_ptr = out_data[out_max_index].data().dptr<float>();
+    *min_output_ptr       = cached_min_output_;
+    *max_output_ptr       = cached_max_output_;
   }
 }
 
@@ -599,11 +601,11 @@ static std::vector<std::string> SgMKLDNNFCListOutputNames(const NodeAttrs& attrs
 }
 
 template <typename T>
-static inline void FillBaseInputOutputInfo(const MKLDNNFCFullParam &param,
-                                           std::vector<T> *base_in_attrs,
-                                           std::vector<T> *base_out_attrs,
-                                           std::vector<T> *in_attrs,
-                                           std::vector<T> *out_attrs) {
+static inline void FillBaseInputOutputInfo(const MKLDNNFCFullParam& param,
+                                           std::vector<T>* base_in_attrs,
+                                           std::vector<T>* base_out_attrs,
+                                           std::vector<T>* in_attrs,
+                                           std::vector<T>* out_attrs) {
   auto base_num_inputs = FCInputIndex(param).GetBase();
 
   base_out_attrs->push_back(out_attrs->at(0));
@@ -612,14 +614,14 @@ static inline void FillBaseInputOutputInfo(const MKLDNNFCFullParam &param,
   }
 }
 
-static bool SgMKLDNNFCInferShape(const nnvm::NodeAttrs& attrs, mxnet::ShapeVector* in_shapes,
+static bool SgMKLDNNFCInferShape(const nnvm::NodeAttrs& attrs,
+                                 mxnet::ShapeVector* in_shapes,
                                  mxnet::ShapeVector* out_shapes) {
   auto const& full_param = nnvm::get<MKLDNNFCFullParam>(attrs.parsed);
   if (full_param.mkldnn_param.quantized) {
     mxnet::ShapeVector base_in_shapes;
     mxnet::ShapeVector base_out_shapes;
-    FillBaseInputOutputInfo(full_param, &base_in_shapes, &base_out_shapes,
-                            in_shapes, out_shapes);
+    FillBaseInputOutputInfo(full_param, &base_in_shapes, &base_out_shapes, in_shapes, out_shapes);
     bool ret = DefaultSubgraphOpShape(attrs, &base_in_shapes, &base_out_shapes);
 
     for (size_t i = 0; i < in_shapes->size(); ++i) {
@@ -640,7 +642,8 @@ static bool SgMKLDNNFCInferShape(const nnvm::NodeAttrs& attrs, mxnet::ShapeVecto
   }
 }
 
-static bool SgMKLDNNFCInferType(const nnvm::NodeAttrs& attrs, std::vector<int>* in_types,
+static bool SgMKLDNNFCInferType(const nnvm::NodeAttrs& attrs,
+                                std::vector<int>* in_types,
                                 std::vector<int>* out_types) {
   auto const& full_param = nnvm::get<MKLDNNFCFullParam>(attrs.parsed);
   if (full_param.mkldnn_param.quantized) {
@@ -650,30 +653,28 @@ static bool SgMKLDNNFCInferType(const nnvm::NodeAttrs& attrs, std::vector<int>* 
       channel_wise = true;
     }
     size_t num_integer_inputs = FCInputIndex(full_param).GetQuantized();
-    CHECK(in_types->at(0) == mshadow::kInt8 ||
-          in_types->at(0) == mshadow::kUint8)
-        << "QuantizedFullyConnected only supports int8/uint8 input, while "
-        << in_types->at(0) << " is given.";
+    CHECK(in_types->at(0) == mshadow::kInt8 || in_types->at(0) == mshadow::kUint8)
+        << "QuantizedFullyConnected only supports int8/uint8 input, while " << in_types->at(0)
+        << " is given.";
     if (channel_wise) {
       for (size_t i = 1; i < in_types->size(); ++i) {
         TYPE_ASSIGN_CHECK(*in_types, i, mshadow::kFloat32);
       }
     } else {
-        TYPE_ASSIGN_CHECK(*in_types, 1, mshadow::kInt8);
-        if (!full_param.default_param.no_bias) {
-          if (in_types->at(2) == -1) {
-            TYPE_ASSIGN_CHECK(*in_types, 2, mshadow::kInt32);
-          } else {
-            CHECK(in_types->at(2) == mshadow::kInt8 ||
-                  in_types->at(2) == mshadow::kInt32)
-                << "QuantizedFullyConnected only supports int8/int32 bias, "
-                   "while "
-                << in_types->at(2) << " is given.";
-          }
+      TYPE_ASSIGN_CHECK(*in_types, 1, mshadow::kInt8);
+      if (!full_param.default_param.no_bias) {
+        if (in_types->at(2) == -1) {
+          TYPE_ASSIGN_CHECK(*in_types, 2, mshadow::kInt32);
+        } else {
+          CHECK(in_types->at(2) == mshadow::kInt8 || in_types->at(2) == mshadow::kInt32)
+              << "QuantizedFullyConnected only supports int8/int32 bias, "
+                 "while "
+              << in_types->at(2) << " is given.";
         }
-        for (size_t i = num_integer_inputs; i < in_types->size(); ++i) {
-          TYPE_ASSIGN_CHECK(*in_types, i, mshadow::kFloat32);
-        }
+      }
+      for (size_t i = num_integer_inputs; i < in_types->size(); ++i) {
+        TYPE_ASSIGN_CHECK(*in_types, i, mshadow::kFloat32);
+      }
     }
 
     if (full_param.mkldnn_param.enable_float_output) {
@@ -698,17 +699,18 @@ static bool SgMKLDNNFCInferType(const nnvm::NodeAttrs& attrs, std::vector<int>* 
   }
 }
 
-static bool SgMKLDNNFCStorageType(const nnvm::NodeAttrs& attrs, const int dev_mask,
-                                  DispatchMode* dispatch_mode, std::vector<int>* in_attrs,
+static bool SgMKLDNNFCStorageType(const nnvm::NodeAttrs& attrs,
+                                  const int dev_mask,
+                                  DispatchMode* dispatch_mode,
+                                  std::vector<int>* in_attrs,
                                   std::vector<int>* out_attrs) {
   auto const& full_param = nnvm::get<MKLDNNFCFullParam>(attrs.parsed);
   if (full_param.mkldnn_param.quantized) {
     std::vector<int> base_in_attrs;
     std::vector<int> base_out_attrs;
-    FillBaseInputOutputInfo(full_param, &base_in_attrs, &base_out_attrs,
-                            in_attrs, out_attrs);
-    bool ret = DefaultSubgraphOpStorageType(attrs, dev_mask, dispatch_mode,
-                                            &base_in_attrs, &base_out_attrs);
+    FillBaseInputOutputInfo(full_param, &base_in_attrs, &base_out_attrs, in_attrs, out_attrs);
+    bool ret = DefaultSubgraphOpStorageType(attrs, dev_mask, dispatch_mode, &base_in_attrs,
+                                            &base_out_attrs);
 
     for (size_t i = 0; i < in_attrs->size(); ++i) {
       if (i < base_in_attrs.size())
@@ -728,10 +730,8 @@ static bool SgMKLDNNFCStorageType(const nnvm::NodeAttrs& attrs, const int dev_ma
   }
 }
 
-
-std::vector<std::pair<int, int>> SgMKLDNNFCInplaceOption(
-    const NodeAttrs &attrs) {
-  auto const &param = nnvm::get<MKLDNNFCFullParam>(attrs.parsed);
+std::vector<std::pair<int, int>> SgMKLDNNFCInplaceOption(const NodeAttrs& attrs) {
+  auto const& param = nnvm::get<MKLDNNFCFullParam>(attrs.parsed);
   if (param.mkldnn_param.with_sum) {
     return std::vector<std::pair<int, int>>{{FCInputIndex(param).sum, 0}};
   } else {
@@ -739,16 +739,17 @@ std::vector<std::pair<int, int>> SgMKLDNNFCInplaceOption(
   }
 }
 
-
-static OpStatePtr CreateSgMKLDNNFCState(const nnvm::NodeAttrs &attrs,
+static OpStatePtr CreateSgMKLDNNFCState(const nnvm::NodeAttrs& attrs,
                                         Context ctx,
-                                        const mxnet::ShapeVector &in_shapes,
-                                        const std::vector<int> &in_types) {
+                                        const mxnet::ShapeVector& in_shapes,
+                                        const std::vector<int>& in_types) {
   return OpStatePtr::Create<SgMKLDNNFCOp>(attrs);
 }
 
-static void SgMKLDNNFCForward(const OpStatePtr& state_pointer, const OpContext& ctx,
-                              const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+static void SgMKLDNNFCForward(const OpStatePtr& state_pointer,
+                              const OpContext& ctx,
+                              const std::vector<NDArray>& inputs,
+                              const std::vector<OpReqType>& req,
                               const std::vector<NDArray>& outputs) {
   SgMKLDNNFCOp& op = state_pointer.get_state<SgMKLDNNFCOp>();
   op.Forward(ctx, inputs, req, outputs);
@@ -768,7 +769,8 @@ nnvm::ObjectPtr SgMKLDNNFCQuantizedOp(const NodeAttrs& attrs) {
   return node;
 }
 
-static bool SgMKLDNNAvoidFCQuantizeInput(const NodeAttrs& attrs, const size_t index_to_check,
+static bool SgMKLDNNAvoidFCQuantizeInput(const NodeAttrs& attrs,
+                                         const size_t index_to_check,
                                          const std::string quantize_granularity) {
   auto const& full_param = nnvm::get<MKLDNNFCFullParam>(attrs.parsed);
   std::unordered_set<size_t> avoid_indexes;
@@ -780,47 +782,47 @@ static bool SgMKLDNNAvoidFCQuantizeInput(const NodeAttrs& attrs, const size_t in
     }
   }
   if (idx.IsSumInputFloat()) {
-      avoid_indexes.insert(idx.sum);
+    avoid_indexes.insert(idx.sum);
   }
   return avoid_indexes.count(index_to_check);
 }
 
 NNVM_REGISTER_OP(_sg_mkldnn_fully_connected)
-.describe(R"code(_sg_mkldnn_fully_connected)code" ADD_FILELINE)
-.set_num_inputs([](const NodeAttrs& attrs) {
-  auto const &full_param = nnvm::get<MKLDNNFCFullParam>(attrs.parsed);
-  return FCInputIndex(full_param).GetTotal();
-})
-.set_num_outputs([](const NodeAttrs& attrs) {
-  auto const &full_param = nnvm::get<MKLDNNFCFullParam>(attrs.parsed);
-  return (full_param.mkldnn_param.quantized &&
-          !full_param.mkldnn_param.enable_float_output) ? 3 : 1;
-})
-.set_attr_parser(SgMKLDNNFCParamParser)
-.set_attr<nnvm::FListInputNames>("FListInputNames", SgMKLDNNFCListInputNames)
-.set_attr<nnvm::FListOutputNames>("FListOutputNames", SgMKLDNNFCListOutputNames)
-.set_attr<mxnet::FInferShape>("FInferShape", SgMKLDNNFCInferShape)
-.set_attr<nnvm::FInferType>("FInferType", SgMKLDNNFCInferType)
-.set_attr<FInferStorageType>("FInferStorageType", SgMKLDNNFCStorageType)
-.set_attr<FCreateOpState>("FCreateOpState", CreateSgMKLDNNFCState)
-.set_attr<FStatefulComputeEx>("FStatefulComputeEx<cpu>", SgMKLDNNFCForward)
-.set_attr<bool>("TIsMKLDNN", true)
-// TODO(Xinyu): a temp solution to enable GluonCV INT8 flow,
-// will be reverted after the improvement of CachedOP is done.
-.set_attr<nnvm::FGradient>("FGradient", MakeZeroGradNodes)
-.set_attr<FResourceRequest>("FResourceRequest", [](const NodeAttrs& n) {
-  return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
-})
-.set_attr<nnvm::FMutateInputs>("FMutateInputs",
-                               DefaultSubgraphOpMutableInputs)
-.set_attr<std::string>("key_var_num_args", "num_args")
-.set_attr<nnvm::FInplaceOption>("FInplaceOption", SgMKLDNNFCInplaceOption)
-.set_attr<FQuantizable>("FQuantizable", [](const NodeAttrs& attrs) {
-    return QuantizeType::kMust;
-})
-.set_attr<FQuantizedOp>("FQuantizedOp", SgMKLDNNFCQuantizedOp)
-.set_attr<FNeedRequantize>("FNeedRequantize", [](const NodeAttrs& attrs) { return true; })
-.set_attr<FAvoidQuantizeInput>("FAvoidQuantizeInput", SgMKLDNNAvoidFCQuantizeInput);
+    .describe(R"code(_sg_mkldnn_fully_connected)code" ADD_FILELINE)
+    .set_num_inputs([](const NodeAttrs& attrs) {
+      auto const& full_param = nnvm::get<MKLDNNFCFullParam>(attrs.parsed);
+      return FCInputIndex(full_param).GetTotal();
+    })
+    .set_num_outputs([](const NodeAttrs& attrs) {
+      auto const& full_param = nnvm::get<MKLDNNFCFullParam>(attrs.parsed);
+      return (full_param.mkldnn_param.quantized && !full_param.mkldnn_param.enable_float_output)
+                 ? 3
+                 : 1;
+    })
+    .set_attr_parser(SgMKLDNNFCParamParser)
+    .set_attr<nnvm::FListInputNames>("FListInputNames", SgMKLDNNFCListInputNames)
+    .set_attr<nnvm::FListOutputNames>("FListOutputNames", SgMKLDNNFCListOutputNames)
+    .set_attr<mxnet::FInferShape>("FInferShape", SgMKLDNNFCInferShape)
+    .set_attr<nnvm::FInferType>("FInferType", SgMKLDNNFCInferType)
+    .set_attr<FInferStorageType>("FInferStorageType", SgMKLDNNFCStorageType)
+    .set_attr<FCreateOpState>("FCreateOpState", CreateSgMKLDNNFCState)
+    .set_attr<FStatefulComputeEx>("FStatefulComputeEx<cpu>", SgMKLDNNFCForward)
+    .set_attr<bool>("TIsMKLDNN", true)
+    // TODO(Xinyu): a temp solution to enable GluonCV INT8 flow,
+    // will be reverted after the improvement of CachedOP is done.
+    .set_attr<nnvm::FGradient>("FGradient", MakeZeroGradNodes)
+    .set_attr<FResourceRequest>("FResourceRequest",
+                                [](const NodeAttrs& n) {
+                                  return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
+                                })
+    .set_attr<nnvm::FMutateInputs>("FMutateInputs", DefaultSubgraphOpMutableInputs)
+    .set_attr<std::string>("key_var_num_args", "num_args")
+    .set_attr<nnvm::FInplaceOption>("FInplaceOption", SgMKLDNNFCInplaceOption)
+    .set_attr<FQuantizable>("FQuantizable",
+                            [](const NodeAttrs& attrs) { return QuantizeType::kMust; })
+    .set_attr<FQuantizedOp>("FQuantizedOp", SgMKLDNNFCQuantizedOp)
+    .set_attr<FNeedRequantize>("FNeedRequantize", [](const NodeAttrs& attrs) { return true; })
+    .set_attr<FAvoidQuantizeInput>("FAvoidQuantizeInput", SgMKLDNNAvoidFCQuantizeInput);
 
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/subgraph/mkldnn/mkldnn_fc_post_quantize_property.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_fc_post_quantize_property.h
@@ -147,8 +147,8 @@ class SgMKLDNNFCPostQuantizeProperty : public SubgraphProperty {
     return property;
   }
 
-  nnvm::ObjectPtr CreateSubgraphNode(
-      const nnvm::Symbol& sym, const int subgraph_id = 0) const override {
+  nnvm::ObjectPtr CreateSubgraphNode(const nnvm::Symbol& sym,
+                                     const int subgraph_id = 0) const override {
     nnvm::ObjectPtr fc_node         = nullptr;
     nnvm::ObjectPtr requantize_node = nullptr;
     nnvm::ObjectPtr dequantize_node = nullptr;
@@ -190,8 +190,8 @@ class SgMKLDNNFCPostQuantizeProperty : public SubgraphProperty {
     return selector;
   }
 
-  void ConnectSubgraphOutputs(
-      const nnvm::ObjectPtr n, std::vector<nnvm::NodeEntry*>* output_entries) const override {
+  void ConnectSubgraphOutputs(const nnvm::ObjectPtr n,
+                              std::vector<nnvm::NodeEntry*>* output_entries) const override {
     for (size_t i = 0; i < output_entries->size(); ++i) {
       auto entry_ptr = output_entries->at(i);
       *entry_ptr     = nnvm::NodeEntry{n, entry_ptr->index, 0};

--- a/src/operator/subgraph/mkldnn/mkldnn_fc_post_quantize_property.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_fc_post_quantize_property.h
@@ -22,7 +22,7 @@
  * \file mkldnn_fc_post_quantize_property.cc
  * \brief Partition gragph property for MKLDNN Quantized FullyConnected operator
  * \author Ciyong Chen
-*/
+ */
 
 #ifndef MXNET_OPERATOR_SUBGRAPH_MKLDNN_MKLDNN_FC_POST_QUANTIZE_PROPERTY_H_
 #define MXNET_OPERATOR_SUBGRAPH_MKLDNN_MKLDNN_FC_POST_QUANTIZE_PROPERTY_H_
@@ -54,15 +54,13 @@ class SgMKLDNNFCPostQuantizeSelector : public SubgraphSelector {
   bool disable_all;
   bool disable_float_output;
   SelectStatus status;
-  std::vector<const nnvm::Node *> matched_list;
+  std::vector<const nnvm::Node*> matched_list;
 
  public:
-  explicit SgMKLDNNFCPostQuantizeSelector(const bool dis_all,
-                                          const bool dis_float_output)
-      : disable_all(dis_all),
-        disable_float_output(dis_float_output) {}
+  explicit SgMKLDNNFCPostQuantizeSelector(const bool dis_all, const bool dis_float_output)
+      : disable_all(dis_all), disable_float_output(dis_float_output) {}
 
-  bool Select(const nnvm::Node &n) override {
+  bool Select(const nnvm::Node& n) override {
     if ((!disable_all) && n.op() == Op::Get(QUANTIZED_FC_NAME)) {
       status = disable_all ? kSuccess : kStart;
       matched_list.clear();
@@ -72,18 +70,14 @@ class SgMKLDNNFCPostQuantizeSelector : public SubgraphSelector {
     return false;
   }
 
-  bool SelectInput(const nnvm::Node &n, const nnvm::Node &new_node) override {
-    return false;
-  }
+  bool SelectInput(const nnvm::Node& n, const nnvm::Node& new_node) override { return false; }
 
-  bool SelectOutput(const nnvm::Node &n, const nnvm::Node &new_node) override {
-    if (status == kFail || status == kSuccess || new_node.is_variable())
-      return false;
+  bool SelectOutput(const nnvm::Node& n, const nnvm::Node& new_node) override {
+    if (status == kFail || status == kSuccess || new_node.is_variable()) return false;
     // If n isn't the last matched node, then we encoutered a internal
     // branch, we should pop out the node behind n and stop fusion.
     if (matched_list.back() != &n) {
-      if (std::find(matched_list.begin(), matched_list.end(), &n) !=
-        matched_list.end()) {
+      if (std::find(matched_list.begin(), matched_list.end(), &n) != matched_list.end()) {
         while (matched_list.back() != &n) {
           matched_list.pop_back();
         }
@@ -96,9 +90,8 @@ class SgMKLDNNFCPostQuantizeSelector : public SubgraphSelector {
     switch (status) {
       case kStart:
         if (new_node.op() == Op::Get("_contrib_requantize")) {
-          auto const &param = nnvm::get<RequantizeParam>(new_node.attrs.parsed);
-          if (param.min_calib_range.has_value() &&
-              param.max_calib_range.has_value()) {
+          auto const& param = nnvm::get<RequantizeParam>(new_node.attrs.parsed);
+          if (param.min_calib_range.has_value() && param.max_calib_range.has_value()) {
             matched_list.push_back(&new_node);
             status = kRequantize;
             return true;
@@ -106,9 +99,9 @@ class SgMKLDNNFCPostQuantizeSelector : public SubgraphSelector {
         }
       case kRequantize:
         if ((!disable_float_output) && (new_node.op() == Op::Get("_contrib_dequantize"))) {
-            matched_list.push_back(&new_node);
-            status = kSuccess;
-            return true;
+          matched_list.push_back(&new_node);
+          status = kSuccess;
+          return true;
         }
       default:
         status = kSuccess;
@@ -116,16 +109,14 @@ class SgMKLDNNFCPostQuantizeSelector : public SubgraphSelector {
     }
   }
 
-  std::vector<nnvm::Node *> Filter(
-      const std::vector<nnvm::Node *> &candidates) override {
+  std::vector<nnvm::Node*> Filter(const std::vector<nnvm::Node*>& candidates) override {
     if ((status != kSuccess) || (matched_list.size() <= 1)) {
-      return std::vector<nnvm::Node *>(0);
+      return std::vector<nnvm::Node*>(0);
     } else {
-      std::vector<nnvm::Node *> ret;
+      std::vector<nnvm::Node*> ret;
       for (auto i : matched_list) {
-        auto non_const_i = const_cast<nnvm::Node *>(i);
-        if (std::find(candidates.begin(), candidates.end(), non_const_i) !=
-            candidates.end()) {
+        auto non_const_i = const_cast<nnvm::Node*>(i);
+        if (std::find(candidates.begin(), candidates.end(), non_const_i) != candidates.end()) {
           ret.push_back(non_const_i);
         }
       }
@@ -144,25 +135,25 @@ class SgMKLDNNFCPostQuantizeSelector : public SubgraphSelector {
 class SgMKLDNNFCPostQuantizeProperty : public SubgraphProperty {
  public:
   SgMKLDNNFCPostQuantizeProperty() {
-    disable_fuse_all = dmlc::GetEnv("MXNET_DISABLE_MKLDNN_QFC_FUSE_ALL", false);
+    disable_fuse_all     = dmlc::GetEnv("MXNET_DISABLE_MKLDNN_QFC_FUSE_ALL", false);
     disable_float_output = dmlc::GetEnv("MXNET_DISABLE_MKLDNN_QFC_FLOAT_OUTPUT", false);
   }
 
   static SubgraphPropertyPtr Create() {
-    static const std::string &name = "MKLDNN FullyConected post-quantization optimization pass";
-    auto property = std::make_shared<SgMKLDNNFCPostQuantizeProperty>();
+    static const std::string& name = "MKLDNN FullyConected post-quantization optimization pass";
+    auto property                  = std::make_shared<SgMKLDNNFCPostQuantizeProperty>();
     property->SetAttr<std::string>("property_name", name);
     property->SetAttr<bool>("inference_only", true);
     return property;
   }
 
-  nnvm::ObjectPtr CreateSubgraphNode(const nnvm::Symbol &sym,
-                                   const int subgraph_id = 0) const override {
-    nnvm::ObjectPtr fc_node = nullptr;
+  nnvm::ObjectPtr CreateSubgraphNode(
+      const nnvm::Symbol& sym, const int subgraph_id = 0) const override {
+    nnvm::ObjectPtr fc_node         = nullptr;
     nnvm::ObjectPtr requantize_node = nullptr;
     nnvm::ObjectPtr dequantize_node = nullptr;
 
-    DFSVisit(sym.outputs, [&](const nnvm::ObjectPtr &node) {
+    DFSVisit(sym.outputs, [&](const nnvm::ObjectPtr& node) {
       if (node->is_variable()) return;
       if (node->op() == Op::Get(QUANTIZED_FC_NAME)) {
         fc_node = node;
@@ -175,8 +166,7 @@ class SgMKLDNNFCPostQuantizeProperty : public SubgraphProperty {
 
     CHECK_NOTNULL(fc_node);
     CHECK_NOTNULL(requantize_node);
-    auto const &requantize_param =
-        nnvm::get<RequantizeParam>(requantize_node->attrs.parsed);
+    auto const& requantize_param = nnvm::get<RequantizeParam>(requantize_node->attrs.parsed);
     CHECK(requantize_param.min_calib_range.has_value());
     CHECK(requantize_param.max_calib_range.has_value());
 
@@ -196,17 +186,15 @@ class SgMKLDNNFCPostQuantizeProperty : public SubgraphProperty {
 
   SubgraphSelectorPtr CreateSubgraphSelector() const override {
     auto selector =
-        std::make_shared<SgMKLDNNFCPostQuantizeSelector>(disable_fuse_all,
-                                                         disable_float_output);
+        std::make_shared<SgMKLDNNFCPostQuantizeSelector>(disable_fuse_all, disable_float_output);
     return selector;
   }
 
   void ConnectSubgraphOutputs(
-      const nnvm::ObjectPtr n,
-      std::vector<nnvm::NodeEntry *> *output_entries) const override {
+      const nnvm::ObjectPtr n, std::vector<nnvm::NodeEntry*>* output_entries) const override {
     for (size_t i = 0; i < output_entries->size(); ++i) {
       auto entry_ptr = output_entries->at(i);
-      *entry_ptr = nnvm::NodeEntry{n, entry_ptr->index, 0};
+      *entry_ptr     = nnvm::NodeEntry{n, entry_ptr->index, 0};
     }
   }
 

--- a/src/operator/subgraph/mkldnn/mkldnn_fc_post_quantize_property.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_fc_post_quantize_property.h
@@ -71,10 +71,13 @@ class SgMKLDNNFCPostQuantizeSelector : public SubgraphSelector {
     return false;
   }
 
-  bool SelectInput(const nnvm::Node& n, const nnvm::Node& new_node) override { return false; }
+  bool SelectInput(const nnvm::Node& n, const nnvm::Node& new_node) override {
+    return false;
+  }
 
   bool SelectOutput(const nnvm::Node& n, const nnvm::Node& new_node) override {
-    if (status == kFail || status == kSuccess || new_node.is_variable()) return false;
+    if (status == kFail || status == kSuccess || new_node.is_variable())
+      return false;
     // If n isn't the last matched node, then we encoutered a internal
     // branch, we should pop out the node behind n and stop fusion.
     if (matched_list.back() != &n) {
@@ -155,7 +158,8 @@ class SgMKLDNNFCPostQuantizeProperty : public SubgraphProperty {
     nnvm::ObjectPtr dequantize_node = nullptr;
 
     DFSVisit(sym.outputs, [&](const nnvm::ObjectPtr& node) {
-      if (node->is_variable()) return;
+      if (node->is_variable())
+        return;
       if (node->op() == Op::Get(QUANTIZED_FC_NAME)) {
         fc_node = node;
       } else if (node->op() == Op::Get("_contrib_requantize")) {
@@ -171,8 +175,9 @@ class SgMKLDNNFCPostQuantizeProperty : public SubgraphProperty {
     CHECK(requantize_param.min_calib_range.has_value());
     CHECK(requantize_param.max_calib_range.has_value());
 
-    // When only fused quantized_fullyconnected and requantize, set min/max_cablib_range,
-    // When fused quantized_fullyconnected + requantize + dequantize, set dequantize flag to true.
+    // When only fused quantized_fullyconnected and requantize, set
+    // min/max_cablib_range, When fused quantized_fullyconnected + requantize +
+    // dequantize, set dequantize flag to true.
     if (dequantize_node != nullptr) {
       fc_node->attrs.dict["enable_float_output"] = "True";
     } else {

--- a/src/operator/subgraph/mkldnn/mkldnn_fc_post_quantize_property.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_fc_post_quantize_property.h
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <vector>
+
 #include "../../nn/fully_connected-inl.h"
 #include "../../quantization/requantize-inl.h"
 #include "../common.h"

--- a/src/operator/subgraph/mkldnn/mkldnn_fc_property.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_fc_property.h
@@ -68,10 +68,13 @@ class SgMKLDNNFCSelector : public SubgraphSelector {
     return false;
   }
 
-  bool SelectInput(const nnvm::Node& n, const nnvm::Node& new_node) override { return false; }
+  bool SelectInput(const nnvm::Node& n, const nnvm::Node& new_node) override {
+    return false;
+  }
 
   bool SelectOutput(const nnvm::Node& n, const nnvm::Node& new_node) override {
-    if (status_ == kFail || status_ == kSuccess || new_node.is_variable()) return false;
+    if (status_ == kFail || status_ == kSuccess || new_node.is_variable())
+      return false;
 
     // If n isn't the last matched node, then we encoutered a internal
     // branch, we should pop out the node behind n and stop fusion.
@@ -88,7 +91,8 @@ class SgMKLDNNFCSelector : public SubgraphSelector {
 
     switch (status_) {
       case kStart:
-        // Currently, For INT8 FC fusion, only supports relu/bounded_relu(clip)/abs.
+        // Currently, For INT8 FC fusion, only supports
+        // relu/bounded_relu(clip)/abs.
         if (new_node.op() == Op::Get("Activation")) {
           const ActivationParam& param = nnvm::get<ActivationParam>(new_node.attrs.parsed);
           if ((quantized_ && SupportQuantizedMKLDNNAct(param)) ||
@@ -184,7 +188,8 @@ class SgMKLDNNFCProperty : public SubgraphProperty {
     std::ostringstream node_name;
     node_name << "sg_mkldnn_";
     DFSVisit(new_sym.outputs, [&](const nnvm::ObjectPtr& node) {
-      if (node->is_variable()) return;
+      if (node->is_variable())
+        return;
       auto& sub_name = node->op()->name;
       if (sub_name == "FullyConnected") {
         node_name << "fully_connected_";

--- a/src/operator/subgraph/mkldnn/mkldnn_fc_property.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_fc_property.h
@@ -22,7 +22,7 @@
  * \file mkldnn_fc_property.cc
  * \brief Partition gragph property for FullyConnected operator
  * \author Ciyong Chen
-*/
+ */
 
 #ifndef MXNET_OPERATOR_SUBGRAPH_MKLDNN_MKLDNN_FC_PROPERTY_H_
 #define MXNET_OPERATOR_SUBGRAPH_MKLDNN_MKLDNN_FC_PROPERTY_H_
@@ -51,14 +51,13 @@ class SgMKLDNNFCSelector : public SubgraphSelector {
   bool disable_fc_eltwise_;
   bool quantized_;
   SelectStatus status_;
-  std::vector<const nnvm::Node *> matched_list_;
+  std::vector<const nnvm::Node*> matched_list_;
 
  public:
-  explicit SgMKLDNNFCSelector(const bool dis_fc_eltwise, bool quantized) :
-      disable_fc_eltwise_(dis_fc_eltwise),
-      quantized_(quantized) {}
+  explicit SgMKLDNNFCSelector(const bool dis_fc_eltwise, bool quantized)
+      : disable_fc_eltwise_(dis_fc_eltwise), quantized_(quantized) {}
 
-  bool Select(const nnvm::Node &n, const std::shared_ptr<NodeAttr>& node_attr) override {
+  bool Select(const nnvm::Node& n, const std::shared_ptr<NodeAttr>& node_attr) override {
     if (n.op() == Op::Get("FullyConnected") && SupportMKLDNNAttr(node_attr)) {
       status_ = disable_fc_eltwise_ ? kSuccess : kStart;
       matched_list_.clear();
@@ -68,19 +67,15 @@ class SgMKLDNNFCSelector : public SubgraphSelector {
     return false;
   }
 
-  bool SelectInput(const nnvm::Node &n, const nnvm::Node &new_node) override {
-    return false;
-  }
+  bool SelectInput(const nnvm::Node& n, const nnvm::Node& new_node) override { return false; }
 
-  bool SelectOutput(const nnvm::Node &n, const nnvm::Node &new_node) override {
-    if (status_ == kFail || status_ == kSuccess || new_node.is_variable())
-      return false;
+  bool SelectOutput(const nnvm::Node& n, const nnvm::Node& new_node) override {
+    if (status_ == kFail || status_ == kSuccess || new_node.is_variable()) return false;
 
     // If n isn't the last matched node, then we encoutered a internal
     // branch, we should pop out the node behind n and stop fusion.
     if (matched_list_.back() != &n) {
-      if (std::find(matched_list_.begin(), matched_list_.end(), &n) !=
-        matched_list_.end()) {
+      if (std::find(matched_list_.begin(), matched_list_.end(), &n) != matched_list_.end()) {
         while (matched_list_.back() != &n) {
           matched_list_.pop_back();
         }
@@ -94,7 +89,7 @@ class SgMKLDNNFCSelector : public SubgraphSelector {
       case kStart:
         // Currently, For INT8 FC fusion, only supports relu/bounded_relu(clip)/abs.
         if (new_node.op() == Op::Get("Activation")) {
-          const ActivationParam &param = nnvm::get<ActivationParam>(new_node.attrs.parsed);
+          const ActivationParam& param = nnvm::get<ActivationParam>(new_node.attrs.parsed);
           if ((quantized_ && SupportQuantizedMKLDNNAct(param)) ||
               (!quantized_ && SupportMKLDNNAct(param))) {
             matched_list_.push_back(&new_node);
@@ -103,9 +98,8 @@ class SgMKLDNNFCSelector : public SubgraphSelector {
           }
         }
         if (new_node.op() == Op::Get("LeakyReLU")) {
-          const LeakyReLUParam &param = nnvm::get<LeakyReLUParam>(new_node.attrs.parsed);
-          if (param.act_type == leakyrelu::kLeakyReLU ||
-              param.act_type == leakyrelu::kELU ||
+          const LeakyReLUParam& param = nnvm::get<LeakyReLUParam>(new_node.attrs.parsed);
+          if (param.act_type == leakyrelu::kLeakyReLU || param.act_type == leakyrelu::kELU ||
               param.act_type == leakyrelu::kGELU) {
             matched_list_.push_back(&new_node);
             status_ = kSuccess;
@@ -113,8 +107,7 @@ class SgMKLDNNFCSelector : public SubgraphSelector {
           }
         }
         if (!quantized_ && (new_node.op() == Op::Get("square") ||
-            new_node.op() == Op::Get("sqrt") ||
-            new_node.op() == Op::Get("exp"))) {
+                            new_node.op() == Op::Get("sqrt") || new_node.op() == Op::Get("exp"))) {
           matched_list_.push_back(&new_node);
           status_ = kSuccess;
           return true;
@@ -125,7 +118,7 @@ class SgMKLDNNFCSelector : public SubgraphSelector {
           return true;
         }
         if (new_node.op() == Op::Get("clip")) {
-          const ClipParam &param = nnvm::get<ClipParam>(new_node.attrs.parsed);
+          const ClipParam& param = nnvm::get<ClipParam>(new_node.attrs.parsed);
           if (param.a_min == 0.f) {
             matched_list_.push_back(&new_node);
             status_ = kSuccess;
@@ -140,16 +133,14 @@ class SgMKLDNNFCSelector : public SubgraphSelector {
     }
   }
 
-  std::vector<nnvm::Node *> Filter(
-      const std::vector<nnvm::Node *> &candidates) override {
+  std::vector<nnvm::Node*> Filter(const std::vector<nnvm::Node*>& candidates) override {
     if (status_ == kFail) {
-      return std::vector<nnvm::Node *>(0);
+      return std::vector<nnvm::Node*>(0);
     } else {
-      std::vector<nnvm::Node *> ret;
+      std::vector<nnvm::Node*> ret;
       for (auto i : matched_list_) {
-        auto non_const_i = const_cast<nnvm::Node *>(i);
-        if (std::find(candidates.begin(), candidates.end(), non_const_i) !=
-            candidates.end()) {
+        auto non_const_i = const_cast<nnvm::Node*>(i);
+        if (std::find(candidates.begin(), candidates.end(), non_const_i) != candidates.end()) {
           ret.push_back(non_const_i);
         }
       }
@@ -172,8 +163,8 @@ class SgMKLDNNFCProperty : public SubgraphProperty {
   }
 
   static SubgraphPropertyPtr Create() {
-    static const std::string &name = "MKLDNN FullyConnected optimization pass";
-    auto property = std::make_shared<SgMKLDNNFCProperty>();
+    static const std::string& name = "MKLDNN FullyConnected optimization pass";
+    auto property                  = std::make_shared<SgMKLDNNFCProperty>();
     property->SetAttr<std::string>("property_name", name);
     property->SetAttr<bool>("inference_only", true);
     if (dmlc::GetEnv("MXNET_DISABLE_MKLDNN_FC_OPT", 0)) {
@@ -182,8 +173,8 @@ class SgMKLDNNFCProperty : public SubgraphProperty {
     return property;
   }
 
-  nnvm::ObjectPtr CreateSubgraphNode(const nnvm::Symbol &sym,
-                                   const int subgraph_id = 0) const override {
+  nnvm::ObjectPtr CreateSubgraphNode(
+      const nnvm::Symbol& sym, const int subgraph_id = 0) const override {
     nnvm::ObjectPtr n = nnvm::Node::Create();
     // This op has single output, remove duplicated.
     auto last_node = sym.outputs[0].node;
@@ -191,19 +182,19 @@ class SgMKLDNNFCProperty : public SubgraphProperty {
     new_sym.outputs.emplace_back(last_node);
     std::ostringstream node_name;
     node_name << "sg_mkldnn_";
-    DFSVisit(new_sym.outputs, [&](const nnvm::ObjectPtr &node) {
+    DFSVisit(new_sym.outputs, [&](const nnvm::ObjectPtr& node) {
       if (node->is_variable()) return;
-      auto &sub_name = node->op()->name;
+      auto& sub_name = node->op()->name;
       if (sub_name == "FullyConnected") {
         node_name << "fully_connected_";
       } else if (SupportMKLDNNFCEltwiseFusion(sub_name)) {
-          node_name << "eltwise_";
-          n->attrs.dict["with_eltwise"] = "True";
+        node_name << "eltwise_";
+        n->attrs.dict["with_eltwise"] = "True";
       }
     });
     node_name << std::to_string(subgraph_id);
     n->attrs.name = node_name.str();
-    n->attrs.op = Op::Get("_sg_mkldnn_fully_connected");
+    n->attrs.op   = Op::Get("_sg_mkldnn_fully_connected");
     CHECK(n->attrs.op);
     n->attrs.subgraphs.emplace_back(std::make_shared<nnvm::Symbol>(new_sym));
     n->op()->attr_parser(&(n->attrs));
@@ -212,17 +203,16 @@ class SgMKLDNNFCProperty : public SubgraphProperty {
 
   SubgraphSelectorPtr CreateSubgraphSelector() const override {
     bool quantized = HasAttr("quantize") ? GetAttr<bool>("quantize") : false;
-    auto selector = std::make_shared<SgMKLDNNFCSelector>(disable_fc_eltwise_, quantized);
+    auto selector  = std::make_shared<SgMKLDNNFCSelector>(disable_fc_eltwise_, quantized);
     return selector;
   }
 
   void ConnectSubgraphOutputs(
-      const nnvm::ObjectPtr n,
-      std::vector<nnvm::NodeEntry *> *output_entries) const override {
+      const nnvm::ObjectPtr n, std::vector<nnvm::NodeEntry*>* output_entries) const override {
     // Connect all extern output entries to output[0]
     for (size_t i = 0; i < output_entries->size(); ++i) {
       auto entry_ptr = output_entries->at(i);
-      *entry_ptr = nnvm::NodeEntry{n, entry_ptr->index, 0};
+      *entry_ptr     = nnvm::NodeEntry{n, entry_ptr->index, 0};
     }
   }
 

--- a/src/operator/subgraph/mkldnn/mkldnn_fc_property.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_fc_property.h
@@ -30,10 +30,11 @@
 
 #include <string>
 #include <vector>
-#include "../common.h"
+
 #include "../../tensor/matrix_op-inl.h"
-#include "mkldnn_subgraph_base-inl.h"
+#include "../common.h"
 #include "mkldnn_fc-inl.h"
+#include "mkldnn_subgraph_base-inl.h"
 
 namespace mxnet {
 namespace op {

--- a/src/operator/subgraph/mkldnn/mkldnn_fc_property.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_fc_property.h
@@ -173,8 +173,8 @@ class SgMKLDNNFCProperty : public SubgraphProperty {
     return property;
   }
 
-  nnvm::ObjectPtr CreateSubgraphNode(
-      const nnvm::Symbol& sym, const int subgraph_id = 0) const override {
+  nnvm::ObjectPtr CreateSubgraphNode(const nnvm::Symbol& sym,
+                                     const int subgraph_id = 0) const override {
     nnvm::ObjectPtr n = nnvm::Node::Create();
     // This op has single output, remove duplicated.
     auto last_node = sym.outputs[0].node;
@@ -207,8 +207,8 @@ class SgMKLDNNFCProperty : public SubgraphProperty {
     return selector;
   }
 
-  void ConnectSubgraphOutputs(
-      const nnvm::ObjectPtr n, std::vector<nnvm::NodeEntry*>* output_entries) const override {
+  void ConnectSubgraphOutputs(const nnvm::ObjectPtr n,
+                              std::vector<nnvm::NodeEntry*>* output_entries) const override {
     // Connect all extern output entries to output[0]
     for (size_t i = 0; i < output_entries->size(); ++i) {
       auto entry_ptr = output_entries->at(i);

--- a/src/operator/subgraph/mkldnn/mkldnn_fc_sum_fuse.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_fc_sum_fuse.h
@@ -25,15 +25,16 @@
 #define MXNET_OPERATOR_SUBGRAPH_MKLDNN_MKLDNN_FC_SUM_FUSE_H_
 #if MXNET_USE_MKLDNN == 1
 
-#include <string>
-#include <vector>
 #include <memory>
+#include <string>
 #include <unordered_set>
 #include <utility>
-#include "../common.h"
+#include <vector>
+
 #include "../../tensor/matrix_op-inl.h"
-#include "mkldnn_subgraph_base-inl.h"
+#include "../common.h"
 #include "mkldnn_fc-inl.h"
+#include "mkldnn_subgraph_base-inl.h"
 
 namespace mxnet {
 namespace op {
@@ -50,15 +51,14 @@ class SgMKLDNNFCSumFuseSelector : public SubgraphSelector {
  private:
   bool quantized_;
   SelectStatus status_;
-  std::vector<const nnvm::Node *> matched_list_;
+  std::vector<const nnvm::Node*> matched_list_;
 
  public:
-  explicit SgMKLDNNFCSumFuseSelector(bool quantized) :
-      quantized_(quantized) {}
+  explicit SgMKLDNNFCSumFuseSelector(bool quantized) : quantized_(quantized) {}
 
-  bool Select(const nnvm::Node &n, const std::shared_ptr<NodeAttr>& node_attr) override {
+  bool Select(const nnvm::Node& n, const std::shared_ptr<NodeAttr>& node_attr) override {
     if (n.op() == Op::Get("_sg_mkldnn_fully_connected") && SupportMKLDNNAttr(node_attr)) {
-      auto const &fc_param = nnvm::get<MKLDNNFCFullParam>(n.attrs.parsed);
+      auto const& fc_param = nnvm::get<MKLDNNFCFullParam>(n.attrs.parsed);
       // TODO(anko) remove fc_param.mkldnn_param.quantized from if below
       //            to fuse even for not quantized?
       if (fc_param.mkldnn_param.enable_float_output && fc_param.mkldnn_param.quantized) {
@@ -71,19 +71,16 @@ class SgMKLDNNFCSumFuseSelector : public SubgraphSelector {
     return false;
   }
 
-  bool SelectInput(const nnvm::Node &n, const nnvm::Node &new_node) override {
-    return false;
-  }
+  bool SelectInput(const nnvm::Node& n, const nnvm::Node& new_node) override { return false; }
 
-  bool SelectOutput(const nnvm::Node &n, const nnvm::Node &new_node) override {
+  bool SelectOutput(const nnvm::Node& n, const nnvm::Node& new_node) override {
     if (status_ == kFail || status_ == kSuccess || new_node.is_variable()) {
       return false;
     }
     // If n isn't the last matched node, then we encoutered a internal
     // branch, we should pop out the node behind n and stop fusion.
     if (matched_list_.back() != &n) {
-      if (std::find(matched_list_.begin(), matched_list_.end(), &n) !=
-        matched_list_.end()) {
+      if (std::find(matched_list_.begin(), matched_list_.end(), &n) != matched_list_.end()) {
         while (matched_list_.back() != &n) {
           matched_list_.pop_back();
         }
@@ -105,16 +102,14 @@ class SgMKLDNNFCSumFuseSelector : public SubgraphSelector {
     }
   }
 
-  std::vector<nnvm::Node *> Filter(
-      const std::vector<nnvm::Node *> &candidates) override {
+  std::vector<nnvm::Node*> Filter(const std::vector<nnvm::Node*>& candidates) override {
     if (status_ == kFail) {
-      return std::vector<nnvm::Node *>(0);
+      return std::vector<nnvm::Node*>(0);
     } else {
-      std::vector<nnvm::Node *> ret;
+      std::vector<nnvm::Node*> ret;
       for (auto i : matched_list_) {
-        auto non_const_i = const_cast<nnvm::Node *>(i);
-        if (std::find(candidates.begin(), candidates.end(), non_const_i) !=
-            candidates.end()) {
+        auto non_const_i = const_cast<nnvm::Node*>(i);
+        if (std::find(candidates.begin(), candidates.end(), non_const_i) != candidates.end()) {
           ret.push_back(non_const_i);
         }
       }
@@ -135,8 +130,8 @@ class SgMKLDNNFCSumFuseProperty : public SubgraphProperty {
   SgMKLDNNFCSumFuseProperty() {}
 
   static SubgraphPropertyPtr Create() {
-    static const std::string &name = "MKLDNN FullyConnected post quantization second pass";
-    auto property = std::make_shared<SgMKLDNNFCSumFuseProperty>();
+    static const std::string& name = "MKLDNN FullyConnected post quantization second pass";
+    auto property                  = std::make_shared<SgMKLDNNFCSumFuseProperty>();
     property->SetAttr<std::string>("property_name", name);
     property->SetAttr<bool>("inference_only", true);
     if (dmlc::GetEnv("MXNET_DISABLE_MKLDNN_FC_SUM", 0)) {
@@ -145,14 +140,14 @@ class SgMKLDNNFCSumFuseProperty : public SubgraphProperty {
     return property;
   }
 
-  nnvm::ObjectPtr CreateSubgraphNode(const nnvm::Symbol &sym,
-                                   const int subgraph_id = 0) const override {
-    nnvm::ObjectPtr fc_node = nullptr;
+  nnvm::ObjectPtr CreateSubgraphNode(const nnvm::Symbol& sym,
+                                     const int subgraph_id = 0) const override {
+    nnvm::ObjectPtr fc_node     = nullptr;
     nnvm::ObjectPtr ew_add_node = nullptr;
 
-    DFSVisit(sym.outputs, [&](const nnvm::ObjectPtr &node) {
+    DFSVisit(sym.outputs, [&](const nnvm::ObjectPtr& node) {
       if (node->is_variable()) return;
-      auto &sub_name = node->op()->name;
+      auto& sub_name = node->op()->name;
       if (sub_name == "_sg_mkldnn_fully_connected") {
         fc_node = node;
       } else if (sub_name == "elemwise_add") {
@@ -166,10 +161,10 @@ class SgMKLDNNFCSumFuseProperty : public SubgraphProperty {
       auto fc_orginal = fc_node->attrs.subgraphs[0]->outputs[0].node;
       if (fc_orginal->op() == Op::Get("FullyConnected")) {
         nnvm::Symbol new_sym;
-        nnvm::NodeEntry &ew_input_with_fc = (ew_add_node->inputs[1].node == fc_node) ?
-                                        ew_add_node->inputs[1] :
-                                        ew_add_node->inputs[0];
-        ew_input_with_fc.node = fc_orginal;
+        nnvm::NodeEntry& ew_input_with_fc = (ew_add_node->inputs[1].node == fc_node)
+                                                ? ew_add_node->inputs[1]
+                                                : ew_add_node->inputs[0];
+        ew_input_with_fc.node             = fc_orginal;
         new_sym.outputs.emplace_back(ew_add_node);
         fc_node->attrs.subgraphs.clear();
         fc_node->attrs.subgraphs.emplace_back(std::make_shared<nnvm::Symbol>(new_sym));
@@ -182,54 +177,48 @@ class SgMKLDNNFCSumFuseProperty : public SubgraphProperty {
 
   SubgraphSelectorPtr CreateSubgraphSelector() const override {
     bool quantized = HasAttr("quantize") ? GetAttr<bool>("quantize") : false;
-    auto selector =
-      std::make_shared<SgMKLDNNFCSumFuseSelector>(quantized);
+    auto selector  = std::make_shared<SgMKLDNNFCSumFuseSelector>(quantized);
     return selector;
   }
 
-  void ConnectSubgraphOutputs(
-      const nnvm::ObjectPtr n,
-      std::vector<nnvm::NodeEntry *> *output_entries) const override {
+  void ConnectSubgraphOutputs(const nnvm::ObjectPtr n,
+                              std::vector<nnvm::NodeEntry*>* output_entries) const override {
     // Connect all extern output entries to output[0]
     for (size_t i = 0; i < output_entries->size(); ++i) {
       auto entry_ptr = output_entries->at(i);
-      *entry_ptr = nnvm::NodeEntry{n, entry_ptr->index, 0};
+      *entry_ptr     = nnvm::NodeEntry{n, entry_ptr->index, 0};
     }
   }
 
-  void ConnectSubgraphInputs(
-      const nnvm::ObjectPtr n, std::vector<nnvm::NodeEntry *> *input_entries,
-      std::vector<nnvm::NodeEntry> *orig_input_entries) const override {
-    auto sym = n->attrs.subgraphs[0];
-    auto const &fc_param = nnvm::get<MKLDNNFCFullParam>(n->attrs.parsed);
-    std::unordered_set<const nnvm::Node *> node_sets;
-    DFSVisit(sym->outputs, [&](const nnvm::ObjectPtr &node) {
-        if (node->is_variable()) return;
-        node_sets.insert(node.get());
-        if (node->op()->name == "elemwise_add") {
-          const size_t base_inputs = fc_param.default_param.no_bias ? 3 : 4;
+  void ConnectSubgraphInputs(const nnvm::ObjectPtr n,
+                             std::vector<nnvm::NodeEntry*>* input_entries,
+                             std::vector<nnvm::NodeEntry>* orig_input_entries) const override {
+    auto sym             = n->attrs.subgraphs[0];
+    auto const& fc_param = nnvm::get<MKLDNNFCFullParam>(n->attrs.parsed);
+    std::unordered_set<const nnvm::Node*> node_sets;
+    DFSVisit(sym->outputs, [&](const nnvm::ObjectPtr& node) {
+      if (node->is_variable()) return;
+      node_sets.insert(node.get());
+      if (node->op()->name == "elemwise_add") {
+        const size_t base_inputs = fc_param.default_param.no_bias ? 3 : 4;
 
-          // Make sure n is the left operand of sum, if not,
-          // switch sum operands sequence to ensure that
-          // the extra sum operand stays in the last of inputs.
-          if (node_sets.count(node->inputs[1].node.get())) {
-            std::swap(node->inputs[0],  node->inputs[1]);
-            std::rotate(input_entries->begin(),
-                        input_entries->begin() + 1,
-                        input_entries->begin() + base_inputs);
-            std::rotate(orig_input_entries->begin(),
-                        orig_input_entries->begin() + 1,
-                        orig_input_entries->begin() + base_inputs);
-          } else {
-            std::rotate(input_entries->begin() + base_inputs - 1 ,
-                        input_entries->end() - 1,
-                        input_entries->end());
-            std::rotate(orig_input_entries->begin() + base_inputs - 1,
-                        orig_input_entries->end() - 1 ,
-                        orig_input_entries->end());
-          }
+        // Make sure n is the left operand of sum, if not,
+        // switch sum operands sequence to ensure that
+        // the extra sum operand stays in the last of inputs.
+        if (node_sets.count(node->inputs[1].node.get())) {
+          std::swap(node->inputs[0], node->inputs[1]);
+          std::rotate(input_entries->begin(), input_entries->begin() + 1,
+                      input_entries->begin() + base_inputs);
+          std::rotate(orig_input_entries->begin(), orig_input_entries->begin() + 1,
+                      orig_input_entries->begin() + base_inputs);
+        } else {
+          std::rotate(input_entries->begin() + base_inputs - 1, input_entries->end() - 1,
+                      input_entries->end());
+          std::rotate(orig_input_entries->begin() + base_inputs - 1, orig_input_entries->end() - 1,
+                      orig_input_entries->end());
         }
-      });
+      }
+    });
     n->inputs = *orig_input_entries;
   }
 };

--- a/src/operator/subgraph/mkldnn/mkldnn_fc_sum_fuse.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_fc_sum_fuse.h
@@ -18,7 +18,8 @@
  */
 
 /*
-  \brief It fuses FC + SUM for floating point output in second post quantization pass
+  \brief It fuses FC + SUM for floating point output in second post quantization
+  pass
 */
 
 #ifndef MXNET_OPERATOR_SUBGRAPH_MKLDNN_MKLDNN_FC_SUM_FUSE_H_
@@ -71,7 +72,9 @@ class SgMKLDNNFCSumFuseSelector : public SubgraphSelector {
     return false;
   }
 
-  bool SelectInput(const nnvm::Node& n, const nnvm::Node& new_node) override { return false; }
+  bool SelectInput(const nnvm::Node& n, const nnvm::Node& new_node) override {
+    return false;
+  }
 
   bool SelectOutput(const nnvm::Node& n, const nnvm::Node& new_node) override {
     if (status_ == kFail || status_ == kSuccess || new_node.is_variable()) {
@@ -146,7 +149,8 @@ class SgMKLDNNFCSumFuseProperty : public SubgraphProperty {
     nnvm::ObjectPtr ew_add_node = nullptr;
 
     DFSVisit(sym.outputs, [&](const nnvm::ObjectPtr& node) {
-      if (node->is_variable()) return;
+      if (node->is_variable())
+        return;
       auto& sub_name = node->op()->name;
       if (sub_name == "_sg_mkldnn_fully_connected") {
         fc_node = node;
@@ -197,7 +201,8 @@ class SgMKLDNNFCSumFuseProperty : public SubgraphProperty {
     auto const& fc_param = nnvm::get<MKLDNNFCFullParam>(n->attrs.parsed);
     std::unordered_set<const nnvm::Node*> node_sets;
     DFSVisit(sym->outputs, [&](const nnvm::ObjectPtr& node) {
-      if (node->is_variable()) return;
+      if (node->is_variable())
+        return;
       node_sets.insert(node.get());
       if (node->op()->name == "elemwise_add") {
         const size_t base_inputs = fc_param.default_param.no_bias ? 3 : 4;
@@ -207,14 +212,18 @@ class SgMKLDNNFCSumFuseProperty : public SubgraphProperty {
         // the extra sum operand stays in the last of inputs.
         if (node_sets.count(node->inputs[1].node.get())) {
           std::swap(node->inputs[0], node->inputs[1]);
-          std::rotate(input_entries->begin(), input_entries->begin() + 1,
+          std::rotate(input_entries->begin(),
+                      input_entries->begin() + 1,
                       input_entries->begin() + base_inputs);
-          std::rotate(orig_input_entries->begin(), orig_input_entries->begin() + 1,
+          std::rotate(orig_input_entries->begin(),
+                      orig_input_entries->begin() + 1,
                       orig_input_entries->begin() + base_inputs);
         } else {
-          std::rotate(input_entries->begin() + base_inputs - 1, input_entries->end() - 1,
+          std::rotate(input_entries->begin() + base_inputs - 1,
+                      input_entries->end() - 1,
                       input_entries->end());
-          std::rotate(orig_input_entries->begin() + base_inputs - 1, orig_input_entries->end() - 1,
+          std::rotate(orig_input_entries->begin() + base_inputs - 1,
+                      orig_input_entries->end() - 1,
                       orig_input_entries->end());
         }
       }

--- a/src/operator/subgraph/mkldnn/mkldnn_post_quantize_align_scale_property.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_post_quantize_align_scale_property.h
@@ -50,8 +50,10 @@ class SgMKLDNNConcatPostQuantizeSelector : public SubgraphSelectorV2 {
   bool SelectInput(const BiDirectedNode& sn, const BiDirectedNode& snew_node) override {
     const auto& n        = *sn.node;
     const auto& new_node = *snew_node.node;
-    if (new_node.is_variable()) return false;
-    if (visit_list_.count(&n) == 0) return false;
+    if (new_node.is_variable())
+      return false;
+    if (visit_list_.count(&n) == 0)
+      return false;
     bool multiple_outputs = false;
     for (auto i : snew_node.outputs) {
       if (visit_list_.count(i.first) == 0) {
@@ -59,7 +61,8 @@ class SgMKLDNNConcatPostQuantizeSelector : public SubgraphSelectorV2 {
         break;
       }
     }
-    if (multiple_outputs) return false;
+    if (multiple_outputs)
+      return false;
     if (new_node.attrs.dict.count("min_calib_range") != 0 &&
         new_node.attrs.dict.count("max_calib_range") != 0) {
       matched_list_.push_back(&snew_node);
@@ -73,10 +76,12 @@ class SgMKLDNNConcatPostQuantizeSelector : public SubgraphSelectorV2 {
   }
 
   bool SelectOutput(const BiDirectedNode& sn, const BiDirectedNode& snew_node) override {
-    if (!select_output_) return false;
+    if (!select_output_)
+      return false;
     const auto& n        = *sn.node;
     const auto& new_node = *snew_node.node;
-    if (new_node.is_variable()) return false;
+    if (new_node.is_variable())
+      return false;
     if (visit_list_.count(&n) == 0) {
       return false;
     }
@@ -128,19 +133,19 @@ class SgMKLDNNPostQuantizeAlignScaleProperty : public SubgraphProperty {
   /*!
    * \brief Adjust selected nodes calibration range with maximum calib range.
    * For example,
-   * conv1 = mx.symbol.Convolution(data=data, weight=weight, name='conv1', num_filter=64,
-   *                               kernel=(3, 3), stride=(1, 1), no_bias=True)
-   * conv2 = mx.symbol.Convolution(data=data, weight=weight * 2, name='conv2', num_filter=64,
-   *                               kernel=(3, 3), stride=(1, 1), no_bias=True)
-   * conv3 = mx.symbol.Convolution(data=data, weight=weight * 3, name='conv3', num_filter=64,
-   *                               kernel=(3, 3), stride=(1, 1), no_bias=True)
-   * conv4 = mx.symbol.Convolution(data=data, weight=weight * 4, name='conv4', num_filter=64,
-   *                               kernel=(3, 3), stride=(1, 1), no_bias=True)
-   * concat = mx.symbol.Concat(*[conv1, conv2, conv3, conv4], name="concat", dim=1)
+   * conv1 = mx.symbol.Convolution(data=data, weight=weight, name='conv1',
+   * num_filter=64, kernel=(3, 3), stride=(1, 1), no_bias=True) conv2 =
+   * mx.symbol.Convolution(data=data, weight=weight * 2, name='conv2',
+   * num_filter=64, kernel=(3, 3), stride=(1, 1), no_bias=True) conv3 =
+   * mx.symbol.Convolution(data=data, weight=weight * 3, name='conv3',
+   * num_filter=64, kernel=(3, 3), stride=(1, 1), no_bias=True) conv4 =
+   * mx.symbol.Convolution(data=data, weight=weight * 4, name='conv4',
+   * num_filter=64, kernel=(3, 3), stride=(1, 1), no_bias=True) concat =
+   * mx.symbol.Concat(*[conv1, conv2, conv3, conv4], name="concat", dim=1)
    *
-   * This pass will collect the maximum calib range from conv1 to conv4, and apply it to all
-   * conv1 to conv4. Then concat don't need extra scale alignment operation. Performance and
-   * accuracy are both improved.
+   * This pass will collect the maximum calib range from conv1 to conv4, and
+   * apply it to all conv1 to conv4. Then concat don't need extra scale
+   * alignment operation. Performance and accuracy are both improved.
    */
   void AdjustSubgraphNode(const std::vector<nnvm::Node*>& subgraph_nodes,
                           const SubgraphSelectorV2Ptr& subgraph_selector,
@@ -150,14 +155,17 @@ class SgMKLDNNPostQuantizeAlignScaleProperty : public SubgraphProperty {
     for (size_t i = 0; i < subgraph_nodes.size(); ++i) {
       auto this_min_calib = dmlc::stof(subgraph_nodes[i]->attrs.dict["min_calib_range"]);
       auto this_max_calib = dmlc::stof(subgraph_nodes[i]->attrs.dict["max_calib_range"]);
-      if (min_calib > this_min_calib) min_calib = this_min_calib;
-      if (max_calib < this_max_calib) max_calib = this_max_calib;
+      if (min_calib > this_min_calib)
+        min_calib = this_min_calib;
+      if (max_calib < this_max_calib)
+        max_calib = this_max_calib;
     }
     for (size_t i = 0; i < subgraph_nodes.size(); ++i) {
       auto& n                         = *subgraph_nodes[i];
       n.attrs.dict["min_calib_range"] = std::to_string(min_calib);
       n.attrs.dict["max_calib_range"] = std::to_string(max_calib);
-      if (n.op()->attr_parser) n.op()->attr_parser(&(n.attrs));
+      if (n.op()->attr_parser)
+        n.op()->attr_parser(&(n.attrs));
     }
   }
 

--- a/src/operator/subgraph/mkldnn/mkldnn_post_quantize_align_scale_property.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_post_quantize_align_scale_property.h
@@ -22,8 +22,10 @@
 #if MXNET_USE_MKLDNN == 1
 
 #include <dmlc/strtonum.h>
+
 #include <string>
 #include <vector>
+
 #include "../common.h"
 #include "mkldnn_subgraph_base-inl.h"
 

--- a/src/operator/subgraph/mkldnn/mkldnn_post_quantize_align_scale_property.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_post_quantize_align_scale_property.h
@@ -62,9 +62,8 @@ class SgMKLDNNConcatPostQuantizeSelector : public SubgraphSelectorV2 {
         new_node.attrs.dict.count("max_calib_range") != 0) {
       matched_list_.push_back(&snew_node);
       return true;
-    } else if (
-        new_node.op() == Op::Get("_contrib_quantized_concat") ||
-        new_node.op() == Op::Get("_contrib_quantized_pooling")) {
+    } else if (new_node.op() == Op::Get("_contrib_quantized_concat") ||
+               new_node.op() == Op::Get("_contrib_quantized_pooling")) {
       visit_list_.insert(&new_node);
       return true;
     }
@@ -141,9 +140,9 @@ class SgMKLDNNPostQuantizeAlignScaleProperty : public SubgraphProperty {
    * conv1 to conv4. Then concat don't need extra scale alignment operation. Performance and
    * accuracy are both improved.
    */
-  void AdjustSubgraphNode(
-      const std::vector<nnvm::Node*>& subgraph_nodes,
-      const SubgraphSelectorV2Ptr& subgraph_selector, const int subgraph_id = 0) const override {
+  void AdjustSubgraphNode(const std::vector<nnvm::Node*>& subgraph_nodes,
+                          const SubgraphSelectorV2Ptr& subgraph_selector,
+                          const int subgraph_id = 0) const override {
     float min_calib = 0.0f;
     float max_calib = 0.0f;
     for (size_t i = 0; i < subgraph_nodes.size(); ++i) {

--- a/src/operator/subgraph/mkldnn/mkldnn_post_quantize_property.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_post_quantize_property.h
@@ -23,6 +23,7 @@
 #include <set>
 #include <string>
 #include <vector>
+
 #include "../../nn/mkldnn/mkldnn_convolution-inl.h"
 #include "../../quantization/requantize-inl.h"
 #include "../common.h"

--- a/src/operator/subgraph/mkldnn/mkldnn_post_quantize_property.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_post_quantize_property.h
@@ -73,10 +73,13 @@ class SgMKLDNNPostQuantizeSelector : public SubgraphSelector {
     return false;
   }
 
-  bool SelectInput(const nnvm::Node& n, const nnvm::Node& new_node) override { return false; }
+  bool SelectInput(const nnvm::Node& n, const nnvm::Node& new_node) override {
+    return false;
+  }
 
   bool SelectOutput(const nnvm::Node& n, const nnvm::Node& new_node) override {
-    if (status == kFail || status == kSuccess || new_node.is_variable()) return false;
+    if (status == kFail || status == kSuccess || new_node.is_variable())
+      return false;
     // If n isn't the last matched node, then we encoutered a internal
     // branch, we should pop out the node behind n and stop fusion.
     if (matched_list.back() != &n) {
@@ -130,7 +133,8 @@ class SgMKLDNNPostQuantizeProperty : public SubgraphProperty {
     nnvm::ObjectPtr fuse_node       = nullptr;
     nnvm::ObjectPtr requantize_node = nullptr;
     DFSVisit(sym.outputs, [&](const nnvm::ObjectPtr& node) {
-      if (node->is_variable()) return;
+      if (node->is_variable())
+        return;
       auto& op_name = node->op()->name;
       if (support_requantize_fusion_op_name.count(op_name)) {
         fuse_node = node;

--- a/src/operator/subgraph/mkldnn/mkldnn_post_quantize_property.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_post_quantize_property.h
@@ -43,7 +43,7 @@ class SgMKLDNNPostQuantizeSelector : public SubgraphSelector {
 
  private:
   SelectStatus status;
-  std::vector<const nnvm::Node *> matched_list;
+  std::vector<const nnvm::Node*> matched_list;
   std::set<std::string> support_requantize_fusion_op_name;
 
  public:
@@ -52,10 +52,10 @@ class SgMKLDNNPostQuantizeSelector : public SubgraphSelector {
     support_requantize_fusion_op_name.insert("_contrib_quantized_elemwise_add");
   }
 
-  bool Select(const nnvm::Node &n) override {
+  bool Select(const nnvm::Node& n) override {
     if (n.op() && support_requantize_fusion_op_name.count(n.op()->name)) {
       if (n.op()->name == "_sg_mkldnn_conv") {
-        auto const &param = nnvm::get<MKLDNNConvFusionParam>(n.attrs.parsed);
+        auto const& param = nnvm::get<MKLDNNConvFusionParam>(n.attrs.parsed);
         if (param.full_conv_param.mkldnn_param.quantized) {
           status = kStart;
           matched_list.clear();
@@ -72,13 +72,10 @@ class SgMKLDNNPostQuantizeSelector : public SubgraphSelector {
     return false;
   }
 
-  bool SelectInput(const nnvm::Node &n, const nnvm::Node &new_node) override {
-    return false;
-  }
+  bool SelectInput(const nnvm::Node& n, const nnvm::Node& new_node) override { return false; }
 
-  bool SelectOutput(const nnvm::Node &n, const nnvm::Node &new_node) override {
-    if (status == kFail || status == kSuccess || new_node.is_variable())
-      return false;
+  bool SelectOutput(const nnvm::Node& n, const nnvm::Node& new_node) override {
+    if (status == kFail || status == kSuccess || new_node.is_variable()) return false;
     // If n isn't the last matched node, then we encoutered a internal
     // branch, we should pop out the node behind n and stop fusion.
     if (matched_list.back() != &n) {
@@ -86,9 +83,8 @@ class SgMKLDNNPostQuantizeSelector : public SubgraphSelector {
       return false;
     }
     if (new_node.op()->name == "_contrib_requantize") {
-      auto const &param = nnvm::get<RequantizeParam>(new_node.attrs.parsed);
-      if (param.min_calib_range.has_value() &&
-          param.max_calib_range.has_value()) {
+      auto const& param = nnvm::get<RequantizeParam>(new_node.attrs.parsed);
+      if (param.min_calib_range.has_value() && param.max_calib_range.has_value()) {
         matched_list.push_back(&new_node);
         status = kSuccess;
         return true;
@@ -99,10 +95,9 @@ class SgMKLDNNPostQuantizeSelector : public SubgraphSelector {
     return false;
   }
 
-  std::vector<nnvm::Node *> Filter(
-      const std::vector<nnvm::Node *> &candidates) override {
+  std::vector<nnvm::Node*> Filter(const std::vector<nnvm::Node*>& candidates) override {
     if (status != kSuccess) {
-      return std::vector<nnvm::Node *>(0);
+      return std::vector<nnvm::Node*>(0);
     } else {
       return candidates;
     }
@@ -123,19 +118,19 @@ class SgMKLDNNPostQuantizeProperty : public SubgraphProperty {
     support_requantize_fusion_op_name.insert("_contrib_quantized_elemwise_add");
   }
   static SubgraphPropertyPtr Create() {
-    static const std::string &name = "MKLDNN post-quantization optimization pass";
-    auto property = std::make_shared<SgMKLDNNPostQuantizeProperty>();
+    static const std::string& name = "MKLDNN post-quantization optimization pass";
+    auto property                  = std::make_shared<SgMKLDNNPostQuantizeProperty>();
     property->SetAttr<std::string>("property_name", name);
     property->SetAttr<bool>("inference_only", true);
     return property;
   }
-  nnvm::ObjectPtr CreateSubgraphNode(const nnvm::Symbol &sym,
-                                   const int subgraph_id = 0) const override {
-    nnvm::ObjectPtr fuse_node = nullptr;
+  nnvm::ObjectPtr CreateSubgraphNode(
+      const nnvm::Symbol& sym, const int subgraph_id = 0) const override {
+    nnvm::ObjectPtr fuse_node       = nullptr;
     nnvm::ObjectPtr requantize_node = nullptr;
-    DFSVisit(sym.outputs, [&](const nnvm::ObjectPtr &node) {
+    DFSVisit(sym.outputs, [&](const nnvm::ObjectPtr& node) {
       if (node->is_variable()) return;
-      auto &op_name = node->op()->name;
+      auto& op_name = node->op()->name;
       if (support_requantize_fusion_op_name.count(op_name)) {
         fuse_node = node;
       } else if (op_name == "_contrib_requantize") {
@@ -144,8 +139,7 @@ class SgMKLDNNPostQuantizeProperty : public SubgraphProperty {
     });
     CHECK_NOTNULL(fuse_node);
     CHECK_NOTNULL(requantize_node);
-    auto const &requantize_param =
-        nnvm::get<RequantizeParam>(requantize_node->attrs.parsed);
+    auto const& requantize_param = nnvm::get<RequantizeParam>(requantize_node->attrs.parsed);
     CHECK(requantize_param.min_calib_range.has_value());
     CHECK(requantize_param.max_calib_range.has_value());
     fuse_node->attrs.dict["min_calib_range"] =
@@ -162,11 +156,10 @@ class SgMKLDNNPostQuantizeProperty : public SubgraphProperty {
   }
 
   void ConnectSubgraphOutputs(
-      const nnvm::ObjectPtr n,
-      std::vector<nnvm::NodeEntry *> *output_entries) const override {
+      const nnvm::ObjectPtr n, std::vector<nnvm::NodeEntry*>* output_entries) const override {
     for (size_t i = 0; i < output_entries->size(); ++i) {
       auto entry_ptr = output_entries->at(i);
-      *entry_ptr = nnvm::NodeEntry{n, entry_ptr->index, 0};
+      *entry_ptr     = nnvm::NodeEntry{n, entry_ptr->index, 0};
     }
   }
 

--- a/src/operator/subgraph/mkldnn/mkldnn_post_quantize_property.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_post_quantize_property.h
@@ -124,8 +124,8 @@ class SgMKLDNNPostQuantizeProperty : public SubgraphProperty {
     property->SetAttr<bool>("inference_only", true);
     return property;
   }
-  nnvm::ObjectPtr CreateSubgraphNode(
-      const nnvm::Symbol& sym, const int subgraph_id = 0) const override {
+  nnvm::ObjectPtr CreateSubgraphNode(const nnvm::Symbol& sym,
+                                     const int subgraph_id = 0) const override {
     nnvm::ObjectPtr fuse_node       = nullptr;
     nnvm::ObjectPtr requantize_node = nullptr;
     DFSVisit(sym.outputs, [&](const nnvm::ObjectPtr& node) {
@@ -155,8 +155,8 @@ class SgMKLDNNPostQuantizeProperty : public SubgraphProperty {
     return selector;
   }
 
-  void ConnectSubgraphOutputs(
-      const nnvm::ObjectPtr n, std::vector<nnvm::NodeEntry*>* output_entries) const override {
+  void ConnectSubgraphOutputs(const nnvm::ObjectPtr n,
+                              std::vector<nnvm::NodeEntry*>* output_entries) const override {
     for (size_t i = 0; i < output_entries->size(); ++i) {
       auto entry_ptr = output_entries->at(i);
       *entry_ptr     = nnvm::NodeEntry{n, entry_ptr->index, 0};

--- a/src/operator/subgraph/mkldnn/mkldnn_subgraph_property.cc
+++ b/src/operator/subgraph/mkldnn/mkldnn_subgraph_property.cc
@@ -33,8 +33,8 @@ namespace mxnet {
 namespace op {
 
 MXNET_REGISTER_SUBGRAPH_BACKEND(MKLDNN)
-.set_attr("enable", MKLDNNEnvSet())
-.set_attr("context", Context::CPU());
+    .set_attr("enable", MKLDNNEnvSet())
+    .set_attr("context", Context::CPU());
 
 MXNET_REGISTER_SUBGRAPH_PROPERTY(MKLDNN, SgMKLDNNConvProperty);
 
@@ -42,14 +42,11 @@ MXNET_REGISTER_SUBGRAPH_PROPERTY(MKLDNN, SgMKLDNNFCProperty);
 
 MXNET_REGISTER_SUBGRAPH_PROPERTY(MKLDNN, SgMKLDNNTransformerProperty);
 
-MXNET_REGISTER_SUBGRAPH_BACKEND(MKLDNN_QUANTIZE)
-.set_attr("context", Context::CPU());
+MXNET_REGISTER_SUBGRAPH_BACKEND(MKLDNN_QUANTIZE).set_attr("context", Context::CPU());
 
-MXNET_REGISTER_SUBGRAPH_PROPERTY(MKLDNN_QUANTIZE, SgMKLDNNConvProperty)
-.set_attr("quantize", true);
+MXNET_REGISTER_SUBGRAPH_PROPERTY(MKLDNN_QUANTIZE, SgMKLDNNConvProperty).set_attr("quantize", true);
 
-MXNET_REGISTER_SUBGRAPH_PROPERTY(MKLDNN_QUANTIZE, SgMKLDNNFCProperty)
-.set_attr("quantize", true);
+MXNET_REGISTER_SUBGRAPH_PROPERTY(MKLDNN_QUANTIZE, SgMKLDNNFCProperty).set_attr("quantize", true);
 
 MXNET_REGISTER_SUBGRAPH_PROPERTY(MKLDNN_QUANTIZE, SgMKLDNNTransformerProperty);
 

--- a/src/operator/subgraph/mkldnn/mkldnn_subgraph_property.cc
+++ b/src/operator/subgraph/mkldnn/mkldnn_subgraph_property.cc
@@ -20,14 +20,14 @@
 #if MXNET_USE_MKLDNN == 1
 
 #include "mkldnn_conv_property.h"
-#include "mkldnn_fc_property.h"
-#include "mkldnn_post_quantize_property.h"
-#include "mkldnn_fc_post_quantize_property.h"
-#include "mkldnn_fc_sum_fuse.h"
 #include "mkldnn_elemwisemul_post_quantize_property.h"
+#include "mkldnn_fc_post_quantize_property.h"
+#include "mkldnn_fc_property.h"
+#include "mkldnn_fc_sum_fuse.h"
 #include "mkldnn_post_quantize_align_scale_property.h"
-#include "mkldnn_transformer_property.h"
+#include "mkldnn_post_quantize_property.h"
 #include "mkldnn_transformer_post_quantize_property.h"
+#include "mkldnn_transformer_property.h"
 
 namespace mxnet {
 namespace op {
@@ -59,7 +59,7 @@ MXNET_REGISTER_SUBGRAPH_PROPERTY(MKLDNN_QUANTIZE, ElemwiseMulPostQuantizePropert
 
 MXNET_REGISTER_SUBGRAPH_PROPERTY(MKLDNN_QUANTIZE, SgMKLDNNPostQuantizeAlignScaleProperty);
 MXNET_REGISTER_SUBGRAPH_PROPERTY(MKLDNN_QUANTIZE, SgMKLDNNFCSumFuseProperty)
-.set_attr("quantize", true);
+    .set_attr("quantize", true);
 
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/subgraph/mkldnn/mkldnn_transformer-inl.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_transformer-inl.h
@@ -20,8 +20,8 @@
 #ifndef MXNET_OPERATOR_SUBGRAPH_MKLDNN_MKLDNN_TRANSFORMER_INL_H_
 #define MXNET_OPERATOR_SUBGRAPH_MKLDNN_MKLDNN_TRANSFORMER_INL_H_
 
-#include "../../mxnet_op.h"
 #include "../../mshadow_op.h"
+#include "../../mxnet_op.h"
 
 namespace mxnet {
 namespace op {

--- a/src/operator/subgraph/mkldnn/mkldnn_transformer-inl.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_transformer-inl.h
@@ -23,7 +23,6 @@
 #include "../../mxnet_op.h"
 #include "../../mshadow_op.h"
 
-
 namespace mxnet {
 namespace op {
 
@@ -34,22 +33,24 @@ struct MKLDNNSelfAttParam : public dmlc::Parameter<MKLDNNSelfAttParam> {
   dmlc::optional<float> min_calib_range;  // min float value calculated from calibration dataset
   dmlc::optional<float> max_calib_range;  // max float value calculated from calibration dataset
   DMLC_DECLARE_PARAMETER(MKLDNNSelfAttParam) {
-    DMLC_DECLARE_FIELD(heads)
-    .describe("Set number of heads");
-    DMLC_DECLARE_FIELD(quantized).set_default(false)
-    .describe("Whether it's a quantized InterleavedMatMul operator");
-    DMLC_DECLARE_FIELD(enable_float_output).set_default(false)
-    .describe("Whether to enable float32 output");
+    DMLC_DECLARE_FIELD(heads).describe("Set number of heads");
+    DMLC_DECLARE_FIELD(quantized).set_default(false).describe(
+        "Whether it's a quantized InterleavedMatMul operator");
+    DMLC_DECLARE_FIELD(enable_float_output)
+        .set_default(false)
+        .describe("Whether to enable float32 output");
     DMLC_DECLARE_FIELD(min_calib_range)
-    .set_default(dmlc::optional<float>())
-    .describe("The minimum scalar value in the form of float32 obtained "
-              "through calibration. If present, it will be used to by "
-              "quantized InterleavedMatMul op to calculate primitive scale");
+        .set_default(dmlc::optional<float>())
+        .describe(
+            "The minimum scalar value in the form of float32 obtained "
+            "through calibration. If present, it will be used to by "
+            "quantized InterleavedMatMul op to calculate primitive scale");
     DMLC_DECLARE_FIELD(max_calib_range)
-    .set_default(dmlc::optional<float>())
-    .describe("The maximum scalar value in the form of float32 obtained "
-              "through calibration. If present, it will be used to by "
-              "quantized InterleavedMatMul op to calculate primitive scale");
+        .set_default(dmlc::optional<float>())
+        .describe(
+            "The maximum scalar value in the form of float32 obtained "
+            "through calibration. If present, it will be used to by "
+            "quantized InterleavedMatMul op to calculate primitive scale");
   }
 };
 

--- a/src/operator/subgraph/mkldnn/mkldnn_transformer.cc
+++ b/src/operator/subgraph/mkldnn/mkldnn_transformer.cc
@@ -1,21 +1,21 @@
 /*
-* Licensed to the Apache Software Foundation (ASF) under one
-* or more contributor license agreements.  See the NOTICE file
-* distributed with this work for additional information
-* regarding copyright ownership.  The ASF licenses this file
-* to you under the Apache License, Version 2.0 (the
-* "License"); you may not use this file except in compliance
-* with the License.  You may obtain a copy of the License at
-*
-*   http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing,
-* software distributed under the License is distributed on an
-* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied.  See the License for the
-* specific language governing permissions and limitations
-* under the License.
-*/
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 #if MXNET_USE_MKLDNN == 1
 
@@ -34,10 +34,9 @@ namespace op {
 
 DMLC_REGISTER_PARAMETER(MKLDNNSelfAttParam);
 
-template<int base_num_inputs>
-static bool SgMKLDNNSelfAttShape(const NodeAttrs& attrs,
-                                 mxnet::ShapeVector* in_shapes,
-                                 mxnet::ShapeVector* out_shapes) {
+template <int base_num_inputs>
+static bool SgMKLDNNSelfAttShape(
+    const NodeAttrs& attrs, mxnet::ShapeVector* in_shapes, mxnet::ShapeVector* out_shapes) {
   const auto& param = nnvm::get<MKLDNNSelfAttParam>(attrs.parsed);
   if (param.quantized) {
     mxnet::ShapeVector base_in_shapes;
@@ -57,8 +56,8 @@ static bool SgMKLDNNSelfAttShape(const NodeAttrs& attrs,
     out_shapes->resize(3);
     out_shapes->at(0) = base_out_shapes[0];
     if (!param.enable_float_output) {
-      SHAPE_ASSIGN_CHECK(*out_shapes, 1, mxnet::TShape({1}));      // min output
-      SHAPE_ASSIGN_CHECK(*out_shapes, 2, mxnet::TShape({1}));      // max output
+      SHAPE_ASSIGN_CHECK(*out_shapes, 1, mxnet::TShape({1}));  // min output
+      SHAPE_ASSIGN_CHECK(*out_shapes, 2, mxnet::TShape({1}));  // max output
     }
 
     return ret;
@@ -67,28 +66,27 @@ static bool SgMKLDNNSelfAttShape(const NodeAttrs& attrs,
   }
 }
 
-static bool SgMKLDNNSelfAttQKInferType(const nnvm::NodeAttrs &attrs,
-                                       std::vector<int> *in_types,
-                                       std::vector<int> *out_types) {
+static bool SgMKLDNNSelfAttQKInferType(
+    const nnvm::NodeAttrs& attrs, std::vector<int>* in_types, std::vector<int>* out_types) {
   const auto& param = nnvm::get<MKLDNNSelfAttParam>(attrs.parsed);
   if (param.quantized) {
-     CHECK(in_types->at(0) == mshadow::kInt8)
-        << "QuantizedInterleavedMatMulSelfAttQK only supports int8 input, while "
-        << in_types->at(0) << " is given.";
+    CHECK(in_types->at(0) == mshadow::kInt8)
+        << "QuantizedInterleavedMatMulSelfAttQK only supports int8 input, while " << in_types->at(0)
+        << " is given.";
 
     TYPE_ASSIGN_CHECK(*in_types, 1, mshadow::kFloat32);  // min value
     TYPE_ASSIGN_CHECK(*in_types, 2, mshadow::kFloat32);  // max value
 
     if (param.enable_float_output) {
-      TYPE_ASSIGN_CHECK(*out_types, 0, mshadow::kFloat32);     // output
+      TYPE_ASSIGN_CHECK(*out_types, 0, mshadow::kFloat32);  // output
     } else {
       if (param.min_calib_range.has_value() && param.max_calib_range.has_value()) {
-        TYPE_ASSIGN_CHECK(*out_types, 0, mshadow::kInt8);      // output
+        TYPE_ASSIGN_CHECK(*out_types, 0, mshadow::kInt8);  // output
       } else {
-        TYPE_ASSIGN_CHECK(*out_types, 0, mshadow::kInt32);     // output
+        TYPE_ASSIGN_CHECK(*out_types, 0, mshadow::kInt32);  // output
       }
-      TYPE_ASSIGN_CHECK(*out_types, 1, mshadow::kFloat32);     // min output
-      TYPE_ASSIGN_CHECK(*out_types, 2, mshadow::kFloat32);     // max output
+      TYPE_ASSIGN_CHECK(*out_types, 1, mshadow::kFloat32);  // min output
+      TYPE_ASSIGN_CHECK(*out_types, 2, mshadow::kFloat32);  // max output
     }
     return true;
   } else {
@@ -96,13 +94,11 @@ static bool SgMKLDNNSelfAttQKInferType(const nnvm::NodeAttrs &attrs,
   }
 }
 
-template<int base_num_inputs>
-static bool SgMKLDNNSelfAttStorageType(const nnvm::NodeAttrs &attrs,
-                                       const int dev_mask,
-                                       DispatchMode *dispatch_mode,
-                                       std::vector<int> *in_attrs,
-                                       std::vector<int> *out_attrs) {
-  auto const &param = nnvm::get<MKLDNNSelfAttParam>(attrs.parsed);
+template <int base_num_inputs>
+static bool SgMKLDNNSelfAttStorageType(
+    const nnvm::NodeAttrs& attrs, const int dev_mask, DispatchMode* dispatch_mode,
+    std::vector<int>* in_attrs, std::vector<int>* out_attrs) {
+  auto const& param = nnvm::get<MKLDNNSelfAttParam>(attrs.parsed);
   if (param.quantized) {
     std::vector<int> base_in_attrs;
     std::vector<int> base_out_attrs{out_attrs->at(0)};
@@ -110,8 +106,8 @@ static bool SgMKLDNNSelfAttStorageType(const nnvm::NodeAttrs &attrs,
     for (int i = 0; i < base_num_inputs; i++) {
       base_in_attrs.emplace_back(in_attrs->at(i));
     }
-    bool ret = DefaultSubgraphOpStorageType(attrs, dev_mask, dispatch_mode,
-                                            &base_in_attrs, &base_out_attrs);
+    bool ret = DefaultSubgraphOpStorageType(
+        attrs, dev_mask, dispatch_mode, &base_in_attrs, &base_out_attrs);
 
     for (size_t i = 0; i < in_attrs->size(); ++i) {
       if (i < base_in_attrs.size())
@@ -127,37 +123,31 @@ static bool SgMKLDNNSelfAttStorageType(const nnvm::NodeAttrs &attrs,
     }
     return ret;
   } else {
-    return DefaultSubgraphOpStorageType(attrs, dev_mask, dispatch_mode,
-                                        in_attrs, out_attrs);
+    return DefaultSubgraphOpStorageType(attrs, dev_mask, dispatch_mode, in_attrs, out_attrs);
   }
 }
 
 class SgMKLDNNSelfAttQKOp {
  public:
-  explicit SgMKLDNNSelfAttQKOp(const nnvm::NodeAttrs &attrs) :
-    param_(nnvm::get<MKLDNNSelfAttParam>(attrs.parsed)) {}
+  explicit SgMKLDNNSelfAttQKOp(const nnvm::NodeAttrs& attrs)
+      : param_(nnvm::get<MKLDNNSelfAttParam>(attrs.parsed)) {}
 
-  void Forward(const OpContext &ctx,
-               const std::vector<NDArray> &inputs,
-               const std::vector<OpReqType> &req,
-               const std::vector<NDArray> &outputs);
+  void Forward(
+      const OpContext& ctx, const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+      const std::vector<NDArray>& outputs);
 
-  void Backward(const OpContext &ctx,
-                const std::vector<NDArray> &inputs,
-                const std::vector<OpReqType> &req,
-                const std::vector<NDArray> &outputs) {
+  void Backward(
+      const OpContext& ctx, const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+      const std::vector<NDArray>& outputs) {
     LOG(FATAL) << "Not implemented: subgraph mkldnn fully connected only supports "
                   "inference computation.";
   }
 
-  void Initialize(const OpContext &ctx,
-                  const std::vector<NDArray> &inputs,
-                  const std::vector<OpReqType> &req,
-                  const std::vector<NDArray> &outputs);
+  void Initialize(
+      const OpContext& ctx, const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+      const std::vector<NDArray>& outputs);
 
-  bool IsInitialized() {
-    return initialized_;
-  }
+  bool IsInitialized() { return initialized_; }
 
  private:
   bool initialized_{false};
@@ -174,153 +164,144 @@ class SgMKLDNNSelfAttQKOp {
   float data_scale_{0.0f};
 };
 
-static OpStatePtr CreateSgMKLDNNSelfAttQKState(const nnvm::NodeAttrs &attrs,
-                                               Context ctx,
-                                               const mxnet::ShapeVector &in_shapes,
-                                               const std::vector<int> &in_types) {
+static OpStatePtr CreateSgMKLDNNSelfAttQKState(
+    const nnvm::NodeAttrs& attrs, Context ctx, const mxnet::ShapeVector& in_shapes,
+    const std::vector<int>& in_types) {
   return OpStatePtr::Create<SgMKLDNNSelfAttQKOp>(attrs);
 }
 
-static void SgMKLDNNSelfAttQKForward(const OpStatePtr &state_pointer,
-                                     const OpContext &ctx,
-                                     const std::vector<NDArray> &inputs,
-                                     const std::vector<OpReqType> &req,
-                                     const std::vector<NDArray> &outputs) {
-  SgMKLDNNSelfAttQKOp &op = state_pointer.get_state<SgMKLDNNSelfAttQKOp>();
+static void SgMKLDNNSelfAttQKForward(
+    const OpStatePtr& state_pointer, const OpContext& ctx, const std::vector<NDArray>& inputs,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs) {
+  SgMKLDNNSelfAttQKOp& op = state_pointer.get_state<SgMKLDNNSelfAttQKOp>();
   if (!op.IsInitialized()) {
     op.Initialize(ctx, inputs, req, outputs);
   }
   op.Forward(ctx, inputs, req, outputs);
 }
 
-void SgMKLDNNSelfAttQKOp::Initialize(const OpContext &ctx,
-                                     const std::vector<NDArray> &inputs,
-                                     const std::vector<OpReqType> &req,
-                                     const std::vector<NDArray> &outputs) {
-    using namespace mkldnn;
-    const auto qkv_tensor = inputs[0];
-    const auto out_tensor = outputs[0];
-    const auto qkv_dtype = get_mkldnn_type(qkv_tensor.dtype());
+void SgMKLDNNSelfAttQKOp::Initialize(
+    const OpContext& ctx, const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+    const std::vector<NDArray>& outputs) {
+  using namespace mkldnn;
+  const auto qkv_tensor = inputs[0];
+  const auto out_tensor = outputs[0];
+  const auto qkv_dtype  = get_mkldnn_type(qkv_tensor.dtype());
 
-    const memory::dim heads          = param_.heads;
-    const memory::dim sequences      = inputs[0].shape()[1];
-    const memory::dim qkv_seq_len    = inputs[0].shape()[0];
-    const memory::dim output_lin_dim = inputs[0].shape()[2];
-    const memory::dim embed_dim      = output_lin_dim / 3;
-    const memory::dim head_dim       = embed_dim / heads;
-    const memory::dim attn_batches   = heads * sequences;
-    const memory::dim lead_dim       = attn_batches * 3 * head_dim;
-    const memory::dim batch_stride   = 3 * head_dim;
+  const memory::dim heads          = param_.heads;
+  const memory::dim sequences      = inputs[0].shape()[1];
+  const memory::dim qkv_seq_len    = inputs[0].shape()[0];
+  const memory::dim output_lin_dim = inputs[0].shape()[2];
+  const memory::dim embed_dim      = output_lin_dim / 3;
+  const memory::dim head_dim       = embed_dim / heads;
+  const memory::dim attn_batches   = heads * sequences;
+  const memory::dim lead_dim       = attn_batches * 3 * head_dim;
+  const memory::dim batch_stride   = 3 * head_dim;
 
-    float min_data = 0.0f;
-    float max_data = 0.0f;
+  float min_data = 0.0f;
+  float max_data = 0.0f;
 
-    if (param_.quantized) {
-      min_data_ = inputs[1].data().dptr<float>()[0];
-      max_data_ = inputs[2].data().dptr<float>()[0];
-    }
+  if (param_.quantized) {
+    min_data_ = inputs[1].data().dptr<float>()[0];
+    max_data_ = inputs[2].data().dptr<float>()[0];
+  }
 
-    const auto engine = CpuEngine::Get()->get_engine();
+  const auto engine = CpuEngine::Get()->get_engine();
 
-    memory::dims query_dims    = {attn_batches, qkv_seq_len, head_dim};
-    memory::dims key_dims      = {attn_batches, head_dim, qkv_seq_len};
-    memory::dims out_dims      = {attn_batches, qkv_seq_len, qkv_seq_len};
+  memory::dims query_dims = {attn_batches, qkv_seq_len, head_dim};
+  memory::dims key_dims   = {attn_batches, head_dim, qkv_seq_len};
+  memory::dims out_dims   = {attn_batches, qkv_seq_len, qkv_seq_len};
 
-    memory::dims query_strides = {batch_stride, lead_dim, 1};
-    memory::dims key_strides   = {batch_stride, 1, lead_dim};
+  memory::dims query_strides = {batch_stride, lead_dim, 1};
+  memory::dims key_strides   = {batch_stride, 1, lead_dim};
 
-    auto query_md = memory::desc(query_dims, qkv_dtype, query_strides);
-    auto key_md   = memory::desc(key_dims, qkv_dtype, key_strides);
+  auto query_md = memory::desc(query_dims, qkv_dtype, query_strides);
+  auto key_md   = memory::desc(key_dims, qkv_dtype, key_strides);
 
-    memory::desc out_md;
+  memory::desc out_md;
 
-    float oscale = 1.0f;
-    if (param_.quantized) {
-      data_scale_ = GetQuantizeScale(qkv_tensor.dtype(), min_data_, max_data_);
+  float oscale = 1.0f;
+  if (param_.quantized) {
+    data_scale_ = GetQuantizeScale(qkv_tensor.dtype(), min_data_, max_data_);
 
-      if (param_.min_calib_range.has_value() &&
-          param_.max_calib_range.has_value()) {
-        min_output_ = param_.min_calib_range.value();
-        max_output_ = param_.max_calib_range.value();
-        oscale =
-            GetQuantizeScale(out_tensor.dtype(), min_output_, max_output_) /
-            (data_scale_ * data_scale_);
-        out_md = memory::desc(out_dims, memory::data_type::s8, memory::format_tag::abc);
-      } else if (param_.enable_float_output) {
-        oscale = 1.0f / (data_scale_ * data_scale_);
-        out_md = dnnl::memory::desc(out_dims, memory::data_type::f32, memory::format_tag::abc);
-      } else {
-        mshadow::Stream<cpu> *s = ctx.get_stream<cpu>();
-        mxnet_op::Kernel<QuantizationRangeForS8S8MultiplicationStruct, cpu>::Launch(
-              s, 1, &min_output_, &max_output_, &min_data, &max_data, &min_data,
-              &max_data);
-        out_md = dnnl::memory::desc(out_dims, memory::data_type::s32, memory::format_tag::abc);
-      }
-    } else {
+    if (param_.min_calib_range.has_value() && param_.max_calib_range.has_value()) {
+      min_output_ = param_.min_calib_range.value();
+      max_output_ = param_.max_calib_range.value();
+      oscale      = GetQuantizeScale(out_tensor.dtype(), min_output_, max_output_) /
+               (data_scale_ * data_scale_);
+      out_md = memory::desc(out_dims, memory::data_type::s8, memory::format_tag::abc);
+    } else if (param_.enable_float_output) {
+      oscale = 1.0f / (data_scale_ * data_scale_);
       out_md = dnnl::memory::desc(out_dims, memory::data_type::f32, memory::format_tag::abc);
+    } else {
+      mshadow::Stream<cpu>* s = ctx.get_stream<cpu>();
+      mxnet_op::Kernel<QuantizationRangeForS8S8MultiplicationStruct, cpu>::Launch(
+          s, 1, &min_output_, &max_output_, &min_data, &max_data, &min_data, &max_data);
+      out_md = dnnl::memory::desc(out_dims, memory::data_type::s32, memory::format_tag::abc);
     }
-    oscale /= sqrt(static_cast<float>(head_dim));  // combine quantized scale and sqrt(head_dim)
+  } else {
+    out_md = dnnl::memory::desc(out_dims, memory::data_type::f32, memory::format_tag::abc);
+  }
+  oscale /= sqrt(static_cast<float>(head_dim));  // combine quantized scale and sqrt(head_dim)
 
-    dnnl::primitive_attr attr;
-    attr.set_output_scales(0, {oscale});
-    auto matmul_d = matmul::desc(query_md, key_md, out_md);
-    auto matmul_pd = matmul::primitive_desc(matmul_d, attr, engine);
+  dnnl::primitive_attr attr;
+  attr.set_output_scales(0, {oscale});
+  auto matmul_d  = matmul::desc(query_md, key_md, out_md);
+  auto matmul_pd = matmul::primitive_desc(matmul_d, attr, engine);
 
-    fwd_ = std::make_shared<matmul>(matmul_pd);
+  fwd_ = std::make_shared<matmul>(matmul_pd);
 
-    MSHADOW_TYPE_SWITCH(inputs[0].dtype(), DType, {
-      DType* query_mem_ptr = inputs[0].data().dptr<DType>();
-      DType* key_mem_ptr   = query_mem_ptr + head_dim;
-      cached_query_mem_ = std::make_shared<memory>(query_md, engine, query_mem_ptr);
-      cached_key_mem_ = std::make_shared<memory>(key_md, engine, key_mem_ptr);
-    });
-    MSHADOW_TYPE_SWITCH(outputs[0].dtype(), DType, {
-      cached_out_mem_ = std::make_shared<memory>(out_md, engine, outputs[0].data().dptr<DType>());
-    });
+  MSHADOW_TYPE_SWITCH(inputs[0].dtype(), DType, {
+    DType* query_mem_ptr = inputs[0].data().dptr<DType>();
+    DType* key_mem_ptr   = query_mem_ptr + head_dim;
+    cached_query_mem_    = std::make_shared<memory>(query_md, engine, query_mem_ptr);
+    cached_key_mem_      = std::make_shared<memory>(key_md, engine, key_mem_ptr);
+  });
+  MSHADOW_TYPE_SWITCH(outputs[0].dtype(), DType, {
+    cached_out_mem_ = std::make_shared<memory>(out_md, engine, outputs[0].data().dptr<DType>());
+  });
 
-    args_[DNNL_ARG_SRC]     = *cached_query_mem_;
-    args_[DNNL_ARG_WEIGHTS] = *cached_key_mem_;
-    args_[DNNL_ARG_DST]     = *cached_out_mem_;
-    initialized_ = true;
+  args_[DNNL_ARG_SRC]     = *cached_query_mem_;
+  args_[DNNL_ARG_WEIGHTS] = *cached_key_mem_;
+  args_[DNNL_ARG_DST]     = *cached_out_mem_;
+  initialized_            = true;
 }
 
+void SgMKLDNNSelfAttQKOp::Forward(
+    const OpContext& ctx, const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+    const std::vector<NDArray>& outputs) {
+  const size_t head_dim = inputs[0].shape()[2] / 3 / param_.heads;
 
-void SgMKLDNNSelfAttQKOp::Forward(const OpContext &ctx,
-                                  const std::vector<NDArray> &inputs,
-                                  const std::vector<OpReqType> &req,
-                                  const std::vector<NDArray> &outputs) {
-    const size_t head_dim = inputs[0].shape()[2] / 3 / param_.heads;
+  MSHADOW_TYPE_SWITCH(inputs[0].dtype(), DType, {
+    DType* query_mem_ptr = inputs[0].data().dptr<DType>();
+    DType* key_mem_ptr   = query_mem_ptr + head_dim;
+    cached_query_mem_->set_data_handle(query_mem_ptr);
+    cached_key_mem_->set_data_handle(key_mem_ptr);
+  });
 
-    MSHADOW_TYPE_SWITCH(inputs[0].dtype(), DType, {
-      DType* query_mem_ptr = inputs[0].data().dptr<DType>();
-      DType* key_mem_ptr   = query_mem_ptr + head_dim;
-      cached_query_mem_->set_data_handle(query_mem_ptr);
-      cached_key_mem_->set_data_handle(key_mem_ptr);
-    });
+  MSHADOW_TYPE_SWITCH(outputs[0].dtype(), DType, {
+    cached_out_mem_->set_data_handle(outputs[0].data().dptr<DType>());
+  });
 
-    MSHADOW_TYPE_SWITCH(outputs[0].dtype(), DType, {
-      cached_out_mem_->set_data_handle(outputs[0].data().dptr<DType>());
-    });
+  MKLDNNStream::Get()->RegisterPrimArgs(*fwd_, args_);
+  MKLDNNStream::Get()->Submit();
 
-    MKLDNNStream::Get()->RegisterPrimArgs(*fwd_, args_);
-    MKLDNNStream::Get()->Submit();
+  if (param_.quantized && !param_.enable_float_output) {
+    float* output_min = outputs[1].data().dptr<float>();
+    float* output_max = outputs[2].data().dptr<float>();
 
-    if (param_.quantized && !param_.enable_float_output) {
-      float* output_min = outputs[1].data().dptr<float>();
-      float* output_max = outputs[2].data().dptr<float>();
-
-      *output_min = min_output_;
-      *output_max = max_output_;
-    }
+    *output_min = min_output_;
+    *output_max = max_output_;
+  }
 }
 
 nnvm::ObjectPtr SgMKLDNNSelfAttQKQuantizedOp(const NodeAttrs& attrs) {
-  nnvm::ObjectPtr node = nnvm::Node::Create();
-  auto const &param = nnvm::get<MKLDNNSelfAttParam>(attrs.parsed);
-  node->attrs.op = Op::Get("_sg_mkldnn_selfatt_qk");
-  node->attrs.name = "quantized_" + attrs.name;
-  node->attrs.dict = attrs.dict;
-  node->attrs.dict["heads"] = std::to_string(param.heads);
+  nnvm::ObjectPtr node          = nnvm::Node::Create();
+  auto const& param             = nnvm::get<MKLDNNSelfAttParam>(attrs.parsed);
+  node->attrs.op                = Op::Get("_sg_mkldnn_selfatt_qk");
+  node->attrs.name              = "quantized_" + attrs.name;
+  node->attrs.dict              = attrs.dict;
+  node->attrs.dict["heads"]     = std::to_string(param.heads);
   node->attrs.dict["quantized"] = "True";
   node->attrs.subgraphs.reserve(attrs.subgraphs.size());
   for (auto sub : attrs.subgraphs) {
@@ -331,62 +312,65 @@ nnvm::ObjectPtr SgMKLDNNSelfAttQKQuantizedOp(const NodeAttrs& attrs) {
 }
 
 NNVM_REGISTER_OP(_sg_mkldnn_selfatt_qk)
-.describe(R"code(_sg_mkldnn_selfatt_qk)code" ADD_FILELINE)
-.set_num_inputs([](const NodeAttrs& attrs) {
-  auto const& param = nnvm::get<MKLDNNSelfAttParam>(attrs.parsed);
-  if (param.quantized) {
-    return 3;
-  } else {
-    return 1;
-  }
-})
-.set_num_outputs([](const NodeAttrs& attrs) {
-  auto const& param = nnvm::get<MKLDNNSelfAttParam>(attrs.parsed);
-  if (param.quantized && !param.enable_float_output) {
-    return 3;
-  } else {
-    return 1;
-  }
-})
-.set_attr_parser(ParamParser<MKLDNNSelfAttParam>)
-.set_attr<nnvm::FListInputNames>("FListInputNames", [](const NodeAttrs& attrs) {
-  auto const& param = nnvm::get<MKLDNNSelfAttParam>(attrs.parsed);
-  std::vector<std::string> input_names {"queries_keys_values"};
-  if (param.quantized) {
-    input_names.emplace_back("min_qkv");
-    input_names.emplace_back("max_qkv");
-  }
-  return input_names;
-})
-.set_attr<nnvm::FListOutputNames>("FListOutputNames", [](const NodeAttrs& attrs) {
-  auto const& param = nnvm::get<MKLDNNSelfAttParam>(attrs.parsed);
-  std::vector<std::string> output_names {"output"};
-  if (param.quantized && !param.enable_float_output) {
-    output_names.emplace_back("min_output");
-    output_names.emplace_back("max_output");
-  }
-  return output_names;
-})
-.set_attr<mxnet::FInferShape>("FInferShape", SgMKLDNNSelfAttShape<1>)
-.set_attr<nnvm::FInferType>("FInferType", SgMKLDNNSelfAttQKInferType)
-.set_attr<FInferStorageType>("FInferStorageType", SgMKLDNNSelfAttStorageType<1>)
-.set_attr<FCreateOpState>("FCreateOpState", CreateSgMKLDNNSelfAttQKState)
-.set_attr<FStatefulComputeEx>("FStatefulComputeEx<cpu>", SgMKLDNNSelfAttQKForward)
-.set_attr<bool>("TIsMKLDNN", true)
-.set_attr<nnvm::FGradient>("FGradient", MakeZeroGradNodes)
-.set_attr<FQuantizable>("FQuantizable", [](const NodeAttrs& attrs) {
-    return QuantizeType::kMust;
-})
-.set_attr<FQuantizedOp>("FQuantizedOp", SgMKLDNNSelfAttQKQuantizedOp)
-.set_attr<FNeedRequantize>("FNeedRequantize", [](const NodeAttrs& attrs) { return true; })
-.add_argument("queries_keys_values", "NDArray-or-Symbol", "Interleaved queries, keys and values")
-.add_arguments(MKLDNNSelfAttParam::__FIELDS__());
+    .describe(R"code(_sg_mkldnn_selfatt_qk)code" ADD_FILELINE)
+    .set_num_inputs([](const NodeAttrs& attrs) {
+      auto const& param = nnvm::get<MKLDNNSelfAttParam>(attrs.parsed);
+      if (param.quantized) {
+        return 3;
+      } else {
+        return 1;
+      }
+    })
+    .set_num_outputs([](const NodeAttrs& attrs) {
+      auto const& param = nnvm::get<MKLDNNSelfAttParam>(attrs.parsed);
+      if (param.quantized && !param.enable_float_output) {
+        return 3;
+      } else {
+        return 1;
+      }
+    })
+    .set_attr_parser(ParamParser<MKLDNNSelfAttParam>)
+    .set_attr<nnvm::FListInputNames>(
+        "FListInputNames",
+        [](const NodeAttrs& attrs) {
+          auto const& param = nnvm::get<MKLDNNSelfAttParam>(attrs.parsed);
+          std::vector<std::string> input_names{"queries_keys_values"};
+          if (param.quantized) {
+            input_names.emplace_back("min_qkv");
+            input_names.emplace_back("max_qkv");
+          }
+          return input_names;
+        })
+    .set_attr<nnvm::FListOutputNames>(
+        "FListOutputNames",
+        [](const NodeAttrs& attrs) {
+          auto const& param = nnvm::get<MKLDNNSelfAttParam>(attrs.parsed);
+          std::vector<std::string> output_names{"output"};
+          if (param.quantized && !param.enable_float_output) {
+            output_names.emplace_back("min_output");
+            output_names.emplace_back("max_output");
+          }
+          return output_names;
+        })
+    .set_attr<mxnet::FInferShape>("FInferShape", SgMKLDNNSelfAttShape<1>)
+    .set_attr<nnvm::FInferType>("FInferType", SgMKLDNNSelfAttQKInferType)
+    .set_attr<FInferStorageType>("FInferStorageType", SgMKLDNNSelfAttStorageType<1>)
+    .set_attr<FCreateOpState>("FCreateOpState", CreateSgMKLDNNSelfAttQKState)
+    .set_attr<FStatefulComputeEx>("FStatefulComputeEx<cpu>", SgMKLDNNSelfAttQKForward)
+    .set_attr<bool>("TIsMKLDNN", true)
+    .set_attr<nnvm::FGradient>("FGradient", MakeZeroGradNodes)
+    .set_attr<FQuantizable>(
+        "FQuantizable", [](const NodeAttrs& attrs) { return QuantizeType::kMust; })
+    .set_attr<FQuantizedOp>("FQuantizedOp", SgMKLDNNSelfAttQKQuantizedOp)
+    .set_attr<FNeedRequantize>("FNeedRequantize", [](const NodeAttrs& attrs) { return true; })
+    .add_argument(
+        "queries_keys_values", "NDArray-or-Symbol", "Interleaved queries, keys and values")
+    .add_arguments(MKLDNNSelfAttParam::__FIELDS__());
 
 /**********************************_sg_mkldnn_selfatt_valatt**********************************/
 
-static bool SgMKLDNNSelfAttValAttInferType(const nnvm::NodeAttrs &attrs,
-                                         std::vector<int> *in_types,
-                                         std::vector<int> *out_types) {
+static bool SgMKLDNNSelfAttValAttInferType(
+    const nnvm::NodeAttrs& attrs, std::vector<int>* in_types, std::vector<int>* out_types) {
   const auto& param = nnvm::get<MKLDNNSelfAttParam>(attrs.parsed);
   if (param.quantized) {
     TYPE_ASSIGN_CHECK(*in_types, 0, mshadow::kInt8);   // qkv input
@@ -398,15 +382,15 @@ static bool SgMKLDNNSelfAttValAttInferType(const nnvm::NodeAttrs &attrs,
     }
 
     if (param.enable_float_output) {
-      TYPE_ASSIGN_CHECK(*out_types, 0, mshadow::kFloat32);     // output
+      TYPE_ASSIGN_CHECK(*out_types, 0, mshadow::kFloat32);  // output
     } else {
       if (param.min_calib_range.has_value() && param.max_calib_range.has_value()) {
-        TYPE_ASSIGN_CHECK(*out_types, 0, mshadow::kInt8);      // output
+        TYPE_ASSIGN_CHECK(*out_types, 0, mshadow::kInt8);  // output
       } else {
-        TYPE_ASSIGN_CHECK(*out_types, 0, mshadow::kInt32);     // output
+        TYPE_ASSIGN_CHECK(*out_types, 0, mshadow::kInt32);  // output
       }
-      TYPE_ASSIGN_CHECK(*out_types, 1, mshadow::kFloat32);     // min output
-      TYPE_ASSIGN_CHECK(*out_types, 2, mshadow::kFloat32);     // max output
+      TYPE_ASSIGN_CHECK(*out_types, 1, mshadow::kFloat32);  // min output
+      TYPE_ASSIGN_CHECK(*out_types, 2, mshadow::kFloat32);  // max output
     }
     return true;
   } else {
@@ -415,12 +399,12 @@ static bool SgMKLDNNSelfAttValAttInferType(const nnvm::NodeAttrs &attrs,
 }
 
 nnvm::ObjectPtr SgMKLDNNSelfAttValAttQuantizedOp(const NodeAttrs& attrs) {
-  nnvm::ObjectPtr node = nnvm::Node::Create();
-  auto const &param = nnvm::get<MKLDNNSelfAttParam>(attrs.parsed);
-  node->attrs.op = Op::Get("_sg_mkldnn_selfatt_valatt");
-  node->attrs.name = "quantized_" + attrs.name;
-  node->attrs.dict = attrs.dict;
-  node->attrs.dict["heads"] = std::to_string(param.heads);
+  nnvm::ObjectPtr node          = nnvm::Node::Create();
+  auto const& param             = nnvm::get<MKLDNNSelfAttParam>(attrs.parsed);
+  node->attrs.op                = Op::Get("_sg_mkldnn_selfatt_valatt");
+  node->attrs.name              = "quantized_" + attrs.name;
+  node->attrs.dict              = attrs.dict;
+  node->attrs.dict["heads"]     = std::to_string(param.heads);
   node->attrs.dict["quantized"] = "True";
   node->attrs.subgraphs.reserve(attrs.subgraphs.size());
   for (auto sub : attrs.subgraphs) {
@@ -432,30 +416,25 @@ nnvm::ObjectPtr SgMKLDNNSelfAttValAttQuantizedOp(const NodeAttrs& attrs) {
 
 class MKLDNNSelfAttValAttOp {
  public:
-  explicit MKLDNNSelfAttValAttOp(const nnvm::NodeAttrs &attrs) :
-    param_(nnvm::get<MKLDNNSelfAttParam>(attrs.parsed)) {}
+  explicit MKLDNNSelfAttValAttOp(const nnvm::NodeAttrs& attrs)
+      : param_(nnvm::get<MKLDNNSelfAttParam>(attrs.parsed)) {}
 
-  void Forward(const OpContext &ctx,
-               const std::vector<NDArray> &inputs,
-               const std::vector<OpReqType> &req,
-               const std::vector<NDArray> &outputs);
+  void Forward(
+      const OpContext& ctx, const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+      const std::vector<NDArray>& outputs);
 
-  void Backward(const OpContext &ctx,
-                const std::vector<NDArray> &inputs,
-                const std::vector<OpReqType> &req,
-                const std::vector<NDArray> &outputs) {
+  void Backward(
+      const OpContext& ctx, const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+      const std::vector<NDArray>& outputs) {
     LOG(FATAL) << "Not implemented: subgraph mkldnn fully connected only supports "
                   "inference computation.";
   }
 
-  void Initialize(const OpContext &ctx,
-                  const std::vector<NDArray> &inputs,
-                  const std::vector<OpReqType> &req,
-                  const std::vector<NDArray> &outputs);
+  void Initialize(
+      const OpContext& ctx, const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+      const std::vector<NDArray>& outputs);
 
-  bool IsInitialized() {
-    return initialized_;
-  }
+  bool IsInitialized() { return initialized_; }
 
  private:
   bool initialized_{false};
@@ -475,29 +454,25 @@ class MKLDNNSelfAttValAttOp {
   float att_scale_{0.0f};
 };
 
-static OpStatePtr CreateMKLDNNSelfAttValAttState(const nnvm::NodeAttrs &attrs,
-                                                 Context ctx,
-                                                 const mxnet::ShapeVector &in_shapes,
-                                                 const std::vector<int> &in_types) {
+static OpStatePtr CreateMKLDNNSelfAttValAttState(
+    const nnvm::NodeAttrs& attrs, Context ctx, const mxnet::ShapeVector& in_shapes,
+    const std::vector<int>& in_types) {
   return OpStatePtr::Create<MKLDNNSelfAttValAttOp>(attrs);
 }
 
-static void MKLDNNSelfAttValAttForward(const OpStatePtr &state_pointer,
-                                       const OpContext &ctx,
-                                       const std::vector<NDArray> &inputs,
-                                       const std::vector<OpReqType> &req,
-                                       const std::vector<NDArray> &outputs) {
-  MKLDNNSelfAttValAttOp &op = state_pointer.get_state<MKLDNNSelfAttValAttOp>();
+static void MKLDNNSelfAttValAttForward(
+    const OpStatePtr& state_pointer, const OpContext& ctx, const std::vector<NDArray>& inputs,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs) {
+  MKLDNNSelfAttValAttOp& op = state_pointer.get_state<MKLDNNSelfAttValAttOp>();
   if (!op.IsInitialized()) {
     op.Initialize(ctx, inputs, req, outputs);
   }
   op.Forward(ctx, inputs, req, outputs);
 }
 
-void MKLDNNSelfAttValAttOp::Initialize(const OpContext &ctx,
-                                       const std::vector<NDArray> &inputs,
-                                       const std::vector<OpReqType> &req,
-                                       const std::vector<NDArray> &outputs) {
+void MKLDNNSelfAttValAttOp::Initialize(
+    const OpContext& ctx, const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+    const std::vector<NDArray>& outputs) {
   const dnnl::memory::dim qkv_seq_len    = inputs[0].shape()[0];
   const dnnl::memory::dim sequences      = inputs[0].shape()[1];
   const dnnl::memory::dim output_lin_dim = inputs[0].shape()[2];
@@ -506,7 +481,6 @@ void MKLDNNSelfAttValAttOp::Initialize(const OpContext &ctx,
   const dnnl::memory::dim attn_batches   = param_.heads * sequences;
   const dnnl::memory::dim lead_dim       = attn_batches * 3 * head_dim;
   const dnnl::memory::dim batch_stride   = 3 * head_dim;
-
 
   dnnl::memory::dims att_dims = {attn_batches, qkv_seq_len, qkv_seq_len};
   dnnl::memory::dims qkv_dims = {attn_batches, qkv_seq_len, head_dim};
@@ -518,81 +492,78 @@ void MKLDNNSelfAttValAttOp::Initialize(const OpContext &ctx,
   auto att_dtype = inputs[1].dtype();
   auto qkv_dtype = inputs[0].dtype();
   auto out_dtype = outputs[0].dtype();
-  auto att_md = dnnl::memory::desc(att_dims, get_mkldnn_type(att_dtype), att_strides);
-  auto qkv_md = dnnl::memory::desc(qkv_dims, get_mkldnn_type(qkv_dtype), qkv_strides);
+  auto att_md    = dnnl::memory::desc(att_dims, get_mkldnn_type(att_dtype), att_strides);
+  auto qkv_md    = dnnl::memory::desc(qkv_dims, get_mkldnn_type(qkv_dtype), qkv_strides);
 
   dnnl::memory::desc out_md;
   dnnl::primitive_attr attr;
 
   float oscale = 1.0f;
   if (param_.quantized) {
-    min_qkv_ = inputs[2].data().dptr<float>()[0];
-    max_qkv_ = inputs[3].data().dptr<float>()[0];
-    min_att_ = inputs[4].data().dptr<float>()[0];
-    max_att_ = inputs[5].data().dptr<float>()[0];
+    min_qkv_   = inputs[2].data().dptr<float>()[0];
+    max_qkv_   = inputs[3].data().dptr<float>()[0];
+    min_att_   = inputs[4].data().dptr<float>()[0];
+    max_att_   = inputs[5].data().dptr<float>()[0];
     qkv_scale_ = GetQuantizeScale(qkv_dtype, min_qkv_, max_qkv_);
     att_scale_ = GetQuantizeScale(att_dtype, min_att_, max_att_);
 
-    if (param_.min_calib_range.has_value() &&
-        param_.max_calib_range.has_value()) {
+    if (param_.min_calib_range.has_value() && param_.max_calib_range.has_value()) {
       min_output_ = param_.min_calib_range.value();
       max_output_ = param_.max_calib_range.value();
 
-      oscale = GetQuantizeScale(out_dtype, min_output_, max_output_)  / (qkv_scale_ * att_scale_);
+      oscale = GetQuantizeScale(out_dtype, min_output_, max_output_) / (qkv_scale_ * att_scale_);
       attr.set_output_scales(0, {oscale});
     } else if (param_.enable_float_output) {
       oscale = 1.0f / (qkv_scale_ * att_scale_);
       attr.set_output_scales(0, {oscale});
     } else {
-      mshadow::Stream<cpu> *s = ctx.get_stream<cpu>();
+      mshadow::Stream<cpu>* s = ctx.get_stream<cpu>();
       mxnet_op::Kernel<QuantizationRangeForS8U8MultiplicationStruct, cpu>::Launch(
-              s, 1, &min_output_, &max_output_, &min_qkv_, &max_qkv_, &min_att_,
-              &max_att_);
+          s, 1, &min_output_, &max_output_, &min_qkv_, &max_qkv_, &min_att_, &max_att_);
     }
   }
   out_md = dnnl::memory::desc(dst_dims, get_mkldnn_type(out_dtype), dnnl::memory::format_tag::bac);
 
   const auto engine = CpuEngine::Get()->get_engine();
-  auto matmul_d = dnnl::matmul::desc(att_md, qkv_md, out_md);
-  auto matmul_pd = dnnl::matmul::primitive_desc(matmul_d, attr, engine);
+  auto matmul_d     = dnnl::matmul::desc(att_md, qkv_md, out_md);
+  auto matmul_pd    = dnnl::matmul::primitive_desc(matmul_d, attr, engine);
 
   fwd_ = std::make_shared<dnnl::matmul>(matmul_pd);
 
   MSHADOW_TYPE_SWITCH(att_dtype, DType, {
-    DType* att_ptr = inputs[1].data().dptr<DType>();
+    DType* att_ptr  = inputs[1].data().dptr<DType>();
     cached_att_mem_ = std::make_shared<dnnl::memory>(att_md, engine, att_ptr);
   });
   MSHADOW_TYPE_SWITCH(qkv_dtype, DType, {
-    DType* value_ptr = inputs[0].data().dptr<DType>() + 2*head_dim;
-    cached_qkv_mem_ = std::make_shared<dnnl::memory>(qkv_md, engine, value_ptr);
+    DType* value_ptr = inputs[0].data().dptr<DType>() + 2 * head_dim;
+    cached_qkv_mem_  = std::make_shared<dnnl::memory>(qkv_md, engine, value_ptr);
   });
   MSHADOW_TYPE_SWITCH(out_dtype, DType, {
-    DType* out_ptr = outputs[0].data().dptr<DType>();
+    DType* out_ptr  = outputs[0].data().dptr<DType>();
     cached_out_mem_ = std::make_shared<dnnl::memory>(out_md, engine, out_ptr);
   });
 
-  args_[DNNL_ARG_SRC] = *cached_att_mem_;
+  args_[DNNL_ARG_SRC]     = *cached_att_mem_;
   args_[DNNL_ARG_WEIGHTS] = *cached_qkv_mem_;
-  args_[DNNL_ARG_DST] = *cached_out_mem_;
-  initialized_ = true;
+  args_[DNNL_ARG_DST]     = *cached_out_mem_;
+  initialized_            = true;
 }
 
-void MKLDNNSelfAttValAttOp::Forward(const OpContext &ctx,
-                                    const std::vector<NDArray> &inputs,
-                                    const std::vector<OpReqType> &req,
-                                    const std::vector<NDArray> &outputs) {
-  const auto engine = CpuEngine::Get()->get_engine();
+void MKLDNNSelfAttValAttOp::Forward(
+    const OpContext& ctx, const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+    const std::vector<NDArray>& outputs) {
+  const auto engine     = CpuEngine::Get()->get_engine();
   const size_t head_dim = inputs[0].shape()[2] / param_.heads / 3;
   MSHADOW_TYPE_SWITCH(inputs[1].dtype(), DType, {
-    DType* att_ptr  = inputs[1].data().dptr<DType>();
+    DType* att_ptr = inputs[1].data().dptr<DType>();
     cached_att_mem_->set_data_handle(att_ptr);
   });
   MSHADOW_TYPE_SWITCH(inputs[0].dtype(), DType, {
-    DType* value_ptr = inputs[0].data().dptr<DType>() + 2*head_dim;
+    DType* value_ptr = inputs[0].data().dptr<DType>() + 2 * head_dim;
     cached_qkv_mem_->set_data_handle(value_ptr);
   });
   MSHADOW_TYPE_SWITCH(outputs[0].dtype(), DType, {
-    DType* out_ptr  = outputs[0].data().dptr<DType>();
+    DType* out_ptr = outputs[0].data().dptr<DType>();
     cached_out_mem_->set_data_handle(out_ptr);
   });
 
@@ -609,60 +580,64 @@ void MKLDNNSelfAttValAttOp::Forward(const OpContext &ctx,
 }
 
 NNVM_REGISTER_OP(_sg_mkldnn_selfatt_valatt)
-.describe(R"code(_sg_mkldnn_selfatt_valatt)code" ADD_FILELINE)
-.set_num_inputs([](const NodeAttrs& attrs) {
-  auto const& param = nnvm::get<MKLDNNSelfAttParam>(attrs.parsed);
-  if (param.quantized) {
-    return 6;
-  } else {
-    return 2;
-  }
-})
-.set_num_outputs([](const NodeAttrs& attrs) {
-  auto const& param = nnvm::get<MKLDNNSelfAttParam>(attrs.parsed);
-  if (param.quantized && !param.enable_float_output) {
-    return 3;
-  } else {
-    return 1;
-  }
-})
-.set_attr_parser(ParamParser<MKLDNNSelfAttParam>)
-.set_attr<nnvm::FListInputNames>("FListInputNames", [](const NodeAttrs& attrs) {
-  auto const& param = nnvm::get<MKLDNNSelfAttParam>(attrs.parsed);
-  std::vector<std::string> input_names {"queries_keys_values", "attention"};
-  if (param.quantized) {
-    input_names.emplace_back("min_qkv");
-    input_names.emplace_back("max_qkv");
+    .describe(R"code(_sg_mkldnn_selfatt_valatt)code" ADD_FILELINE)
+    .set_num_inputs([](const NodeAttrs& attrs) {
+      auto const& param = nnvm::get<MKLDNNSelfAttParam>(attrs.parsed);
+      if (param.quantized) {
+        return 6;
+      } else {
+        return 2;
+      }
+    })
+    .set_num_outputs([](const NodeAttrs& attrs) {
+      auto const& param = nnvm::get<MKLDNNSelfAttParam>(attrs.parsed);
+      if (param.quantized && !param.enable_float_output) {
+        return 3;
+      } else {
+        return 1;
+      }
+    })
+    .set_attr_parser(ParamParser<MKLDNNSelfAttParam>)
+    .set_attr<nnvm::FListInputNames>(
+        "FListInputNames",
+        [](const NodeAttrs& attrs) {
+          auto const& param = nnvm::get<MKLDNNSelfAttParam>(attrs.parsed);
+          std::vector<std::string> input_names{"queries_keys_values", "attention"};
+          if (param.quantized) {
+            input_names.emplace_back("min_qkv");
+            input_names.emplace_back("max_qkv");
 
-    input_names.emplace_back("min_attention");
-    input_names.emplace_back("max_attention");
-  }
-  return input_names;
-})
-.set_attr<nnvm::FListOutputNames>("FListOutputNames", [](const NodeAttrs& attrs) {
-  auto const& param = nnvm::get<MKLDNNSelfAttParam>(attrs.parsed);
-  std::vector<std::string> output_names {"output"};
-  if (param.quantized && !param.enable_float_output) {
-    output_names.emplace_back("min_output");
-    output_names.emplace_back("max_output");
-  }
-  return output_names;
-})
-.set_attr<mxnet::FInferShape>("FInferShape", SgMKLDNNSelfAttShape<2>)
-.set_attr<nnvm::FInferType>("FInferType", SgMKLDNNSelfAttValAttInferType)
-.set_attr<FInferStorageType>("FInferStorageType", SgMKLDNNSelfAttStorageType<2>)
-.set_attr<FCreateOpState>("FCreateOpState", CreateMKLDNNSelfAttValAttState)
-.set_attr<FStatefulComputeEx>("FStatefulComputeEx<cpu>", MKLDNNSelfAttValAttForward)
-.set_attr<bool>("TIsMKLDNN", true)
-.set_attr<nnvm::FGradient>("FGradient", MakeZeroGradNodes)
-.set_attr<FQuantizable>("FQuantizable", [](const NodeAttrs& attrs) {
-    return QuantizeType::kMust;
-})
-.set_attr<FQuantizedOp>("FQuantizedOp", SgMKLDNNSelfAttValAttQuantizedOp)
-.set_attr<FNeedRequantize>("FNeedRequantize", [](const NodeAttrs& attrs) { return true; })
-.add_argument("queries_keys_values", "NDArray-or-Symbol", "Queries, keys and values interleaved")
-.add_argument("attention", "NDArray-or-Symbol", "Attention maps")
-.add_arguments(MKLDNNSelfAttParam::__FIELDS__());
+            input_names.emplace_back("min_attention");
+            input_names.emplace_back("max_attention");
+          }
+          return input_names;
+        })
+    .set_attr<nnvm::FListOutputNames>(
+        "FListOutputNames",
+        [](const NodeAttrs& attrs) {
+          auto const& param = nnvm::get<MKLDNNSelfAttParam>(attrs.parsed);
+          std::vector<std::string> output_names{"output"};
+          if (param.quantized && !param.enable_float_output) {
+            output_names.emplace_back("min_output");
+            output_names.emplace_back("max_output");
+          }
+          return output_names;
+        })
+    .set_attr<mxnet::FInferShape>("FInferShape", SgMKLDNNSelfAttShape<2>)
+    .set_attr<nnvm::FInferType>("FInferType", SgMKLDNNSelfAttValAttInferType)
+    .set_attr<FInferStorageType>("FInferStorageType", SgMKLDNNSelfAttStorageType<2>)
+    .set_attr<FCreateOpState>("FCreateOpState", CreateMKLDNNSelfAttValAttState)
+    .set_attr<FStatefulComputeEx>("FStatefulComputeEx<cpu>", MKLDNNSelfAttValAttForward)
+    .set_attr<bool>("TIsMKLDNN", true)
+    .set_attr<nnvm::FGradient>("FGradient", MakeZeroGradNodes)
+    .set_attr<FQuantizable>(
+        "FQuantizable", [](const NodeAttrs& attrs) { return QuantizeType::kMust; })
+    .set_attr<FQuantizedOp>("FQuantizedOp", SgMKLDNNSelfAttValAttQuantizedOp)
+    .set_attr<FNeedRequantize>("FNeedRequantize", [](const NodeAttrs& attrs) { return true; })
+    .add_argument(
+        "queries_keys_values", "NDArray-or-Symbol", "Queries, keys and values interleaved")
+    .add_argument("attention", "NDArray-or-Symbol", "Attention maps")
+    .add_arguments(MKLDNNSelfAttParam::__FIELDS__());
 
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/subgraph/mkldnn/mkldnn_transformer.cc
+++ b/src/operator/subgraph/mkldnn/mkldnn_transformer.cc
@@ -35,8 +35,8 @@ namespace op {
 DMLC_REGISTER_PARAMETER(MKLDNNSelfAttParam);
 
 template <int base_num_inputs>
-static bool SgMKLDNNSelfAttShape(
-    const NodeAttrs& attrs, mxnet::ShapeVector* in_shapes, mxnet::ShapeVector* out_shapes) {
+static bool SgMKLDNNSelfAttShape(const NodeAttrs& attrs, mxnet::ShapeVector* in_shapes,
+                                 mxnet::ShapeVector* out_shapes) {
   const auto& param = nnvm::get<MKLDNNSelfAttParam>(attrs.parsed);
   if (param.quantized) {
     mxnet::ShapeVector base_in_shapes;
@@ -66,8 +66,8 @@ static bool SgMKLDNNSelfAttShape(
   }
 }
 
-static bool SgMKLDNNSelfAttQKInferType(
-    const nnvm::NodeAttrs& attrs, std::vector<int>* in_types, std::vector<int>* out_types) {
+static bool SgMKLDNNSelfAttQKInferType(const nnvm::NodeAttrs& attrs, std::vector<int>* in_types,
+                                       std::vector<int>* out_types) {
   const auto& param = nnvm::get<MKLDNNSelfAttParam>(attrs.parsed);
   if (param.quantized) {
     CHECK(in_types->at(0) == mshadow::kInt8)
@@ -95,9 +95,9 @@ static bool SgMKLDNNSelfAttQKInferType(
 }
 
 template <int base_num_inputs>
-static bool SgMKLDNNSelfAttStorageType(
-    const nnvm::NodeAttrs& attrs, const int dev_mask, DispatchMode* dispatch_mode,
-    std::vector<int>* in_attrs, std::vector<int>* out_attrs) {
+static bool SgMKLDNNSelfAttStorageType(const nnvm::NodeAttrs& attrs, const int dev_mask,
+                                       DispatchMode* dispatch_mode, std::vector<int>* in_attrs,
+                                       std::vector<int>* out_attrs) {
   auto const& param = nnvm::get<MKLDNNSelfAttParam>(attrs.parsed);
   if (param.quantized) {
     std::vector<int> base_in_attrs;
@@ -106,8 +106,8 @@ static bool SgMKLDNNSelfAttStorageType(
     for (int i = 0; i < base_num_inputs; i++) {
       base_in_attrs.emplace_back(in_attrs->at(i));
     }
-    bool ret = DefaultSubgraphOpStorageType(
-        attrs, dev_mask, dispatch_mode, &base_in_attrs, &base_out_attrs);
+    bool ret = DefaultSubgraphOpStorageType(attrs, dev_mask, dispatch_mode, &base_in_attrs,
+                                            &base_out_attrs);
 
     for (size_t i = 0; i < in_attrs->size(); ++i) {
       if (i < base_in_attrs.size())
@@ -132,20 +132,17 @@ class SgMKLDNNSelfAttQKOp {
   explicit SgMKLDNNSelfAttQKOp(const nnvm::NodeAttrs& attrs)
       : param_(nnvm::get<MKLDNNSelfAttParam>(attrs.parsed)) {}
 
-  void Forward(
-      const OpContext& ctx, const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
-      const std::vector<NDArray>& outputs);
+  void Forward(const OpContext& ctx, const std::vector<NDArray>& inputs,
+               const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs);
 
-  void Backward(
-      const OpContext& ctx, const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
-      const std::vector<NDArray>& outputs) {
+  void Backward(const OpContext& ctx, const std::vector<NDArray>& inputs,
+                const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs) {
     LOG(FATAL) << "Not implemented: subgraph mkldnn fully connected only supports "
                   "inference computation.";
   }
 
-  void Initialize(
-      const OpContext& ctx, const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
-      const std::vector<NDArray>& outputs);
+  void Initialize(const OpContext& ctx, const std::vector<NDArray>& inputs,
+                  const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs);
 
   bool IsInitialized() { return initialized_; }
 
@@ -164,15 +161,16 @@ class SgMKLDNNSelfAttQKOp {
   float data_scale_{0.0f};
 };
 
-static OpStatePtr CreateSgMKLDNNSelfAttQKState(
-    const nnvm::NodeAttrs& attrs, Context ctx, const mxnet::ShapeVector& in_shapes,
-    const std::vector<int>& in_types) {
+static OpStatePtr CreateSgMKLDNNSelfAttQKState(const nnvm::NodeAttrs& attrs, Context ctx,
+                                               const mxnet::ShapeVector& in_shapes,
+                                               const std::vector<int>& in_types) {
   return OpStatePtr::Create<SgMKLDNNSelfAttQKOp>(attrs);
 }
 
-static void SgMKLDNNSelfAttQKForward(
-    const OpStatePtr& state_pointer, const OpContext& ctx, const std::vector<NDArray>& inputs,
-    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs) {
+static void SgMKLDNNSelfAttQKForward(const OpStatePtr& state_pointer, const OpContext& ctx,
+                                     const std::vector<NDArray>& inputs,
+                                     const std::vector<OpReqType>& req,
+                                     const std::vector<NDArray>& outputs) {
   SgMKLDNNSelfAttQKOp& op = state_pointer.get_state<SgMKLDNNSelfAttQKOp>();
   if (!op.IsInitialized()) {
     op.Initialize(ctx, inputs, req, outputs);
@@ -180,9 +178,9 @@ static void SgMKLDNNSelfAttQKForward(
   op.Forward(ctx, inputs, req, outputs);
 }
 
-void SgMKLDNNSelfAttQKOp::Initialize(
-    const OpContext& ctx, const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
-    const std::vector<NDArray>& outputs) {
+void SgMKLDNNSelfAttQKOp::Initialize(const OpContext& ctx, const std::vector<NDArray>& inputs,
+                                     const std::vector<OpReqType>& req,
+                                     const std::vector<NDArray>& outputs) {
   using namespace mkldnn;
   const auto qkv_tensor = inputs[0];
   const auto out_tensor = outputs[0];
@@ -267,9 +265,9 @@ void SgMKLDNNSelfAttQKOp::Initialize(
   initialized_            = true;
 }
 
-void SgMKLDNNSelfAttQKOp::Forward(
-    const OpContext& ctx, const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
-    const std::vector<NDArray>& outputs) {
+void SgMKLDNNSelfAttQKOp::Forward(const OpContext& ctx, const std::vector<NDArray>& inputs,
+                                  const std::vector<OpReqType>& req,
+                                  const std::vector<NDArray>& outputs) {
   const size_t head_dim = inputs[0].shape()[2] / 3 / param_.heads;
 
   MSHADOW_TYPE_SWITCH(inputs[0].dtype(), DType, {
@@ -279,9 +277,8 @@ void SgMKLDNNSelfAttQKOp::Forward(
     cached_key_mem_->set_data_handle(key_mem_ptr);
   });
 
-  MSHADOW_TYPE_SWITCH(outputs[0].dtype(), DType, {
-    cached_out_mem_->set_data_handle(outputs[0].data().dptr<DType>());
-  });
+  MSHADOW_TYPE_SWITCH(outputs[0].dtype(), DType,
+                      { cached_out_mem_->set_data_handle(outputs[0].data().dptr<DType>()); });
 
   MKLDNNStream::Get()->RegisterPrimArgs(*fwd_, args_);
   MKLDNNStream::Get()->Submit();
@@ -330,28 +327,28 @@ NNVM_REGISTER_OP(_sg_mkldnn_selfatt_qk)
       }
     })
     .set_attr_parser(ParamParser<MKLDNNSelfAttParam>)
-    .set_attr<nnvm::FListInputNames>(
-        "FListInputNames",
-        [](const NodeAttrs& attrs) {
-          auto const& param = nnvm::get<MKLDNNSelfAttParam>(attrs.parsed);
-          std::vector<std::string> input_names{"queries_keys_values"};
-          if (param.quantized) {
-            input_names.emplace_back("min_qkv");
-            input_names.emplace_back("max_qkv");
-          }
-          return input_names;
-        })
-    .set_attr<nnvm::FListOutputNames>(
-        "FListOutputNames",
-        [](const NodeAttrs& attrs) {
-          auto const& param = nnvm::get<MKLDNNSelfAttParam>(attrs.parsed);
-          std::vector<std::string> output_names{"output"};
-          if (param.quantized && !param.enable_float_output) {
-            output_names.emplace_back("min_output");
-            output_names.emplace_back("max_output");
-          }
-          return output_names;
-        })
+    .set_attr<nnvm::FListInputNames>("FListInputNames",
+                                     [](const NodeAttrs& attrs) {
+                                       auto const& param =
+                                           nnvm::get<MKLDNNSelfAttParam>(attrs.parsed);
+                                       std::vector<std::string> input_names{"queries_keys_values"};
+                                       if (param.quantized) {
+                                         input_names.emplace_back("min_qkv");
+                                         input_names.emplace_back("max_qkv");
+                                       }
+                                       return input_names;
+                                     })
+    .set_attr<nnvm::FListOutputNames>("FListOutputNames",
+                                      [](const NodeAttrs& attrs) {
+                                        auto const& param =
+                                            nnvm::get<MKLDNNSelfAttParam>(attrs.parsed);
+                                        std::vector<std::string> output_names{"output"};
+                                        if (param.quantized && !param.enable_float_output) {
+                                          output_names.emplace_back("min_output");
+                                          output_names.emplace_back("max_output");
+                                        }
+                                        return output_names;
+                                      })
     .set_attr<mxnet::FInferShape>("FInferShape", SgMKLDNNSelfAttShape<1>)
     .set_attr<nnvm::FInferType>("FInferType", SgMKLDNNSelfAttQKInferType)
     .set_attr<FInferStorageType>("FInferStorageType", SgMKLDNNSelfAttStorageType<1>)
@@ -359,18 +356,18 @@ NNVM_REGISTER_OP(_sg_mkldnn_selfatt_qk)
     .set_attr<FStatefulComputeEx>("FStatefulComputeEx<cpu>", SgMKLDNNSelfAttQKForward)
     .set_attr<bool>("TIsMKLDNN", true)
     .set_attr<nnvm::FGradient>("FGradient", MakeZeroGradNodes)
-    .set_attr<FQuantizable>(
-        "FQuantizable", [](const NodeAttrs& attrs) { return QuantizeType::kMust; })
+    .set_attr<FQuantizable>("FQuantizable",
+                            [](const NodeAttrs& attrs) { return QuantizeType::kMust; })
     .set_attr<FQuantizedOp>("FQuantizedOp", SgMKLDNNSelfAttQKQuantizedOp)
     .set_attr<FNeedRequantize>("FNeedRequantize", [](const NodeAttrs& attrs) { return true; })
-    .add_argument(
-        "queries_keys_values", "NDArray-or-Symbol", "Interleaved queries, keys and values")
+    .add_argument("queries_keys_values", "NDArray-or-Symbol",
+                  "Interleaved queries, keys and values")
     .add_arguments(MKLDNNSelfAttParam::__FIELDS__());
 
 /**********************************_sg_mkldnn_selfatt_valatt**********************************/
 
-static bool SgMKLDNNSelfAttValAttInferType(
-    const nnvm::NodeAttrs& attrs, std::vector<int>* in_types, std::vector<int>* out_types) {
+static bool SgMKLDNNSelfAttValAttInferType(const nnvm::NodeAttrs& attrs, std::vector<int>* in_types,
+                                           std::vector<int>* out_types) {
   const auto& param = nnvm::get<MKLDNNSelfAttParam>(attrs.parsed);
   if (param.quantized) {
     TYPE_ASSIGN_CHECK(*in_types, 0, mshadow::kInt8);   // qkv input
@@ -419,20 +416,17 @@ class MKLDNNSelfAttValAttOp {
   explicit MKLDNNSelfAttValAttOp(const nnvm::NodeAttrs& attrs)
       : param_(nnvm::get<MKLDNNSelfAttParam>(attrs.parsed)) {}
 
-  void Forward(
-      const OpContext& ctx, const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
-      const std::vector<NDArray>& outputs);
+  void Forward(const OpContext& ctx, const std::vector<NDArray>& inputs,
+               const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs);
 
-  void Backward(
-      const OpContext& ctx, const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
-      const std::vector<NDArray>& outputs) {
+  void Backward(const OpContext& ctx, const std::vector<NDArray>& inputs,
+                const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs) {
     LOG(FATAL) << "Not implemented: subgraph mkldnn fully connected only supports "
                   "inference computation.";
   }
 
-  void Initialize(
-      const OpContext& ctx, const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
-      const std::vector<NDArray>& outputs);
+  void Initialize(const OpContext& ctx, const std::vector<NDArray>& inputs,
+                  const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs);
 
   bool IsInitialized() { return initialized_; }
 
@@ -454,15 +448,16 @@ class MKLDNNSelfAttValAttOp {
   float att_scale_{0.0f};
 };
 
-static OpStatePtr CreateMKLDNNSelfAttValAttState(
-    const nnvm::NodeAttrs& attrs, Context ctx, const mxnet::ShapeVector& in_shapes,
-    const std::vector<int>& in_types) {
+static OpStatePtr CreateMKLDNNSelfAttValAttState(const nnvm::NodeAttrs& attrs, Context ctx,
+                                                 const mxnet::ShapeVector& in_shapes,
+                                                 const std::vector<int>& in_types) {
   return OpStatePtr::Create<MKLDNNSelfAttValAttOp>(attrs);
 }
 
-static void MKLDNNSelfAttValAttForward(
-    const OpStatePtr& state_pointer, const OpContext& ctx, const std::vector<NDArray>& inputs,
-    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs) {
+static void MKLDNNSelfAttValAttForward(const OpStatePtr& state_pointer, const OpContext& ctx,
+                                       const std::vector<NDArray>& inputs,
+                                       const std::vector<OpReqType>& req,
+                                       const std::vector<NDArray>& outputs) {
   MKLDNNSelfAttValAttOp& op = state_pointer.get_state<MKLDNNSelfAttValAttOp>();
   if (!op.IsInitialized()) {
     op.Initialize(ctx, inputs, req, outputs);
@@ -470,9 +465,9 @@ static void MKLDNNSelfAttValAttForward(
   op.Forward(ctx, inputs, req, outputs);
 }
 
-void MKLDNNSelfAttValAttOp::Initialize(
-    const OpContext& ctx, const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
-    const std::vector<NDArray>& outputs) {
+void MKLDNNSelfAttValAttOp::Initialize(const OpContext& ctx, const std::vector<NDArray>& inputs,
+                                       const std::vector<OpReqType>& req,
+                                       const std::vector<NDArray>& outputs) {
   const dnnl::memory::dim qkv_seq_len    = inputs[0].shape()[0];
   const dnnl::memory::dim sequences      = inputs[0].shape()[1];
   const dnnl::memory::dim output_lin_dim = inputs[0].shape()[2];
@@ -549,9 +544,9 @@ void MKLDNNSelfAttValAttOp::Initialize(
   initialized_            = true;
 }
 
-void MKLDNNSelfAttValAttOp::Forward(
-    const OpContext& ctx, const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
-    const std::vector<NDArray>& outputs) {
+void MKLDNNSelfAttValAttOp::Forward(const OpContext& ctx, const std::vector<NDArray>& inputs,
+                                    const std::vector<OpReqType>& req,
+                                    const std::vector<NDArray>& outputs) {
   const auto engine     = CpuEngine::Get()->get_engine();
   const size_t head_dim = inputs[0].shape()[2] / param_.heads / 3;
   MSHADOW_TYPE_SWITCH(inputs[1].dtype(), DType, {
@@ -612,17 +607,17 @@ NNVM_REGISTER_OP(_sg_mkldnn_selfatt_valatt)
           }
           return input_names;
         })
-    .set_attr<nnvm::FListOutputNames>(
-        "FListOutputNames",
-        [](const NodeAttrs& attrs) {
-          auto const& param = nnvm::get<MKLDNNSelfAttParam>(attrs.parsed);
-          std::vector<std::string> output_names{"output"};
-          if (param.quantized && !param.enable_float_output) {
-            output_names.emplace_back("min_output");
-            output_names.emplace_back("max_output");
-          }
-          return output_names;
-        })
+    .set_attr<nnvm::FListOutputNames>("FListOutputNames",
+                                      [](const NodeAttrs& attrs) {
+                                        auto const& param =
+                                            nnvm::get<MKLDNNSelfAttParam>(attrs.parsed);
+                                        std::vector<std::string> output_names{"output"};
+                                        if (param.quantized && !param.enable_float_output) {
+                                          output_names.emplace_back("min_output");
+                                          output_names.emplace_back("max_output");
+                                        }
+                                        return output_names;
+                                      })
     .set_attr<mxnet::FInferShape>("FInferShape", SgMKLDNNSelfAttShape<2>)
     .set_attr<nnvm::FInferType>("FInferType", SgMKLDNNSelfAttValAttInferType)
     .set_attr<FInferStorageType>("FInferStorageType", SgMKLDNNSelfAttStorageType<2>)
@@ -630,12 +625,12 @@ NNVM_REGISTER_OP(_sg_mkldnn_selfatt_valatt)
     .set_attr<FStatefulComputeEx>("FStatefulComputeEx<cpu>", MKLDNNSelfAttValAttForward)
     .set_attr<bool>("TIsMKLDNN", true)
     .set_attr<nnvm::FGradient>("FGradient", MakeZeroGradNodes)
-    .set_attr<FQuantizable>(
-        "FQuantizable", [](const NodeAttrs& attrs) { return QuantizeType::kMust; })
+    .set_attr<FQuantizable>("FQuantizable",
+                            [](const NodeAttrs& attrs) { return QuantizeType::kMust; })
     .set_attr<FQuantizedOp>("FQuantizedOp", SgMKLDNNSelfAttValAttQuantizedOp)
     .set_attr<FNeedRequantize>("FNeedRequantize", [](const NodeAttrs& attrs) { return true; })
-    .add_argument(
-        "queries_keys_values", "NDArray-or-Symbol", "Queries, keys and values interleaved")
+    .add_argument("queries_keys_values", "NDArray-or-Symbol",
+                  "Queries, keys and values interleaved")
     .add_argument("attention", "NDArray-or-Symbol", "Attention maps")
     .add_arguments(MKLDNNSelfAttParam::__FIELDS__());
 

--- a/src/operator/subgraph/mkldnn/mkldnn_transformer.cc
+++ b/src/operator/subgraph/mkldnn/mkldnn_transformer.cc
@@ -73,8 +73,9 @@ static bool SgMKLDNNSelfAttQKInferType(const nnvm::NodeAttrs& attrs,
   const auto& param = nnvm::get<MKLDNNSelfAttParam>(attrs.parsed);
   if (param.quantized) {
     CHECK(in_types->at(0) == mshadow::kInt8)
-        << "QuantizedInterleavedMatMulSelfAttQK only supports int8 input, while " << in_types->at(0)
-        << " is given.";
+        << "QuantizedInterleavedMatMulSelfAttQK only supports int8 input, "
+           "while "
+        << in_types->at(0) << " is given.";
 
     TYPE_ASSIGN_CHECK(*in_types, 1, mshadow::kFloat32);  // min value
     TYPE_ASSIGN_CHECK(*in_types, 2, mshadow::kFloat32);  // max value
@@ -110,8 +111,8 @@ static bool SgMKLDNNSelfAttStorageType(const nnvm::NodeAttrs& attrs,
     for (int i = 0; i < base_num_inputs; i++) {
       base_in_attrs.emplace_back(in_attrs->at(i));
     }
-    bool ret = DefaultSubgraphOpStorageType(attrs, dev_mask, dispatch_mode, &base_in_attrs,
-                                            &base_out_attrs);
+    bool ret = DefaultSubgraphOpStorageType(
+        attrs, dev_mask, dispatch_mode, &base_in_attrs, &base_out_attrs);
 
     for (size_t i = 0; i < in_attrs->size(); ++i) {
       if (i < base_in_attrs.size())
@@ -154,7 +155,9 @@ class SgMKLDNNSelfAttQKOp {
                   const std::vector<OpReqType>& req,
                   const std::vector<NDArray>& outputs);
 
-  bool IsInitialized() { return initialized_; }
+  bool IsInitialized() {
+    return initialized_;
+  }
 
  private:
   bool initialized_{false};
@@ -291,8 +294,9 @@ void SgMKLDNNSelfAttQKOp::Forward(const OpContext& ctx,
     cached_key_mem_->set_data_handle(key_mem_ptr);
   });
 
-  MSHADOW_TYPE_SWITCH(outputs[0].dtype(), DType,
-                      { cached_out_mem_->set_data_handle(outputs[0].data().dptr<DType>()); });
+  MSHADOW_TYPE_SWITCH(outputs[0].dtype(), DType, {
+    cached_out_mem_->set_data_handle(outputs[0].data().dptr<DType>());
+  });
 
   MKLDNNStream::Get()->RegisterPrimArgs(*fwd_, args_);
   MKLDNNStream::Get()->Submit();
@@ -450,7 +454,9 @@ class MKLDNNSelfAttValAttOp {
                   const std::vector<OpReqType>& req,
                   const std::vector<NDArray>& outputs);
 
-  bool IsInitialized() { return initialized_; }
+  bool IsInitialized() {
+    return initialized_;
+  }
 
  private:
   bool initialized_{false};

--- a/src/operator/subgraph/mkldnn/mkldnn_transformer_post_quantize_property.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_transformer_post_quantize_property.h
@@ -23,6 +23,7 @@
 
 #include <string>
 #include <vector>
+
 #include "../../quantization/requantize-inl.h"
 #include "../common.h"
 #include "mkldnn_subgraph_base-inl.h"

--- a/src/operator/subgraph/mkldnn/mkldnn_transformer_post_quantize_property.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_transformer_post_quantize_property.h
@@ -62,10 +62,13 @@ class SgMKLDNNTransformerPostQuantizeSelector : public SubgraphSelector {
     return false;
   }
 
-  bool SelectInput(const nnvm::Node& n, const nnvm::Node& new_node) override { return false; }
+  bool SelectInput(const nnvm::Node& n, const nnvm::Node& new_node) override {
+    return false;
+  }
 
   bool SelectOutput(const nnvm::Node& n, const nnvm::Node& new_node) override {
-    if (status == kFail || status == kSuccess || new_node.is_variable()) return false;
+    if (status == kFail || status == kSuccess || new_node.is_variable())
+      return false;
     // If n isn't the last matched node, then we encoutered a internal
     // branch, we should pop out the node behind n and stop fusion.
     if (matched_list.back() != &n) {
@@ -146,7 +149,8 @@ class SgMKLDNNTransformerPostQuantizeProperty : public SubgraphProperty {
     nnvm::ObjectPtr dequantize_node  = nullptr;
 
     DFSVisit(sym.outputs, [&](const nnvm::ObjectPtr& node) {
-      if (node->is_variable()) return;
+      if (node->is_variable())
+        return;
       if (node->op() == Op::Get("_sg_mkldnn_selfatt_qk") ||
           node->op() == Op::Get("_sg_mkldnn_selfatt_valatt")) {
         interleaved_node = node;
@@ -163,9 +167,9 @@ class SgMKLDNNTransformerPostQuantizeProperty : public SubgraphProperty {
     CHECK(requantize_param.min_calib_range.has_value());
     CHECK(requantize_param.max_calib_range.has_value());
 
-    // When only fusing quantized_interleaved_matmul and requantize, set min/max_cablib_range,
-    // When fusing quantized_interleaved_matmul + requantize + dequantize,
-    // set dequantize flag to true.
+    // When only fusing quantized_interleaved_matmul and requantize, set
+    // min/max_cablib_range, When fusing quantized_interleaved_matmul +
+    // requantize + dequantize, set dequantize flag to true.
     if (dequantize_node != nullptr) {
       interleaved_node->attrs.dict["enable_float_output"] = "True";
     } else {

--- a/src/operator/subgraph/mkldnn/mkldnn_transformer_post_quantize_property.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_transformer_post_quantize_property.h
@@ -138,8 +138,8 @@ class SgMKLDNNTransformerPostQuantizeProperty : public SubgraphProperty {
     return property;
   }
 
-  nnvm::ObjectPtr CreateSubgraphNode(
-      const nnvm::Symbol& sym, const int subgraph_id = 0) const override {
+  nnvm::ObjectPtr CreateSubgraphNode(const nnvm::Symbol& sym,
+                                     const int subgraph_id = 0) const override {
     nnvm::ObjectPtr interleaved_node = nullptr;
     nnvm::ObjectPtr requantize_node  = nullptr;
     nnvm::ObjectPtr dequantize_node  = nullptr;
@@ -178,8 +178,8 @@ class SgMKLDNNTransformerPostQuantizeProperty : public SubgraphProperty {
   }
 
   SubgraphSelectorPtr CreateSubgraphSelector() const override {
-    auto selector = std::make_shared<SgMKLDNNTransformerPostQuantizeSelector>(
-        disable_fuse_all, disable_float_output);
+    auto selector = std::make_shared<SgMKLDNNTransformerPostQuantizeSelector>(disable_fuse_all,
+                                                                              disable_float_output);
     return selector;
   }
 

--- a/src/operator/subgraph/mkldnn/mkldnn_transformer_property.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_transformer_property.h
@@ -71,8 +71,8 @@ class SgMKLDNNTransformerProperty : public SubgraphProperty {
     return property;
   }
 
-  nnvm::ObjectPtr CreateSubgraphNode(
-      const nnvm::Symbol& sym, const int subgraph_id = 0) const override {
+  nnvm::ObjectPtr CreateSubgraphNode(const nnvm::Symbol& sym,
+                                     const int subgraph_id = 0) const override {
     nnvm::ObjectPtr n = nnvm::Node::Create();
     // This op has single output, remove duplicated.
     auto last_node = sym.outputs[0].node;
@@ -105,8 +105,8 @@ class SgMKLDNNTransformerProperty : public SubgraphProperty {
     return selector;
   }
 
-  void ConnectSubgraphOutputs(
-      const nnvm::ObjectPtr n, std::vector<nnvm::NodeEntry*>* output_entries) const override {
+  void ConnectSubgraphOutputs(const nnvm::ObjectPtr n,
+                              std::vector<nnvm::NodeEntry*>* output_entries) const override {
     // Connect all extern output entries to output[0]
     for (size_t i = 0; i < output_entries->size(); ++i) {
       auto entry_ptr = output_entries->at(i);

--- a/src/operator/subgraph/mkldnn/mkldnn_transformer_property.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_transformer_property.h
@@ -38,10 +38,12 @@ namespace op {
 #define SELFATT_VALATT "_contrib_interleaved_matmul_selfatt_valatt"
 
 const std::map<std::string, std::string> OpMapping = {
-    {SELFATT_QK, "_sg_mkldnn_selfatt_qk"}, {SELFATT_VALATT, "_sg_mkldnn_selfatt_valatt"}};
+    {SELFATT_QK, "_sg_mkldnn_selfatt_qk"},
+    {SELFATT_VALATT, "_sg_mkldnn_selfatt_valatt"}};
 
 const std::map<std::string, std::string> NameMapping = {
-    {SELFATT_QK, "sg_mkldnn_selfatt_qk"}, {SELFATT_VALATT, "sg_mkldnn_selfatt_valatt"}};
+    {SELFATT_QK, "sg_mkldnn_selfatt_qk"},
+    {SELFATT_VALATT, "sg_mkldnn_selfatt_valatt"}};
 
 class SgMKLDNNTransformerSelector : public SubgraphSelector {
  public:
@@ -52,9 +54,13 @@ class SgMKLDNNTransformerSelector : public SubgraphSelector {
     return false;
   }
 
-  bool SelectInput(const nnvm::Node& n, const nnvm::Node& new_node) override { return false; }
+  bool SelectInput(const nnvm::Node& n, const nnvm::Node& new_node) override {
+    return false;
+  }
 
-  bool SelectOutput(const nnvm::Node& n, const nnvm::Node& new_node) override { return false; }
+  bool SelectOutput(const nnvm::Node& n, const nnvm::Node& new_node) override {
+    return false;
+  }
 };
 
 class SgMKLDNNTransformerProperty : public SubgraphProperty {

--- a/src/operator/subgraph/mkldnn/mkldnn_transformer_property.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_transformer_property.h
@@ -24,11 +24,12 @@
 #include <map>
 #include <string>
 #include <vector>
-#include "../common.h"
-#include "../../tensor/matrix_op-inl.h"
+
 #include "../../contrib/transformer-inl.h"
-#include "mkldnn_transformer-inl.h"
+#include "../../tensor/matrix_op-inl.h"
+#include "../common.h"
 #include "mkldnn_subgraph_base-inl.h"
+#include "mkldnn_transformer-inl.h"
 
 namespace mxnet {
 namespace op {

--- a/src/operator/subgraph/mkldnn/mkldnn_transformer_property.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_transformer_property.h
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-
 #ifndef MXNET_OPERATOR_SUBGRAPH_MKLDNN_MKLDNN_TRANSFORMER_PROPERTY_H_
 #define MXNET_OPERATOR_SUBGRAPH_MKLDNN_MKLDNN_TRANSFORMER_PROPERTY_H_
 #if MXNET_USE_MKLDNN == 1
@@ -38,32 +37,23 @@ namespace op {
 #define SELFATT_VALATT "_contrib_interleaved_matmul_selfatt_valatt"
 
 const std::map<std::string, std::string> OpMapping = {
-  {SELFATT_QK,     "_sg_mkldnn_selfatt_qk"},
-  {SELFATT_VALATT, "_sg_mkldnn_selfatt_valatt"}
-};
+    {SELFATT_QK, "_sg_mkldnn_selfatt_qk"}, {SELFATT_VALATT, "_sg_mkldnn_selfatt_valatt"}};
 
 const std::map<std::string, std::string> NameMapping = {
-  {SELFATT_QK,     "sg_mkldnn_selfatt_qk"},
-  {SELFATT_VALATT, "sg_mkldnn_selfatt_valatt"}
-};
+    {SELFATT_QK, "sg_mkldnn_selfatt_qk"}, {SELFATT_VALATT, "sg_mkldnn_selfatt_valatt"}};
 
 class SgMKLDNNTransformerSelector : public SubgraphSelector {
  public:
-  bool Select(const nnvm::Node &n, const std::shared_ptr<NodeAttr>& node_attr) override {
-    if (n.op() == Op::Get(SELFATT_QK) ||
-        n.op() == Op::Get(SELFATT_VALATT)) {
+  bool Select(const nnvm::Node& n, const std::shared_ptr<NodeAttr>& node_attr) override {
+    if (n.op() == Op::Get(SELFATT_QK) || n.op() == Op::Get(SELFATT_VALATT)) {
       return true;
     }
     return false;
   }
 
-  bool SelectInput(const nnvm::Node &n, const nnvm::Node &new_node) override {
-    return false;
-  }
+  bool SelectInput(const nnvm::Node& n, const nnvm::Node& new_node) override { return false; }
 
-  bool SelectOutput(const nnvm::Node &n, const nnvm::Node &new_node) override {
-    return false;
-  }
+  bool SelectOutput(const nnvm::Node& n, const nnvm::Node& new_node) override { return false; }
 };
 
 class SgMKLDNNTransformerProperty : public SubgraphProperty {
@@ -71,8 +61,8 @@ class SgMKLDNNTransformerProperty : public SubgraphProperty {
   SgMKLDNNTransformerProperty() {}
 
   static SubgraphPropertyPtr Create() {
-    static const std::string &name = "MKLDNN Transformer optimization pass";
-    auto property = std::make_shared<SgMKLDNNTransformerProperty>();
+    static const std::string& name = "MKLDNN Transformer optimization pass";
+    auto property                  = std::make_shared<SgMKLDNNTransformerProperty>();
     property->SetAttr<std::string>("property_name", name);
     property->SetAttr<bool>("inference_only", true);
     if (dmlc::GetEnv("MXNET_DISABLE_MKLDNN_TRANSFORMER_OPT", 0)) {
@@ -81,8 +71,8 @@ class SgMKLDNNTransformerProperty : public SubgraphProperty {
     return property;
   }
 
-  nnvm::ObjectPtr CreateSubgraphNode(const nnvm::Symbol &sym,
-                                   const int subgraph_id = 0) const override {
+  nnvm::ObjectPtr CreateSubgraphNode(
+      const nnvm::Symbol& sym, const int subgraph_id = 0) const override {
     nnvm::ObjectPtr n = nnvm::Node::Create();
     // This op has single output, remove duplicated.
     auto last_node = sym.outputs[0].node;
@@ -91,22 +81,19 @@ class SgMKLDNNTransformerProperty : public SubgraphProperty {
     std::ostringstream node_name;
     std::string op_name;
     MKLDNNSelfAttParam new_param;
-    DFSVisit(new_sym.outputs, [&](const nnvm::ObjectPtr &node) {
-      if (node->op() &&
-          (node->op()->name == SELFATT_QK ||
-           node->op()->name == SELFATT_VALATT)) {
-        op_name = node->op()->name;
-        auto param = nnvm::get<InterleavedMatMulParam>(node->attrs.parsed);
-        new_param.heads = param.heads;
-        new_param.quantized = false;
+    DFSVisit(new_sym.outputs, [&](const nnvm::ObjectPtr& node) {
+      if (node->op() && (node->op()->name == SELFATT_QK || node->op()->name == SELFATT_VALATT)) {
+        op_name                       = node->op()->name;
+        auto param                    = nnvm::get<InterleavedMatMulParam>(node->attrs.parsed);
+        new_param.heads               = param.heads;
+        new_param.quantized           = false;
         new_param.enable_float_output = false;
       }
     });
     node_name << NameMapping.at(op_name) << "_" << std::to_string(subgraph_id);
 
-
     n->attrs.name = node_name.str();
-    n->attrs.op = Op::Get(OpMapping.at(op_name));
+    n->attrs.op   = Op::Get(OpMapping.at(op_name));
     CHECK(n->attrs.op);
     n->attrs.subgraphs.emplace_back(std::make_shared<nnvm::Symbol>(new_sym));
     n->attrs.parsed = new_param;
@@ -119,12 +106,11 @@ class SgMKLDNNTransformerProperty : public SubgraphProperty {
   }
 
   void ConnectSubgraphOutputs(
-      const nnvm::ObjectPtr n,
-      std::vector<nnvm::NodeEntry *> *output_entries) const override {
+      const nnvm::ObjectPtr n, std::vector<nnvm::NodeEntry*>* output_entries) const override {
     // Connect all extern output entries to output[0]
     for (size_t i = 0; i < output_entries->size(); ++i) {
       auto entry_ptr = output_entries->at(i);
-      *entry_ptr = nnvm::NodeEntry{n, entry_ptr->index, 0};
+      *entry_ptr     = nnvm::NodeEntry{n, entry_ptr->index, 0};
     }
   }
 };

--- a/src/operator/tensor/amp_cast.cc
+++ b/src/operator/tensor/amp_cast.cc
@@ -31,11 +31,9 @@ DMLC_REGISTER_PARAMETER(AMPCastParam);
 DMLC_REGISTER_PARAMETER(AMPMultiCastParam);
 
 #if MXNET_USE_MKLDNN == 1
-static void AMPCastExCPU(const nnvm::NodeAttrs& attrs,
-                    const OpContext& ctx,
-                    const std::vector<NDArray>& inputs,
-                    const std::vector<OpReqType>& req,
-                    const std::vector<NDArray>& outputs) {
+static void AMPCastExCPU(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& inputs,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs) {
   CHECK_EQ(inputs.size(), 1U);
   CHECK_EQ(outputs.size(), 1U);
   if (req[0] == kWriteInplace) {
@@ -44,17 +42,16 @@ static void AMPCastExCPU(const nnvm::NodeAttrs& attrs,
   auto data = inputs[0];
   if (data.dtype() != mshadow::kFloat16 && outputs[0].dtype() != mshadow::kFloat16) {
     mkldnn::engine cpu_engine = mxnet::CpuEngine::Get()->get_engine();
-    if (data.IsView() && data.IsMKLDNNData())
-      data = data.Reorder2Default();
-    const auto i_mem = data.GetMKLDNNData();
-    const size_t i_ndim = data.shape().ndim();
+    if (data.IsView() && data.IsMKLDNNData()) data = data.Reorder2Default();
+    const auto i_mem            = data.GetMKLDNNData();
+    const size_t i_ndim         = data.shape().ndim();
     mkldnn::memory::dims i_dims = mkldnn::memory::dims(i_ndim);
     for (size_t i = 0; i < i_ndim; i++) {
       i_dims[i] = static_cast<int>(data.shape()[i]);
     }
-    const auto o_desc =
-        mkldnn::memory::desc(i_dims, get_mkldnn_type(outputs[0].dtype()),
-                            static_cast<mkldnn::memory::format_tag>(GetDefaultFormat(i_ndim)));
+    const auto o_desc = mkldnn::memory::desc(
+        i_dims, get_mkldnn_type(outputs[0].dtype()),
+        static_cast<mkldnn::memory::format_tag>(GetDefaultFormat(i_ndim)));
     const auto out_mem = CreateMKLDNNMem(outputs[0], o_desc, req[0]);
     mkldnn_args_map_t reorder_args;
     reorder_args[MKLDNN_ARG_SRC] = *i_mem;
@@ -66,18 +63,18 @@ static void AMPCastExCPU(const nnvm::NodeAttrs& attrs,
   FallBackCompute(AMPCastCompute<cpu>, attrs, ctx, inputs, req, outputs);
 }
 
-inline static bool AMPCastStorageType(const nnvm::NodeAttrs& attrs, const int dev_mask,
-                                      DispatchMode* dispatch_mode, std::vector<int>* in_attrs,
-                                      std::vector<int>* out_attrs) {
+inline static bool AMPCastStorageType(
+    const nnvm::NodeAttrs& attrs, const int dev_mask, DispatchMode* dispatch_mode,
+    std::vector<int>* in_attrs, std::vector<int>* out_attrs) {
   CHECK_EQ(in_attrs->size(), 1);
   CHECK_EQ(out_attrs->size(), 1);
   auto ret = MKLDNNStorageType(attrs, dev_mask, true, dispatch_mode, in_attrs, out_attrs);
   return ret;
 }
 
-static void AMPMultiCastExCPU(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
-                              const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
-                              const std::vector<NDArray>& outputs) {
+static void AMPMultiCastExCPU(
+    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& inputs,
+    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs) {
   const AMPMultiCastParam& param = nnvm::get<AMPMultiCastParam>(attrs.parsed);
   CHECK_EQ(inputs.size(), param.num_outputs);
   CHECK_EQ(outputs.size(), param.num_outputs);
@@ -87,17 +84,16 @@ static void AMPMultiCastExCPU(const nnvm::NodeAttrs& attrs, const OpContext& ctx
       continue;
     }
     auto data = inputs[i];
-    if (data.IsView() && data.IsMKLDNNData())
-      data = data.Reorder2Default();
-    const auto i_mem = data.GetMKLDNNData();
-    const size_t i_ndim = data.shape().ndim();
+    if (data.IsView() && data.IsMKLDNNData()) data = data.Reorder2Default();
+    const auto i_mem            = data.GetMKLDNNData();
+    const size_t i_ndim         = data.shape().ndim();
     mkldnn::memory::dims i_dims = mkldnn::memory::dims(i_ndim);
     for (size_t j = 0; j < i_ndim; j++) {
       i_dims[j] = static_cast<int>(data.shape()[j]);
     }
-    const auto o_desc =
-        mkldnn::memory::desc(i_dims, get_mkldnn_type(outputs[i].dtype()),
-                             static_cast<mkldnn::memory::format_tag>(GetDefaultFormat(i_ndim)));
+    const auto o_desc = mkldnn::memory::desc(
+        i_dims, get_mkldnn_type(outputs[i].dtype()),
+        static_cast<mkldnn::memory::format_tag>(GetDefaultFormat(i_ndim)));
     const auto out_mem = CreateMKLDNNMem(outputs[i], o_desc, req[i]);
     mkldnn_args_map_t reorder_args;
     reorder_args[MKLDNN_ARG_SRC] = *i_mem;
@@ -107,9 +103,9 @@ static void AMPMultiCastExCPU(const nnvm::NodeAttrs& attrs, const OpContext& ctx
   MKLDNNStream::Get()->Submit();
 }
 
-inline static bool AMPMultiCastStorageType(const nnvm::NodeAttrs& attrs, const int dev_mask,
-                                           DispatchMode* dispatch_mode, std::vector<int>* in_attrs,
-                                           std::vector<int>* out_attrs) {
+inline static bool AMPMultiCastStorageType(
+    const nnvm::NodeAttrs& attrs, const int dev_mask, DispatchMode* dispatch_mode,
+    std::vector<int>* in_attrs, std::vector<int>* out_attrs) {
   const AMPMultiCastParam& param = nnvm::get<AMPMultiCastParam>(attrs.parsed);
   CHECK_EQ(in_attrs->size(), param.num_outputs);
   CHECK_EQ(out_attrs->size(), param.num_outputs);
@@ -119,143 +115,144 @@ inline static bool AMPMultiCastStorageType(const nnvm::NodeAttrs& attrs, const i
 #endif  // MXNET_USE_MKLDNN == 1
 
 NNVM_REGISTER_OP(amp_cast)
-.describe(R"code(Cast function between low precision float/FP32 used by AMP.
+    .describe(R"code(Cast function between low precision float/FP32 used by AMP.
 
 It casts only between low precision float/FP32 and does not do anything for other types.
 )code" ADD_FILELINE)
-.set_attr_parser(ParamParser<AMPCastParam>)
-.set_attr<mxnet::FInferShape>("FInferShape", ElemwiseShape<1, 1>)
-.set_attr<nnvm::FInferType>("FInferType", AMPCastType)
-.set_attr<nnvm::FInplaceOption>("FInplaceOption",
-  [](const NodeAttrs& attrs){
-    return std::vector<std::pair<int, int> >{{0, 0}};
-  })
-.set_attr<nnvm::FInplaceIdentity>("FInplaceIdentity",
-  [](const NodeAttrs& attrs){
-    return std::vector<bool>{true};
-  })
-.set_attr<FCompute>("FCompute<cpu>", AMPCastCompute<cpu>)
+    .set_attr_parser(ParamParser<AMPCastParam>)
+    .set_attr<mxnet::FInferShape>("FInferShape", ElemwiseShape<1, 1>)
+    .set_attr<nnvm::FInferType>("FInferType", AMPCastType)
+    .set_attr<nnvm::FInplaceOption>(
+        "FInplaceOption",
+        [](const NodeAttrs& attrs) {
+          return std::vector<std::pair<int, int>>{{0, 0}};
+        })
+    .set_attr<nnvm::FInplaceIdentity>(
+        "FInplaceIdentity", [](const NodeAttrs& attrs) { return std::vector<bool>{true}; })
+    .set_attr<FCompute>("FCompute<cpu>", AMPCastCompute<cpu>)
 #if MXNET_USE_MKLDNN == 1
-.set_attr<bool>("TIsMKLDNN", true)
-.set_attr<FInferStorageType>("FInferStorageType", AMPCastStorageType)
-.set_attr<FComputeEx>("FComputeEx<cpu>", AMPCastExCPU)
+    .set_attr<bool>("TIsMKLDNN", true)
+    .set_attr<FInferStorageType>("FInferStorageType", AMPCastStorageType)
+    .set_attr<FComputeEx>("FComputeEx<cpu>", AMPCastExCPU)
 #endif
-.set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseNone{"_backward_amp_cast"})
-.add_argument("data", "NDArray-or-Symbol", "The input.")
-.add_arguments(AMPCastParam::__FIELDS__());
+    .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseNone{"_backward_amp_cast"})
+    .add_argument("data", "NDArray-or-Symbol", "The input.")
+    .add_arguments(AMPCastParam::__FIELDS__());
 
 NNVM_REGISTER_OP(_backward_amp_cast)
-.set_attr<nnvm::TIsBackward>("TIsBackward", true)
-.set_attr<nnvm::FInplaceOption>("FInplaceOption",
-  [](const NodeAttrs& attrs){
-    return std::vector<std::pair<int, int> >{{0, 0}};
-  })
-.set_attr<nnvm::FInplaceIdentity>("FInplaceIdentity",
-  [](const NodeAttrs& attrs){
-    return std::vector<bool>{true};
-  })
+    .set_attr<nnvm::TIsBackward>("TIsBackward", true)
+    .set_attr<nnvm::FInplaceOption>(
+        "FInplaceOption",
+        [](const NodeAttrs& attrs) {
+          return std::vector<std::pair<int, int>>{{0, 0}};
+        })
+    .set_attr<nnvm::FInplaceIdentity>(
+        "FInplaceIdentity", [](const NodeAttrs& attrs) { return std::vector<bool>{true}; })
 #if MXNET_USE_MKLDNN == 1
-.set_attr<bool>("TIsMKLDNN", true)
-.set_attr<FInferStorageType>("FInferStorageType", AMPCastStorageType)
-.set_attr<FComputeEx>("FComputeEx<cpu>", AMPCastExCPU)
+    .set_attr<bool>("TIsMKLDNN", true)
+    .set_attr<FInferStorageType>("FInferStorageType", AMPCastStorageType)
+    .set_attr<FComputeEx>("FComputeEx<cpu>", AMPCastExCPU)
 #endif
-.set_attr<FCompute>("FCompute<cpu>", AMPCastCompute<cpu>);
+    .set_attr<FCompute>("FCompute<cpu>", AMPCastCompute<cpu>);
 
 NNVM_REGISTER_OP(amp_multicast)
-.describe(R"code(Cast function used by AMP, that casts its inputs to the common widest type.
+    .describe(R"code(Cast function used by AMP, that casts its inputs to the common widest type.
 
 It casts only between low precision float/FP32 and does not do anything for other types.
 
 )code" ADD_FILELINE)
-.set_num_inputs([](const nnvm::NodeAttrs& attrs) {
-    const AMPMultiCastParam& param = dmlc::get<AMPMultiCastParam>(attrs.parsed);
-    return static_cast<uint32_t>(param.num_outputs);
-})
-.set_num_outputs([](const nnvm::NodeAttrs& attrs) {
-    const AMPMultiCastParam& param = dmlc::get<AMPMultiCastParam>(attrs.parsed);
-    return static_cast<uint32_t>(param.num_outputs);
-})
-.set_attr_parser(ParamParser<AMPMultiCastParam>)
-.set_attr<mxnet::FInferShape>("FInferShape", AMPMultiCastShape)
-.set_attr<nnvm::FInferType>("FInferType", AMPMultiCastType)
-.set_attr<nnvm::FListInputNames>("FListInputNames",
-  [](const NodeAttrs& attrs) {
-    uint32_t num_args =
-        dmlc::get<AMPMultiCastParam>(attrs.parsed).num_outputs;
-    std::vector<std::string> ret;
-    for (uint32_t i = 0; i < num_args; ++i) {
-      ret.push_back(std::string("data_") + std::to_string(i));
-    }
-    return ret;
-  })
-.set_attr<nnvm::FInplaceOption>("FInplaceOption",
-  [](const NodeAttrs& attrs) {
-    int num_args =
-        dmlc::get<AMPMultiCastParam>(attrs.parsed).num_outputs;
-    std::vector<std::pair<int, int>> ret;
-    for (int i = 0; i < num_args; ++i) {
-      ret.emplace_back(i, i);
-    }
-    return ret;
-  })
-.set_attr<nnvm::FInplaceIdentity>("FInplaceIdentity",
-  [](const NodeAttrs& attrs) {
-    int num_args =
-        dmlc::get<AMPMultiCastParam>(attrs.parsed).num_outputs;
-    return std::vector<bool>(num_args, true);
-  })
-.set_attr<FCompute>("FCompute<cpu>", AMPMultiCastCompute<cpu>)
+    .set_num_inputs([](const nnvm::NodeAttrs& attrs) {
+      const AMPMultiCastParam& param = dmlc::get<AMPMultiCastParam>(attrs.parsed);
+      return static_cast<uint32_t>(param.num_outputs);
+    })
+    .set_num_outputs([](const nnvm::NodeAttrs& attrs) {
+      const AMPMultiCastParam& param = dmlc::get<AMPMultiCastParam>(attrs.parsed);
+      return static_cast<uint32_t>(param.num_outputs);
+    })
+    .set_attr_parser(ParamParser<AMPMultiCastParam>)
+    .set_attr<mxnet::FInferShape>("FInferShape", AMPMultiCastShape)
+    .set_attr<nnvm::FInferType>("FInferType", AMPMultiCastType)
+    .set_attr<nnvm::FListInputNames>(
+        "FListInputNames",
+        [](const NodeAttrs& attrs) {
+          uint32_t num_args = dmlc::get<AMPMultiCastParam>(attrs.parsed).num_outputs;
+          std::vector<std::string> ret;
+          for (uint32_t i = 0; i < num_args; ++i) {
+            ret.push_back(std::string("data_") + std::to_string(i));
+          }
+          return ret;
+        })
+    .set_attr<nnvm::FInplaceOption>(
+        "FInplaceOption",
+        [](const NodeAttrs& attrs) {
+          int num_args = dmlc::get<AMPMultiCastParam>(attrs.parsed).num_outputs;
+          std::vector<std::pair<int, int>> ret;
+          for (int i = 0; i < num_args; ++i) {
+            ret.emplace_back(i, i);
+          }
+          return ret;
+        })
+    .set_attr<nnvm::FInplaceIdentity>(
+        "FInplaceIdentity",
+        [](const NodeAttrs& attrs) {
+          int num_args = dmlc::get<AMPMultiCastParam>(attrs.parsed).num_outputs;
+          return std::vector<bool>(num_args, true);
+        })
+    .set_attr<FCompute>("FCompute<cpu>", AMPMultiCastCompute<cpu>)
 #if MXNET_USE_MKLDNN == 1
-.set_attr<bool>("TIsMKLDNN", true)
-.set_attr<FInferStorageType>("FInferStorageType", AMPMultiCastStorageType)
-.set_attr<FComputeEx>("FComputeEx<cpu>", AMPMultiCastExCPU)
+    .set_attr<bool>("TIsMKLDNN", true)
+    .set_attr<FInferStorageType>("FInferStorageType", AMPMultiCastStorageType)
+    .set_attr<FComputeEx>("FComputeEx<cpu>", AMPMultiCastExCPU)
 #endif
-.set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseNone{"_backward_amp_multicast"})
-.add_argument("data", "NDArray-or-Symbol[]", "Weights")
-.add_arguments(AMPMultiCastParam::__FIELDS__());
+    .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseNone{"_backward_amp_multicast"})
+    .add_argument("data", "NDArray-or-Symbol[]", "Weights")
+    .add_arguments(AMPMultiCastParam::__FIELDS__());
 
 NNVM_REGISTER_OP(_backward_amp_multicast)
-.set_attr<nnvm::TIsBackward>("TIsBackward", true)
-.set_num_inputs([](const nnvm::NodeAttrs& attrs) {
-    const AMPMultiCastParam& param = dmlc::get<AMPMultiCastParam>(attrs.parsed);
-    return static_cast<uint32_t>(param.num_outputs);
-  })
-.set_num_outputs([](const nnvm::NodeAttrs& attrs) {
-    const AMPMultiCastParam& param = dmlc::get<AMPMultiCastParam>(attrs.parsed);
-    return static_cast<uint32_t>(param.num_outputs);
-  })
-.set_attr_parser(ParamParser<AMPMultiCastParam>)
-.set_attr<nnvm::FListInputNames>("FListInputNames",
-  [](const NodeAttrs& attrs) {
-    uint32_t num_args = dmlc::get<AMPMultiCastParam>(attrs.parsed).num_outputs;
-    std::vector<std::string> ret;
-    for (uint32_t i = 0; i < num_args; ++i) {
-      ret.push_back(std::string("grad_") + std::to_string(i));
-    }
-    return ret;
-  })
-.set_attr<nnvm::FInplaceOption>("FInplaceOption",
-  [](const NodeAttrs& attrs){
-    int num_args = dmlc::get<AMPMultiCastParam>(attrs.parsed).num_outputs;
-    std::vector<std::pair<int, int>> ret;
-    for (int i = 0; i < num_args; ++i) {
-      ret.emplace_back(i, i);
-    }
-    return ret;
-  })
-.set_attr<nnvm::FInplaceIdentity>("FInplaceIdentity",
-  [](const NodeAttrs& attrs){
-    int num_args = dmlc::get<AMPMultiCastParam>(attrs.parsed).num_outputs;
-    return std::vector<bool>(num_args, true);
-  })
+    .set_attr<nnvm::TIsBackward>("TIsBackward", true)
+    .set_num_inputs([](const nnvm::NodeAttrs& attrs) {
+      const AMPMultiCastParam& param = dmlc::get<AMPMultiCastParam>(attrs.parsed);
+      return static_cast<uint32_t>(param.num_outputs);
+    })
+    .set_num_outputs([](const nnvm::NodeAttrs& attrs) {
+      const AMPMultiCastParam& param = dmlc::get<AMPMultiCastParam>(attrs.parsed);
+      return static_cast<uint32_t>(param.num_outputs);
+    })
+    .set_attr_parser(ParamParser<AMPMultiCastParam>)
+    .set_attr<nnvm::FListInputNames>(
+        "FListInputNames",
+        [](const NodeAttrs& attrs) {
+          uint32_t num_args = dmlc::get<AMPMultiCastParam>(attrs.parsed).num_outputs;
+          std::vector<std::string> ret;
+          for (uint32_t i = 0; i < num_args; ++i) {
+            ret.push_back(std::string("grad_") + std::to_string(i));
+          }
+          return ret;
+        })
+    .set_attr<nnvm::FInplaceOption>(
+        "FInplaceOption",
+        [](const NodeAttrs& attrs) {
+          int num_args = dmlc::get<AMPMultiCastParam>(attrs.parsed).num_outputs;
+          std::vector<std::pair<int, int>> ret;
+          for (int i = 0; i < num_args; ++i) {
+            ret.emplace_back(i, i);
+          }
+          return ret;
+        })
+    .set_attr<nnvm::FInplaceIdentity>(
+        "FInplaceIdentity",
+        [](const NodeAttrs& attrs) {
+          int num_args = dmlc::get<AMPMultiCastParam>(attrs.parsed).num_outputs;
+          return std::vector<bool>(num_args, true);
+        })
 #if MXNET_USE_MKLDNN == 1
-.set_attr<bool>("TIsMKLDNN", true)
-.set_attr<FInferStorageType>("FInferStorageType", AMPMultiCastStorageType)
-.set_attr<FComputeEx>("FComputeEx<cpu>", AMPMultiCastExCPU)
+    .set_attr<bool>("TIsMKLDNN", true)
+    .set_attr<FInferStorageType>("FInferStorageType", AMPMultiCastStorageType)
+    .set_attr<FComputeEx>("FComputeEx<cpu>", AMPMultiCastExCPU)
 #endif
-.set_attr<FCompute>("FCompute<cpu>", AMPMultiCastCompute<cpu>)
-.add_argument("grad", "NDArray-or-Symbol[]", "Gradients")
-.add_arguments(AMPMultiCastParam::__FIELDS__());
+    .set_attr<FCompute>("FCompute<cpu>", AMPMultiCastCompute<cpu>)
+    .add_argument("grad", "NDArray-or-Symbol[]", "Gradients")
+    .add_arguments(AMPMultiCastParam::__FIELDS__());
 
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/tensor/amp_cast.cc
+++ b/src/operator/tensor/amp_cast.cc
@@ -31,8 +31,10 @@ DMLC_REGISTER_PARAMETER(AMPCastParam);
 DMLC_REGISTER_PARAMETER(AMPMultiCastParam);
 
 #if MXNET_USE_MKLDNN == 1
-static void AMPCastExCPU(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
-                         const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+static void AMPCastExCPU(const nnvm::NodeAttrs& attrs,
+                         const OpContext& ctx,
+                         const std::vector<NDArray>& inputs,
+                         const std::vector<OpReqType>& req,
                          const std::vector<NDArray>& outputs) {
   CHECK_EQ(inputs.size(), 1U);
   CHECK_EQ(outputs.size(), 1U);
@@ -63,8 +65,10 @@ static void AMPCastExCPU(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
   FallBackCompute(AMPCastCompute<cpu>, attrs, ctx, inputs, req, outputs);
 }
 
-inline static bool AMPCastStorageType(const nnvm::NodeAttrs& attrs, const int dev_mask,
-                                      DispatchMode* dispatch_mode, std::vector<int>* in_attrs,
+inline static bool AMPCastStorageType(const nnvm::NodeAttrs& attrs,
+                                      const int dev_mask,
+                                      DispatchMode* dispatch_mode,
+                                      std::vector<int>* in_attrs,
                                       std::vector<int>* out_attrs) {
   CHECK_EQ(in_attrs->size(), 1);
   CHECK_EQ(out_attrs->size(), 1);
@@ -72,8 +76,10 @@ inline static bool AMPCastStorageType(const nnvm::NodeAttrs& attrs, const int de
   return ret;
 }
 
-static void AMPMultiCastExCPU(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
-                              const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+static void AMPMultiCastExCPU(const nnvm::NodeAttrs& attrs,
+                              const OpContext& ctx,
+                              const std::vector<NDArray>& inputs,
+                              const std::vector<OpReqType>& req,
                               const std::vector<NDArray>& outputs) {
   const AMPMultiCastParam& param = nnvm::get<AMPMultiCastParam>(attrs.parsed);
   CHECK_EQ(inputs.size(), param.num_outputs);
@@ -103,8 +109,10 @@ static void AMPMultiCastExCPU(const nnvm::NodeAttrs& attrs, const OpContext& ctx
   MKLDNNStream::Get()->Submit();
 }
 
-inline static bool AMPMultiCastStorageType(const nnvm::NodeAttrs& attrs, const int dev_mask,
-                                           DispatchMode* dispatch_mode, std::vector<int>* in_attrs,
+inline static bool AMPMultiCastStorageType(const nnvm::NodeAttrs& attrs,
+                                           const int dev_mask,
+                                           DispatchMode* dispatch_mode,
+                                           std::vector<int>* in_attrs,
                                            std::vector<int>* out_attrs) {
   const AMPMultiCastParam& param = nnvm::get<AMPMultiCastParam>(attrs.parsed);
   CHECK_EQ(in_attrs->size(), param.num_outputs);

--- a/src/operator/tensor/amp_cast.cc
+++ b/src/operator/tensor/amp_cast.cc
@@ -31,9 +31,9 @@ DMLC_REGISTER_PARAMETER(AMPCastParam);
 DMLC_REGISTER_PARAMETER(AMPMultiCastParam);
 
 #if MXNET_USE_MKLDNN == 1
-static void AMPCastExCPU(
-    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& inputs,
-    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs) {
+static void AMPCastExCPU(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+                         const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+                         const std::vector<NDArray>& outputs) {
   CHECK_EQ(inputs.size(), 1U);
   CHECK_EQ(outputs.size(), 1U);
   if (req[0] == kWriteInplace) {
@@ -49,9 +49,9 @@ static void AMPCastExCPU(
     for (size_t i = 0; i < i_ndim; i++) {
       i_dims[i] = static_cast<int>(data.shape()[i]);
     }
-    const auto o_desc = mkldnn::memory::desc(
-        i_dims, get_mkldnn_type(outputs[0].dtype()),
-        static_cast<mkldnn::memory::format_tag>(GetDefaultFormat(i_ndim)));
+    const auto o_desc =
+        mkldnn::memory::desc(i_dims, get_mkldnn_type(outputs[0].dtype()),
+                             static_cast<mkldnn::memory::format_tag>(GetDefaultFormat(i_ndim)));
     const auto out_mem = CreateMKLDNNMem(outputs[0], o_desc, req[0]);
     mkldnn_args_map_t reorder_args;
     reorder_args[MKLDNN_ARG_SRC] = *i_mem;
@@ -63,18 +63,18 @@ static void AMPCastExCPU(
   FallBackCompute(AMPCastCompute<cpu>, attrs, ctx, inputs, req, outputs);
 }
 
-inline static bool AMPCastStorageType(
-    const nnvm::NodeAttrs& attrs, const int dev_mask, DispatchMode* dispatch_mode,
-    std::vector<int>* in_attrs, std::vector<int>* out_attrs) {
+inline static bool AMPCastStorageType(const nnvm::NodeAttrs& attrs, const int dev_mask,
+                                      DispatchMode* dispatch_mode, std::vector<int>* in_attrs,
+                                      std::vector<int>* out_attrs) {
   CHECK_EQ(in_attrs->size(), 1);
   CHECK_EQ(out_attrs->size(), 1);
   auto ret = MKLDNNStorageType(attrs, dev_mask, true, dispatch_mode, in_attrs, out_attrs);
   return ret;
 }
 
-static void AMPMultiCastExCPU(
-    const nnvm::NodeAttrs& attrs, const OpContext& ctx, const std::vector<NDArray>& inputs,
-    const std::vector<OpReqType>& req, const std::vector<NDArray>& outputs) {
+static void AMPMultiCastExCPU(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
+                              const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+                              const std::vector<NDArray>& outputs) {
   const AMPMultiCastParam& param = nnvm::get<AMPMultiCastParam>(attrs.parsed);
   CHECK_EQ(inputs.size(), param.num_outputs);
   CHECK_EQ(outputs.size(), param.num_outputs);
@@ -91,9 +91,9 @@ static void AMPMultiCastExCPU(
     for (size_t j = 0; j < i_ndim; j++) {
       i_dims[j] = static_cast<int>(data.shape()[j]);
     }
-    const auto o_desc = mkldnn::memory::desc(
-        i_dims, get_mkldnn_type(outputs[i].dtype()),
-        static_cast<mkldnn::memory::format_tag>(GetDefaultFormat(i_ndim)));
+    const auto o_desc =
+        mkldnn::memory::desc(i_dims, get_mkldnn_type(outputs[i].dtype()),
+                             static_cast<mkldnn::memory::format_tag>(GetDefaultFormat(i_ndim)));
     const auto out_mem = CreateMKLDNNMem(outputs[i], o_desc, req[i]);
     mkldnn_args_map_t reorder_args;
     reorder_args[MKLDNN_ARG_SRC] = *i_mem;
@@ -103,9 +103,9 @@ static void AMPMultiCastExCPU(
   MKLDNNStream::Get()->Submit();
 }
 
-inline static bool AMPMultiCastStorageType(
-    const nnvm::NodeAttrs& attrs, const int dev_mask, DispatchMode* dispatch_mode,
-    std::vector<int>* in_attrs, std::vector<int>* out_attrs) {
+inline static bool AMPMultiCastStorageType(const nnvm::NodeAttrs& attrs, const int dev_mask,
+                                           DispatchMode* dispatch_mode, std::vector<int>* in_attrs,
+                                           std::vector<int>* out_attrs) {
   const AMPMultiCastParam& param = nnvm::get<AMPMultiCastParam>(attrs.parsed);
   CHECK_EQ(in_attrs->size(), param.num_outputs);
   CHECK_EQ(out_attrs->size(), param.num_outputs);
@@ -122,13 +122,14 @@ It casts only between low precision float/FP32 and does not do anything for othe
     .set_attr_parser(ParamParser<AMPCastParam>)
     .set_attr<mxnet::FInferShape>("FInferShape", ElemwiseShape<1, 1>)
     .set_attr<nnvm::FInferType>("FInferType", AMPCastType)
-    .set_attr<nnvm::FInplaceOption>(
-        "FInplaceOption",
-        [](const NodeAttrs& attrs) {
-          return std::vector<std::pair<int, int>>{{0, 0}};
-        })
-    .set_attr<nnvm::FInplaceIdentity>(
-        "FInplaceIdentity", [](const NodeAttrs& attrs) { return std::vector<bool>{true}; })
+    .set_attr<nnvm::FInplaceOption>("FInplaceOption",
+                                    [](const NodeAttrs& attrs) {
+                                      return std::vector<std::pair<int, int>>{{0, 0}};
+                                    })
+    .set_attr<nnvm::FInplaceIdentity>("FInplaceIdentity",
+                                      [](const NodeAttrs& attrs) {
+                                        return std::vector<bool>{true};
+                                      })
     .set_attr<FCompute>("FCompute<cpu>", AMPCastCompute<cpu>)
 #if MXNET_USE_MKLDNN == 1
     .set_attr<bool>("TIsMKLDNN", true)
@@ -141,13 +142,14 @@ It casts only between low precision float/FP32 and does not do anything for othe
 
 NNVM_REGISTER_OP(_backward_amp_cast)
     .set_attr<nnvm::TIsBackward>("TIsBackward", true)
-    .set_attr<nnvm::FInplaceOption>(
-        "FInplaceOption",
-        [](const NodeAttrs& attrs) {
-          return std::vector<std::pair<int, int>>{{0, 0}};
-        })
-    .set_attr<nnvm::FInplaceIdentity>(
-        "FInplaceIdentity", [](const NodeAttrs& attrs) { return std::vector<bool>{true}; })
+    .set_attr<nnvm::FInplaceOption>("FInplaceOption",
+                                    [](const NodeAttrs& attrs) {
+                                      return std::vector<std::pair<int, int>>{{0, 0}};
+                                    })
+    .set_attr<nnvm::FInplaceIdentity>("FInplaceIdentity",
+                                      [](const NodeAttrs& attrs) {
+                                        return std::vector<bool>{true};
+                                      })
 #if MXNET_USE_MKLDNN == 1
     .set_attr<bool>("TIsMKLDNN", true)
     .set_attr<FInferStorageType>("FInferStorageType", AMPCastStorageType)
@@ -172,32 +174,32 @@ It casts only between low precision float/FP32 and does not do anything for othe
     .set_attr_parser(ParamParser<AMPMultiCastParam>)
     .set_attr<mxnet::FInferShape>("FInferShape", AMPMultiCastShape)
     .set_attr<nnvm::FInferType>("FInferType", AMPMultiCastType)
-    .set_attr<nnvm::FListInputNames>(
-        "FListInputNames",
-        [](const NodeAttrs& attrs) {
-          uint32_t num_args = dmlc::get<AMPMultiCastParam>(attrs.parsed).num_outputs;
-          std::vector<std::string> ret;
-          for (uint32_t i = 0; i < num_args; ++i) {
-            ret.push_back(std::string("data_") + std::to_string(i));
-          }
-          return ret;
-        })
-    .set_attr<nnvm::FInplaceOption>(
-        "FInplaceOption",
-        [](const NodeAttrs& attrs) {
-          int num_args = dmlc::get<AMPMultiCastParam>(attrs.parsed).num_outputs;
-          std::vector<std::pair<int, int>> ret;
-          for (int i = 0; i < num_args; ++i) {
-            ret.emplace_back(i, i);
-          }
-          return ret;
-        })
-    .set_attr<nnvm::FInplaceIdentity>(
-        "FInplaceIdentity",
-        [](const NodeAttrs& attrs) {
-          int num_args = dmlc::get<AMPMultiCastParam>(attrs.parsed).num_outputs;
-          return std::vector<bool>(num_args, true);
-        })
+    .set_attr<nnvm::FListInputNames>("FListInputNames",
+                                     [](const NodeAttrs& attrs) {
+                                       uint32_t num_args =
+                                           dmlc::get<AMPMultiCastParam>(attrs.parsed).num_outputs;
+                                       std::vector<std::string> ret;
+                                       for (uint32_t i = 0; i < num_args; ++i) {
+                                         ret.push_back(std::string("data_") + std::to_string(i));
+                                       }
+                                       return ret;
+                                     })
+    .set_attr<nnvm::FInplaceOption>("FInplaceOption",
+                                    [](const NodeAttrs& attrs) {
+                                      int num_args =
+                                          dmlc::get<AMPMultiCastParam>(attrs.parsed).num_outputs;
+                                      std::vector<std::pair<int, int>> ret;
+                                      for (int i = 0; i < num_args; ++i) {
+                                        ret.emplace_back(i, i);
+                                      }
+                                      return ret;
+                                    })
+    .set_attr<nnvm::FInplaceIdentity>("FInplaceIdentity",
+                                      [](const NodeAttrs& attrs) {
+                                        int num_args =
+                                            dmlc::get<AMPMultiCastParam>(attrs.parsed).num_outputs;
+                                        return std::vector<bool>(num_args, true);
+                                      })
     .set_attr<FCompute>("FCompute<cpu>", AMPMultiCastCompute<cpu>)
 #if MXNET_USE_MKLDNN == 1
     .set_attr<bool>("TIsMKLDNN", true)
@@ -219,32 +221,32 @@ NNVM_REGISTER_OP(_backward_amp_multicast)
       return static_cast<uint32_t>(param.num_outputs);
     })
     .set_attr_parser(ParamParser<AMPMultiCastParam>)
-    .set_attr<nnvm::FListInputNames>(
-        "FListInputNames",
-        [](const NodeAttrs& attrs) {
-          uint32_t num_args = dmlc::get<AMPMultiCastParam>(attrs.parsed).num_outputs;
-          std::vector<std::string> ret;
-          for (uint32_t i = 0; i < num_args; ++i) {
-            ret.push_back(std::string("grad_") + std::to_string(i));
-          }
-          return ret;
-        })
-    .set_attr<nnvm::FInplaceOption>(
-        "FInplaceOption",
-        [](const NodeAttrs& attrs) {
-          int num_args = dmlc::get<AMPMultiCastParam>(attrs.parsed).num_outputs;
-          std::vector<std::pair<int, int>> ret;
-          for (int i = 0; i < num_args; ++i) {
-            ret.emplace_back(i, i);
-          }
-          return ret;
-        })
-    .set_attr<nnvm::FInplaceIdentity>(
-        "FInplaceIdentity",
-        [](const NodeAttrs& attrs) {
-          int num_args = dmlc::get<AMPMultiCastParam>(attrs.parsed).num_outputs;
-          return std::vector<bool>(num_args, true);
-        })
+    .set_attr<nnvm::FListInputNames>("FListInputNames",
+                                     [](const NodeAttrs& attrs) {
+                                       uint32_t num_args =
+                                           dmlc::get<AMPMultiCastParam>(attrs.parsed).num_outputs;
+                                       std::vector<std::string> ret;
+                                       for (uint32_t i = 0; i < num_args; ++i) {
+                                         ret.push_back(std::string("grad_") + std::to_string(i));
+                                       }
+                                       return ret;
+                                     })
+    .set_attr<nnvm::FInplaceOption>("FInplaceOption",
+                                    [](const NodeAttrs& attrs) {
+                                      int num_args =
+                                          dmlc::get<AMPMultiCastParam>(attrs.parsed).num_outputs;
+                                      std::vector<std::pair<int, int>> ret;
+                                      for (int i = 0; i < num_args; ++i) {
+                                        ret.emplace_back(i, i);
+                                      }
+                                      return ret;
+                                    })
+    .set_attr<nnvm::FInplaceIdentity>("FInplaceIdentity",
+                                      [](const NodeAttrs& attrs) {
+                                        int num_args =
+                                            dmlc::get<AMPMultiCastParam>(attrs.parsed).num_outputs;
+                                        return std::vector<bool>(num_args, true);
+                                      })
 #if MXNET_USE_MKLDNN == 1
     .set_attr<bool>("TIsMKLDNN", true)
     .set_attr<FInferStorageType>("FInferStorageType", AMPMultiCastStorageType)

--- a/src/operator/tensor/amp_cast.cc
+++ b/src/operator/tensor/amp_cast.cc
@@ -44,7 +44,8 @@ static void AMPCastExCPU(const nnvm::NodeAttrs& attrs,
   auto data = inputs[0];
   if (data.dtype() != mshadow::kFloat16 && outputs[0].dtype() != mshadow::kFloat16) {
     mkldnn::engine cpu_engine = mxnet::CpuEngine::Get()->get_engine();
-    if (data.IsView() && data.IsMKLDNNData()) data = data.Reorder2Default();
+    if (data.IsView() && data.IsMKLDNNData())
+      data = data.Reorder2Default();
     const auto i_mem            = data.GetMKLDNNData();
     const size_t i_ndim         = data.shape().ndim();
     mkldnn::memory::dims i_dims = mkldnn::memory::dims(i_ndim);
@@ -52,7 +53,8 @@ static void AMPCastExCPU(const nnvm::NodeAttrs& attrs,
       i_dims[i] = static_cast<int>(data.shape()[i]);
     }
     const auto o_desc =
-        mkldnn::memory::desc(i_dims, get_mkldnn_type(outputs[0].dtype()),
+        mkldnn::memory::desc(i_dims,
+                             get_mkldnn_type(outputs[0].dtype()),
                              static_cast<mkldnn::memory::format_tag>(GetDefaultFormat(i_ndim)));
     const auto out_mem = CreateMKLDNNMem(outputs[0], o_desc, req[0]);
     mkldnn_args_map_t reorder_args;
@@ -90,7 +92,8 @@ static void AMPMultiCastExCPU(const nnvm::NodeAttrs& attrs,
       continue;
     }
     auto data = inputs[i];
-    if (data.IsView() && data.IsMKLDNNData()) data = data.Reorder2Default();
+    if (data.IsView() && data.IsMKLDNNData())
+      data = data.Reorder2Default();
     const auto i_mem            = data.GetMKLDNNData();
     const size_t i_ndim         = data.shape().ndim();
     mkldnn::memory::dims i_dims = mkldnn::memory::dims(i_ndim);
@@ -98,7 +101,8 @@ static void AMPMultiCastExCPU(const nnvm::NodeAttrs& attrs,
       i_dims[j] = static_cast<int>(data.shape()[j]);
     }
     const auto o_desc =
-        mkldnn::memory::desc(i_dims, get_mkldnn_type(outputs[i].dtype()),
+        mkldnn::memory::desc(i_dims,
+                             get_mkldnn_type(outputs[i].dtype()),
                              static_cast<mkldnn::memory::format_tag>(GetDefaultFormat(i_ndim)));
     const auto out_mem = CreateMKLDNNMem(outputs[i], o_desc, req[i]);
     mkldnn_args_map_t reorder_args;
@@ -166,7 +170,8 @@ NNVM_REGISTER_OP(_backward_amp_cast)
     .set_attr<FCompute>("FCompute<cpu>", AMPCastCompute<cpu>);
 
 NNVM_REGISTER_OP(amp_multicast)
-    .describe(R"code(Cast function used by AMP, that casts its inputs to the common widest type.
+    .describe(
+        R"code(Cast function used by AMP, that casts its inputs to the common widest type.
 
 It casts only between low precision float/FP32 and does not do anything for other types.
 

--- a/src/operator/tensor/cast_storage-inl.h
+++ b/src/operator/tensor/cast_storage-inl.h
@@ -26,11 +26,13 @@
 
 #include <dmlc/timer.h>
 #include <mxnet/ndarray.h>
-#include <vector>
+
 #include <algorithm>
+#include <vector>
+
+#include "../../src/operator/tensor/init_op.h"
 #include "../mxnet_op.h"
 #include "../operator_common.h"
-#include "../../src/operator/tensor/init_op.h"
 #ifdef __CUDACC__
 #include "./cast_storage-inl.cuh"
 #endif  // __CUDACC__
@@ -47,7 +49,9 @@ namespace op {
 struct MarkRspRowIdx {
   // i represents the row index of the tensor data
   template <typename DType, typename RType>
-  MSHADOW_CINLINE static void Map(int i, RType* row_idx, const DType* data,
+  MSHADOW_CINLINE static void Map(int i,
+                                  RType* row_idx,
+                                  const DType* data,
                                   const nnvm::dim_t row_length) {
     using nnvm::dim_t;
     dim_t j      = 0;
@@ -68,7 +72,9 @@ struct MarkRspRowIdx {
 /*!
  * \brief CPU implementation of casting a dns tensor to rsp type.
  */
-inline void CastStorageDnsRspImpl(const OpContext& ctx, const cpu& cpu_dev, const TBlob& dns,
+inline void CastStorageDnsRspImpl(const OpContext& ctx,
+                                  const cpu& cpu_dev,
+                                  const TBlob& dns,
                                   NDArray* rsp) {
   using namespace rowsparse;
   using namespace mshadow;
@@ -111,8 +117,8 @@ inline void CastStorageDnsRspImpl(const OpContext& ctx, const cpu& cpu_dev, cons
 // TODO(haibin) Use memcopy instead will be much faster than assigning each individual element
 struct CastStorageRspDnsKernel {
   template <typename DType, typename IType>
-  MSHADOW_XINLINE static void Map(int i, const nnvm::dim_t row_length, const IType* idx,
-                                  const DType* data, DType* dns) {
+  MSHADOW_XINLINE static void Map(
+      int i, const nnvm::dim_t row_length, const IType* idx, const DType* data, DType* dns) {
     using nnvm::dim_t;
     IType rid        = idx[i];
     dim_t dns_offset = rid * row_length;
@@ -165,8 +171,11 @@ struct FillCsrIndPtr {
    * \param num_cols  number of columns of the dns tensor
    */
   template <typename DType, typename IType>
-  MSHADOW_CINLINE static void Map(int i, IType* indptr, const DType* dns,
-                                  const nnvm::dim_t num_rows, const nnvm::dim_t num_cols) {
+  MSHADOW_CINLINE static void Map(int i,
+                                  IType* indptr,
+                                  const DType* dns,
+                                  const nnvm::dim_t num_rows,
+                                  const nnvm::dim_t num_cols) {
     using nnvm::dim_t;
     indptr[i + 1]      = 0;
     const dim_t offset = i * num_cols;
@@ -193,8 +202,12 @@ struct FillCsrColIdxAndVals {
    * \param num_cols  number of columns of the dns tensor
    */
   template <typename DType, typename IType, typename CType>
-  MSHADOW_CINLINE static void Map(int i, DType* val, CType* col_idx, const IType* indptr,
-                                  const DType* dns, const nnvm::dim_t num_rows,
+  MSHADOW_CINLINE static void Map(int i,
+                                  DType* val,
+                                  CType* col_idx,
+                                  const IType* indptr,
+                                  const DType* dns,
+                                  const nnvm::dim_t num_rows,
                                   const nnvm::dim_t num_cols) {
     using nnvm::dim_t;
     const dim_t offset = i * num_cols;
@@ -212,7 +225,9 @@ struct FillCsrColIdxAndVals {
 /*!
  * \brief CPU implementation of casting a dns matrix to csr type.
  */
-inline void CastStorageDnsCsrImpl(const OpContext& ctx, const cpu& cpu_dev, const TBlob& dns,
+inline void CastStorageDnsCsrImpl(const OpContext& ctx,
+                                  const cpu& cpu_dev,
+                                  const TBlob& dns,
                                   NDArray* csr) {
   CHECK(csr != nullptr);
   CHECK_EQ(csr->storage_type(), kCSRStorage);
@@ -264,8 +279,11 @@ struct CopyCsrDataToDns {
    * \param num_cols  number of columns of the dns tensor
    */
   template <typename DType, typename IType, typename CType>
-  MSHADOW_XINLINE static void Map(index_t i, DType* dns_data, const CType* col_idx,
-                                  const IType* indptr, const DType* csr_data,
+  MSHADOW_XINLINE static void Map(index_t i,
+                                  DType* dns_data,
+                                  const CType* col_idx,
+                                  const IType* indptr,
+                                  const DType* csr_data,
                                   const nnvm::dim_t num_cols) {
     const nnvm::dim_t offset = i * num_cols;
     for (IType j = indptr[i]; j < indptr[i + 1]; ++j) {
@@ -400,8 +418,10 @@ struct CastStorageParam : public dmlc::Parameter<CastStorageParam> {
   }
 };
 
-inline bool CastStorageInferStorageType(const nnvm::NodeAttrs& attrs, const int dev_mask,
-                                        DispatchMode* dispatch_mode, std::vector<int>* in_attrs,
+inline bool CastStorageInferStorageType(const nnvm::NodeAttrs& attrs,
+                                        const int dev_mask,
+                                        DispatchMode* dispatch_mode,
+                                        std::vector<int>* in_attrs,
                                         std::vector<int>* out_attrs) {
   CHECK_EQ(in_attrs->size(), 1U);
   CHECK_EQ(out_attrs->size(), 1U);
@@ -444,8 +464,10 @@ inline bool CastStorageInferStorageType(const nnvm::NodeAttrs& attrs, const int 
 }
 
 template <typename xpu>
-void CastStorageComputeEx(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
-                          const std::vector<NDArray>& inputs, const std::vector<OpReqType>& req,
+void CastStorageComputeEx(const nnvm::NodeAttrs& attrs,
+                          const OpContext& ctx,
+                          const std::vector<NDArray>& inputs,
+                          const std::vector<OpReqType>& req,
                           const std::vector<NDArray>& outputs) {
   CHECK_EQ(inputs.size(), 1);
   CHECK_EQ(outputs.size(), 1);

--- a/tests/cpp/include/test_mkldnn.h
+++ b/tests/cpp/include/test_mkldnn.h
@@ -42,7 +42,8 @@ inline static mkldnn::memory::desc GetMemDesc(const mxnet::TShape s,
                                               const int dtype,
                                               const mkldnn::memory::format_tag format_tag) {
   mkldnn::memory::dims dims(s.ndim());
-  for (size_t i = 0; i < dims.size(); i++) dims[i] = s[i];
+  for (size_t i = 0; i < dims.size(); i++)
+    dims[i] = s[i];
   mkldnn::memory::desc desc{dims, get_mkldnn_type(dtype), format_tag};
   return desc;
 }
@@ -52,9 +53,11 @@ inline static mkldnn::memory::desc GetExpandedMemDesc(mkldnn::memory::desc md,
                                                       const int dim = 0) {
   CHECK(dim < md.data.ndims) << "dimension cannot be larger than total dimensions of input";
   mxnet::TShape s(md.data.ndims, -1);
-  for (size_t i = 0; i < md.data.ndims; i++) s[i] = md.data.dims[i];
+  for (size_t i = 0; i < md.data.ndims; i++)
+    s[i] = md.data.dims[i];
   s[dim] = static_cast<int64_t>(s[dim] * scale);
-  return GetMemDesc(s, mshadow::DataType<mshadow::default_real_t>::kFlag,
+  return GetMemDesc(s,
+                    mshadow::DataType<mshadow::default_real_t>::kFlag,
                     static_cast<mkldnn::memory::format_tag>(GetDefaultFormat(md)));
 }
 
@@ -88,9 +91,11 @@ inline static void InitMKLDNNArray(NDArray* arr,
 }
 
 inline static bool IsSameShape(const mkldnn::memory::desc& desc, const mxnet::TShape& shape) {
-  if (desc.data.ndims != shape.ndim()) return false;
+  if (desc.data.ndims != shape.ndim())
+    return false;
   for (size_t i = 0; i < shape.ndim(); i++)
-    if (desc.data.dims[i] != shape[i]) return false;
+    if (desc.data.dims[i] != shape[i])
+      return false;
   return true;
 }
 
@@ -102,20 +107,25 @@ inline static bool IsSameShape(const mkldnn::memory::desc& desc, const mxnet::TS
 inline static std::vector<mkldnn::memory::format_tag> GetMKLDNNFormat(size_t num_dims, int dtype) {
   if (num_dims == 4) {
     mkldnn::memory::dims data_dims{1, 3, 224, 224};
-    mkldnn::memory::desc data_md{data_dims, get_mkldnn_type(dtype),
-                                 mkldnn::memory::format_tag::any};
+    mkldnn::memory::desc data_md{
+        data_dims, get_mkldnn_type(dtype), mkldnn::memory::format_tag::any};
     mkldnn::memory::dims weight_dims{96, 3, 11, 11};
-    mkldnn::memory::desc weight_md{weight_dims, get_mkldnn_type(dtype),
-                                   mkldnn::memory::format_tag::any};
+    mkldnn::memory::desc weight_md{
+        weight_dims, get_mkldnn_type(dtype), mkldnn::memory::format_tag::any};
     mkldnn::memory::dims output_dims{1, 96, 54, 54};
-    mkldnn::memory::desc out_md{output_dims, get_mkldnn_type(dtype),
-                                mkldnn::memory::format_tag::any};
+    mkldnn::memory::desc out_md{
+        output_dims, get_mkldnn_type(dtype), mkldnn::memory::format_tag::any};
     mkldnn::memory::dims strides{4, 4};
     mkldnn::memory::dims padding{0, 0};
 
     mkldnn::convolution_forward::desc desc(mkldnn::prop_kind::forward_training,
-                                           mkldnn::algorithm::convolution_direct, data_md,
-                                           weight_md, out_md, strides, padding, padding);
+                                           mkldnn::algorithm::convolution_direct,
+                                           data_md,
+                                           weight_md,
+                                           out_md,
+                                           strides,
+                                           padding,
+                                           padding);
     mkldnn::convolution_forward::primitive_desc pd(desc, CpuEngine::Get()->get_engine());
     while (pd.dst_desc().get_size() != GetMemDescSize(out_md) ||
            pd.src_desc().get_size() != GetMemDescSize(data_md) ||
@@ -129,20 +139,25 @@ inline static std::vector<mkldnn::memory::format_tag> GetMKLDNNFormat(size_t num
     return ret;
   } else if (num_dims == 5) {
     mkldnn::memory::dims data_dims{1, 32, 112, 112};
-    mkldnn::memory::desc data_md{data_dims, get_mkldnn_type(dtype),
-                                 mkldnn::memory::format_tag::any};
+    mkldnn::memory::desc data_md{
+        data_dims, get_mkldnn_type(dtype), mkldnn::memory::format_tag::any};
     mkldnn::memory::dims weight_dims{32, 1, 1, 3, 3};
-    mkldnn::memory::desc weight_md{weight_dims, get_mkldnn_type(dtype),
-                                   mkldnn::memory::format_tag::any};
+    mkldnn::memory::desc weight_md{
+        weight_dims, get_mkldnn_type(dtype), mkldnn::memory::format_tag::any};
     mkldnn::memory::dims output_dims{1, 32, 112, 112};
-    mkldnn::memory::desc out_md{output_dims, get_mkldnn_type(dtype),
-                                mkldnn::memory::format_tag::any};
+    mkldnn::memory::desc out_md{
+        output_dims, get_mkldnn_type(dtype), mkldnn::memory::format_tag::any};
     mkldnn::memory::dims strides{1, 1};
     mkldnn::memory::dims padding{1, 1};
 
     mkldnn::convolution_forward::desc desc(mkldnn::prop_kind::forward_training,
-                                           mkldnn::algorithm::convolution_direct, data_md,
-                                           weight_md, out_md, strides, padding, padding);
+                                           mkldnn::algorithm::convolution_direct,
+                                           data_md,
+                                           weight_md,
+                                           out_md,
+                                           strides,
+                                           padding,
+                                           padding);
     mkldnn::convolution_forward::primitive_desc pd(desc, CpuEngine::Get()->get_engine());
     while (pd.dst_desc().get_size() != GetMemDescSize(out_md) ||
            pd.src_desc().get_size() != GetMemDescSize(data_md) ||
@@ -303,7 +318,8 @@ inline std::string CreateShapeString(int value, int dim) {
   ss << "(";
   for (int i = 0; i < dim; i++) {
     ss << value;
-    if (i != dim - 1) ss << ",";
+    if (i != dim - 1)
+      ss << ",";
   }
   ss << ")";
   return ss.str();
@@ -322,23 +338,22 @@ inline void PrintVerifyMsg(const NDArrayAttrs& arr1, const NDArrayAttrs& arr2) {
  * 1. Normal NDArray
  * 2. Normal NDArray with MKLDNN layout (output from an MKLDNN operator)
  * 3. Normal NDArray with MKLDNN layout whose MKLDNN memory may have different
- *    dimensions from the NDArray (result of MKLDNNDataReorderAsync). However, this
- *    type of NDArrays only exists for weight arrays. I don't think we should
+ *    dimensions from the NDArray (result of MKLDNNDataReorderAsync). However,
+ * this type of NDArrays only exists for weight arrays. I don't think we should
  *    pass them to all operators.
  *    In the inference mode, the MKLDNN memory in the weight array will be
  *    reordered to 5 dimensions.
  * 4. Reshaped/sliced NDArray
- * 5. Reshaped/sliced NDArray with MKLDNN layout (reshape/slice from Normal NDArray
- *    with MKLDNN layout)
+ * 5. Reshaped/sliced NDArray with MKLDNN layout (reshape/slice from Normal
+ * NDArray with MKLDNN layout)
  * 6. Reshaped/sliced NDArray with MKLDNN layout whose MKLDNN memory may have
  *    different dimensions from the NDArray (result of MKLDNNDataReorderAsync).
- *    However, this type of NDArrays only exists for weight arrays. I don't think
- *    we should pass them to all operators.
- *    In the inference mode, the MKLDNN memory in the weight array will be
- *    reordered to 5 dimensions.
+ *    However, this type of NDArrays only exists for weight arrays. I don't
+ * think we should pass them to all operators. In the inference mode, the MKLDNN
+ * memory in the weight array will be reordered to 5 dimensions.
  *
- *  num_inputs / dim arguments used to scale shape (used for concat backwards to enlarge input
- * shapes)
+ *  num_inputs / dim arguments used to scale shape (used for concat backwards to
+ * enlarge input shapes)
  */
 inline std::vector<NDArrayAttrs> GetTestInputArrays(int types                = ArrayTypes::All,
                                                     bool rand                = false,
@@ -354,7 +369,8 @@ inline std::vector<NDArrayAttrs> GetTestInputArrays(int types                = A
 
   int slice_amount = scale[0];
   for (auto shape : shapes) {
-    if (scale.size() > shape.ndim()) continue;
+    if (scale.size() > shape.ndim())
+      continue;
 
     for (size_t dim = 0; dim < scale.size(); ++dim)
       shape[dim] = static_cast<int>(round(shape[dim] * scale[dim]));
@@ -383,7 +399,8 @@ inline std::vector<NDArrayAttrs> GetTestInputArrays(int types                = A
           md = GetExpandedMemDesc(md, scale[dim]);
       }
 
-      if (shape.Size() != md.get_size() / sizeof(mshadow::default_real_t)) continue;
+      if (shape.Size() != md.get_size() / sizeof(mshadow::default_real_t))
+        continue;
 
       // Type 2, 3.
       arr = NDArray(shape, Context());
@@ -433,8 +450,8 @@ inline std::vector<NDArrayAttrs> GetTestInputArrays(int types                = A
  * 1. Normal NDArray
  * 2. Normal NDArray with MKLDNN layout (output from an MKLDNN operator)
  * 3. Normal NDArray with MKLDNN layout whose MKLDNN memory may have different
- *    dimensions from the NDArray (result of MKLDNNDataReorderAsync). However, this
- *    type of NDArrays only exists for weight arrays. I don't think we should
+ *    dimensions from the NDArray (result of MKLDNNDataReorderAsync). However,
+ * this type of NDArrays only exists for weight arrays. I don't think we should
  *    pass them to all operators.
  *    In the inference mode, the MKLDNN memory in the weight array will be
  *    reordered to 5 dimensions.
@@ -446,7 +463,8 @@ inline std::vector<NDArrayAttrs> GetTestInputArrays(int types                = A
  * 8. Reused NDArray with MKLDNN layout.
  * 9. Reused NDArray with MKLDNN layout of different dimensions.
  *
- * Optional num_inputs / dim args can be passed to modify input shape (used for Concat test)
+ * Optional num_inputs / dim args can be passed to modify input shape (used for
+ * Concat test)
  */
 inline std::vector<NDArrayAttrs> GetTestOutputArrays(const mxnet::TShape& shp,
                                                      const std::vector<mkldnn::memory::desc>& mds,
@@ -509,11 +527,14 @@ inline std::vector<NDArrayAttrs> GetTestOutputArrays(const mxnet::TShape& shp,
   }
 
   for (auto md : mds) {
-    if (shape.Size() != md.get_size() / sizeof(mshadow::default_real_t)) continue;
+    if (shape.Size() != md.get_size() / sizeof(mshadow::default_real_t))
+      continue;
 
-    if (scale.size() > md.data.ndims) continue;
+    if (scale.size() > md.data.ndims)
+      continue;
 
-    for (int dim = 0; dim < scale.size(); dim++) md = GetExpandedMemDesc(md, scale[dim]);
+    for (int dim = 0; dim < scale.size(); dim++)
+      md = GetExpandedMemDesc(md, scale[dim]);
 
     // Type 2, 3.
     arr      = NDArray(shape, Context());
@@ -560,18 +581,20 @@ inline std::vector<NDArrayAttrs> GetTestOutputArrays(const mxnet::TShape& shp,
 inline int GetDim(mxnet::TShape input_shape, mxnet::TShape output_shape) {
   CHECK(input_shape.Size() != output_shape.Size());
   for (size_t i = 0; i < input_shape.ndim(); i++) {
-    if (input_shape[i] != output_shape[i]) return i;
+    if (input_shape[i] != output_shape[i])
+      return i;
   }
   return -1;
 }
 
 /*
- * Calculates the size of continuous block of array inside larger concatenated array
- * Used to verify concat/concat backwards operator
+ * Calculates the size of continuous block of array inside larger concatenated
+ * array Used to verify concat/concat backwards operator
  */
 inline int GetBlockSize(mxnet::TShape shape, int dim) {
   int block_size = 1;
-  for (int i = shape.ndim() - 1; i >= dim; i--) block_size *= shape[i];
+  for (int i = shape.ndim() - 1; i >= dim; i--)
+    block_size *= shape[i];
   return block_size;
 }
 
@@ -618,7 +641,8 @@ inline void VerifySumResult(const std::vector<NDArray*>& in_arrs,
   mshadow::default_real_t* d1 = in1.data().dptr<mshadow::default_real_t>();
   mshadow::default_real_t* d2 = in2.data().dptr<mshadow::default_real_t>();
   mshadow::default_real_t* o  = out.data().dptr<mshadow::default_real_t>();
-  for (size_t i = 0; i < in1.shape().Size(); i++) ASSERT_EQ(d1[i] + d2[i], o[i]);
+  for (size_t i = 0; i < in1.shape().Size(); i++)
+    ASSERT_EQ(d1[i] + d2[i], o[i]);
 }
 
 #endif  // MXNET_USE_MKLDNN == 1

--- a/tests/cpp/include/test_mkldnn.h
+++ b/tests/cpp/include/test_mkldnn.h
@@ -37,23 +37,22 @@
 
 using namespace mxnet;
 
-inline static mkldnn::memory::desc GetMemDesc(
-    const mxnet::TShape s, const int dtype, const mkldnn::memory::format_tag format_tag) {
+inline static mkldnn::memory::desc GetMemDesc(const mxnet::TShape s, const int dtype,
+                                              const mkldnn::memory::format_tag format_tag) {
   mkldnn::memory::dims dims(s.ndim());
   for (size_t i = 0; i < dims.size(); i++) dims[i] = s[i];
   mkldnn::memory::desc desc{dims, get_mkldnn_type(dtype), format_tag};
   return desc;
 }
 
-inline static mkldnn::memory::desc GetExpandedMemDesc(
-    mkldnn::memory::desc md, const float scale, const int dim = 0) {
+inline static mkldnn::memory::desc GetExpandedMemDesc(mkldnn::memory::desc md, const float scale,
+                                                      const int dim = 0) {
   CHECK(dim < md.data.ndims) << "dimension cannot be larger than total dimensions of input";
   mxnet::TShape s(md.data.ndims, -1);
   for (size_t i = 0; i < md.data.ndims; i++) s[i] = md.data.dims[i];
   s[dim] = static_cast<int64_t>(s[dim] * scale);
-  return GetMemDesc(
-      s, mshadow::DataType<mshadow::default_real_t>::kFlag,
-      static_cast<mkldnn::memory::format_tag>(GetDefaultFormat(md)));
+  return GetMemDesc(s, mshadow::DataType<mshadow::default_real_t>::kFlag,
+                    static_cast<mkldnn::memory::format_tag>(GetDefaultFormat(md)));
 }
 
 struct TestArrayShapes {
@@ -76,8 +75,8 @@ inline static void InitDefaultArray(NDArray* arr, bool is_rand = false, int max 
 }
 
 // Init arrays with the specified layout.
-inline static void InitMKLDNNArray(
-    NDArray* arr, const mkldnn::memory::desc& desc, bool is_rand = false, int max = 50) {
+inline static void InitMKLDNNArray(NDArray* arr, const mkldnn::memory::desc& desc,
+                                   bool is_rand = false, int max = 50) {
   InitDefaultArray(arr, is_rand, max);
   arr->MKLDNNDataReorderAsync(desc);
   arr->WaitToRead();
@@ -98,20 +97,20 @@ inline static bool IsSameShape(const mkldnn::memory::desc& desc, const mxnet::TS
 inline static std::vector<mkldnn::memory::format_tag> GetMKLDNNFormat(size_t num_dims, int dtype) {
   if (num_dims == 4) {
     mkldnn::memory::dims data_dims{1, 3, 224, 224};
-    mkldnn::memory::desc data_md{
-        data_dims, get_mkldnn_type(dtype), mkldnn::memory::format_tag::any};
+    mkldnn::memory::desc data_md{data_dims, get_mkldnn_type(dtype),
+                                 mkldnn::memory::format_tag::any};
     mkldnn::memory::dims weight_dims{96, 3, 11, 11};
-    mkldnn::memory::desc weight_md{
-        weight_dims, get_mkldnn_type(dtype), mkldnn::memory::format_tag::any};
+    mkldnn::memory::desc weight_md{weight_dims, get_mkldnn_type(dtype),
+                                   mkldnn::memory::format_tag::any};
     mkldnn::memory::dims output_dims{1, 96, 54, 54};
-    mkldnn::memory::desc out_md{
-        output_dims, get_mkldnn_type(dtype), mkldnn::memory::format_tag::any};
+    mkldnn::memory::desc out_md{output_dims, get_mkldnn_type(dtype),
+                                mkldnn::memory::format_tag::any};
     mkldnn::memory::dims strides{4, 4};
     mkldnn::memory::dims padding{0, 0};
 
-    mkldnn::convolution_forward::desc desc(
-        mkldnn::prop_kind::forward_training, mkldnn::algorithm::convolution_direct, data_md,
-        weight_md, out_md, strides, padding, padding);
+    mkldnn::convolution_forward::desc desc(mkldnn::prop_kind::forward_training,
+                                           mkldnn::algorithm::convolution_direct, data_md,
+                                           weight_md, out_md, strides, padding, padding);
     mkldnn::convolution_forward::primitive_desc pd(desc, CpuEngine::Get()->get_engine());
     while (pd.dst_desc().get_size() != GetMemDescSize(out_md) ||
            pd.src_desc().get_size() != GetMemDescSize(data_md) ||
@@ -125,20 +124,20 @@ inline static std::vector<mkldnn::memory::format_tag> GetMKLDNNFormat(size_t num
     return ret;
   } else if (num_dims == 5) {
     mkldnn::memory::dims data_dims{1, 32, 112, 112};
-    mkldnn::memory::desc data_md{
-        data_dims, get_mkldnn_type(dtype), mkldnn::memory::format_tag::any};
+    mkldnn::memory::desc data_md{data_dims, get_mkldnn_type(dtype),
+                                 mkldnn::memory::format_tag::any};
     mkldnn::memory::dims weight_dims{32, 1, 1, 3, 3};
-    mkldnn::memory::desc weight_md{
-        weight_dims, get_mkldnn_type(dtype), mkldnn::memory::format_tag::any};
+    mkldnn::memory::desc weight_md{weight_dims, get_mkldnn_type(dtype),
+                                   mkldnn::memory::format_tag::any};
     mkldnn::memory::dims output_dims{1, 32, 112, 112};
-    mkldnn::memory::desc out_md{
-        output_dims, get_mkldnn_type(dtype), mkldnn::memory::format_tag::any};
+    mkldnn::memory::desc out_md{output_dims, get_mkldnn_type(dtype),
+                                mkldnn::memory::format_tag::any};
     mkldnn::memory::dims strides{1, 1};
     mkldnn::memory::dims padding{1, 1};
 
-    mkldnn::convolution_forward::desc desc(
-        mkldnn::prop_kind::forward_training, mkldnn::algorithm::convolution_direct, data_md,
-        weight_md, out_md, strides, padding, padding);
+    mkldnn::convolution_forward::desc desc(mkldnn::prop_kind::forward_training,
+                                           mkldnn::algorithm::convolution_direct, data_md,
+                                           weight_md, out_md, strides, padding, padding);
     mkldnn::convolution_forward::primitive_desc pd(desc, CpuEngine::Get()->get_engine());
     while (pd.dst_desc().get_size() != GetMemDescSize(out_md) ||
            pd.src_desc().get_size() != GetMemDescSize(data_md) ||
@@ -261,8 +260,8 @@ enum ArrayTypes {
   All                     = 8191,
 };
 
-inline NDArray CreateKernelNDArray(
-    mxnet::TShape kernel, int num_filters, mxnet::TShape input, bool is_deconv = false) {
+inline NDArray CreateKernelNDArray(mxnet::TShape kernel, int num_filters, mxnet::TShape input,
+                                   bool is_deconv = false) {
   CHECK_EQ(kernel.ndim(), 2) << "mkldnn only supports 2d filters on 4d inputs";
   mxnet::TShape target_shape(4, -1);
   target_shape[0] = is_deconv ? input[1] : num_filters;
@@ -334,9 +333,10 @@ inline void PrintVerifyMsg(const NDArrayAttrs& arr1, const NDArrayAttrs& arr2) {
  *  num_inputs / dim arguments used to scale shape (used for concat backwards to enlarge input
  * shapes)
  */
-inline std::vector<NDArrayAttrs> GetTestInputArrays(
-    int types = ArrayTypes::All, bool rand = false, std::vector<float> scale = {1},
-    bool spatial_data_format = false, int max = 50) {
+inline std::vector<NDArrayAttrs> GetTestInputArrays(int types = ArrayTypes::All, bool rand = false,
+                                                    std::vector<float> scale = {1},
+                                                    bool spatial_data_format = false,
+                                                    int max                  = 50) {
   TestArrayShapes tas                   = GetTestArrayShapes(spatial_data_format);
   std::vector<mxnet::TShape> shapes     = tas.shapes;
   std::vector<mkldnn::memory::desc> mds = tas.mds;
@@ -362,8 +362,8 @@ inline std::vector<NDArrayAttrs> GetTestInputArrays(
     arr = NDArray(shape, Context());
     if (types & ArrayTypes::NormalReshaped) {
       InitDefaultArray(&arr, rand, max);
-      in_arrs.emplace_back(
-          arr.Slice(slice_amount, arr.shape()[0] - slice_amount), "Reshaped Normal NDArray");
+      in_arrs.emplace_back(arr.Slice(slice_amount, arr.shape()[0] - slice_amount),
+                           "Reshaped Normal NDArray");
     }
 
     for (auto md : mds) {
@@ -383,9 +383,8 @@ inline std::vector<NDArrayAttrs> GetTestInputArrays(
         desc_str = "MKLDNN NDArray";
         InitMKLDNNArray(&arr, md, rand, max);
         in_arrs.emplace_back(arr, desc_str);
-      } else if (
-          shape.ndim() == md.data.ndims && !IsSameShape(md, shape) &&
-          types & ArrayTypes::MKLDNNDiffShape) {
+      } else if (shape.ndim() == md.data.ndims && !IsSameShape(md, shape) &&
+                 types & ArrayTypes::MKLDNNDiffShape) {
         desc_str = "MKLDNN NDArray with different shape";
         InitMKLDNNArray(&arr, md, rand, max);
         in_arrs.emplace_back(arr, desc_str);
@@ -404,9 +403,8 @@ inline std::vector<NDArrayAttrs> GetTestInputArrays(
         desc_str = "Reshaped MKLDNN NDArray";
         InitMKLDNNArray(&arr, md, rand, max);
         in_arrs.emplace_back(arr.Slice(slice_amount, arr.shape()[0] - slice_amount), desc_str);
-      } else if (
-          shape.ndim() == md.data.ndims && !IsSameShape(md, shape) &&
-          types & ArrayTypes::MKLDNNReshapedDiffShape) {
+      } else if (shape.ndim() == md.data.ndims && !IsSameShape(md, shape) &&
+                 types & ArrayTypes::MKLDNNReshapedDiffShape) {
         desc_str = "Reshaped MKLDNN NDArray with different shape";
         InitMKLDNNArray(&arr, md, rand, max);
         in_arrs.emplace_back(arr.Slice(slice_amount, arr.shape()[0] - slice_amount), desc_str);
@@ -442,9 +440,11 @@ inline std::vector<NDArrayAttrs> GetTestInputArrays(
  *
  * Optional num_inputs / dim args can be passed to modify input shape (used for Concat test)
  */
-inline std::vector<NDArrayAttrs> GetTestOutputArrays(
-    const mxnet::TShape& shp, const std::vector<mkldnn::memory::desc>& mds,
-    std::vector<float> scale = {1}, bool rand = true, int types = ArrayTypes::All, int max = 50) {
+inline std::vector<NDArrayAttrs> GetTestOutputArrays(const mxnet::TShape& shp,
+                                                     const std::vector<mkldnn::memory::desc>& mds,
+                                                     std::vector<float> scale = {1},
+                                                     bool rand = true, int types = ArrayTypes::All,
+                                                     int max = 50) {
   mxnet::TShape shape = shp;
 
   for (int dim = 0; dim < scale.size(); dim++)
@@ -570,12 +570,12 @@ inline int CalculateWidthPoolOutput(int width, int kernel, int padding, int stri
   return (width - kernel + 2 * padding) / stride + 1;
 }
 
-using VerifyFunc = std::function<void(
-    const std::vector<NDArray*>& in_arrs, const std::vector<NDArray*>& out_arrs)>;
+using VerifyFunc = std::function<void(const std::vector<NDArray*>& in_arrs,
+                                      const std::vector<NDArray*>& out_arrs)>;
 
-inline void VerifyAddRequest(
-    const std::vector<NDArray*>& in_arrs, const std::vector<NDArray*>& original_outputs,
-    const std::vector<NDArray*>& new_outputs, VerifyFunc verify_fn) {
+inline void VerifyAddRequest(const std::vector<NDArray*>& in_arrs,
+                             const std::vector<NDArray*>& original_outputs,
+                             const std::vector<NDArray*>& new_outputs, VerifyFunc verify_fn) {
   CHECK(original_outputs.size() == new_outputs.size());
   std::vector<NDArray*> tmp_outputs;
   NDArray tmp;
@@ -587,8 +587,8 @@ inline void VerifyAddRequest(
   verify_fn(in_arrs, tmp_outputs);
 }
 
-inline void VerifyCopyResult(
-    const std::vector<NDArray*>& in_arrs, const std::vector<NDArray*>& out_arrs) {
+inline void VerifyCopyResult(const std::vector<NDArray*>& in_arrs,
+                             const std::vector<NDArray*>& out_arrs) {
   NDArray tmp1 = in_arrs[0]->Reorder2Default();
   NDArray tmp2 = out_arrs[0]->Reorder2Default();
   EXPECT_EQ(tmp1.shape().Size(), tmp2.shape().Size());
@@ -597,8 +597,8 @@ inline void VerifyCopyResult(
   EXPECT_EQ(memcmp(d1.dptr_, d2.dptr_, tmp1.shape().Size() * sizeof(mshadow::default_real_t)), 0);
 }
 
-inline void VerifySumResult(
-    const std::vector<NDArray*>& in_arrs, const std::vector<NDArray*>& out_arrs) {
+inline void VerifySumResult(const std::vector<NDArray*>& in_arrs,
+                            const std::vector<NDArray*>& out_arrs) {
   NDArray in1 = in_arrs[0]->Reorder2Default();
   NDArray in2 = in_arrs[1]->Reorder2Default();
   NDArray out = out_arrs[0]->Reorder2Default();

--- a/tests/cpp/include/test_mkldnn.h
+++ b/tests/cpp/include/test_mkldnn.h
@@ -37,11 +37,10 @@
 
 using namespace mxnet;
 
-inline static mkldnn::memory::desc GetMemDesc(const mxnet::TShape s, const int dtype,
-                                              const mkldnn::memory::format_tag format_tag) {
+inline static mkldnn::memory::desc GetMemDesc(
+    const mxnet::TShape s, const int dtype, const mkldnn::memory::format_tag format_tag) {
   mkldnn::memory::dims dims(s.ndim());
-  for (size_t i = 0; i < dims.size(); i++)
-    dims[i] = s[i];
+  for (size_t i = 0; i < dims.size(); i++) dims[i] = s[i];
   mkldnn::memory::desc desc{dims, get_mkldnn_type(dtype), format_tag};
   return desc;
 }
@@ -50,11 +49,11 @@ inline static mkldnn::memory::desc GetExpandedMemDesc(
     mkldnn::memory::desc md, const float scale, const int dim = 0) {
   CHECK(dim < md.data.ndims) << "dimension cannot be larger than total dimensions of input";
   mxnet::TShape s(md.data.ndims, -1);
-  for (size_t i = 0; i < md.data.ndims; i++)
-    s[i] = md.data.dims[i];
+  for (size_t i = 0; i < md.data.ndims; i++) s[i] = md.data.dims[i];
   s[dim] = static_cast<int64_t>(s[dim] * scale);
-  return GetMemDesc(s, mshadow::DataType<mshadow::default_real_t>::kFlag,
-                    static_cast<mkldnn::memory::format_tag>(GetDefaultFormat(md)));
+  return GetMemDesc(
+      s, mshadow::DataType<mshadow::default_real_t>::kFlag,
+      static_cast<mkldnn::memory::format_tag>(GetDefaultFormat(md)));
 }
 
 struct TestArrayShapes {
@@ -63,10 +62,10 @@ struct TestArrayShapes {
 };
 
 // Init arrays with the default layout.
-inline static void InitDefaultArray(NDArray *arr, bool is_rand = false, int max = 50) {
-  const TBlob &blob = arr->data();
-  mshadow::default_real_t *data = blob.dptr<mshadow::default_real_t>();
-  int size = blob.Size();
+inline static void InitDefaultArray(NDArray* arr, bool is_rand = false, int max = 50) {
+  const TBlob& blob             = arr->data();
+  mshadow::default_real_t* data = blob.dptr<mshadow::default_real_t>();
+  int size                      = blob.Size();
 
   for (int i = 0; i < size; i++)
     if (is_rand) {
@@ -76,16 +75,15 @@ inline static void InitDefaultArray(NDArray *arr, bool is_rand = false, int max 
     }
 }
 
-
 // Init arrays with the specified layout.
-inline static void InitMKLDNNArray(NDArray *arr, const mkldnn::memory::desc &desc,
-                                   bool is_rand = false, int max = 50) {
+inline static void InitMKLDNNArray(
+    NDArray* arr, const mkldnn::memory::desc& desc, bool is_rand = false, int max = 50) {
   InitDefaultArray(arr, is_rand, max);
   arr->MKLDNNDataReorderAsync(desc);
   arr->WaitToRead();
 }
 
-inline static bool IsSameShape(const mkldnn::memory::desc &desc, const mxnet::TShape &shape) {
+inline static bool IsSameShape(const mkldnn::memory::desc& desc, const mxnet::TShape& shape) {
   if (desc.data.ndims != shape.ndim()) return false;
   for (size_t i = 0; i < shape.ndim(); i++)
     if (desc.data.dims[i] != shape[i]) return false;
@@ -100,21 +98,20 @@ inline static bool IsSameShape(const mkldnn::memory::desc &desc, const mxnet::TS
 inline static std::vector<mkldnn::memory::format_tag> GetMKLDNNFormat(size_t num_dims, int dtype) {
   if (num_dims == 4) {
     mkldnn::memory::dims data_dims{1, 3, 224, 224};
-    mkldnn::memory::desc data_md{data_dims, get_mkldnn_type(dtype),
-                                 mkldnn::memory::format_tag::any};
+    mkldnn::memory::desc data_md{
+        data_dims, get_mkldnn_type(dtype), mkldnn::memory::format_tag::any};
     mkldnn::memory::dims weight_dims{96, 3, 11, 11};
-    mkldnn::memory::desc weight_md{weight_dims, get_mkldnn_type(dtype),
-                                   mkldnn::memory::format_tag::any};
+    mkldnn::memory::desc weight_md{
+        weight_dims, get_mkldnn_type(dtype), mkldnn::memory::format_tag::any};
     mkldnn::memory::dims output_dims{1, 96, 54, 54};
-    mkldnn::memory::desc out_md{output_dims, get_mkldnn_type(dtype),
-                                mkldnn::memory::format_tag::any};
+    mkldnn::memory::desc out_md{
+        output_dims, get_mkldnn_type(dtype), mkldnn::memory::format_tag::any};
     mkldnn::memory::dims strides{4, 4};
     mkldnn::memory::dims padding{0, 0};
 
-    mkldnn::convolution_forward::desc desc(mkldnn::prop_kind::forward_training,
-                                           mkldnn::algorithm::convolution_direct,
-                                           data_md, weight_md, out_md, strides,
-                                           padding, padding);
+    mkldnn::convolution_forward::desc desc(
+        mkldnn::prop_kind::forward_training, mkldnn::algorithm::convolution_direct, data_md,
+        weight_md, out_md, strides, padding, padding);
     mkldnn::convolution_forward::primitive_desc pd(desc, CpuEngine::Get()->get_engine());
     while (pd.dst_desc().get_size() != GetMemDescSize(out_md) ||
            pd.src_desc().get_size() != GetMemDescSize(data_md) ||
@@ -128,21 +125,20 @@ inline static std::vector<mkldnn::memory::format_tag> GetMKLDNNFormat(size_t num
     return ret;
   } else if (num_dims == 5) {
     mkldnn::memory::dims data_dims{1, 32, 112, 112};
-    mkldnn::memory::desc data_md{data_dims, get_mkldnn_type(dtype),
-                                 mkldnn::memory::format_tag::any};
+    mkldnn::memory::desc data_md{
+        data_dims, get_mkldnn_type(dtype), mkldnn::memory::format_tag::any};
     mkldnn::memory::dims weight_dims{32, 1, 1, 3, 3};
-    mkldnn::memory::desc weight_md{weight_dims, get_mkldnn_type(dtype),
-                                   mkldnn::memory::format_tag::any};
+    mkldnn::memory::desc weight_md{
+        weight_dims, get_mkldnn_type(dtype), mkldnn::memory::format_tag::any};
     mkldnn::memory::dims output_dims{1, 32, 112, 112};
-    mkldnn::memory::desc out_md{output_dims, get_mkldnn_type(dtype),
-                                mkldnn::memory::format_tag::any};
+    mkldnn::memory::desc out_md{
+        output_dims, get_mkldnn_type(dtype), mkldnn::memory::format_tag::any};
     mkldnn::memory::dims strides{1, 1};
     mkldnn::memory::dims padding{1, 1};
 
-    mkldnn::convolution_forward::desc desc(mkldnn::prop_kind::forward_training,
-                                           mkldnn::algorithm::convolution_direct,
-                                           data_md, weight_md, out_md, strides,
-                                           padding, padding);
+    mkldnn::convolution_forward::desc desc(
+        mkldnn::prop_kind::forward_training, mkldnn::algorithm::convolution_direct, data_md,
+        weight_md, out_md, strides, padding, padding);
     mkldnn::convolution_forward::primitive_desc pd(desc, CpuEngine::Get()->get_engine());
     while (pd.dst_desc().get_size() != GetMemDescSize(out_md) ||
            pd.src_desc().get_size() != GetMemDescSize(data_md) ||
@@ -188,12 +184,18 @@ inline static TestArrayShapes GetTestArrayShapes(bool spatial_data_format = fals
   {
     // 4D
     mxnet::TShape s1(4, -1);
-    s1[0] = 10; s1[1] = 96; s1[2] = 54; s1[3] = 54;
+    s1[0] = 10;
+    s1[1] = 96;
+    s1[2] = 54;
+    s1[3] = 54;
     shapes.push_back(s1);
     mds.push_back(GetMemDesc(s1, dtype, mkldnn::memory::format_tag::nchw));
 
     mxnet::TShape s2(4, -1);
-    s2[0] = 96; s2[1] = 3; s2[2] = 11; s2[3] = 11;
+    s2[0] = 96;
+    s2[1] = 3;
+    s2[2] = 11;
+    s2[3] = 11;
     shapes.push_back(s2);
     mds.push_back(GetMemDesc(s2, dtype, mkldnn::memory::format_tag::oihw));
 
@@ -205,7 +207,11 @@ inline static TestArrayShapes GetTestArrayShapes(bool spatial_data_format = fals
   {
     // 5D
     mxnet::TShape s(5, -1);
-    s[0] = 96; s[1] = 1; s[2] = 3; s[3] = 11; s[4] = 11;
+    s[0] = 96;
+    s[1] = 1;
+    s[2] = 3;
+    s[3] = 11;
+    s[4] = 11;
     shapes.push_back(s);
     mds.push_back(GetMemDesc(s, dtype, mkldnn::memory::format_tag::goihw));
 
@@ -217,7 +223,7 @@ inline static TestArrayShapes GetTestArrayShapes(bool spatial_data_format = fals
 
   TestArrayShapes ret;
   ret.shapes = shapes;
-  ret.mds = mds;
+  ret.mds    = mds;
   return ret;
 }
 
@@ -239,32 +245,31 @@ struct OpAttrs {
 };
 
 enum ArrayTypes {
-  Normal = 1,
-  MKLDNN = 2,
-  MKLDNNDiffShape = 4,
-  MKLDNNDiffDim = 8,
-  NormalReshaped = 16,
-  MKLDNNReshaped = 32,
+  Normal                  = 1,
+  MKLDNN                  = 2,
+  MKLDNNDiffShape         = 4,
+  MKLDNNDiffDim           = 8,
+  NormalReshaped          = 16,
+  MKLDNNReshaped          = 32,
   MKLDNNReshapedDiffShape = 64,
-  MKLDNNReshapedDiffDim = 128,
-  NormalReused = 256,
-  MKLDNNReused = 512,
-  MKLDNNReusedDiffDim = 1024,
-  NormalReshapedReused = 2048,
-  NormalReusedDiffDtype = 4096,
-  All = 8191,
+  MKLDNNReshapedDiffDim   = 128,
+  NormalReused            = 256,
+  MKLDNNReused            = 512,
+  MKLDNNReusedDiffDim     = 1024,
+  NormalReshapedReused    = 2048,
+  NormalReusedDiffDtype   = 4096,
+  All                     = 8191,
 };
 
-
-inline NDArray CreateKernelNDArray(mxnet::TShape kernel, int num_filters, mxnet::TShape input,
-    bool is_deconv = false) {
+inline NDArray CreateKernelNDArray(
+    mxnet::TShape kernel, int num_filters, mxnet::TShape input, bool is_deconv = false) {
   CHECK_EQ(kernel.ndim(), 2) << "mkldnn only supports 2d filters on 4d inputs";
   mxnet::TShape target_shape(4, -1);
   target_shape[0] = is_deconv ? input[1] : num_filters;
   target_shape[1] = is_deconv ? num_filters : input[1];
   target_shape[2] = kernel[0];
   target_shape[3] = kernel[1];
-  int dtype = mshadow::DataType<mshadow::default_real_t>::kFlag;
+  int dtype       = mshadow::DataType<mshadow::default_real_t>::kFlag;
   NDArray arr(target_shape, Context());
   auto pd = GetMemDesc(target_shape, dtype, mkldnn::memory::format_tag::nchw);
   InitMKLDNNArray(&arr, pd);
@@ -280,7 +285,7 @@ inline NDArray CreateBiasNDArray(mxnet::TShape target_shape) {
 }
 
 inline int CalculateWidthConvOutput(int width, int kernel, int padding, int stride) {
-  return (width - kernel + 2 * padding) / stride  + 1;
+  return (width - kernel + 2 * padding) / stride + 1;
 }
 
 inline int CalculateWidthDeconvOutput(int width, int kernel, int padding, int stride) {
@@ -298,12 +303,12 @@ inline std::string CreateShapeString(int value, int dim) {
   return ss.str();
 }
 
-inline void PrintVerifyMsg(const NDArrayAttrs &arr1, const NDArrayAttrs &arr2) {
+inline void PrintVerifyMsg(const NDArrayAttrs& arr1, const NDArrayAttrs& arr2) {
   mxnet::TShape t1 = arr1.arr.shape();
   mxnet::TShape t2 = arr2.arr.shape();
   std::stringstream ss;
-  std::cout << "Verifying: " << arr1.desc.c_str() << " " <<
-            t1 << " with " << arr2.desc.c_str() << " " << t2 << "\n";
+  std::cout << "Verifying: " << arr1.desc.c_str() << " " << t1 << " with " << arr2.desc.c_str()
+            << " " << t2 << "\n";
 }
 
 /*
@@ -326,13 +331,14 @@ inline void PrintVerifyMsg(const NDArrayAttrs &arr1, const NDArrayAttrs &arr2) {
  *    In the inference mode, the MKLDNN memory in the weight array will be
  *    reordered to 5 dimensions.
  *
- *  num_inputs / dim arguments used to scale shape (used for concat backwards to enlarge input shapes)
+ *  num_inputs / dim arguments used to scale shape (used for concat backwards to enlarge input
+ * shapes)
  */
 inline std::vector<NDArrayAttrs> GetTestInputArrays(
-    int types = ArrayTypes::All, bool rand = false,
-    std::vector<float> scale = {1}, bool spatial_data_format = false, int max = 50) {
-  TestArrayShapes tas = GetTestArrayShapes(spatial_data_format);
-  std::vector<mxnet::TShape> shapes = tas.shapes;
+    int types = ArrayTypes::All, bool rand = false, std::vector<float> scale = {1},
+    bool spatial_data_format = false, int max = 50) {
+  TestArrayShapes tas                   = GetTestArrayShapes(spatial_data_format);
+  std::vector<mxnet::TShape> shapes     = tas.shapes;
   std::vector<mkldnn::memory::desc> mds = tas.mds;
 
   std::vector<NDArrayAttrs> in_arrs;
@@ -340,8 +346,7 @@ inline std::vector<NDArrayAttrs> GetTestInputArrays(
 
   int slice_amount = scale[0];
   for (auto shape : shapes) {
-    if (scale.size() > shape.ndim())
-      continue;
+    if (scale.size() > shape.ndim()) continue;
 
     for (size_t dim = 0; dim < scale.size(); ++dim)
       shape[dim] = static_cast<int>(round(shape[dim] * scale[dim]));
@@ -357,10 +362,9 @@ inline std::vector<NDArrayAttrs> GetTestInputArrays(
     arr = NDArray(shape, Context());
     if (types & ArrayTypes::NormalReshaped) {
       InitDefaultArray(&arr, rand, max);
-      in_arrs.emplace_back(arr.Slice(slice_amount, arr.shape()[0] - slice_amount),
-                           "Reshaped Normal NDArray");
+      in_arrs.emplace_back(
+          arr.Slice(slice_amount, arr.shape()[0] - slice_amount), "Reshaped Normal NDArray");
     }
-
 
     for (auto md : mds) {
       for (size_t dim = 0; dim < scale.size(); ++dim) {
@@ -371,48 +375,44 @@ inline std::vector<NDArrayAttrs> GetTestInputArrays(
           md = GetExpandedMemDesc(md, scale[dim]);
       }
 
-      if (shape.Size() != md.get_size() / sizeof(mshadow::default_real_t))
-        continue;
+      if (shape.Size() != md.get_size() / sizeof(mshadow::default_real_t)) continue;
 
       // Type 2, 3.
       arr = NDArray(shape, Context());
-      if (shape.ndim() == md.data.ndims && IsSameShape(md, shape)
-          && types & ArrayTypes::MKLDNN) {
+      if (shape.ndim() == md.data.ndims && IsSameShape(md, shape) && types & ArrayTypes::MKLDNN) {
         desc_str = "MKLDNN NDArray";
         InitMKLDNNArray(&arr, md, rand, max);
         in_arrs.emplace_back(arr, desc_str);
-      } else if (shape.ndim() == md.data.ndims && !IsSameShape(md, shape)
-          && types & ArrayTypes::MKLDNNDiffShape) {
+      } else if (
+          shape.ndim() == md.data.ndims && !IsSameShape(md, shape) &&
+          types & ArrayTypes::MKLDNNDiffShape) {
         desc_str = "MKLDNN NDArray with different shape";
         InitMKLDNNArray(&arr, md, rand, max);
         in_arrs.emplace_back(arr, desc_str);
       } else if (shape.ndim() != md.data.ndims && types & ArrayTypes::MKLDNNDiffDim) {
         std::stringstream ss;
-        ss << "MKLDNN NDArray with different dim " <<
-           shape.ndim() << "/" << md.data.ndims;
+        ss << "MKLDNN NDArray with different dim " << shape.ndim() << "/" << md.data.ndims;
         desc_str = ss.str();
         InitMKLDNNArray(&arr, md, rand, max);
         in_arrs.emplace_back(arr, desc_str);
       }
 
-
       // Type 5, 6.
       arr = NDArray(shape, Context());
-      if (shape.ndim() == md.data.ndims && IsSameShape(md, shape)
-          && types & ArrayTypes::MKLDNNReshaped) {
+      if (shape.ndim() == md.data.ndims && IsSameShape(md, shape) &&
+          types & ArrayTypes::MKLDNNReshaped) {
         desc_str = "Reshaped MKLDNN NDArray";
         InitMKLDNNArray(&arr, md, rand, max);
         in_arrs.emplace_back(arr.Slice(slice_amount, arr.shape()[0] - slice_amount), desc_str);
-      } else if (shape.ndim() == md.data.ndims && !IsSameShape(md, shape)
-          && types & ArrayTypes::MKLDNNReshapedDiffShape) {
+      } else if (
+          shape.ndim() == md.data.ndims && !IsSameShape(md, shape) &&
+          types & ArrayTypes::MKLDNNReshapedDiffShape) {
         desc_str = "Reshaped MKLDNN NDArray with different shape";
         InitMKLDNNArray(&arr, md, rand, max);
         in_arrs.emplace_back(arr.Slice(slice_amount, arr.shape()[0] - slice_amount), desc_str);
-      } else if (shape.ndim() != md.data.ndims
-          && types & ArrayTypes::MKLDNNReshapedDiffDim) {
+      } else if (shape.ndim() != md.data.ndims && types & ArrayTypes::MKLDNNReshapedDiffDim) {
         std::stringstream ss;
-        ss << "MKLDNN NDArray with different dim " <<
-           shape.ndim() << "/" << md.data.ndims;
+        ss << "MKLDNN NDArray with different dim " << shape.ndim() << "/" << md.data.ndims;
         desc_str = ss.str();
         InitMKLDNNArray(&arr, md, rand, max);
         in_arrs.emplace_back(arr.Slice(slice_amount, arr.shape()[0] - slice_amount), desc_str);
@@ -443,9 +443,8 @@ inline std::vector<NDArrayAttrs> GetTestInputArrays(
  * Optional num_inputs / dim args can be passed to modify input shape (used for Concat test)
  */
 inline std::vector<NDArrayAttrs> GetTestOutputArrays(
-    const mxnet::TShape &shp,
-    const std::vector<mkldnn::memory::desc> &mds,
-    std::vector<float>scale = {1}, bool rand = true, int types = ArrayTypes::All, int max = 50) {
+    const mxnet::TShape& shp, const std::vector<mkldnn::memory::desc>& mds,
+    std::vector<float> scale = {1}, bool rand = true, int types = ArrayTypes::All, int max = 50) {
   mxnet::TShape shape = shp;
 
   for (int dim = 0; dim < scale.size(); dim++)
@@ -495,28 +494,24 @@ inline std::vector<NDArrayAttrs> GetTestOutputArrays(
     s[0] = shape.Size() * GetTypeSize(mshadow::default_type_flag) * 2;
     NDArray arr3(s, Context(), true, mshadow::kUint8);
     tmp_shape[0] = shape[0] * 2;
-    arr3 = arr3.AsArray(tmp_shape, mshadow::default_type_flag);
+    arr3         = arr3.AsArray(tmp_shape, mshadow::default_type_flag);
     InitDefaultArray(&arr3, rand, max);
     in_arrs.emplace_back(arr3.Slice(1, shape[0] + 1), "Reused+Reshaped NDArray");
   }
 
   for (auto md : mds) {
-    if (shape.Size() != md.get_size() / sizeof(mshadow::default_real_t))
-      continue;
+    if (shape.Size() != md.get_size() / sizeof(mshadow::default_real_t)) continue;
 
-    if (scale.size() > md.data.ndims)
-      continue;
+    if (scale.size() > md.data.ndims) continue;
 
-    for (int dim = 0; dim < scale.size(); dim++)
-      md = GetExpandedMemDesc(md, scale[dim]);
+    for (int dim = 0; dim < scale.size(); dim++) md = GetExpandedMemDesc(md, scale[dim]);
 
     // Type 2, 3.
-    arr = NDArray(shape, Context());
+    arr      = NDArray(shape, Context());
     desc_str = "MKLDNN NDArray";
     if (shape.ndim() != md.data.ndims) {
       std::stringstream ss;
-      ss << "MKLDNN NDArray with different memory layout "
-         << shape.ndim() << "/" << md.data.ndims;
+      ss << "MKLDNN NDArray with different memory layout " << shape.ndim() << "/" << md.data.ndims;
       desc_str = ss.str();
     }
 
@@ -529,15 +524,15 @@ inline std::vector<NDArrayAttrs> GetTestOutputArrays(
     // Type 8, 9.
     // Get a reused version.
     mxnet::TShape s(1, -1);
-    s[0] = shape.Size();
+    s[0]        = shape.Size();
     NDArray arr = NDArray(s, Context());
-    arr = arr.AsArray(shape, arr.dtype());
+    arr         = arr.AsArray(shape, arr.dtype());
     InitMKLDNNArray(&arr, md, rand, max);
     desc_str = "Reused MKLDNN NDArray";
     if (shape.ndim() != md.data.ndims) {
       std::stringstream ss;
-      ss << "Reused MKLDNN NDArray with different memory layout "
-         << shape.ndim() << "/" << md.data.ndims;
+      ss << "Reused MKLDNN NDArray with different memory layout " << shape.ndim() << "/"
+         << md.data.ndims;
       desc_str = ss.str();
     }
 
@@ -556,8 +551,7 @@ inline std::vector<NDArrayAttrs> GetTestOutputArrays(
 inline int GetDim(mxnet::TShape input_shape, mxnet::TShape output_shape) {
   CHECK(input_shape.Size() != output_shape.Size());
   for (size_t i = 0; i < input_shape.ndim(); i++) {
-    if (input_shape[i] != output_shape[i])
-      return i;
+    if (input_shape[i] != output_shape[i]) return i;
   }
   return -1;
 }
@@ -568,22 +562,20 @@ inline int GetDim(mxnet::TShape input_shape, mxnet::TShape output_shape) {
  */
 inline int GetBlockSize(mxnet::TShape shape, int dim) {
   int block_size = 1;
-  for (int i = shape.ndim() - 1; i >= dim; i--)
-    block_size *= shape[i];
+  for (int i = shape.ndim() - 1; i >= dim; i--) block_size *= shape[i];
   return block_size;
 }
 
 inline int CalculateWidthPoolOutput(int width, int kernel, int padding, int stride) {
-  return (width - kernel + 2 * padding) / stride  + 1;
+  return (width - kernel + 2 * padding) / stride + 1;
 }
 
-using VerifyFunc = std::function<void (const std::vector<NDArray *> &in_arrs,
-                                       const std::vector<NDArray *> &out_arrs)>;
+using VerifyFunc = std::function<void(
+    const std::vector<NDArray*>& in_arrs, const std::vector<NDArray*>& out_arrs)>;
 
-inline void VerifyAddRequest(const std::vector<NDArray*> &in_arrs,
-                             const std::vector<NDArray*> &original_outputs,
-                             const std::vector<NDArray*> &new_outputs,
-                             VerifyFunc verify_fn) {
+inline void VerifyAddRequest(
+    const std::vector<NDArray*>& in_arrs, const std::vector<NDArray*>& original_outputs,
+    const std::vector<NDArray*>& new_outputs, VerifyFunc verify_fn) {
   CHECK(original_outputs.size() == new_outputs.size());
   std::vector<NDArray*> tmp_outputs;
   NDArray tmp;
@@ -595,30 +587,28 @@ inline void VerifyAddRequest(const std::vector<NDArray*> &in_arrs,
   verify_fn(in_arrs, tmp_outputs);
 }
 
-inline void VerifyCopyResult(const std::vector<NDArray *> &in_arrs,
-                             const std::vector<NDArray *> &out_arrs) {
+inline void VerifyCopyResult(
+    const std::vector<NDArray*>& in_arrs, const std::vector<NDArray*>& out_arrs) {
   NDArray tmp1 = in_arrs[0]->Reorder2Default();
   NDArray tmp2 = out_arrs[0]->Reorder2Default();
   EXPECT_EQ(tmp1.shape().Size(), tmp2.shape().Size());
   TBlob d1 = tmp1.data();
   TBlob d2 = tmp2.data();
-  EXPECT_EQ(memcmp(d1.dptr_, d2.dptr_,
-                   tmp1.shape().Size() * sizeof(mshadow::default_real_t)), 0);
+  EXPECT_EQ(memcmp(d1.dptr_, d2.dptr_, tmp1.shape().Size() * sizeof(mshadow::default_real_t)), 0);
 }
 
-inline void VerifySumResult(const std::vector<NDArray *> &in_arrs,
-                            const std::vector<NDArray *> &out_arrs) {
+inline void VerifySumResult(
+    const std::vector<NDArray*>& in_arrs, const std::vector<NDArray*>& out_arrs) {
   NDArray in1 = in_arrs[0]->Reorder2Default();
   NDArray in2 = in_arrs[1]->Reorder2Default();
   NDArray out = out_arrs[0]->Reorder2Default();
   EXPECT_EQ(in1.shape().Size(), in2.shape().Size());
   EXPECT_EQ(in1.shape().Size(), out.shape().Size());
 
-  mshadow::default_real_t *d1 = in1.data().dptr<mshadow::default_real_t>();
-  mshadow::default_real_t *d2 = in2.data().dptr<mshadow::default_real_t>();
-  mshadow::default_real_t *o = out.data().dptr<mshadow::default_real_t>();
-  for (size_t i = 0; i < in1.shape().Size(); i++)
-    ASSERT_EQ(d1[i] + d2[i], o[i]);
+  mshadow::default_real_t* d1 = in1.data().dptr<mshadow::default_real_t>();
+  mshadow::default_real_t* d2 = in2.data().dptr<mshadow::default_real_t>();
+  mshadow::default_real_t* o  = out.data().dptr<mshadow::default_real_t>();
+  for (size_t i = 0; i < in1.shape().Size(); i++) ASSERT_EQ(d1[i] + d2[i], o[i]);
 }
 
 #endif  // MXNET_USE_MKLDNN == 1

--- a/tests/cpp/include/test_mkldnn.h
+++ b/tests/cpp/include/test_mkldnn.h
@@ -31,13 +31,15 @@
 #include <set>
 #include <string>
 #include <vector>
-#include "../../../3rdparty/mkldnn/include/mkldnn_types.h"
+
 #include "../../../3rdparty/googletest/googletest/include/gtest/gtest.h"
+#include "../../../3rdparty/mkldnn/include/mkldnn_types.h"
 #include "../../../src/operator/nn/mkldnn/mkldnn_base-inl.h"
 
 using namespace mxnet;
 
-inline static mkldnn::memory::desc GetMemDesc(const mxnet::TShape s, const int dtype,
+inline static mkldnn::memory::desc GetMemDesc(const mxnet::TShape s,
+                                              const int dtype,
                                               const mkldnn::memory::format_tag format_tag) {
   mkldnn::memory::dims dims(s.ndim());
   for (size_t i = 0; i < dims.size(); i++) dims[i] = s[i];
@@ -45,7 +47,8 @@ inline static mkldnn::memory::desc GetMemDesc(const mxnet::TShape s, const int d
   return desc;
 }
 
-inline static mkldnn::memory::desc GetExpandedMemDesc(mkldnn::memory::desc md, const float scale,
+inline static mkldnn::memory::desc GetExpandedMemDesc(mkldnn::memory::desc md,
+                                                      const float scale,
                                                       const int dim = 0) {
   CHECK(dim < md.data.ndims) << "dimension cannot be larger than total dimensions of input";
   mxnet::TShape s(md.data.ndims, -1);
@@ -75,8 +78,10 @@ inline static void InitDefaultArray(NDArray* arr, bool is_rand = false, int max 
 }
 
 // Init arrays with the specified layout.
-inline static void InitMKLDNNArray(NDArray* arr, const mkldnn::memory::desc& desc,
-                                   bool is_rand = false, int max = 50) {
+inline static void InitMKLDNNArray(NDArray* arr,
+                                   const mkldnn::memory::desc& desc,
+                                   bool is_rand = false,
+                                   int max      = 50) {
   InitDefaultArray(arr, is_rand, max);
   arr->MKLDNNDataReorderAsync(desc);
   arr->WaitToRead();
@@ -260,7 +265,9 @@ enum ArrayTypes {
   All                     = 8191,
 };
 
-inline NDArray CreateKernelNDArray(mxnet::TShape kernel, int num_filters, mxnet::TShape input,
+inline NDArray CreateKernelNDArray(mxnet::TShape kernel,
+                                   int num_filters,
+                                   mxnet::TShape input,
                                    bool is_deconv = false) {
   CHECK_EQ(kernel.ndim(), 2) << "mkldnn only supports 2d filters on 4d inputs";
   mxnet::TShape target_shape(4, -1);
@@ -333,7 +340,8 @@ inline void PrintVerifyMsg(const NDArrayAttrs& arr1, const NDArrayAttrs& arr2) {
  *  num_inputs / dim arguments used to scale shape (used for concat backwards to enlarge input
  * shapes)
  */
-inline std::vector<NDArrayAttrs> GetTestInputArrays(int types = ArrayTypes::All, bool rand = false,
+inline std::vector<NDArrayAttrs> GetTestInputArrays(int types                = ArrayTypes::All,
+                                                    bool rand                = false,
                                                     std::vector<float> scale = {1},
                                                     bool spatial_data_format = false,
                                                     int max                  = 50) {
@@ -443,8 +451,9 @@ inline std::vector<NDArrayAttrs> GetTestInputArrays(int types = ArrayTypes::All,
 inline std::vector<NDArrayAttrs> GetTestOutputArrays(const mxnet::TShape& shp,
                                                      const std::vector<mkldnn::memory::desc>& mds,
                                                      std::vector<float> scale = {1},
-                                                     bool rand = true, int types = ArrayTypes::All,
-                                                     int max = 50) {
+                                                     bool rand                = true,
+                                                     int types                = ArrayTypes::All,
+                                                     int max                  = 50) {
   mxnet::TShape shape = shp;
 
   for (int dim = 0; dim < scale.size(); dim++)
@@ -575,7 +584,8 @@ using VerifyFunc = std::function<void(const std::vector<NDArray*>& in_arrs,
 
 inline void VerifyAddRequest(const std::vector<NDArray*>& in_arrs,
                              const std::vector<NDArray*>& original_outputs,
-                             const std::vector<NDArray*>& new_outputs, VerifyFunc verify_fn) {
+                             const std::vector<NDArray*>& new_outputs,
+                             VerifyFunc verify_fn) {
   CHECK(original_outputs.size() == new_outputs.size());
   std::vector<NDArray*> tmp_outputs;
   NDArray tmp;

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -26,19 +26,21 @@
 #if MXNET_USE_MKLDNN == 1
 
 #include <mkldnn_types.h>
-#include <cmath>
+
 #include <climits>
+#include <cmath>
 #include <set>
-#include "gtest/gtest.h"
-#include "mxnet/imperative.h"
+
+#include "../../src/operator/nn/convolution-inl.h"
+#include "../../src/operator/nn/deconvolution-inl.h"
 #include "../../src/operator/nn/mkldnn/mkldnn_base-inl.h"
 #include "../../src/operator/nn/mkldnn/mkldnn_ops-inl.h"
 #include "../../src/operator/nn/mkldnn/mkldnn_pooling-inl.h"
 #include "../../src/operator/nn/pooling-inl.h"
-#include "../../src/operator/nn/convolution-inl.h"
-#include "../../src/operator/nn/deconvolution-inl.h"
 #include "../include/test_mkldnn.h"
 #include "../include/test_util.h"
+#include "gtest/gtest.h"
+#include "mxnet/imperative.h"
 
 using namespace mxnet;
 using namespace mxnet::test;
@@ -576,9 +578,12 @@ void TestConcatOp(const OpAttrs& attrs, VerifyFunc verify_fn, bool backwards = f
   }
 }
 
-void TestOpExBackward(const OpAttrs& forward_attrs, const OpAttrs& backwards_attrs,
-                      const OpReqType& req, const std::vector<NDArray*>& inputs,
-                      const std::vector<NDArray*>& outputs, const NDArrayAttrs& in_arr,
+void TestOpExBackward(const OpAttrs& forward_attrs,
+                      const OpAttrs& backwards_attrs,
+                      const OpReqType& req,
+                      const std::vector<NDArray*>& inputs,
+                      const std::vector<NDArray*>& outputs,
+                      const NDArrayAttrs& in_arr,
                       const NDArrayAttrs& out_arr) {
   std::vector<NDArray*> backwards_input(backwards_attrs.num_inputs);
   std::vector<NDArray*> backwards_outputs(backwards_attrs.num_outputs);
@@ -701,9 +706,12 @@ void TestOpEx(const OpAttrs& forward_attrs, const OpAttrs& backwards_attrs) {
   }
 }
 
-void TestOpExBNBackward(const OpAttrs& forward_attrs, const OpAttrs& backwards_attrs,
-                        const OpReqType& req, const std::vector<NDArray*>& inputs,
-                        const std::vector<NDArray*>& outputs, const NDArrayAttrs& in_arr,
+void TestOpExBNBackward(const OpAttrs& forward_attrs,
+                        const OpAttrs& backwards_attrs,
+                        const OpReqType& req,
+                        const std::vector<NDArray*>& inputs,
+                        const std::vector<NDArray*>& outputs,
+                        const NDArrayAttrs& in_arr,
                         NDArrayAttrs* out_arr) {
   std::vector<NDArray*> backwards_input(backwards_attrs.num_inputs);
 
@@ -931,7 +939,8 @@ void TestFullyConnectedOp(const OpAttrs& forward_attrs, const OpAttrs& backwards
 }
 
 template <typename P>
-void TestConvOp(const OpAttrs& forward_attrs, const OpAttrs& backwards_attrs,
+void TestConvOp(const OpAttrs& forward_attrs,
+                const OpAttrs& backwards_attrs,
                 bool is_deconv = false) {
   std::vector<NDArray*> inputs(forward_attrs.num_inputs);
   std::vector<NDArray*> outputs(forward_attrs.num_outputs);

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -357,8 +357,8 @@ void VerifyActResult(const std::vector<NDArray*>& in_arrs, const std::vector<NDA
   }
 }
 
-void VerifyActBackwardsResult(
-    const std::vector<NDArray*>& in_arrs, const std::vector<NDArray*>& out_arrs) {
+void VerifyActBackwardsResult(const std::vector<NDArray*>& in_arrs,
+                              const std::vector<NDArray*>& out_arrs) {
   NDArray tmp1                = in_arrs[0]->Reorder2Default();   // out grads
   NDArray tmp2                = in_arrs[1]->Reorder2Default();   // input
   NDArray tmp3                = out_arrs[0]->Reorder2Default();  // input grads
@@ -374,8 +374,8 @@ void VerifyActBackwardsResult(
   }
 }
 
-void VerifySumBackwardsResult(
-    const std::vector<NDArray*>& in_arrs, const std::vector<NDArray*>& out_arrs) {
+void VerifySumBackwardsResult(const std::vector<NDArray*>& in_arrs,
+                              const std::vector<NDArray*>& out_arrs) {
   NDArray out_grads            = in_arrs[0]->Reorder2Default();   // out grads
   NDArray input_grads1         = out_arrs[0]->Reorder2Default();  // input grads
   NDArray input_grads2         = out_arrs[1]->Reorder2Default();  // input grads
@@ -388,8 +388,8 @@ void VerifySumBackwardsResult(
   }
 }
 
-void VerifyConcatResult(
-    const std::vector<NDArray*>& in_arrs, const std::vector<NDArray*>& out_arrs) {
+void VerifyConcatResult(const std::vector<NDArray*>& in_arrs,
+                        const std::vector<NDArray*>& out_arrs) {
   int num_inputs            = in_arrs.size();
   int input_size            = in_arrs[0]->shape().Size();
   mxnet::TShape input_shape = in_arrs[0]->shape();
@@ -406,15 +406,14 @@ void VerifyConcatResult(
     mshadow::default_real_t* data = tmp.data().dptr<mshadow::default_real_t>();
     for (size_t block_num = 0; block_num < num_blocks; block_num++) {
       for (size_t i = 0; i < block_size; i++)
-        ASSERT_EQ(
-            data[block_num * block_size + i],
-            out_data[(block_num * num_inputs + input_num) * block_size + i]);
+        ASSERT_EQ(data[block_num * block_size + i],
+                  out_data[(block_num * num_inputs + input_num) * block_size + i]);
     }
   }
 }
 
-void VerifyConcatBackwardsResult(
-    const std::vector<NDArray*>& in_arrs, const std::vector<NDArray*>& out_arrs) {
+void VerifyConcatBackwardsResult(const std::vector<NDArray*>& in_arrs,
+                                 const std::vector<NDArray*>& out_arrs) {
   // in_arrs is larger array, out_arr is ammler
   int num_inputs            = out_arrs.size();
   int input_size            = out_arrs[0]->shape().Size();
@@ -432,9 +431,8 @@ void VerifyConcatBackwardsResult(
     mshadow::default_real_t* data = tmp.data().dptr<mshadow::default_real_t>();
     for (size_t block_num = 0; block_num < num_blocks; block_num++) {
       for (size_t i = 0; i < block_size; i++)
-        ASSERT_EQ(
-            data[block_num * block_size + i],
-            out_data[(block_num * num_inputs + input_num) * block_size + i]);
+        ASSERT_EQ(data[block_num * block_size + i],
+                  out_data[(block_num * num_inputs + input_num) * block_size + i]);
     }
   }
 }
@@ -464,8 +462,8 @@ void TestOp(const OpAttrs& attrs, VerifyFunc verify_fn) {
             outputs[i] = &out_arrs[i][output_i].arr;
           }
           PrintVerifyMsg(in_arr, out_arrs[0][output_i]);
-          Imperative::Get()->InvokeOp(
-              Context(), attrs.attrs, inputs, outputs, req, dispatch, mxnet::OpStatePtr());
+          Imperative::Get()->InvokeOp(Context(), attrs.attrs, inputs, outputs, req, dispatch,
+                                      mxnet::OpStatePtr());
           Engine::Get()->WaitForAll();
           verify_fn(inputs, outputs);
         }
@@ -486,8 +484,8 @@ void TestOp(const OpAttrs& attrs, VerifyFunc verify_fn) {
           outputs[i] = &arr.arr;
         }
         PrintVerifyMsg(orig, arr);
-        Imperative::Get()->InvokeOp(
-            Context(), attrs.attrs, inputs, outputs, req, dispatch, mxnet::OpStatePtr());
+        Imperative::Get()->InvokeOp(Context(), attrs.attrs, inputs, outputs, req, dispatch,
+                                    mxnet::OpStatePtr());
         Engine::Get()->WaitForAll();
         std::vector<NDArray*> orig_inputs(attrs.num_inputs);
         for (int i = 0; i < attrs.num_inputs; i++) orig_inputs[i] = &orig.arr;
@@ -514,8 +512,8 @@ void TestOp(const OpAttrs& attrs, VerifyFunc verify_fn) {
             req[i]              = kAddTo;
           }
           PrintVerifyMsg(in_arr, out_arrs[0][output_i]);
-          Imperative::Get()->InvokeOp(
-              Context(), attrs.attrs, inputs, outputs, req, dispatch, mxnet::OpStatePtr());
+          Imperative::Get()->InvokeOp(Context(), attrs.attrs, inputs, outputs, req, dispatch,
+                                      mxnet::OpStatePtr());
           Engine::Get()->WaitForAll();
           VerifyAddRequest(inputs, original_outputs, outputs, verify_fn);
         }
@@ -569,8 +567,8 @@ void TestConcatOp(const OpAttrs& attrs, VerifyFunc verify_fn, bool backwards = f
           outputs[i] = &out_arrs[i][output_i].arr;
         }
         PrintVerifyMsg(in_arr, out_arrs[0][output_i]);
-        Imperative::Get()->InvokeOp(
-            Context(), attrs.attrs, inputs, outputs, req, dispatch, mxnet::OpStatePtr());
+        Imperative::Get()->InvokeOp(Context(), attrs.attrs, inputs, outputs, req, dispatch,
+                                    mxnet::OpStatePtr());
         Engine::Get()->WaitForAll();
         verify_fn(inputs, outputs);
       }
@@ -578,10 +576,10 @@ void TestConcatOp(const OpAttrs& attrs, VerifyFunc verify_fn, bool backwards = f
   }
 }
 
-void TestOpExBackward(
-    const OpAttrs& forward_attrs, const OpAttrs& backwards_attrs, const OpReqType& req,
-    const std::vector<NDArray*>& inputs, const std::vector<NDArray*>& outputs,
-    const NDArrayAttrs& in_arr, const NDArrayAttrs& out_arr) {
+void TestOpExBackward(const OpAttrs& forward_attrs, const OpAttrs& backwards_attrs,
+                      const OpReqType& req, const std::vector<NDArray*>& inputs,
+                      const std::vector<NDArray*>& outputs, const NDArrayAttrs& in_arr,
+                      const NDArrayAttrs& out_arr) {
   std::vector<NDArray*> backwards_input(backwards_attrs.num_inputs);
   std::vector<NDArray*> backwards_outputs(backwards_attrs.num_outputs);
   std::vector<NDArray*> backwards_ex_outputs(backwards_attrs.num_outputs);
@@ -601,12 +599,12 @@ void TestOpExBackward(
 
     std::cout << "Backwards: ";
     PrintVerifyMsg(out_arr, in_arr);
-    Imperative::Get()->InvokeOp(
-        Context(), backwards_attrs.attrs, backwards_input, backwards_outputs, back_req,
-        DispatchMode::kFCompute, mxnet::OpStatePtr());
-    Imperative::Get()->InvokeOp(
-        Context(), backwards_attrs.attrs, backwards_input, backwards_ex_outputs, back_req,
-        DispatchMode::kFComputeEx, mxnet::OpStatePtr());
+    Imperative::Get()->InvokeOp(Context(), backwards_attrs.attrs, backwards_input,
+                                backwards_outputs, back_req, DispatchMode::kFCompute,
+                                mxnet::OpStatePtr());
+    Imperative::Get()->InvokeOp(Context(), backwards_attrs.attrs, backwards_input,
+                                backwards_ex_outputs, back_req, DispatchMode::kFComputeEx,
+                                mxnet::OpStatePtr());
     Engine::Get()->WaitForAll();
     if (backwards_attrs.attrs.op->name == "_backward_LRN") {
       AssertEqual(backwards_outputs, backwards_ex_outputs, 1e-5, 1e-8, true);
@@ -655,12 +653,10 @@ void TestOpEx(const OpAttrs& forward_attrs, const OpAttrs& backwards_attrs) {
         Imperative::Get()->set_is_training(true);
 
         PrintVerifyMsg(in_arr, out_arrs[0][output_i]);
-        Imperative::Get()->InvokeOp(
-            Context(), forward_attrs.attrs, inputs, outputs, req, DispatchMode::kFCompute,
-            mxnet::OpStatePtr());
-        Imperative::Get()->InvokeOp(
-            Context(), forward_attrs.attrs, inputs, ex_outputs, req, DispatchMode::kFComputeEx,
-            mxnet::OpStatePtr());
+        Imperative::Get()->InvokeOp(Context(), forward_attrs.attrs, inputs, outputs, req,
+                                    DispatchMode::kFCompute, mxnet::OpStatePtr());
+        Imperative::Get()->InvokeOp(Context(), forward_attrs.attrs, inputs, ex_outputs, req,
+                                    DispatchMode::kFComputeEx, mxnet::OpStatePtr());
         Engine::Get()->WaitForAll();
         // TODO(pengzhao-intel): Need to fix op, should work for the whole vector
         if (forward_attrs.attrs.op->name == "LRN") {
@@ -668,9 +664,8 @@ void TestOpEx(const OpAttrs& forward_attrs, const OpAttrs& backwards_attrs) {
         }
 
         if (!backwards_attrs.requests.empty()) {
-          TestOpExBackward(
-              forward_attrs, backwards_attrs, OpReqType::kWriteTo, inputs, outputs, in_arr,
-              out_arrs[0][output_i]);
+          TestOpExBackward(forward_attrs, backwards_attrs, OpReqType::kWriteTo, inputs, outputs,
+                           in_arr, out_arrs[0][output_i]);
         }
       }
     }
@@ -693,12 +688,10 @@ void TestOpEx(const OpAttrs& forward_attrs, const OpAttrs& backwards_attrs) {
       }
       Imperative::Get()->set_is_training(true);
       PrintVerifyMsg(orig, in_arr);
-      Imperative::Get()->InvokeOp(
-          Context(), forward_attrs.attrs, inputs, outputs, req, DispatchMode::kFCompute,
-          mxnet::OpStatePtr());
-      Imperative::Get()->InvokeOp(
-          Context(), forward_attrs.attrs, inputs, ex_outputs, req, DispatchMode::kFComputeEx,
-          mxnet::OpStatePtr());
+      Imperative::Get()->InvokeOp(Context(), forward_attrs.attrs, inputs, outputs, req,
+                                  DispatchMode::kFCompute, mxnet::OpStatePtr());
+      Imperative::Get()->InvokeOp(Context(), forward_attrs.attrs, inputs, ex_outputs, req,
+                                  DispatchMode::kFComputeEx, mxnet::OpStatePtr());
       Engine::Get()->WaitForAll();
       // TODO(unassigned): Need to fix op, should work for the whole vector
       if (forward_attrs.attrs.op->name == "LRN") {
@@ -708,10 +701,10 @@ void TestOpEx(const OpAttrs& forward_attrs, const OpAttrs& backwards_attrs) {
   }
 }
 
-void TestOpExBNBackward(
-    const OpAttrs& forward_attrs, const OpAttrs& backwards_attrs, const OpReqType& req,
-    const std::vector<NDArray*>& inputs, const std::vector<NDArray*>& outputs,
-    const NDArrayAttrs& in_arr, NDArrayAttrs* out_arr) {
+void TestOpExBNBackward(const OpAttrs& forward_attrs, const OpAttrs& backwards_attrs,
+                        const OpReqType& req, const std::vector<NDArray*>& inputs,
+                        const std::vector<NDArray*>& outputs, const NDArrayAttrs& in_arr,
+                        NDArrayAttrs* out_arr) {
   std::vector<NDArray*> backwards_input(backwards_attrs.num_inputs);
 
   std::vector<NDArray> backwards_buffer(backwards_attrs.num_outputs);
@@ -743,12 +736,12 @@ void TestOpExBNBackward(
 
     std::cout << "Backwards: ";
     PrintVerifyMsg(*out_arr, in_arr);
-    Imperative::Get()->InvokeOp(
-        Context(), backwards_attrs.attrs, backwards_input, backwards_outputs, backwards_req,
-        DispatchMode::kFCompute, mxnet::OpStatePtr());
-    Imperative::Get()->InvokeOp(
-        Context(), backwards_attrs.attrs, backwards_input, backwards_ex_outputs, backwards_req,
-        DispatchMode::kFComputeEx, mxnet::OpStatePtr());
+    Imperative::Get()->InvokeOp(Context(), backwards_attrs.attrs, backwards_input,
+                                backwards_outputs, backwards_req, DispatchMode::kFCompute,
+                                mxnet::OpStatePtr());
+    Imperative::Get()->InvokeOp(Context(), backwards_attrs.attrs, backwards_input,
+                                backwards_ex_outputs, backwards_req, DispatchMode::kFComputeEx,
+                                mxnet::OpStatePtr());
     Engine::Get()->WaitForAll();
     // TODO(unassigned): Need to fix op, should work for the whole vector
     AssertEqual(backwards_outputs, backwards_ex_outputs, 1e-4, 1e-2, true);
@@ -805,19 +798,16 @@ void TestOpExBN(const OpAttrs& forward_attrs, const OpAttrs& backwards_attrs) {
         Imperative::Get()->set_is_training(true);
 
         PrintVerifyMsg(in_arr, out_arrs[0][output_i]);
-        Imperative::Get()->InvokeOp(
-            Context(), forward_attrs.attrs, inputs, outputs, req, DispatchMode::kFCompute,
-            mxnet::OpStatePtr());
-        Imperative::Get()->InvokeOp(
-            Context(), forward_attrs.attrs, inputs2, ex_outputs, req, DispatchMode::kFComputeEx,
-            mxnet::OpStatePtr());
+        Imperative::Get()->InvokeOp(Context(), forward_attrs.attrs, inputs, outputs, req,
+                                    DispatchMode::kFCompute, mxnet::OpStatePtr());
+        Imperative::Get()->InvokeOp(Context(), forward_attrs.attrs, inputs2, ex_outputs, req,
+                                    DispatchMode::kFComputeEx, mxnet::OpStatePtr());
         Engine::Get()->WaitForAll();
         AssertEqual(outputs, ex_outputs, 1e-4, 1e-2, true);
 
         if (!backwards_attrs.requests.empty()) {
-          TestOpExBNBackward(
-              forward_attrs, backwards_attrs, OpReqType::kWriteTo, inputs, outputs, in_arr,
-              &out_arrs[0][output_i]);
+          TestOpExBNBackward(forward_attrs, backwards_attrs, OpReqType::kWriteTo, inputs, outputs,
+                             in_arr, &out_arrs[0][output_i]);
         }
       }
     }
@@ -897,12 +887,10 @@ void TestFullyConnectedOp(const OpAttrs& forward_attrs, const OpAttrs& backwards
         Imperative::Get()->set_is_training(true);
 
         PrintVerifyMsg(in_arr, out_arrs[0][output_i]);
-        Imperative::Get()->InvokeOp(
-            Context(), forward_attrs.attrs, inputs, outputs, req, DispatchMode::kFCompute,
-            mxnet::OpStatePtr());
-        Imperative::Get()->InvokeOp(
-            Context(), forward_attrs.attrs, inputs, ex_outputs, req, DispatchMode::kFComputeEx,
-            mxnet::OpStatePtr());
+        Imperative::Get()->InvokeOp(Context(), forward_attrs.attrs, inputs, outputs, req,
+                                    DispatchMode::kFCompute, mxnet::OpStatePtr());
+        Imperative::Get()->InvokeOp(Context(), forward_attrs.attrs, inputs, ex_outputs, req,
+                                    DispatchMode::kFComputeEx, mxnet::OpStatePtr());
         Engine::Get()->WaitForAll();
         AssertEqual(outputs, ex_outputs);
 
@@ -929,12 +917,12 @@ void TestFullyConnectedOp(const OpAttrs& forward_attrs, const OpAttrs& backwards
 
         std::cout << "Backwards: ";
         PrintVerifyMsg(out_arrs[0][output_i], tmp_output);
-        Imperative::Get()->InvokeOp(
-            Context(), backwards_attrs.attrs, backwards_input, backwards_outputs, back_req,
-            DispatchMode::kFCompute, mxnet::OpStatePtr());
-        Imperative::Get()->InvokeOp(
-            Context(), backwards_attrs.attrs, backwards_input, backwards_ex_outputs, back_req,
-            DispatchMode::kFComputeEx, mxnet::OpStatePtr());
+        Imperative::Get()->InvokeOp(Context(), backwards_attrs.attrs, backwards_input,
+                                    backwards_outputs, back_req, DispatchMode::kFCompute,
+                                    mxnet::OpStatePtr());
+        Imperative::Get()->InvokeOp(Context(), backwards_attrs.attrs, backwards_input,
+                                    backwards_ex_outputs, back_req, DispatchMode::kFComputeEx,
+                                    mxnet::OpStatePtr());
         Engine::Get()->WaitForAll();
         AssertEqual(backwards_outputs, backwards_ex_outputs, 1e-6, 1e-6);
       }
@@ -943,8 +931,8 @@ void TestFullyConnectedOp(const OpAttrs& forward_attrs, const OpAttrs& backwards
 }
 
 template <typename P>
-void TestConvOp(
-    const OpAttrs& forward_attrs, const OpAttrs& backwards_attrs, bool is_deconv = false) {
+void TestConvOp(const OpAttrs& forward_attrs, const OpAttrs& backwards_attrs,
+                bool is_deconv = false) {
   std::vector<NDArray*> inputs(forward_attrs.num_inputs);
   std::vector<NDArray*> outputs(forward_attrs.num_outputs);
   std::vector<NDArray*> ex_outputs(forward_attrs.num_outputs);
@@ -993,10 +981,10 @@ void TestConvOp(
     scale_vector[3] = scale;
 
     for (size_t i = 0; i < forward_attrs.num_outputs; ++i) {
-      out_arrs[i] = GetTestOutputArrays(
-          in_arr.arr.shape(), mds, scale_vector, true, forward_attrs.output_types);
-      ex_out_arrs[i] = GetTestOutputArrays(
-          in_arr.arr.shape(), mds, scale_vector, true, forward_attrs.output_types);
+      out_arrs[i]    = GetTestOutputArrays(in_arr.arr.shape(), mds, scale_vector, true,
+                                        forward_attrs.output_types);
+      ex_out_arrs[i] = GetTestOutputArrays(in_arr.arr.shape(), mds, scale_vector, true,
+                                           forward_attrs.output_types);
     }
     NDArray ndkernel = CreateKernelNDArray(kernel, num_filter, in_arr.arr.shape(), is_deconv);
     mxnet::TShape bias_shape = {num_filter};
@@ -1017,12 +1005,10 @@ void TestConvOp(
       Imperative::Get()->set_is_training(true);
 
       PrintVerifyMsg(in_arr, out_arrs[0][output_i]);
-      Imperative::Get()->InvokeOp(
-          Context(), forward_attrs.attrs, inputs, outputs, req, DispatchMode::kFCompute,
-          mxnet::OpStatePtr());
-      Imperative::Get()->InvokeOp(
-          Context(), forward_attrs.attrs, inputs, ex_outputs, req, DispatchMode::kFComputeEx,
-          mxnet::OpStatePtr());
+      Imperative::Get()->InvokeOp(Context(), forward_attrs.attrs, inputs, outputs, req,
+                                  DispatchMode::kFCompute, mxnet::OpStatePtr());
+      Imperative::Get()->InvokeOp(Context(), forward_attrs.attrs, inputs, ex_outputs, req,
+                                  DispatchMode::kFComputeEx, mxnet::OpStatePtr());
       Engine::Get()->WaitForAll();
       VerifyCopyResult(outputs, ex_outputs);
 
@@ -1057,12 +1043,12 @@ void TestConvOp(
 
       std::cout << "Backwards: ";
       PrintVerifyMsg(out_arrs[0][output_i], tmp_output);
-      Imperative::Get()->InvokeOp(
-          Context(), backwards_attrs.attrs, backwards_input, backwards_outputs, back_req,
-          DispatchMode::kFCompute, mxnet::OpStatePtr());
-      Imperative::Get()->InvokeOp(
-          Context(), backwards_attrs.attrs, backwards_input, backwards_ex_outputs, back_req,
-          DispatchMode::kFComputeEx, mxnet::OpStatePtr());
+      Imperative::Get()->InvokeOp(Context(), backwards_attrs.attrs, backwards_input,
+                                  backwards_outputs, back_req, DispatchMode::kFCompute,
+                                  mxnet::OpStatePtr());
+      Imperative::Get()->InvokeOp(Context(), backwards_attrs.attrs, backwards_input,
+                                  backwards_ex_outputs, back_req, DispatchMode::kFComputeEx,
+                                  mxnet::OpStatePtr());
       Engine::Get()->WaitForAll();
       VerifyCopyResult(backwards_outputs, backwards_ex_outputs);
     }
@@ -1130,12 +1116,10 @@ void TestPoolingOp(const OpAttrs& forward_attrs, const OpAttrs& backwards_attrs)
       Imperative::Get()->set_is_training(true);
 
       PrintVerifyMsg(in_arr, out_arrs[0][output_i]);
-      Imperative::Get()->InvokeOp(
-          Context(), forward_attrs.attrs, inputs, outputs, req, DispatchMode::kFCompute,
-          mxnet::OpStatePtr());
-      Imperative::Get()->InvokeOp(
-          Context(), forward_attrs.attrs, inputs, ex_outputs, req, DispatchMode::kFComputeEx,
-          mxnet::OpStatePtr());
+      Imperative::Get()->InvokeOp(Context(), forward_attrs.attrs, inputs, outputs, req,
+                                  DispatchMode::kFCompute, mxnet::OpStatePtr());
+      Imperative::Get()->InvokeOp(Context(), forward_attrs.attrs, inputs, ex_outputs, req,
+                                  DispatchMode::kFComputeEx, mxnet::OpStatePtr());
       Engine::Get()->WaitForAll();
       VerifyCopyResult(outputs, ex_outputs);
 
@@ -1161,12 +1145,12 @@ void TestPoolingOp(const OpAttrs& forward_attrs, const OpAttrs& backwards_attrs)
       back_req[0]             = kWriteTo;
       std::cout << "Backwards: ";
       PrintVerifyMsg(out_arrs[0][output_i], tmp_output);
-      Imperative::Get()->InvokeOp(
-          Context(), backwards_attrs.attrs, backwards_input, backwards_outputs, back_req,
-          DispatchMode::kFCompute, mxnet::OpStatePtr());
-      Imperative::Get()->InvokeOp(
-          Context(), backwards_attrs.attrs, backwards_input, backwards_ex_outputs, back_req,
-          DispatchMode::kFComputeEx, mxnet::OpStatePtr());
+      Imperative::Get()->InvokeOp(Context(), backwards_attrs.attrs, backwards_input,
+                                  backwards_outputs, back_req, DispatchMode::kFCompute,
+                                  mxnet::OpStatePtr());
+      Imperative::Get()->InvokeOp(Context(), backwards_attrs.attrs, backwards_input,
+                                  backwards_ex_outputs, back_req, DispatchMode::kFComputeEx,
+                                  mxnet::OpStatePtr());
       Engine::Get()->WaitForAll();
       VerifyCopyResult(backwards_outputs, backwards_ex_outputs);
     }

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -45,8 +45,8 @@ using namespace mxnet::test;
 
 OpAttrs GetCopyOp() {
   OpAttrs attrs;
-  attrs.attrs.op = Op::Get("_copy");
-  attrs.num_inputs = 1;
+  attrs.attrs.op    = Op::Get("_copy");
+  attrs.num_inputs  = 1;
   attrs.num_outputs = 1;
   attrs.dispatches.resize(2);
   attrs.dispatches[0] = DispatchMode::kFCompute;
@@ -59,8 +59,8 @@ OpAttrs GetCopyOp() {
 
 OpAttrs GetCopyBackwardsOp() {
   OpAttrs attrs;
-  attrs.attrs.op = Op::Get("_backward_copy");
-  attrs.num_inputs = 1;
+  attrs.attrs.op    = Op::Get("_backward_copy");
+  attrs.num_inputs  = 1;
   attrs.num_outputs = 1;
   attrs.dispatches.resize(2);
   attrs.dispatches[0] = DispatchMode::kFCompute;
@@ -76,7 +76,7 @@ OpAttrs GetReluOp() {
   attrs.attrs.op = Op::Get("Activation");
   attrs.attrs.dict.insert({"act_type", "relu"});
   attrs.attrs.op->attr_parser(&attrs.attrs);
-  attrs.num_inputs = 1;
+  attrs.num_inputs  = 1;
   attrs.num_outputs = 1;
   attrs.dispatches.resize(2);
   attrs.dispatches[0] = DispatchMode::kFCompute;
@@ -92,7 +92,7 @@ OpAttrs GetReluBackwardsOp() {
   attrs.attrs.op = Op::Get("_backward_Activation");
   attrs.attrs.dict.insert({"act_type", "relu"});
   attrs.attrs.op->attr_parser(&attrs.attrs);
-  attrs.num_inputs = 2;
+  attrs.num_inputs  = 2;
   attrs.num_outputs = 1;
   attrs.dispatches.resize(2);
   attrs.dispatches[0] = DispatchMode::kFCompute;
@@ -105,8 +105,8 @@ OpAttrs GetReluBackwardsOp() {
 
 OpAttrs GetSumOp() {
   OpAttrs attrs;
-  attrs.attrs.op = Op::Get("elemwise_add");
-  attrs.num_inputs = 2;
+  attrs.attrs.op    = Op::Get("elemwise_add");
+  attrs.num_inputs  = 2;
   attrs.num_outputs = 1;
   attrs.dispatches.resize(2);
   attrs.dispatches[0] = DispatchMode::kFCompute;
@@ -119,8 +119,8 @@ OpAttrs GetSumOp() {
 
 OpAttrs GetSumBackwardsOp() {
   OpAttrs attrs;
-  attrs.attrs.op = Op::Get("_backward_add");
-  attrs.num_inputs = 1;
+  attrs.attrs.op    = Op::Get("_backward_add");
+  attrs.num_inputs  = 1;
   attrs.num_outputs = 2;
   attrs.dispatches.resize(2);
   attrs.dispatches[0] = DispatchMode::kFCompute;
@@ -133,11 +133,11 @@ OpAttrs GetSumBackwardsOp() {
 
 OpAttrs GetConcatOp(int num_args, int dim) {
   OpAttrs attrs;
-  attrs.attrs.op = Op::Get("concat");
-  attrs.num_inputs = num_args;
+  attrs.attrs.op    = Op::Get("concat");
+  attrs.num_inputs  = num_args;
   attrs.num_outputs = 1;
-  attrs.attrs.dict.insert({"num_args" , std::to_string(num_args)});
-  attrs.attrs.dict.insert({"dim" , std::to_string(dim)});
+  attrs.attrs.dict.insert({"num_args", std::to_string(num_args)});
+  attrs.attrs.dict.insert({"dim", std::to_string(dim)});
   attrs.attrs.op->attr_parser(&attrs.attrs);
   attrs.dispatches.resize(2);
   attrs.dispatches[0] = DispatchMode::kFCompute;
@@ -147,11 +147,11 @@ OpAttrs GetConcatOp(int num_args, int dim) {
 
 OpAttrs GetConcatBackwardsOp(int num_args, int dim) {
   OpAttrs attrs;
-  attrs.attrs.op = Op::Get("_backward_Concat");
-  attrs.num_inputs = 2;
+  attrs.attrs.op    = Op::Get("_backward_Concat");
+  attrs.num_inputs  = 2;
   attrs.num_outputs = num_args;
-  attrs.attrs.dict.insert({"num_args" , std::to_string(num_args)});
-  attrs.attrs.dict.insert({"dim" , std::to_string(dim)});
+  attrs.attrs.dict.insert({"num_args", std::to_string(num_args)});
+  attrs.attrs.dict.insert({"dim", std::to_string(dim)});
   attrs.attrs.op->attr_parser(&attrs.attrs);
   attrs.dispatches.resize(2);
   attrs.dispatches[0] = DispatchMode::kFCompute;
@@ -161,21 +161,21 @@ OpAttrs GetConcatBackwardsOp(int num_args, int dim) {
 
 OpAttrs GetPoolingOp(int kernel, int dim, int stride, int pad) {
   OpAttrs attrs;
-  attrs.attrs.op = Op::Get("Pooling");
-  attrs.num_inputs = 1;
+  attrs.attrs.op    = Op::Get("Pooling");
+  attrs.num_inputs  = 1;
   attrs.num_outputs = (dim == 2 || dim == 3) ? 2 : 1;
-  attrs.attrs.dict.insert({"kernel" , CreateShapeString(kernel, dim)});
-  attrs.attrs.dict.insert({"stride" , CreateShapeString(stride, dim)});
-  attrs.attrs.dict.insert({"pad" , CreateShapeString(pad, dim)});
-  attrs.attrs.dict.insert({"pool_type" , "max"});
+  attrs.attrs.dict.insert({"kernel", CreateShapeString(kernel, dim)});
+  attrs.attrs.dict.insert({"stride", CreateShapeString(stride, dim)});
+  attrs.attrs.dict.insert({"pad", CreateShapeString(pad, dim)});
+  attrs.attrs.dict.insert({"pool_type", "max"});
   attrs.attrs.op->attr_parser(&attrs.attrs);
   return attrs;
 }
 
 OpAttrs GetPoolingBackwardsOp(int kernel, int dim, int stride, int pad) {
   OpAttrs attrs;
-  attrs.attrs.op = Op::Get("_backward_Pooling");
-  attrs.num_inputs = (dim == 2 || dim == 3) ? 5 : 3;
+  attrs.attrs.op    = Op::Get("_backward_Pooling");
+  attrs.num_inputs  = (dim == 2 || dim == 3) ? 5 : 3;
   attrs.num_outputs = 1;
   attrs.attrs.dict.insert({"kernel", CreateShapeString(kernel, dim)});
   attrs.attrs.dict.insert({"stride", CreateShapeString(stride, dim)});
@@ -187,30 +187,26 @@ OpAttrs GetPoolingBackwardsOp(int kernel, int dim, int stride, int pad) {
 
 OpAttrs GetLRNOp() {
   OpAttrs attrs;
-  attrs.attrs.op = Op::Get("LRN");
-  attrs.num_inputs = 1;
+  attrs.attrs.op    = Op::Get("LRN");
+  attrs.num_inputs  = 1;
   attrs.num_outputs = 2;
-  attrs.attrs.dict.insert({"nsize" , "3"});
+  attrs.attrs.dict.insert({"nsize", "3"});
   attrs.attrs.op->attr_parser(&attrs.attrs);
   attrs.accept_dims.insert(4);
   attrs.requests.insert(OpReqType::kWriteTo);
-  attrs.input_types = ArrayTypes::Normal |
-      ArrayTypes::MKLDNN |
-      ArrayTypes::NormalReshaped |
-      ArrayTypes::MKLDNNReshaped;
-  attrs.output_types = ArrayTypes::Normal |
-      ArrayTypes::MKLDNN |
-      ArrayTypes::NormalReshaped |
-      ArrayTypes::MKLDNNReshaped;
+  attrs.input_types = ArrayTypes::Normal | ArrayTypes::MKLDNN | ArrayTypes::NormalReshaped |
+                      ArrayTypes::MKLDNNReshaped;
+  attrs.output_types = ArrayTypes::Normal | ArrayTypes::MKLDNN | ArrayTypes::NormalReshaped |
+                       ArrayTypes::MKLDNNReshaped;
   return attrs;
 }
 
 OpAttrs GetLRNBackwardsOp() {
   OpAttrs attrs;
-  attrs.attrs.op = Op::Get("_backward_LRN");
-  attrs.num_inputs = 3;
+  attrs.attrs.op    = Op::Get("_backward_LRN");
+  attrs.num_inputs  = 3;
   attrs.num_outputs = 1;
-  attrs.attrs.dict.insert({"nsize" , "3"});
+  attrs.attrs.dict.insert({"nsize", "3"});
   attrs.attrs.op->attr_parser(&attrs.attrs);
   attrs.dispatches.resize(2);
   attrs.requests.insert(OpReqType::kWriteTo);
@@ -219,48 +215,40 @@ OpAttrs GetLRNBackwardsOp() {
 
 OpAttrs GetSoftmaxOp() {
   OpAttrs attrs;
-  attrs.attrs.op = Op::Get("softmax");
-  attrs.num_inputs = 1;
+  attrs.attrs.op    = Op::Get("softmax");
+  attrs.num_inputs  = 1;
   attrs.num_outputs = 1;
   attrs.attrs.op->attr_parser(&attrs.attrs);
   attrs.accept_dims.insert({1, 2, 3, 4, 5});
   attrs.requests.insert(OpReqType::kWriteTo);
   attrs.requests.insert(OpReqType::kWriteInplace);
-  attrs.input_types = ArrayTypes::Normal |
-    ArrayTypes::MKLDNN |
-    ArrayTypes::NormalReshaped |
-    ArrayTypes::MKLDNNReshaped;
-  attrs.output_types = ArrayTypes::Normal |
-    ArrayTypes::MKLDNN |
-    ArrayTypes::NormalReshaped |
-    ArrayTypes::MKLDNNReshaped;
+  attrs.input_types = ArrayTypes::Normal | ArrayTypes::MKLDNN | ArrayTypes::NormalReshaped |
+                      ArrayTypes::MKLDNNReshaped;
+  attrs.output_types = ArrayTypes::Normal | ArrayTypes::MKLDNN | ArrayTypes::NormalReshaped |
+                       ArrayTypes::MKLDNNReshaped;
   return attrs;
 }
 
 OpAttrs GetFullyConnectedOp() {
   OpAttrs attrs;
   attrs.attrs.op = Op::Get("FullyConnected");
-  attrs.attrs.dict.insert({"num_hidden" , "20"});
-  attrs.num_inputs = 3;
+  attrs.attrs.dict.insert({"num_hidden", "20"});
+  attrs.num_inputs  = 3;
   attrs.num_outputs = 1;
   attrs.attrs.op->attr_parser(&attrs.attrs);
   attrs.requests.insert(OpReqType::kWriteTo);
-  attrs.input_types = ArrayTypes::Normal |
-      ArrayTypes::MKLDNN |
-      ArrayTypes::NormalReshaped |
-      ArrayTypes::MKLDNNReshaped;
-  attrs.output_types = ArrayTypes::Normal |
-      ArrayTypes::MKLDNN |
-      ArrayTypes::NormalReshaped |
-      ArrayTypes::MKLDNNReshaped;
+  attrs.input_types = ArrayTypes::Normal | ArrayTypes::MKLDNN | ArrayTypes::NormalReshaped |
+                      ArrayTypes::MKLDNNReshaped;
+  attrs.output_types = ArrayTypes::Normal | ArrayTypes::MKLDNN | ArrayTypes::NormalReshaped |
+                       ArrayTypes::MKLDNNReshaped;
   return attrs;
 }
 
 OpAttrs GetFullyConnectedBackwardsOp() {
   OpAttrs attrs;
   attrs.attrs.op = Op::Get("_backward_FullyConnected");
-  attrs.attrs.dict.insert({"num_hidden" , "20"});
-  attrs.num_inputs = 3;
+  attrs.attrs.dict.insert({"num_hidden", "20"});
+  attrs.num_inputs  = 3;
   attrs.num_outputs = 3;
   attrs.attrs.op->attr_parser(&attrs.attrs);
   attrs.requests.insert(OpReqType::kWriteTo);
@@ -269,206 +257,189 @@ OpAttrs GetFullyConnectedBackwardsOp() {
 
 OpAttrs GetConvOp(int kernel, int num_filters, int dim, int stride, int pad) {
   OpAttrs attrs;
-  attrs.attrs.op = Op::Get("Convolution");
-  attrs.num_inputs = 3;
+  attrs.attrs.op    = Op::Get("Convolution");
+  attrs.num_inputs  = 3;
   attrs.num_outputs = 1;
-  attrs.attrs.dict.insert({"kernel" , CreateShapeString(kernel, dim)});
-  attrs.attrs.dict.insert({"num_filter" , std::to_string(num_filters)});
-  attrs.attrs.dict.insert({"stride" , CreateShapeString(stride, dim)});
-  attrs.attrs.dict.insert({"pad" , CreateShapeString(pad, dim)});
+  attrs.attrs.dict.insert({"kernel", CreateShapeString(kernel, dim)});
+  attrs.attrs.dict.insert({"num_filter", std::to_string(num_filters)});
+  attrs.attrs.dict.insert({"stride", CreateShapeString(stride, dim)});
+  attrs.attrs.dict.insert({"pad", CreateShapeString(pad, dim)});
   attrs.attrs.op->attr_parser(&attrs.attrs);
-  attrs.input_types = ArrayTypes::Normal |
-      ArrayTypes::MKLDNN |
-      ArrayTypes::NormalReshaped |
-      ArrayTypes::MKLDNNReshaped |
-      ArrayTypes::NormalReused |
-      ArrayTypes::MKLDNNReused |
-      ArrayTypes::NormalReshapedReused;
-  attrs.output_types = ArrayTypes::Normal |
-      ArrayTypes::MKLDNN |
-      ArrayTypes::NormalReshaped |
-      ArrayTypes::MKLDNNReshaped |
-      ArrayTypes::NormalReused |
-      ArrayTypes::MKLDNNReused |
-      ArrayTypes::NormalReshapedReused |
-      ArrayTypes::NormalReusedDiffDtype;
+  attrs.input_types = ArrayTypes::Normal | ArrayTypes::MKLDNN | ArrayTypes::NormalReshaped |
+                      ArrayTypes::MKLDNNReshaped | ArrayTypes::NormalReused |
+                      ArrayTypes::MKLDNNReused | ArrayTypes::NormalReshapedReused;
+  attrs.output_types = ArrayTypes::Normal | ArrayTypes::MKLDNN | ArrayTypes::NormalReshaped |
+                       ArrayTypes::MKLDNNReshaped | ArrayTypes::NormalReused |
+                       ArrayTypes::MKLDNNReused | ArrayTypes::NormalReshapedReused |
+                       ArrayTypes::NormalReusedDiffDtype;
   return attrs;
 }
 
 OpAttrs GetConvBackwardOp(int kernel, int num_filters, int dim, int stride, int pad) {
   OpAttrs attrs;
-  attrs.attrs.op = Op::Get("_backward_Convolution");
-  attrs.num_inputs = 4;
+  attrs.attrs.op    = Op::Get("_backward_Convolution");
+  attrs.num_inputs  = 4;
   attrs.num_outputs = 3;
-  attrs.attrs.dict.insert({"kernel" , CreateShapeString(kernel, dim)});
-  attrs.attrs.dict.insert({"num_filter" , std::to_string(num_filters)});
-  attrs.attrs.dict.insert({"stride" , CreateShapeString(stride, dim)});
-  attrs.attrs.dict.insert({"pad" , CreateShapeString(pad, dim)});
+  attrs.attrs.dict.insert({"kernel", CreateShapeString(kernel, dim)});
+  attrs.attrs.dict.insert({"num_filter", std::to_string(num_filters)});
+  attrs.attrs.dict.insert({"stride", CreateShapeString(stride, dim)});
+  attrs.attrs.dict.insert({"pad", CreateShapeString(pad, dim)});
   attrs.attrs.op->attr_parser(&attrs.attrs);
   return attrs;
 }
 
 OpAttrs GetDeconvOp(int kernel, int num_filters, int dim, int stride, int pad) {
   OpAttrs attrs;
-  attrs.attrs.op = Op::Get("Deconvolution");
-  attrs.num_inputs = 2;
+  attrs.attrs.op    = Op::Get("Deconvolution");
+  attrs.num_inputs  = 2;
   attrs.num_outputs = 1;
-  attrs.attrs.dict.insert({"kernel" , CreateShapeString(kernel, dim)});
-  attrs.attrs.dict.insert({"num_filter" , std::to_string(num_filters)});
-  attrs.attrs.dict.insert({"stride" , CreateShapeString(stride, dim)});
-  attrs.attrs.dict.insert({"pad" , CreateShapeString(pad, dim)});
+  attrs.attrs.dict.insert({"kernel", CreateShapeString(kernel, dim)});
+  attrs.attrs.dict.insert({"num_filter", std::to_string(num_filters)});
+  attrs.attrs.dict.insert({"stride", CreateShapeString(stride, dim)});
+  attrs.attrs.dict.insert({"pad", CreateShapeString(pad, dim)});
   attrs.attrs.op->attr_parser(&attrs.attrs);
-  attrs.input_types = ArrayTypes::Normal |
-      ArrayTypes::MKLDNN |
-      ArrayTypes::NormalReshaped |
-      ArrayTypes::MKLDNNReshaped |
-      ArrayTypes::NormalReused |
-      ArrayTypes::MKLDNNReused |
-      ArrayTypes::NormalReshapedReused;
-  attrs.output_types = ArrayTypes::Normal |
-      ArrayTypes::MKLDNN |
-      ArrayTypes::NormalReshaped |
-      ArrayTypes::MKLDNNReshaped |
-      ArrayTypes::NormalReused |
-      ArrayTypes::MKLDNNReused |
-      ArrayTypes::NormalReshapedReused |
-      ArrayTypes::NormalReusedDiffDtype;
+  attrs.input_types = ArrayTypes::Normal | ArrayTypes::MKLDNN | ArrayTypes::NormalReshaped |
+                      ArrayTypes::MKLDNNReshaped | ArrayTypes::NormalReused |
+                      ArrayTypes::MKLDNNReused | ArrayTypes::NormalReshapedReused;
+  attrs.output_types = ArrayTypes::Normal | ArrayTypes::MKLDNN | ArrayTypes::NormalReshaped |
+                       ArrayTypes::MKLDNNReshaped | ArrayTypes::NormalReused |
+                       ArrayTypes::MKLDNNReused | ArrayTypes::NormalReshapedReused |
+                       ArrayTypes::NormalReusedDiffDtype;
   return attrs;
 }
 
 OpAttrs GetDeconvBackwardOp(int kernel, int num_filters, int dim, int stride, int pad) {
   OpAttrs attrs;
-  attrs.attrs.op = Op::Get("_backward_Deconvolution");
-  attrs.num_inputs = 3;
+  attrs.attrs.op    = Op::Get("_backward_Deconvolution");
+  attrs.num_inputs  = 3;
   attrs.num_outputs = 2;
-  attrs.attrs.dict.insert({"kernel" , CreateShapeString(kernel, dim)});
-  attrs.attrs.dict.insert({"num_filter" , std::to_string(num_filters)});
-  attrs.attrs.dict.insert({"stride" , CreateShapeString(stride, dim)});
-  attrs.attrs.dict.insert({"pad" , CreateShapeString(pad, dim)});
+  attrs.attrs.dict.insert({"kernel", CreateShapeString(kernel, dim)});
+  attrs.attrs.dict.insert({"num_filter", std::to_string(num_filters)});
+  attrs.attrs.dict.insert({"stride", CreateShapeString(stride, dim)});
+  attrs.attrs.dict.insert({"pad", CreateShapeString(pad, dim)});
   attrs.attrs.op->attr_parser(&attrs.attrs);
   return attrs;
 }
 
 OpAttrs GetBNOp() {
   OpAttrs attrs;
-  attrs.attrs.op = Op::Get("BatchNorm");
-  attrs.num_inputs = 5;
+  attrs.attrs.op    = Op::Get("BatchNorm");
+  attrs.num_inputs  = 5;
   attrs.num_outputs = 3;
   attrs.accept_dims.insert(4);
   attrs.requests.insert(OpReqType::kWriteTo);
   attrs.attrs.op->attr_parser(&attrs.attrs);
-  attrs.input_types = ArrayTypes::Normal |
-      ArrayTypes::MKLDNN;
-  attrs.output_types = ArrayTypes::Normal |
-      ArrayTypes::MKLDNN;
+  attrs.input_types  = ArrayTypes::Normal | ArrayTypes::MKLDNN;
+  attrs.output_types = ArrayTypes::Normal | ArrayTypes::MKLDNN;
   return attrs;
 }
 
 OpAttrs GetBNBackwardOp() {
   OpAttrs attrs;
-  attrs.attrs.op = Op::Get("_backward_BatchNorm");
-  attrs.num_inputs = 8;
+  attrs.attrs.op    = Op::Get("_backward_BatchNorm");
+  attrs.num_inputs  = 8;
   attrs.num_outputs = 3;
   attrs.attrs.op->attr_parser(&attrs.attrs);
   attrs.requests.insert(OpReqType::kWriteTo);
   return attrs;
 }
 
-void VerifyActResult(const std::vector<NDArray *> &in_arrs,
-                     const std::vector<NDArray *> &out_arrs) {
-  NDArray tmp1 = in_arrs[0]->Reorder2Default();
-  NDArray tmp2 = out_arrs[0]->Reorder2Default();
-  TBlob blob1 = tmp1.data();
-  TBlob blob2 = tmp2.data();
-  mshadow::default_real_t *d1 = static_cast<mshadow::default_real_t*>(blob1.dptr_);
-  mshadow::default_real_t *d2 = static_cast<mshadow::default_real_t*>(blob2.dptr_);
+void VerifyActResult(const std::vector<NDArray*>& in_arrs, const std::vector<NDArray*>& out_arrs) {
+  NDArray tmp1                = in_arrs[0]->Reorder2Default();
+  NDArray tmp2                = out_arrs[0]->Reorder2Default();
+  TBlob blob1                 = tmp1.data();
+  TBlob blob2                 = tmp2.data();
+  mshadow::default_real_t* d1 = static_cast<mshadow::default_real_t*>(blob1.dptr_);
+  mshadow::default_real_t* d2 = static_cast<mshadow::default_real_t*>(blob2.dptr_);
   EXPECT_EQ(tmp1.shape().Size(), tmp2.shape().Size());
   for (size_t i = 0; i < tmp1.shape().Size(); i++) {
     EXPECT_EQ(std::fmax(d1[i], 0), d2[i]);
   }
 }
 
-void VerifyActBackwardsResult(const std::vector<NDArray *> &in_arrs,
-                              const std::vector<NDArray *> &out_arrs) {
-  NDArray tmp1 = in_arrs[0]->Reorder2Default();  // out grads
-  NDArray tmp2 = in_arrs[1]->Reorder2Default();  // input
-  NDArray tmp3 = out_arrs[0]->Reorder2Default();  // input grads
-  TBlob blob1 = tmp1.data();
-  TBlob blob2 = tmp2.data();
-  TBlob blob3 = tmp3.data();
-  mshadow::default_real_t *d1 = static_cast<mshadow::default_real_t*>(blob1.dptr_);
-  mshadow::default_real_t *d2 = static_cast<mshadow::default_real_t*>(blob2.dptr_);
-  mshadow::default_real_t *d3 = static_cast<mshadow::default_real_t*>(blob3.dptr_);
+void VerifyActBackwardsResult(
+    const std::vector<NDArray*>& in_arrs, const std::vector<NDArray*>& out_arrs) {
+  NDArray tmp1                = in_arrs[0]->Reorder2Default();   // out grads
+  NDArray tmp2                = in_arrs[1]->Reorder2Default();   // input
+  NDArray tmp3                = out_arrs[0]->Reorder2Default();  // input grads
+  TBlob blob1                 = tmp1.data();
+  TBlob blob2                 = tmp2.data();
+  TBlob blob3                 = tmp3.data();
+  mshadow::default_real_t* d1 = static_cast<mshadow::default_real_t*>(blob1.dptr_);
+  mshadow::default_real_t* d2 = static_cast<mshadow::default_real_t*>(blob2.dptr_);
+  mshadow::default_real_t* d3 = static_cast<mshadow::default_real_t*>(blob3.dptr_);
   EXPECT_EQ(tmp1.shape().Size(), tmp2.shape().Size());
   for (size_t i = 0; i < tmp1.shape().Size(); i++) {
     ASSERT_EQ(d2[i] > 0 ? d1[i] : 0, d3[i]);
   }
 }
 
-void VerifySumBackwardsResult(const std::vector<NDArray *> &in_arrs,
-                               const std::vector<NDArray *> &out_arrs) {
-  NDArray out_grads = in_arrs[0]->Reorder2Default();  // out grads
-  NDArray input_grads1 = out_arrs[0]->Reorder2Default();  // input grads
-  NDArray input_grads2 = out_arrs[1]->Reorder2Default();  // input grads
-  mshadow::default_real_t *og = out_grads.data().dptr<mshadow::default_real_t>();
-  mshadow::default_real_t *ig1 = input_grads1.data().dptr<mshadow::default_real_t>();
-  mshadow::default_real_t *ig2 = input_grads2.data().dptr<mshadow::default_real_t>();
+void VerifySumBackwardsResult(
+    const std::vector<NDArray*>& in_arrs, const std::vector<NDArray*>& out_arrs) {
+  NDArray out_grads            = in_arrs[0]->Reorder2Default();   // out grads
+  NDArray input_grads1         = out_arrs[0]->Reorder2Default();  // input grads
+  NDArray input_grads2         = out_arrs[1]->Reorder2Default();  // input grads
+  mshadow::default_real_t* og  = out_grads.data().dptr<mshadow::default_real_t>();
+  mshadow::default_real_t* ig1 = input_grads1.data().dptr<mshadow::default_real_t>();
+  mshadow::default_real_t* ig2 = input_grads2.data().dptr<mshadow::default_real_t>();
   for (size_t i = 0; i < out_grads.shape().Size(); i++) {
     ASSERT_EQ(og[i], ig1[i]);
     ASSERT_EQ(og[i], ig2[i]);
   }
 }
 
-void VerifyConcatResult(const std::vector<NDArray *> &in_arrs,
-                        const std::vector<NDArray *> &out_arrs) {
-  int num_inputs = in_arrs.size();
-  int input_size = in_arrs[0]->shape().Size();
+void VerifyConcatResult(
+    const std::vector<NDArray*>& in_arrs, const std::vector<NDArray*>& out_arrs) {
+  int num_inputs            = in_arrs.size();
+  int input_size            = in_arrs[0]->shape().Size();
   mxnet::TShape input_shape = in_arrs[0]->shape();
-  NDArray output = out_arrs[0]->Reorder2Default();
-  size_t total_size = output.shape().Size();
+  NDArray output            = out_arrs[0]->Reorder2Default();
+  size_t total_size         = output.shape().Size();
   EXPECT_EQ(input_size * num_inputs, total_size);
-  mshadow::default_real_t *out_data = output.data().dptr<mshadow::default_real_t>();
+  mshadow::default_real_t* out_data = output.data().dptr<mshadow::default_real_t>();
 
-  int dim = GetDim(input_shape, output.shape());
+  int dim        = GetDim(input_shape, output.shape());
   int block_size = GetBlockSize(input_shape, dim);
   int num_blocks = input_size / block_size;
   for (size_t input_num = 0; input_num < num_inputs; input_num++) {
-    NDArray tmp = in_arrs[input_num]->Reorder2Default();
+    NDArray tmp                   = in_arrs[input_num]->Reorder2Default();
     mshadow::default_real_t* data = tmp.data().dptr<mshadow::default_real_t>();
     for (size_t block_num = 0; block_num < num_blocks; block_num++) {
       for (size_t i = 0; i < block_size; i++)
-        ASSERT_EQ(data[block_num * block_size + i],
-                  out_data[(block_num * num_inputs + input_num) * block_size + i]);
+        ASSERT_EQ(
+            data[block_num * block_size + i],
+            out_data[(block_num * num_inputs + input_num) * block_size + i]);
     }
   }
 }
 
-void VerifyConcatBackwardsResult(const std::vector<NDArray *> &in_arrs,
-                                 const std::vector<NDArray *> &out_arrs) {
+void VerifyConcatBackwardsResult(
+    const std::vector<NDArray*>& in_arrs, const std::vector<NDArray*>& out_arrs) {
   // in_arrs is larger array, out_arr is ammler
-  int num_inputs = out_arrs.size();
-  int input_size = out_arrs[0]->shape().Size();
+  int num_inputs            = out_arrs.size();
+  int input_size            = out_arrs[0]->shape().Size();
   mxnet::TShape input_shape = out_arrs[0]->shape();
-  NDArray output = in_arrs[0]->Reorder2Default();
-  size_t total_size = output.shape().Size();
+  NDArray output            = in_arrs[0]->Reorder2Default();
+  size_t total_size         = output.shape().Size();
   EXPECT_EQ(input_size * num_inputs, total_size);
-  mshadow::default_real_t *out_data = output.data().dptr<mshadow::default_real_t>();
+  mshadow::default_real_t* out_data = output.data().dptr<mshadow::default_real_t>();
 
-  int dim = GetDim(input_shape, output.shape());
+  int dim        = GetDim(input_shape, output.shape());
   int block_size = GetBlockSize(input_shape, dim);
   int num_blocks = input_size / block_size;
   for (size_t input_num = 0; input_num < num_inputs; input_num++) {
-    NDArray tmp = out_arrs[input_num]->Reorder2Default();
+    NDArray tmp                   = out_arrs[input_num]->Reorder2Default();
     mshadow::default_real_t* data = tmp.data().dptr<mshadow::default_real_t>();
     for (size_t block_num = 0; block_num < num_blocks; block_num++) {
       for (size_t i = 0; i < block_size; i++)
-        ASSERT_EQ(data[block_num * block_size + i],
-                  out_data[(block_num * num_inputs + input_num) * block_size + i]);
+        ASSERT_EQ(
+            data[block_num * block_size + i],
+            out_data[(block_num * num_inputs + input_num) * block_size + i]);
     }
   }
 }
 
-void TestOp(const OpAttrs &attrs, VerifyFunc verify_fn) {
+void TestOp(const OpAttrs& attrs, VerifyFunc verify_fn) {
   std::vector<NDArray*> inputs(attrs.num_inputs);
   std::vector<NDArray*> outputs(attrs.num_outputs);
   std::vector<OpReqType> req(attrs.num_outputs);
@@ -476,26 +447,25 @@ void TestOp(const OpAttrs &attrs, VerifyFunc verify_fn) {
   std::vector<std::vector<NDArrayAttrs>> out_arrs(attrs.num_outputs);
   std::vector<DispatchMode> dispatches = attrs.dispatches;
 
-  TestArrayShapes tas = GetTestArrayShapes();
+  TestArrayShapes tas                   = GetTestArrayShapes();
   std::vector<mkldnn::memory::desc> mds = tas.mds;
 
   if (attrs.requests.find(OpReqType::kWriteTo) != attrs.requests.end()) {
     std::vector<NDArrayAttrs> in_arrs = GetTestInputArrays();
-    for (auto &in_arr : in_arrs) {
-      for (auto &dispatch : dispatches) {
+    for (auto& in_arr : in_arrs) {
+      for (auto& dispatch : dispatches) {
         std::vector<std::vector<NDArrayAttrs>> out_arrs(attrs.num_outputs);
         for (int i = 0; i < attrs.num_outputs; i++)
           out_arrs[i] = GetTestOutputArrays(in_arr.arr.shape(), mds);
-        for (int i = 0; i < attrs.num_inputs; i++)
-          inputs[i] = &in_arr.arr;
+        for (int i = 0; i < attrs.num_inputs; i++) inputs[i] = &in_arr.arr;
         for (size_t output_i = 0; output_i < out_arrs[0].size(); output_i++) {
           for (int i = 0; i < attrs.num_outputs; i++) {
-            req[i] = kWriteTo;
+            req[i]     = kWriteTo;
             outputs[i] = &out_arrs[i][output_i].arr;
           }
           PrintVerifyMsg(in_arr, out_arrs[0][output_i]);
-          Imperative::Get()->InvokeOp(Context(), attrs.attrs, inputs,
-                                      outputs, req, dispatch, mxnet::OpStatePtr());
+          Imperative::Get()->InvokeOp(
+              Context(), attrs.attrs, inputs, outputs, req, dispatch, mxnet::OpStatePtr());
           Engine::Get()->WaitForAll();
           verify_fn(inputs, outputs);
         }
@@ -504,26 +474,23 @@ void TestOp(const OpAttrs &attrs, VerifyFunc verify_fn) {
   }
 
   if (attrs.requests.find(OpReqType::kWriteInplace) != attrs.requests.end()) {
-    for (auto &dispatch : dispatches) {
+    for (auto& dispatch : dispatches) {
       in_arrs = GetTestInputArrays();
-      for (auto &arr : in_arrs) {
+      for (auto& arr : in_arrs) {
         // If the array is a view, we shouldn't write data to it.
-        if (arr.arr.IsView())
-          continue;
+        if (arr.arr.IsView()) continue;
         NDArrayAttrs orig(arr.arr.Copy(arr.arr.ctx()), "InPlace Copy");
-        for (int i = 0; i < attrs.num_inputs; i++)
-          inputs[i] = &arr.arr;
+        for (int i = 0; i < attrs.num_inputs; i++) inputs[i] = &arr.arr;
         for (int i = 0; i < attrs.num_outputs; i++) {
-          req[i] = kWriteInplace;
+          req[i]     = kWriteInplace;
           outputs[i] = &arr.arr;
         }
         PrintVerifyMsg(orig, arr);
-        Imperative::Get()->InvokeOp(Context(), attrs.attrs, inputs, outputs, req,
-                                    dispatch, mxnet::OpStatePtr());
+        Imperative::Get()->InvokeOp(
+            Context(), attrs.attrs, inputs, outputs, req, dispatch, mxnet::OpStatePtr());
         Engine::Get()->WaitForAll();
-        std::vector<NDArray *> orig_inputs(attrs.num_inputs);
-        for (int i = 0; i < attrs.num_inputs; i++)
-          orig_inputs[i] = &orig.arr;
+        std::vector<NDArray*> orig_inputs(attrs.num_inputs);
+        for (int i = 0; i < attrs.num_inputs; i++) orig_inputs[i] = &orig.arr;
         verify_fn(orig_inputs, outputs);
       }
     }
@@ -532,24 +499,23 @@ void TestOp(const OpAttrs &attrs, VerifyFunc verify_fn) {
   if (attrs.requests.find(OpReqType::kAddTo) != attrs.requests.end()) {
     std::vector<NDArray*> original_outputs(attrs.num_outputs);
     in_arrs = GetTestInputArrays();
-    for (auto &in_arr : in_arrs) {
-      for (auto &dispatch : dispatches) {
+    for (auto& in_arr : in_arrs) {
+      for (auto& dispatch : dispatches) {
         for (int i = 0; i < attrs.num_outputs; i++)
           out_arrs[i] = GetTestOutputArrays(in_arr.arr.shape(), mds);
-        for (size_t i = 0; i < attrs.num_inputs; i++)
-          inputs[i] = &in_arr.arr;
+        for (size_t i = 0; i < attrs.num_inputs; i++) inputs[i] = &in_arr.arr;
         for (size_t output_i = 0; output_i < out_arrs[0].size(); output_i++) {
           NDArray tmp;
           for (size_t i = 0; i < attrs.num_outputs; i++) {
-            auto out_arr = out_arrs[i][output_i];
-            tmp = out_arr.arr.Copy(out_arr.arr.ctx());
-            original_outputs[i] =  &tmp;
-            outputs[i] = &out_arrs[i][output_i].arr;
-            req[i] = kAddTo;
+            auto out_arr        = out_arrs[i][output_i];
+            tmp                 = out_arr.arr.Copy(out_arr.arr.ctx());
+            original_outputs[i] = &tmp;
+            outputs[i]          = &out_arrs[i][output_i].arr;
+            req[i]              = kAddTo;
           }
           PrintVerifyMsg(in_arr, out_arrs[0][output_i]);
-          Imperative::Get()->InvokeOp(Context(), attrs.attrs, inputs,
-                                      outputs, req, dispatch, mxnet::OpStatePtr());
+          Imperative::Get()->InvokeOp(
+              Context(), attrs.attrs, inputs, outputs, req, dispatch, mxnet::OpStatePtr());
           Engine::Get()->WaitForAll();
           VerifyAddRequest(inputs, original_outputs, outputs, verify_fn);
         }
@@ -558,14 +524,13 @@ void TestOp(const OpAttrs &attrs, VerifyFunc verify_fn) {
   }
 }
 
-void TestConcatOp(const OpAttrs &attrs, VerifyFunc verify_fn,
-                  bool backwards = false) {
+void TestConcatOp(const OpAttrs& attrs, VerifyFunc verify_fn, bool backwards = false) {
   std::vector<NDArray*> inputs(attrs.num_inputs);
   std::vector<NDArray*> outputs(attrs.num_outputs);
   std::vector<OpReqType> req(attrs.num_outputs);
   std::vector<DispatchMode> dispatches = attrs.dispatches;
 
-  TestArrayShapes tas = GetTestArrayShapes();
+  TestArrayShapes tas                   = GetTestArrayShapes();
   std::vector<mkldnn::memory::desc> mds = tas.mds;
 
   std::vector<NDArrayAttrs> in_arrs = GetTestInputArrays();
@@ -573,43 +538,39 @@ void TestConcatOp(const OpAttrs &attrs, VerifyFunc verify_fn,
   // concat backwards uses scaled up inputs
   if (backwards) {
     std::string str_dim = const_cast<OpAttrs&>(attrs).attrs.dict["dim"];
-    int dim = std::stoi(str_dim);
-    std::vector<float> scale_vector(dim+1);
-    for (size_t i = 0; i < dim+1; ++i)
-      scale_vector[i] = 1;
+    int dim             = std::stoi(str_dim);
+    std::vector<float> scale_vector(dim + 1);
+    for (size_t i = 0; i < dim + 1; ++i) scale_vector[i] = 1;
     scale_vector[dim] = attrs.num_outputs;
-    in_arrs = GetTestInputArrays(ArrayTypes::All, false, scale_vector);
+    in_arrs           = GetTestInputArrays(ArrayTypes::All, false, scale_vector);
   }
 
-  for (auto &in_arr : in_arrs) {
-    for (auto &dispatch : dispatches) {
+  for (auto& in_arr : in_arrs) {
+    for (auto& dispatch : dispatches) {
       std::vector<std::vector<NDArrayAttrs>> out_arrs(attrs.num_outputs);
 
       std::string str_dim = const_cast<OpAttrs&>(attrs).attrs.dict["dim"];
-      int dim = std::stoi(str_dim);
-      if (dim >= in_arr.arr.shape().ndim())
-        continue;
-      float scale = backwards ? 1 / static_cast<float>(attrs.num_outputs) :
-          static_cast<float>(attrs.num_inputs);
+      int dim             = std::stoi(str_dim);
+      if (dim >= in_arr.arr.shape().ndim()) continue;
+      float scale = backwards ? 1 / static_cast<float>(attrs.num_outputs)
+                              : static_cast<float>(attrs.num_inputs);
 
       std::vector<float> scale_vector(in_arr.arr.shape().ndim());
-      for (int i = 0; i < in_arr.arr.shape().ndim(); i++)
-        scale_vector[i] = 1;
+      for (int i = 0; i < in_arr.arr.shape().ndim(); i++) scale_vector[i] = 1;
       scale_vector[dim] = scale;
       for (int i = 0; i < attrs.num_outputs; i++)
         out_arrs[i] = GetTestOutputArrays(in_arr.arr.shape(), mds, scale_vector);
 
-      for (int i = 0; i < attrs.num_inputs; i++)
-        inputs[i] = &in_arr.arr;
+      for (int i = 0; i < attrs.num_inputs; i++) inputs[i] = &in_arr.arr;
 
       for (size_t output_i = 0; output_i < out_arrs[0].size(); output_i++) {
         for (int i = 0; i < attrs.num_outputs; i++) {
-          req[i] = kWriteTo;
+          req[i]     = kWriteTo;
           outputs[i] = &out_arrs[i][output_i].arr;
         }
         PrintVerifyMsg(in_arr, out_arrs[0][output_i]);
-        Imperative::Get()->InvokeOp(Context(), attrs.attrs, inputs,
-                                    outputs, req, dispatch, mxnet::OpStatePtr());
+        Imperative::Get()->InvokeOp(
+            Context(), attrs.attrs, inputs, outputs, req, dispatch, mxnet::OpStatePtr());
         Engine::Get()->WaitForAll();
         verify_fn(inputs, outputs);
       }
@@ -617,13 +578,10 @@ void TestConcatOp(const OpAttrs &attrs, VerifyFunc verify_fn,
   }
 }
 
-void TestOpExBackward(const OpAttrs &forward_attrs,
-                      const OpAttrs &backwards_attrs,
-                      const OpReqType &req,
-                      const std::vector<NDArray*> &inputs,
-                      const std::vector<NDArray*> &outputs,
-                      const NDArrayAttrs &in_arr,
-                      const NDArrayAttrs &out_arr) {
+void TestOpExBackward(
+    const OpAttrs& forward_attrs, const OpAttrs& backwards_attrs, const OpReqType& req,
+    const std::vector<NDArray*>& inputs, const std::vector<NDArray*>& outputs,
+    const NDArrayAttrs& in_arr, const NDArrayAttrs& out_arr) {
   std::vector<NDArray*> backwards_input(backwards_attrs.num_inputs);
   std::vector<NDArray*> backwards_outputs(backwards_attrs.num_outputs);
   std::vector<NDArray*> backwards_ex_outputs(backwards_attrs.num_outputs);
@@ -632,24 +590,23 @@ void TestOpExBackward(const OpAttrs &forward_attrs,
   if (req == kWriteTo) {
     // backwards test performed same time since output needed
     backwards_input[0] = outputs[0];  // output grad
-    backwards_input[1] = inputs[0];  // input
+    backwards_input[1] = inputs[0];   // input
     backwards_input[2] = outputs[1];  // out norm
 
-    auto tmp_output = in_arr.arr;
-    backwards_outputs[0] = &tmp_output;
+    auto tmp_output         = in_arr.arr;
+    backwards_outputs[0]    = &tmp_output;
     backwards_ex_outputs[0] = &tmp_output;
 
-    for (int i = 0; i < backwards_attrs.num_outputs; i++)
-      back_req[i] = kWriteTo;
+    for (int i = 0; i < backwards_attrs.num_outputs; i++) back_req[i] = kWriteTo;
 
     std::cout << "Backwards: ";
     PrintVerifyMsg(out_arr, in_arr);
     Imperative::Get()->InvokeOp(
-        Context(), backwards_attrs.attrs, backwards_input, backwards_outputs,
-        back_req, DispatchMode::kFCompute, mxnet::OpStatePtr());
+        Context(), backwards_attrs.attrs, backwards_input, backwards_outputs, back_req,
+        DispatchMode::kFCompute, mxnet::OpStatePtr());
     Imperative::Get()->InvokeOp(
-        Context(), backwards_attrs.attrs, backwards_input, backwards_ex_outputs,
-        back_req, DispatchMode::kFComputeEx, mxnet::OpStatePtr());
+        Context(), backwards_attrs.attrs, backwards_input, backwards_ex_outputs, back_req,
+        DispatchMode::kFComputeEx, mxnet::OpStatePtr());
     Engine::Get()->WaitForAll();
     if (backwards_attrs.attrs.op->name == "_backward_LRN") {
       AssertEqual(backwards_outputs, backwards_ex_outputs, 1e-5, 1e-8, true);
@@ -657,15 +614,14 @@ void TestOpExBackward(const OpAttrs &forward_attrs,
   }
 }
 
-
 // compares output of fcompute with fcomputex
-void TestOpEx(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
+void TestOpEx(const OpAttrs& forward_attrs, const OpAttrs& backwards_attrs) {
   std::vector<NDArray*> inputs(forward_attrs.num_inputs);
   std::vector<NDArray*> outputs(forward_attrs.num_outputs);
   std::vector<NDArray*> ex_outputs(forward_attrs.num_outputs);
   std::vector<OpReqType> req(forward_attrs.num_outputs);
 
-  TestArrayShapes tas = GetTestArrayShapes();
+  TestArrayShapes tas                   = GetTestArrayShapes();
   std::vector<mkldnn::memory::desc> mds = tas.mds;
 
   std::vector<NDArrayAttrs> in_arrs = GetTestInputArrays(forward_attrs.input_types, true);
@@ -688,24 +644,23 @@ void TestOpEx(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
             GetTestOutputArrays(in_arr.arr.shape(), mds, {1}, false, forward_attrs.output_types);
       }
 
-      for (int i = 0; i < forward_attrs.num_inputs; i++)
-        inputs[i] = &in_arr.arr;
+      for (int i = 0; i < forward_attrs.num_inputs; i++) inputs[i] = &in_arr.arr;
 
       for (size_t output_i = 0; output_i < out_arrs[0].size(); output_i++) {
         for (int i = 0; i < forward_attrs.num_outputs; i++) {
-          req[i] = kWriteTo;
-          outputs[i] = &out_arrs[i][output_i].arr;
+          req[i]        = kWriteTo;
+          outputs[i]    = &out_arrs[i][output_i].arr;
           ex_outputs[i] = &ex_out_arrs[i][output_i].arr;
         }
         Imperative::Get()->set_is_training(true);
 
         PrintVerifyMsg(in_arr, out_arrs[0][output_i]);
         Imperative::Get()->InvokeOp(
-            Context(), forward_attrs.attrs, inputs, outputs, req,
-            DispatchMode::kFCompute, mxnet::OpStatePtr());
+            Context(), forward_attrs.attrs, inputs, outputs, req, DispatchMode::kFCompute,
+            mxnet::OpStatePtr());
         Imperative::Get()->InvokeOp(
-            Context(), forward_attrs.attrs, inputs, ex_outputs, req,
-            DispatchMode::kFComputeEx, mxnet::OpStatePtr());
+            Context(), forward_attrs.attrs, inputs, ex_outputs, req, DispatchMode::kFComputeEx,
+            mxnet::OpStatePtr());
         Engine::Get()->WaitForAll();
         // TODO(pengzhao-intel): Need to fix op, should work for the whole vector
         if (forward_attrs.attrs.op->name == "LRN") {
@@ -713,8 +668,9 @@ void TestOpEx(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
         }
 
         if (!backwards_attrs.requests.empty()) {
-          TestOpExBackward(forward_attrs, backwards_attrs, OpReqType::kWriteTo,
-                           inputs, outputs, in_arr, out_arrs[0][output_i]);
+          TestOpExBackward(
+              forward_attrs, backwards_attrs, OpReqType::kWriteTo, inputs, outputs, in_arr,
+              out_arrs[0][output_i]);
         }
       }
     }
@@ -725,26 +681,24 @@ void TestOpEx(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
       auto in_arr = in_arrs[i1];
 
       // If the array is a view, we shouldn't write data to it.
-      if (in_arr.arr.IsView())
-        continue;
+      if (in_arr.arr.IsView()) continue;
 
       NDArrayAttrs orig(in_arr.arr.Copy(in_arr.arr.ctx()), "InPlace Copy");
-      for (int i = 0; i < forward_attrs.num_inputs; i++)
-        inputs[i] = &in_arr.arr;
+      for (int i = 0; i < forward_attrs.num_inputs; i++) inputs[i] = &in_arr.arr;
 
       for (int i = 0; i < forward_attrs.num_outputs; i++) {
-        req[i] = kWriteInplace;
-        outputs[i] = &in_arr.arr;
+        req[i]        = kWriteInplace;
+        outputs[i]    = &in_arr.arr;
         ex_outputs[i] = &in_arr.arr;
       }
       Imperative::Get()->set_is_training(true);
       PrintVerifyMsg(orig, in_arr);
       Imperative::Get()->InvokeOp(
-          Context(), forward_attrs.attrs, inputs, outputs, req,
-          DispatchMode::kFCompute, mxnet::OpStatePtr());
+          Context(), forward_attrs.attrs, inputs, outputs, req, DispatchMode::kFCompute,
+          mxnet::OpStatePtr());
       Imperative::Get()->InvokeOp(
-          Context(), forward_attrs.attrs, inputs, ex_outputs, req,
-          DispatchMode::kFComputeEx, mxnet::OpStatePtr());
+          Context(), forward_attrs.attrs, inputs, ex_outputs, req, DispatchMode::kFComputeEx,
+          mxnet::OpStatePtr());
       Engine::Get()->WaitForAll();
       // TODO(unassigned): Need to fix op, should work for the whole vector
       if (forward_attrs.attrs.op->name == "LRN") {
@@ -754,14 +708,10 @@ void TestOpEx(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
   }
 }
 
-
-void TestOpExBNBackward(const OpAttrs &forward_attrs,
-                        const OpAttrs &backwards_attrs,
-                        const OpReqType &req,
-                        const std::vector<NDArray*> &inputs,
-                        const std::vector<NDArray*> &outputs,
-                        const NDArrayAttrs &in_arr,
-                        NDArrayAttrs* out_arr) {
+void TestOpExBNBackward(
+    const OpAttrs& forward_attrs, const OpAttrs& backwards_attrs, const OpReqType& req,
+    const std::vector<NDArray*>& inputs, const std::vector<NDArray*>& outputs,
+    const NDArrayAttrs& in_arr, NDArrayAttrs* out_arr) {
   std::vector<NDArray*> backwards_input(backwards_attrs.num_inputs);
 
   std::vector<NDArray> backwards_buffer(backwards_attrs.num_outputs);
@@ -773,19 +723,19 @@ void TestOpExBNBackward(const OpAttrs &forward_attrs,
 
   if (req == kWriteTo) {
     backwards_input[0] = &(out_arr->arr);  // output grad
-    backwards_input[1] = outputs[1];  // mean
-    backwards_input[2] = outputs[2];  // var
-    backwards_input[3] = inputs[0];  // data
-    backwards_input[4] = inputs[1];  // gamma
-    backwards_input[5] = inputs[2];  // beta
-    backwards_input[6] = inputs[3];  // moving mean
-    backwards_input[7] = inputs[4];  // moving var
+    backwards_input[1] = outputs[1];       // mean
+    backwards_input[2] = outputs[2];       // var
+    backwards_input[3] = inputs[0];        // data
+    backwards_input[4] = inputs[1];        // gamma
+    backwards_input[5] = inputs[2];        // beta
+    backwards_input[6] = inputs[3];        // moving mean
+    backwards_input[7] = inputs[4];        // moving var
 
     for (size_t i = 0; i < backwards_attrs.num_outputs; i++) {
       auto tmp_output = in_arr.arr;
       backwards_buffer.emplace_back(tmp_output.Copy(Context()));
       backwards_buffer2.emplace_back(tmp_output.Copy(Context()));
-      backwards_outputs[i] = &backwards_buffer.back();
+      backwards_outputs[i]    = &backwards_buffer.back();
       backwards_ex_outputs[i] = &backwards_buffer2.back();
       Engine::Get()->WaitForAll();
       backwards_req[i] = kWriteTo;
@@ -794,11 +744,11 @@ void TestOpExBNBackward(const OpAttrs &forward_attrs,
     std::cout << "Backwards: ";
     PrintVerifyMsg(*out_arr, in_arr);
     Imperative::Get()->InvokeOp(
-        Context(), backwards_attrs.attrs, backwards_input, backwards_outputs,
-        backwards_req, DispatchMode::kFCompute, mxnet::OpStatePtr());
+        Context(), backwards_attrs.attrs, backwards_input, backwards_outputs, backwards_req,
+        DispatchMode::kFCompute, mxnet::OpStatePtr());
     Imperative::Get()->InvokeOp(
-        Context(), backwards_attrs.attrs, backwards_input, backwards_ex_outputs,
-        backwards_req, DispatchMode::kFComputeEx, mxnet::OpStatePtr());
+        Context(), backwards_attrs.attrs, backwards_input, backwards_ex_outputs, backwards_req,
+        DispatchMode::kFComputeEx, mxnet::OpStatePtr());
     Engine::Get()->WaitForAll();
     // TODO(unassigned): Need to fix op, should work for the whole vector
     AssertEqual(backwards_outputs, backwards_ex_outputs, 1e-4, 1e-2, true);
@@ -806,7 +756,7 @@ void TestOpExBNBackward(const OpAttrs &forward_attrs,
 }
 
 // compares output of fcompute with fcomputex
-void TestOpExBN(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
+void TestOpExBN(const OpAttrs& forward_attrs, const OpAttrs& backwards_attrs) {
   std::vector<NDArray*> inputs(forward_attrs.num_inputs);
   std::vector<NDArray*> inputs2(forward_attrs.num_inputs);
   std::vector<NDArray> inputs_buffer(forward_attrs.num_inputs);
@@ -815,7 +765,7 @@ void TestOpExBN(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
   std::vector<NDArray*> ex_outputs(forward_attrs.num_outputs);
   std::vector<OpReqType> req(forward_attrs.num_outputs);
 
-  TestArrayShapes tas = GetTestArrayShapes();
+  TestArrayShapes tas                   = GetTestArrayShapes();
   std::vector<mkldnn::memory::desc> mds = tas.mds;
 
   std::vector<NDArrayAttrs> in_arrs = GetTestInputArrays(forward_attrs.input_types, false);
@@ -844,29 +794,30 @@ void TestOpExBN(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
           inputs_buffer.emplace_back(in_arr.arr.Copy(Context()));
           inputs2_buffer.emplace_back(in_arr.arr.Copy(Context()));
           Engine::Get()->WaitForAll();
-          inputs[i] = &inputs_buffer.back();
+          inputs[i]  = &inputs_buffer.back();
           inputs2[i] = &inputs2_buffer.back();
         }
         for (int i = 0; i < forward_attrs.num_outputs; i++) {
-          req[i] = kWriteTo;
-          outputs[i] = &out_arrs[i][output_i].arr;
+          req[i]        = kWriteTo;
+          outputs[i]    = &out_arrs[i][output_i].arr;
           ex_outputs[i] = &ex_out_arrs[i][output_i].arr;
         }
         Imperative::Get()->set_is_training(true);
 
         PrintVerifyMsg(in_arr, out_arrs[0][output_i]);
         Imperative::Get()->InvokeOp(
-            Context(), forward_attrs.attrs, inputs, outputs, req,
-            DispatchMode::kFCompute, mxnet::OpStatePtr());
+            Context(), forward_attrs.attrs, inputs, outputs, req, DispatchMode::kFCompute,
+            mxnet::OpStatePtr());
         Imperative::Get()->InvokeOp(
-            Context(), forward_attrs.attrs, inputs2, ex_outputs, req,
-            DispatchMode::kFComputeEx, mxnet::OpStatePtr());
+            Context(), forward_attrs.attrs, inputs2, ex_outputs, req, DispatchMode::kFComputeEx,
+            mxnet::OpStatePtr());
         Engine::Get()->WaitForAll();
         AssertEqual(outputs, ex_outputs, 1e-4, 1e-2, true);
 
         if (!backwards_attrs.requests.empty()) {
-          TestOpExBNBackward(forward_attrs, backwards_attrs, OpReqType::kWriteTo,
-                             inputs, outputs, in_arr, &out_arrs[0][output_i]);
+          TestOpExBNBackward(
+              forward_attrs, backwards_attrs, OpReqType::kWriteTo, inputs, outputs, in_arr,
+              &out_arrs[0][output_i]);
         }
       }
     }
@@ -882,7 +833,7 @@ uint32_t GetFCWeightDim2(const mxnet::TShape arr) {
   return dim;
 }
 
-void TestFullyConnectedOp(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
+void TestFullyConnectedOp(const OpAttrs& forward_attrs, const OpAttrs& backwards_attrs) {
   std::vector<NDArray*> inputs(forward_attrs.num_inputs);
   std::vector<NDArray*> outputs(forward_attrs.num_outputs);
   std::vector<NDArray*> ex_outputs(forward_attrs.num_outputs);
@@ -894,7 +845,7 @@ void TestFullyConnectedOp(const OpAttrs &forward_attrs, const OpAttrs &backwards
   std::vector<OpReqType> req(forward_attrs.num_outputs);
   std::vector<OpReqType> back_req(backwards_attrs.num_outputs);
 
-  TestArrayShapes tas = GetTestArrayShapes();
+  TestArrayShapes tas                   = GetTestArrayShapes();
   std::vector<mkldnn::memory::desc> mds = tas.mds;
 
   std::vector<NDArrayAttrs> in_arrs =
@@ -903,14 +854,13 @@ void TestFullyConnectedOp(const OpAttrs &forward_attrs, const OpAttrs &backwards
   std::vector<std::vector<NDArrayAttrs>> ex_out_arrs(forward_attrs.num_outputs);
 
   std::string str_hid = const_cast<OpAttrs&>(forward_attrs).attrs.dict["num_hidden"];
-  int num_hid = std::stoi(str_hid);
+  int num_hid         = std::stoi(str_hid);
 
   if (forward_attrs.requests.find(OpReqType::kWriteTo) != forward_attrs.requests.end()) {
     for (int i1 = 0; i1 < in_arrs.size(); i1++) {
-      auto in_arr = in_arrs[i1];
+      auto in_arr   = in_arrs[i1];
       auto in_shape = in_arr.arr.shape();
-      if (in_shape.ndim() < 2)
-        continue;
+      if (in_shape.ndim() < 2) continue;
 
       mxnet::TShape wt_shape(2, -1);
       wt_shape[0] = num_hid;
@@ -940,26 +890,26 @@ void TestFullyConnectedOp(const OpAttrs &forward_attrs, const OpAttrs &backwards
 
       for (size_t output_i = 0; output_i < out_arrs[0].size(); output_i++) {
         for (int i = 0; i < forward_attrs.num_outputs; i++) {
-          req[i] = kWriteTo;
-          outputs[i] = &out_arrs[i][output_i].arr;
+          req[i]        = kWriteTo;
+          outputs[i]    = &out_arrs[i][output_i].arr;
           ex_outputs[i] = &ex_out_arrs[i][output_i].arr;
         }
         Imperative::Get()->set_is_training(true);
 
         PrintVerifyMsg(in_arr, out_arrs[0][output_i]);
         Imperative::Get()->InvokeOp(
-            Context(), forward_attrs.attrs, inputs, outputs, req,
-            DispatchMode::kFCompute, mxnet::OpStatePtr());
+            Context(), forward_attrs.attrs, inputs, outputs, req, DispatchMode::kFCompute,
+            mxnet::OpStatePtr());
         Imperative::Get()->InvokeOp(
-            Context(), forward_attrs.attrs, inputs, ex_outputs, req,
-            DispatchMode::kFComputeEx, mxnet::OpStatePtr());
+            Context(), forward_attrs.attrs, inputs, ex_outputs, req, DispatchMode::kFComputeEx,
+            mxnet::OpStatePtr());
         Engine::Get()->WaitForAll();
         AssertEqual(outputs, ex_outputs);
 
         // backwards test performed same time since output needed
         backwards_input[0] = outputs[0];  // output grad
-        backwards_input[1] = inputs[0];  // input
-        backwards_input[2] = inputs[1];  // weights
+        backwards_input[1] = inputs[0];   // input
+        backwards_input[2] = inputs[1];   // weights
 
         auto tmp_output = GetTestInputArrays(forward_attrs.input_types, true, {1}, false, 1)[i1];
         NDArray back_weights(wt_shape, Context());
@@ -975,17 +925,16 @@ void TestFullyConnectedOp(const OpAttrs &forward_attrs, const OpAttrs &backwards
         backwards_ex_outputs[1] = &back_ex_weights;
         backwards_ex_outputs[2] = &back_ex_bias;
 
-        for (int i = 0; i < backwards_attrs.num_outputs; i++)
-          back_req[i] = kWriteTo;
+        for (int i = 0; i < backwards_attrs.num_outputs; i++) back_req[i] = kWriteTo;
 
         std::cout << "Backwards: ";
         PrintVerifyMsg(out_arrs[0][output_i], tmp_output);
         Imperative::Get()->InvokeOp(
-            Context(), backwards_attrs.attrs, backwards_input, backwards_outputs,
-            back_req, DispatchMode::kFCompute, mxnet::OpStatePtr());
+            Context(), backwards_attrs.attrs, backwards_input, backwards_outputs, back_req,
+            DispatchMode::kFCompute, mxnet::OpStatePtr());
         Imperative::Get()->InvokeOp(
-            Context(), backwards_attrs.attrs, backwards_input, backwards_ex_outputs,
-            back_req, DispatchMode::kFComputeEx, mxnet::OpStatePtr());
+            Context(), backwards_attrs.attrs, backwards_input, backwards_ex_outputs, back_req,
+            DispatchMode::kFComputeEx, mxnet::OpStatePtr());
         Engine::Get()->WaitForAll();
         AssertEqual(backwards_outputs, backwards_ex_outputs, 1e-6, 1e-6);
       }
@@ -993,9 +942,9 @@ void TestFullyConnectedOp(const OpAttrs &forward_attrs, const OpAttrs &backwards
   }
 }
 
-template<typename P>
-void TestConvOp(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs,
-                bool is_deconv = false) {
+template <typename P>
+void TestConvOp(
+    const OpAttrs& forward_attrs, const OpAttrs& backwards_attrs, bool is_deconv = false) {
   std::vector<NDArray*> inputs(forward_attrs.num_inputs);
   std::vector<NDArray*> outputs(forward_attrs.num_outputs);
   std::vector<NDArray*> ex_outputs(forward_attrs.num_outputs);
@@ -1004,23 +953,22 @@ void TestConvOp(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs,
   std::vector<NDArray*> backwards_outputs(backwards_attrs.num_outputs);
   std::vector<NDArray*> backwards_ex_outputs(backwards_attrs.num_outputs);
 
-
   std::vector<OpReqType> req(forward_attrs.num_outputs);
   std::vector<OpReqType> back_req(backwards_attrs.num_outputs);
   std::vector<DispatchMode> dispatches = forward_attrs.dispatches;
 
-  TestArrayShapes tas = GetTestArrayShapes();
+  TestArrayShapes tas                   = GetTestArrayShapes();
   std::vector<mkldnn::memory::desc> mds = tas.mds;
 
   P param;
   param.Init(forward_attrs.attrs.dict);
-  mxnet::TShape kernel = param.kernel;
+  mxnet::TShape kernel  = param.kernel;
   mxnet::TShape padding = param.pad;
-  mxnet::TShape stride = param.stride;
-  int num_filter = param.num_filter;
+  mxnet::TShape stride  = param.stride;
+  int num_filter        = param.num_filter;
 
-  std::vector<NDArrayAttrs> in_arrs = GetTestInputArrays(
-      forward_attrs.input_types, true, {1}, true);
+  std::vector<NDArrayAttrs> in_arrs =
+      GetTestInputArrays(forward_attrs.input_types, true, {1}, true);
   std::vector<std::vector<NDArrayAttrs>> out_arrs(forward_attrs.num_outputs);
   std::vector<std::vector<NDArrayAttrs>> ex_out_arrs(forward_attrs.num_outputs);
 
@@ -1029,15 +977,14 @@ void TestConvOp(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs,
 
     // can only conv only 4D inputs
     mxnet::TShape input_shape = in_arr.arr.shape();
-    if (input_shape.ndim() != kernel.ndim() + 2)
-      continue;
+    if (input_shape.ndim() != kernel.ndim() + 2) continue;
 
-    float scale = CalculateWidthConvOutput(input_shape[2], kernel[0], padding[0], stride[0])
-        / static_cast<float>(input_shape[2]);
+    float scale = CalculateWidthConvOutput(input_shape[2], kernel[0], padding[0], stride[0]) /
+                  static_cast<float>(input_shape[2]);
 
     if (is_deconv) {
-      scale = CalculateWidthDeconvOutput(input_shape[2], kernel[0], padding[0], stride[0])
-        / static_cast<float>(input_shape[2]);
+      scale = CalculateWidthDeconvOutput(input_shape[2], kernel[0], padding[0], stride[0]) /
+              static_cast<float>(input_shape[2]);
     }
     std::vector<float> scale_vector(in_arr.arr.shape().ndim());
     scale_vector[0] = 1;
@@ -1046,16 +993,16 @@ void TestConvOp(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs,
     scale_vector[3] = scale;
 
     for (size_t i = 0; i < forward_attrs.num_outputs; ++i) {
-      out_arrs[i] = GetTestOutputArrays(in_arr.arr.shape(), mds,
-                                        scale_vector, true, forward_attrs.output_types);
-      ex_out_arrs[i] = GetTestOutputArrays(in_arr.arr.shape(), mds,
-                                           scale_vector, true, forward_attrs.output_types);
+      out_arrs[i] = GetTestOutputArrays(
+          in_arr.arr.shape(), mds, scale_vector, true, forward_attrs.output_types);
+      ex_out_arrs[i] = GetTestOutputArrays(
+          in_arr.arr.shape(), mds, scale_vector, true, forward_attrs.output_types);
     }
     NDArray ndkernel = CreateKernelNDArray(kernel, num_filter, in_arr.arr.shape(), is_deconv);
     mxnet::TShape bias_shape = {num_filter};
-    NDArray ndbias = CreateBiasNDArray(bias_shape);
-    inputs[0] = &in_arr.arr;
-    inputs[1] = &ndkernel;
+    NDArray ndbias           = CreateBiasNDArray(bias_shape);
+    inputs[0]                = &in_arr.arr;
+    inputs[1]                = &ndkernel;
 
     if (!param.no_bias) {
       inputs[2] = &ndbias;
@@ -1063,65 +1010,66 @@ void TestConvOp(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs,
 
     for (size_t output_i = 0; output_i < out_arrs[0].size(); output_i++) {
       for (size_t i = 0; i < forward_attrs.num_outputs; ++i) {
-        req[i] = kWriteTo;
-        outputs[i] = &out_arrs[i][output_i].arr;
+        req[i]        = kWriteTo;
+        outputs[i]    = &out_arrs[i][output_i].arr;
         ex_outputs[i] = &ex_out_arrs[i][output_i].arr;
       }
       Imperative::Get()->set_is_training(true);
 
       PrintVerifyMsg(in_arr, out_arrs[0][output_i]);
-      Imperative::Get()->InvokeOp(Context(), forward_attrs.attrs, inputs,
-                                  outputs, req, DispatchMode::kFCompute, mxnet::OpStatePtr());
-      Imperative::Get()->InvokeOp(Context(), forward_attrs.attrs, inputs,
-                                  ex_outputs, req, DispatchMode::kFComputeEx, mxnet::OpStatePtr());
+      Imperative::Get()->InvokeOp(
+          Context(), forward_attrs.attrs, inputs, outputs, req, DispatchMode::kFCompute,
+          mxnet::OpStatePtr());
+      Imperative::Get()->InvokeOp(
+          Context(), forward_attrs.attrs, inputs, ex_outputs, req, DispatchMode::kFComputeEx,
+          mxnet::OpStatePtr());
       Engine::Get()->WaitForAll();
       VerifyCopyResult(outputs, ex_outputs);
 
       // backwards test performed same time since output needed
       backwards_input[0] = outputs[0];  // output grad
-      backwards_input[1] = inputs[0];  // input
-      backwards_input[2] = inputs[1];  // kernel
+      backwards_input[1] = inputs[0];   // input
+      backwards_input[2] = inputs[1];   // kernel
 
       if (!param.no_bias) {
         backwards_input[3] = inputs[2];  // bias
       }
 
-      auto tmp_output = GetTestInputArrays(forward_attrs.input_types, true, {1}, true)[i1];
-      NDArray tmp_kernel = CreateKernelNDArray(kernel, num_filter, in_arr.arr.shape(), is_deconv);
-      NDArray tmp_bias = CreateBiasNDArray(bias_shape);
+      auto tmp_output      = GetTestInputArrays(forward_attrs.input_types, true, {1}, true)[i1];
+      NDArray tmp_kernel   = CreateKernelNDArray(kernel, num_filter, in_arr.arr.shape(), is_deconv);
+      NDArray tmp_bias     = CreateBiasNDArray(bias_shape);
       backwards_outputs[0] = &tmp_output.arr;
       backwards_outputs[1] = &tmp_kernel;
       if (!param.no_bias) {
         backwards_outputs[2] = &tmp_bias;
       }
 
-      auto tmp_output2 = GetTestInputArrays(forward_attrs.input_types, true, {1}, true)[i1];
+      auto tmp_output2    = GetTestInputArrays(forward_attrs.input_types, true, {1}, true)[i1];
       NDArray tmp_kernel2 = CreateKernelNDArray(kernel, num_filter, in_arr.arr.shape(), is_deconv);
-      NDArray tmp_bias2 = CreateBiasNDArray(bias_shape);
+      NDArray tmp_bias2   = CreateBiasNDArray(bias_shape);
       backwards_ex_outputs[0] = &tmp_output2.arr;
       backwards_ex_outputs[1] = &tmp_kernel2;
       if (!param.no_bias) {
         backwards_ex_outputs[2] = &tmp_bias2;
       }
 
-      for (size_t i = 0; i < backwards_attrs.num_outputs; ++i)
-        back_req[i] = kWriteTo;
+      for (size_t i = 0; i < backwards_attrs.num_outputs; ++i) back_req[i] = kWriteTo;
 
       std::cout << "Backwards: ";
       PrintVerifyMsg(out_arrs[0][output_i], tmp_output);
       Imperative::Get()->InvokeOp(
-          Context(), backwards_attrs.attrs, backwards_input, backwards_outputs,
-          back_req, DispatchMode::kFCompute, mxnet::OpStatePtr());
+          Context(), backwards_attrs.attrs, backwards_input, backwards_outputs, back_req,
+          DispatchMode::kFCompute, mxnet::OpStatePtr());
       Imperative::Get()->InvokeOp(
-          Context(), backwards_attrs.attrs, backwards_input, backwards_ex_outputs,
-          back_req, DispatchMode::kFComputeEx, mxnet::OpStatePtr());
+          Context(), backwards_attrs.attrs, backwards_input, backwards_ex_outputs, back_req,
+          DispatchMode::kFComputeEx, mxnet::OpStatePtr());
       Engine::Get()->WaitForAll();
       VerifyCopyResult(backwards_outputs, backwards_ex_outputs);
     }
   }
 }
 
-void TestPoolingOp(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
+void TestPoolingOp(const OpAttrs& forward_attrs, const OpAttrs& backwards_attrs) {
   std::vector<NDArray*> inputs(forward_attrs.num_inputs);
   std::vector<NDArray*> outputs(forward_attrs.num_outputs);
   std::vector<NDArray*> ex_outputs(forward_attrs.num_outputs);
@@ -1130,19 +1078,18 @@ void TestPoolingOp(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs)
   std::vector<NDArray*> backwards_outputs(backwards_attrs.num_outputs);
   std::vector<NDArray*> backwards_ex_outputs(backwards_attrs.num_outputs);
 
-
   std::vector<OpReqType> req(forward_attrs.num_outputs);
   std::vector<OpReqType> back_req(backwards_attrs.num_outputs);
   std::vector<DispatchMode> dispatches = forward_attrs.dispatches;
 
-  TestArrayShapes tas = GetTestArrayShapes();
+  TestArrayShapes tas                   = GetTestArrayShapes();
   std::vector<mkldnn::memory::desc> mds = tas.mds;
 
   mxnet::op::PoolingParam param;
   param.Init(forward_attrs.attrs.dict);
-  mxnet::TShape kernel = param.kernel;
+  mxnet::TShape kernel  = param.kernel;
   mxnet::TShape padding = param.pad;
-  mxnet::TShape stride = param.stride;
+  mxnet::TShape stride  = param.stride;
 
   std::vector<NDArrayAttrs> in_arrs = GetTestInputArrays();
   std::vector<std::vector<NDArrayAttrs>> out_arrs(forward_attrs.num_outputs);
@@ -1153,74 +1100,73 @@ void TestPoolingOp(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs)
 
     // can only pool only 3D and 4D inputs
     mxnet::TShape input_shape = in_arr.arr.shape();
-    if (input_shape.ndim() != kernel.ndim() + 2)
-      continue;
+    if (input_shape.ndim() != kernel.ndim() + 2) continue;
     // cannot pool if ndarray and mkldnn memory have different ndim
-    if (in_arr.arr.IsView() || in_arr.arr.GetMKLDNNData()->get_desc().data.ndims
-        != in_arr.arr.shape().ndim())
+    if (in_arr.arr.IsView() ||
+        in_arr.arr.GetMKLDNNData()->get_desc().data.ndims != in_arr.arr.shape().ndim())
       continue;
     std::vector<float> scale_vector(in_arr.arr.shape().ndim());
     for (int i = 0; i < in_arr.arr.shape().ndim(); i++) {
       if (i < 2)
         scale_vector[i] = 1;
       else
-        scale_vector[i] = CalculateWidthPoolOutput(
-            input_shape[i], kernel[i-2], padding[i-2], stride[i-2]) /
+        scale_vector[i] =
+            CalculateWidthPoolOutput(input_shape[i], kernel[i - 2], padding[i - 2], stride[i - 2]) /
             static_cast<float>(input_shape[i]);
     }
     for (int i = 0; i < forward_attrs.num_outputs; i++) {
-      out_arrs[i] = GetTestOutputArrays(in_arr.arr.shape(), mds, scale_vector);
+      out_arrs[i]    = GetTestOutputArrays(in_arr.arr.shape(), mds, scale_vector);
       ex_out_arrs[i] = GetTestOutputArrays(in_arr.arr.shape(), mds, scale_vector);
     }
 
-    for (int i = 0; i < forward_attrs.num_inputs; i++)
-      inputs[i] = &in_arr.arr;
+    for (int i = 0; i < forward_attrs.num_inputs; i++) inputs[i] = &in_arr.arr;
 
     for (size_t output_i = 0; output_i < out_arrs[0].size(); output_i++) {
       for (int i = 0; i < forward_attrs.num_outputs; i++) {
-        req[i] = kWriteTo;
-        outputs[i] = &out_arrs[i][output_i].arr;
+        req[i]        = kWriteTo;
+        outputs[i]    = &out_arrs[i][output_i].arr;
         ex_outputs[i] = &ex_out_arrs[i][output_i].arr;
       }
       Imperative::Get()->set_is_training(true);
 
       PrintVerifyMsg(in_arr, out_arrs[0][output_i]);
-      Imperative::Get()->InvokeOp(Context(), forward_attrs.attrs, inputs,
-                                  outputs, req, DispatchMode::kFCompute, mxnet::OpStatePtr());
-      Imperative::Get()->InvokeOp(Context(), forward_attrs.attrs, inputs,
-                                  ex_outputs, req, DispatchMode::kFComputeEx, mxnet::OpStatePtr());
+      Imperative::Get()->InvokeOp(
+          Context(), forward_attrs.attrs, inputs, outputs, req, DispatchMode::kFCompute,
+          mxnet::OpStatePtr());
+      Imperative::Get()->InvokeOp(
+          Context(), forward_attrs.attrs, inputs, ex_outputs, req, DispatchMode::kFComputeEx,
+          mxnet::OpStatePtr());
       Engine::Get()->WaitForAll();
       VerifyCopyResult(outputs, ex_outputs);
-
 
       // backwards test performed same time since output needed
       if (backwards_attrs.num_inputs == 3) {
         backwards_input[0] = outputs[0];  // output grad
-        backwards_input[1] = inputs[0];  // input
+        backwards_input[1] = inputs[0];   // input
         backwards_input[2] = outputs[0];  // output
       } else if (backwards_attrs.num_inputs == 5) {
-        backwards_input[0] = outputs[0];  // output grad
-        backwards_input[1] = outputs[0];  // workspace grad
-        backwards_input[2] = inputs[0];  // input
-        backwards_input[3] = outputs[0];  // output
+        backwards_input[0] = outputs[0];     // output grad
+        backwards_input[1] = outputs[0];     // workspace grad
+        backwards_input[2] = inputs[0];      // input
+        backwards_input[3] = outputs[0];     // output
         backwards_input[4] = ex_outputs[1];  // workspace
       }
 
       // needs copies of inputs since they be reused in next iteration
       // cannot use Copy method since we need to maintain MKLDNN format
-      auto tmp_output = GetTestInputArrays()[i1];
-      auto tmp_output2 = GetTestInputArrays()[i1];
-      backwards_outputs[0] = &tmp_output.arr;
+      auto tmp_output         = GetTestInputArrays()[i1];
+      auto tmp_output2        = GetTestInputArrays()[i1];
+      backwards_outputs[0]    = &tmp_output.arr;
       backwards_ex_outputs[0] = &tmp_output2.arr;
-      back_req[0] = kWriteTo;
+      back_req[0]             = kWriteTo;
       std::cout << "Backwards: ";
       PrintVerifyMsg(out_arrs[0][output_i], tmp_output);
       Imperative::Get()->InvokeOp(
-          Context(), backwards_attrs.attrs, backwards_input, backwards_outputs,
-          back_req, DispatchMode::kFCompute, mxnet::OpStatePtr());
+          Context(), backwards_attrs.attrs, backwards_input, backwards_outputs, back_req,
+          DispatchMode::kFCompute, mxnet::OpStatePtr());
       Imperative::Get()->InvokeOp(
-          Context(), backwards_attrs.attrs, backwards_input, backwards_ex_outputs,
-          back_req, DispatchMode::kFComputeEx, mxnet::OpStatePtr());
+          Context(), backwards_attrs.attrs, backwards_input, backwards_ex_outputs, back_req,
+          DispatchMode::kFComputeEx, mxnet::OpStatePtr());
       Engine::Get()->WaitForAll();
       VerifyCopyResult(backwards_outputs, backwards_ex_outputs);
     }
@@ -1276,7 +1222,7 @@ TEST(IMPERATIVE, ConcatBackwardsOp) {
 }
 
 TEST(IMPERATIVE, LRNOp) {
-  OpAttrs forward_attrs = GetLRNOp();
+  OpAttrs forward_attrs   = GetLRNOp();
   OpAttrs backwards_attrs = GetLRNBackwardsOp();
   TestOpEx(forward_attrs, backwards_attrs);
 }
@@ -1288,7 +1234,7 @@ TEST(IMPERATIVE, SoftmaxOp) {
 }
 
 TEST(IMPERATIVE, FullyConnectedOp) {
-  OpAttrs forward_attrs = GetFullyConnectedOp();
+  OpAttrs forward_attrs   = GetFullyConnectedOp();
   OpAttrs backwards_attrs = GetFullyConnectedBackwardsOp();
   TestFullyConnectedOp(forward_attrs, backwards_attrs);
 }
@@ -1298,9 +1244,8 @@ TEST(IMPERATIVE, PoolingOp) {
     for (int kernel = 1; kernel < 4; kernel++) {
       for (int stride = 1; stride < 3; stride++) {
         for (int pad = 0; pad < 2; pad++) {
-          if (kernel / 2. < pad)
-            continue;
-          OpAttrs forward_attrs = GetPoolingOp(kernel, dim, stride, pad);
+          if (kernel / 2. < pad) continue;
+          OpAttrs forward_attrs   = GetPoolingOp(kernel, dim, stride, pad);
           OpAttrs backwards_attrs = GetPoolingBackwardsOp(kernel, dim, stride, pad);
           TestPoolingOp(forward_attrs, backwards_attrs);
         }
@@ -1315,9 +1260,8 @@ TEST(IMPERATIVE, ConvOp) {
     for (size_t kernel = 1; kernel < 4; ++kernel) {
       for (size_t stride = 1; stride < 3; ++stride) {
         for (size_t pad = 0; pad < 2; ++pad) {
-          if (kernel / 2. < pad)
-            continue;
-          OpAttrs forward_attrs = GetConvOp(kernel, num_filters, dim, stride, pad);
+          if (kernel / 2. < pad) continue;
+          OpAttrs forward_attrs   = GetConvOp(kernel, num_filters, dim, stride, pad);
           OpAttrs backwards_attrs = GetConvBackwardOp(kernel, num_filters, dim, stride, pad);
           TestConvOp<mxnet::op::ConvolutionParam>(forward_attrs, backwards_attrs);
         }
@@ -1332,9 +1276,8 @@ TEST(IMPERATIVE, DeconvOp) {
     for (size_t kernel = 1; kernel < 3; ++kernel) {
       for (size_t stride = 1; stride < 3; ++stride) {
         for (size_t pad = 0; pad < 2; ++pad) {
-          if (kernel / 2. < pad)
-            continue;
-          OpAttrs forward_attrs = GetDeconvOp(kernel, num_filters, dim, stride, pad);
+          if (kernel / 2. < pad) continue;
+          OpAttrs forward_attrs   = GetDeconvOp(kernel, num_filters, dim, stride, pad);
           OpAttrs backwards_attrs = GetDeconvBackwardOp(kernel, num_filters, dim, stride, pad);
           TestConvOp<mxnet::op::DeconvolutionParam>(forward_attrs, backwards_attrs, true);
         }
@@ -1344,7 +1287,7 @@ TEST(IMPERATIVE, DeconvOp) {
 }
 
 TEST(IMPERATIVE, BNOp) {
-  OpAttrs forward_attrs = GetBNOp();
+  OpAttrs forward_attrs   = GetBNOp();
   OpAttrs backwards_attrs = GetBNBackwardOp();
   TestOpExBN(forward_attrs, backwards_attrs);
 }

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -457,15 +457,16 @@ void TestOp(const OpAttrs& attrs, VerifyFunc verify_fn) {
         std::vector<std::vector<NDArrayAttrs>> out_arrs(attrs.num_outputs);
         for (int i = 0; i < attrs.num_outputs; i++)
           out_arrs[i] = GetTestOutputArrays(in_arr.arr.shape(), mds);
-        for (int i = 0; i < attrs.num_inputs; i++) inputs[i] = &in_arr.arr;
+        for (int i = 0; i < attrs.num_inputs; i++)
+          inputs[i] = &in_arr.arr;
         for (size_t output_i = 0; output_i < out_arrs[0].size(); output_i++) {
           for (int i = 0; i < attrs.num_outputs; i++) {
             req[i]     = kWriteTo;
             outputs[i] = &out_arrs[i][output_i].arr;
           }
           PrintVerifyMsg(in_arr, out_arrs[0][output_i]);
-          Imperative::Get()->InvokeOp(Context(), attrs.attrs, inputs, outputs, req, dispatch,
-                                      mxnet::OpStatePtr());
+          Imperative::Get()->InvokeOp(
+              Context(), attrs.attrs, inputs, outputs, req, dispatch, mxnet::OpStatePtr());
           Engine::Get()->WaitForAll();
           verify_fn(inputs, outputs);
         }
@@ -478,19 +479,22 @@ void TestOp(const OpAttrs& attrs, VerifyFunc verify_fn) {
       in_arrs = GetTestInputArrays();
       for (auto& arr : in_arrs) {
         // If the array is a view, we shouldn't write data to it.
-        if (arr.arr.IsView()) continue;
+        if (arr.arr.IsView())
+          continue;
         NDArrayAttrs orig(arr.arr.Copy(arr.arr.ctx()), "InPlace Copy");
-        for (int i = 0; i < attrs.num_inputs; i++) inputs[i] = &arr.arr;
+        for (int i = 0; i < attrs.num_inputs; i++)
+          inputs[i] = &arr.arr;
         for (int i = 0; i < attrs.num_outputs; i++) {
           req[i]     = kWriteInplace;
           outputs[i] = &arr.arr;
         }
         PrintVerifyMsg(orig, arr);
-        Imperative::Get()->InvokeOp(Context(), attrs.attrs, inputs, outputs, req, dispatch,
-                                    mxnet::OpStatePtr());
+        Imperative::Get()->InvokeOp(
+            Context(), attrs.attrs, inputs, outputs, req, dispatch, mxnet::OpStatePtr());
         Engine::Get()->WaitForAll();
         std::vector<NDArray*> orig_inputs(attrs.num_inputs);
-        for (int i = 0; i < attrs.num_inputs; i++) orig_inputs[i] = &orig.arr;
+        for (int i = 0; i < attrs.num_inputs; i++)
+          orig_inputs[i] = &orig.arr;
         verify_fn(orig_inputs, outputs);
       }
     }
@@ -503,7 +507,8 @@ void TestOp(const OpAttrs& attrs, VerifyFunc verify_fn) {
       for (auto& dispatch : dispatches) {
         for (int i = 0; i < attrs.num_outputs; i++)
           out_arrs[i] = GetTestOutputArrays(in_arr.arr.shape(), mds);
-        for (size_t i = 0; i < attrs.num_inputs; i++) inputs[i] = &in_arr.arr;
+        for (size_t i = 0; i < attrs.num_inputs; i++)
+          inputs[i] = &in_arr.arr;
         for (size_t output_i = 0; output_i < out_arrs[0].size(); output_i++) {
           NDArray tmp;
           for (size_t i = 0; i < attrs.num_outputs; i++) {
@@ -514,8 +519,8 @@ void TestOp(const OpAttrs& attrs, VerifyFunc verify_fn) {
             req[i]              = kAddTo;
           }
           PrintVerifyMsg(in_arr, out_arrs[0][output_i]);
-          Imperative::Get()->InvokeOp(Context(), attrs.attrs, inputs, outputs, req, dispatch,
-                                      mxnet::OpStatePtr());
+          Imperative::Get()->InvokeOp(
+              Context(), attrs.attrs, inputs, outputs, req, dispatch, mxnet::OpStatePtr());
           Engine::Get()->WaitForAll();
           VerifyAddRequest(inputs, original_outputs, outputs, verify_fn);
         }
@@ -540,7 +545,8 @@ void TestConcatOp(const OpAttrs& attrs, VerifyFunc verify_fn, bool backwards = f
     std::string str_dim = const_cast<OpAttrs&>(attrs).attrs.dict["dim"];
     int dim             = std::stoi(str_dim);
     std::vector<float> scale_vector(dim + 1);
-    for (size_t i = 0; i < dim + 1; ++i) scale_vector[i] = 1;
+    for (size_t i = 0; i < dim + 1; ++i)
+      scale_vector[i] = 1;
     scale_vector[dim] = attrs.num_outputs;
     in_arrs           = GetTestInputArrays(ArrayTypes::All, false, scale_vector);
   }
@@ -551,17 +557,20 @@ void TestConcatOp(const OpAttrs& attrs, VerifyFunc verify_fn, bool backwards = f
 
       std::string str_dim = const_cast<OpAttrs&>(attrs).attrs.dict["dim"];
       int dim             = std::stoi(str_dim);
-      if (dim >= in_arr.arr.shape().ndim()) continue;
+      if (dim >= in_arr.arr.shape().ndim())
+        continue;
       float scale = backwards ? 1 / static_cast<float>(attrs.num_outputs)
                               : static_cast<float>(attrs.num_inputs);
 
       std::vector<float> scale_vector(in_arr.arr.shape().ndim());
-      for (int i = 0; i < in_arr.arr.shape().ndim(); i++) scale_vector[i] = 1;
+      for (int i = 0; i < in_arr.arr.shape().ndim(); i++)
+        scale_vector[i] = 1;
       scale_vector[dim] = scale;
       for (int i = 0; i < attrs.num_outputs; i++)
         out_arrs[i] = GetTestOutputArrays(in_arr.arr.shape(), mds, scale_vector);
 
-      for (int i = 0; i < attrs.num_inputs; i++) inputs[i] = &in_arr.arr;
+      for (int i = 0; i < attrs.num_inputs; i++)
+        inputs[i] = &in_arr.arr;
 
       for (size_t output_i = 0; output_i < out_arrs[0].size(); output_i++) {
         for (int i = 0; i < attrs.num_outputs; i++) {
@@ -569,8 +578,8 @@ void TestConcatOp(const OpAttrs& attrs, VerifyFunc verify_fn, bool backwards = f
           outputs[i] = &out_arrs[i][output_i].arr;
         }
         PrintVerifyMsg(in_arr, out_arrs[0][output_i]);
-        Imperative::Get()->InvokeOp(Context(), attrs.attrs, inputs, outputs, req, dispatch,
-                                    mxnet::OpStatePtr());
+        Imperative::Get()->InvokeOp(
+            Context(), attrs.attrs, inputs, outputs, req, dispatch, mxnet::OpStatePtr());
         Engine::Get()->WaitForAll();
         verify_fn(inputs, outputs);
       }
@@ -600,15 +609,24 @@ void TestOpExBackward(const OpAttrs& forward_attrs,
     backwards_outputs[0]    = &tmp_output;
     backwards_ex_outputs[0] = &tmp_output;
 
-    for (int i = 0; i < backwards_attrs.num_outputs; i++) back_req[i] = kWriteTo;
+    for (int i = 0; i < backwards_attrs.num_outputs; i++)
+      back_req[i] = kWriteTo;
 
     std::cout << "Backwards: ";
     PrintVerifyMsg(out_arr, in_arr);
-    Imperative::Get()->InvokeOp(Context(), backwards_attrs.attrs, backwards_input,
-                                backwards_outputs, back_req, DispatchMode::kFCompute,
+    Imperative::Get()->InvokeOp(Context(),
+                                backwards_attrs.attrs,
+                                backwards_input,
+                                backwards_outputs,
+                                back_req,
+                                DispatchMode::kFCompute,
                                 mxnet::OpStatePtr());
-    Imperative::Get()->InvokeOp(Context(), backwards_attrs.attrs, backwards_input,
-                                backwards_ex_outputs, back_req, DispatchMode::kFComputeEx,
+    Imperative::Get()->InvokeOp(Context(),
+                                backwards_attrs.attrs,
+                                backwards_input,
+                                backwards_ex_outputs,
+                                back_req,
+                                DispatchMode::kFComputeEx,
                                 mxnet::OpStatePtr());
     Engine::Get()->WaitForAll();
     if (backwards_attrs.attrs.op->name == "_backward_LRN") {
@@ -647,7 +665,8 @@ void TestOpEx(const OpAttrs& forward_attrs, const OpAttrs& backwards_attrs) {
             GetTestOutputArrays(in_arr.arr.shape(), mds, {1}, false, forward_attrs.output_types);
       }
 
-      for (int i = 0; i < forward_attrs.num_inputs; i++) inputs[i] = &in_arr.arr;
+      for (int i = 0; i < forward_attrs.num_inputs; i++)
+        inputs[i] = &in_arr.arr;
 
       for (size_t output_i = 0; output_i < out_arrs[0].size(); output_i++) {
         for (int i = 0; i < forward_attrs.num_outputs; i++) {
@@ -658,19 +677,35 @@ void TestOpEx(const OpAttrs& forward_attrs, const OpAttrs& backwards_attrs) {
         Imperative::Get()->set_is_training(true);
 
         PrintVerifyMsg(in_arr, out_arrs[0][output_i]);
-        Imperative::Get()->InvokeOp(Context(), forward_attrs.attrs, inputs, outputs, req,
-                                    DispatchMode::kFCompute, mxnet::OpStatePtr());
-        Imperative::Get()->InvokeOp(Context(), forward_attrs.attrs, inputs, ex_outputs, req,
-                                    DispatchMode::kFComputeEx, mxnet::OpStatePtr());
+        Imperative::Get()->InvokeOp(Context(),
+                                    forward_attrs.attrs,
+                                    inputs,
+                                    outputs,
+                                    req,
+                                    DispatchMode::kFCompute,
+                                    mxnet::OpStatePtr());
+        Imperative::Get()->InvokeOp(Context(),
+                                    forward_attrs.attrs,
+                                    inputs,
+                                    ex_outputs,
+                                    req,
+                                    DispatchMode::kFComputeEx,
+                                    mxnet::OpStatePtr());
         Engine::Get()->WaitForAll();
-        // TODO(pengzhao-intel): Need to fix op, should work for the whole vector
+        // TODO(pengzhao-intel): Need to fix op, should work for the whole
+        // vector
         if (forward_attrs.attrs.op->name == "LRN") {
           AssertEqual(outputs, ex_outputs, 1e-5, 1e-8, true);
         }
 
         if (!backwards_attrs.requests.empty()) {
-          TestOpExBackward(forward_attrs, backwards_attrs, OpReqType::kWriteTo, inputs, outputs,
-                           in_arr, out_arrs[0][output_i]);
+          TestOpExBackward(forward_attrs,
+                           backwards_attrs,
+                           OpReqType::kWriteTo,
+                           inputs,
+                           outputs,
+                           in_arr,
+                           out_arrs[0][output_i]);
         }
       }
     }
@@ -681,10 +716,12 @@ void TestOpEx(const OpAttrs& forward_attrs, const OpAttrs& backwards_attrs) {
       auto in_arr = in_arrs[i1];
 
       // If the array is a view, we shouldn't write data to it.
-      if (in_arr.arr.IsView()) continue;
+      if (in_arr.arr.IsView())
+        continue;
 
       NDArrayAttrs orig(in_arr.arr.Copy(in_arr.arr.ctx()), "InPlace Copy");
-      for (int i = 0; i < forward_attrs.num_inputs; i++) inputs[i] = &in_arr.arr;
+      for (int i = 0; i < forward_attrs.num_inputs; i++)
+        inputs[i] = &in_arr.arr;
 
       for (int i = 0; i < forward_attrs.num_outputs; i++) {
         req[i]        = kWriteInplace;
@@ -693,10 +730,20 @@ void TestOpEx(const OpAttrs& forward_attrs, const OpAttrs& backwards_attrs) {
       }
       Imperative::Get()->set_is_training(true);
       PrintVerifyMsg(orig, in_arr);
-      Imperative::Get()->InvokeOp(Context(), forward_attrs.attrs, inputs, outputs, req,
-                                  DispatchMode::kFCompute, mxnet::OpStatePtr());
-      Imperative::Get()->InvokeOp(Context(), forward_attrs.attrs, inputs, ex_outputs, req,
-                                  DispatchMode::kFComputeEx, mxnet::OpStatePtr());
+      Imperative::Get()->InvokeOp(Context(),
+                                  forward_attrs.attrs,
+                                  inputs,
+                                  outputs,
+                                  req,
+                                  DispatchMode::kFCompute,
+                                  mxnet::OpStatePtr());
+      Imperative::Get()->InvokeOp(Context(),
+                                  forward_attrs.attrs,
+                                  inputs,
+                                  ex_outputs,
+                                  req,
+                                  DispatchMode::kFComputeEx,
+                                  mxnet::OpStatePtr());
       Engine::Get()->WaitForAll();
       // TODO(unassigned): Need to fix op, should work for the whole vector
       if (forward_attrs.attrs.op->name == "LRN") {
@@ -744,11 +791,19 @@ void TestOpExBNBackward(const OpAttrs& forward_attrs,
 
     std::cout << "Backwards: ";
     PrintVerifyMsg(*out_arr, in_arr);
-    Imperative::Get()->InvokeOp(Context(), backwards_attrs.attrs, backwards_input,
-                                backwards_outputs, backwards_req, DispatchMode::kFCompute,
+    Imperative::Get()->InvokeOp(Context(),
+                                backwards_attrs.attrs,
+                                backwards_input,
+                                backwards_outputs,
+                                backwards_req,
+                                DispatchMode::kFCompute,
                                 mxnet::OpStatePtr());
-    Imperative::Get()->InvokeOp(Context(), backwards_attrs.attrs, backwards_input,
-                                backwards_ex_outputs, backwards_req, DispatchMode::kFComputeEx,
+    Imperative::Get()->InvokeOp(Context(),
+                                backwards_attrs.attrs,
+                                backwards_input,
+                                backwards_ex_outputs,
+                                backwards_req,
+                                DispatchMode::kFComputeEx,
                                 mxnet::OpStatePtr());
     Engine::Get()->WaitForAll();
     // TODO(unassigned): Need to fix op, should work for the whole vector
@@ -806,16 +861,31 @@ void TestOpExBN(const OpAttrs& forward_attrs, const OpAttrs& backwards_attrs) {
         Imperative::Get()->set_is_training(true);
 
         PrintVerifyMsg(in_arr, out_arrs[0][output_i]);
-        Imperative::Get()->InvokeOp(Context(), forward_attrs.attrs, inputs, outputs, req,
-                                    DispatchMode::kFCompute, mxnet::OpStatePtr());
-        Imperative::Get()->InvokeOp(Context(), forward_attrs.attrs, inputs2, ex_outputs, req,
-                                    DispatchMode::kFComputeEx, mxnet::OpStatePtr());
+        Imperative::Get()->InvokeOp(Context(),
+                                    forward_attrs.attrs,
+                                    inputs,
+                                    outputs,
+                                    req,
+                                    DispatchMode::kFCompute,
+                                    mxnet::OpStatePtr());
+        Imperative::Get()->InvokeOp(Context(),
+                                    forward_attrs.attrs,
+                                    inputs2,
+                                    ex_outputs,
+                                    req,
+                                    DispatchMode::kFComputeEx,
+                                    mxnet::OpStatePtr());
         Engine::Get()->WaitForAll();
         AssertEqual(outputs, ex_outputs, 1e-4, 1e-2, true);
 
         if (!backwards_attrs.requests.empty()) {
-          TestOpExBNBackward(forward_attrs, backwards_attrs, OpReqType::kWriteTo, inputs, outputs,
-                             in_arr, &out_arrs[0][output_i]);
+          TestOpExBNBackward(forward_attrs,
+                             backwards_attrs,
+                             OpReqType::kWriteTo,
+                             inputs,
+                             outputs,
+                             in_arr,
+                             &out_arrs[0][output_i]);
         }
       }
     }
@@ -858,7 +928,8 @@ void TestFullyConnectedOp(const OpAttrs& forward_attrs, const OpAttrs& backwards
     for (int i1 = 0; i1 < in_arrs.size(); i1++) {
       auto in_arr   = in_arrs[i1];
       auto in_shape = in_arr.arr.shape();
-      if (in_shape.ndim() < 2) continue;
+      if (in_shape.ndim() < 2)
+        continue;
 
       mxnet::TShape wt_shape(2, -1);
       wt_shape[0] = num_hid;
@@ -895,10 +966,20 @@ void TestFullyConnectedOp(const OpAttrs& forward_attrs, const OpAttrs& backwards
         Imperative::Get()->set_is_training(true);
 
         PrintVerifyMsg(in_arr, out_arrs[0][output_i]);
-        Imperative::Get()->InvokeOp(Context(), forward_attrs.attrs, inputs, outputs, req,
-                                    DispatchMode::kFCompute, mxnet::OpStatePtr());
-        Imperative::Get()->InvokeOp(Context(), forward_attrs.attrs, inputs, ex_outputs, req,
-                                    DispatchMode::kFComputeEx, mxnet::OpStatePtr());
+        Imperative::Get()->InvokeOp(Context(),
+                                    forward_attrs.attrs,
+                                    inputs,
+                                    outputs,
+                                    req,
+                                    DispatchMode::kFCompute,
+                                    mxnet::OpStatePtr());
+        Imperative::Get()->InvokeOp(Context(),
+                                    forward_attrs.attrs,
+                                    inputs,
+                                    ex_outputs,
+                                    req,
+                                    DispatchMode::kFComputeEx,
+                                    mxnet::OpStatePtr());
         Engine::Get()->WaitForAll();
         AssertEqual(outputs, ex_outputs);
 
@@ -921,15 +1002,24 @@ void TestFullyConnectedOp(const OpAttrs& forward_attrs, const OpAttrs& backwards
         backwards_ex_outputs[1] = &back_ex_weights;
         backwards_ex_outputs[2] = &back_ex_bias;
 
-        for (int i = 0; i < backwards_attrs.num_outputs; i++) back_req[i] = kWriteTo;
+        for (int i = 0; i < backwards_attrs.num_outputs; i++)
+          back_req[i] = kWriteTo;
 
         std::cout << "Backwards: ";
         PrintVerifyMsg(out_arrs[0][output_i], tmp_output);
-        Imperative::Get()->InvokeOp(Context(), backwards_attrs.attrs, backwards_input,
-                                    backwards_outputs, back_req, DispatchMode::kFCompute,
+        Imperative::Get()->InvokeOp(Context(),
+                                    backwards_attrs.attrs,
+                                    backwards_input,
+                                    backwards_outputs,
+                                    back_req,
+                                    DispatchMode::kFCompute,
                                     mxnet::OpStatePtr());
-        Imperative::Get()->InvokeOp(Context(), backwards_attrs.attrs, backwards_input,
-                                    backwards_ex_outputs, back_req, DispatchMode::kFComputeEx,
+        Imperative::Get()->InvokeOp(Context(),
+                                    backwards_attrs.attrs,
+                                    backwards_input,
+                                    backwards_ex_outputs,
+                                    back_req,
+                                    DispatchMode::kFComputeEx,
                                     mxnet::OpStatePtr());
         Engine::Get()->WaitForAll();
         AssertEqual(backwards_outputs, backwards_ex_outputs, 1e-6, 1e-6);
@@ -974,7 +1064,8 @@ void TestConvOp(const OpAttrs& forward_attrs,
 
     // can only conv only 4D inputs
     mxnet::TShape input_shape = in_arr.arr.shape();
-    if (input_shape.ndim() != kernel.ndim() + 2) continue;
+    if (input_shape.ndim() != kernel.ndim() + 2)
+      continue;
 
     float scale = CalculateWidthConvOutput(input_shape[2], kernel[0], padding[0], stride[0]) /
                   static_cast<float>(input_shape[2]);
@@ -990,10 +1081,10 @@ void TestConvOp(const OpAttrs& forward_attrs,
     scale_vector[3] = scale;
 
     for (size_t i = 0; i < forward_attrs.num_outputs; ++i) {
-      out_arrs[i]    = GetTestOutputArrays(in_arr.arr.shape(), mds, scale_vector, true,
-                                        forward_attrs.output_types);
-      ex_out_arrs[i] = GetTestOutputArrays(in_arr.arr.shape(), mds, scale_vector, true,
-                                           forward_attrs.output_types);
+      out_arrs[i] = GetTestOutputArrays(
+          in_arr.arr.shape(), mds, scale_vector, true, forward_attrs.output_types);
+      ex_out_arrs[i] = GetTestOutputArrays(
+          in_arr.arr.shape(), mds, scale_vector, true, forward_attrs.output_types);
     }
     NDArray ndkernel = CreateKernelNDArray(kernel, num_filter, in_arr.arr.shape(), is_deconv);
     mxnet::TShape bias_shape = {num_filter};
@@ -1014,10 +1105,20 @@ void TestConvOp(const OpAttrs& forward_attrs,
       Imperative::Get()->set_is_training(true);
 
       PrintVerifyMsg(in_arr, out_arrs[0][output_i]);
-      Imperative::Get()->InvokeOp(Context(), forward_attrs.attrs, inputs, outputs, req,
-                                  DispatchMode::kFCompute, mxnet::OpStatePtr());
-      Imperative::Get()->InvokeOp(Context(), forward_attrs.attrs, inputs, ex_outputs, req,
-                                  DispatchMode::kFComputeEx, mxnet::OpStatePtr());
+      Imperative::Get()->InvokeOp(Context(),
+                                  forward_attrs.attrs,
+                                  inputs,
+                                  outputs,
+                                  req,
+                                  DispatchMode::kFCompute,
+                                  mxnet::OpStatePtr());
+      Imperative::Get()->InvokeOp(Context(),
+                                  forward_attrs.attrs,
+                                  inputs,
+                                  ex_outputs,
+                                  req,
+                                  DispatchMode::kFComputeEx,
+                                  mxnet::OpStatePtr());
       Engine::Get()->WaitForAll();
       VerifyCopyResult(outputs, ex_outputs);
 
@@ -1048,15 +1149,24 @@ void TestConvOp(const OpAttrs& forward_attrs,
         backwards_ex_outputs[2] = &tmp_bias2;
       }
 
-      for (size_t i = 0; i < backwards_attrs.num_outputs; ++i) back_req[i] = kWriteTo;
+      for (size_t i = 0; i < backwards_attrs.num_outputs; ++i)
+        back_req[i] = kWriteTo;
 
       std::cout << "Backwards: ";
       PrintVerifyMsg(out_arrs[0][output_i], tmp_output);
-      Imperative::Get()->InvokeOp(Context(), backwards_attrs.attrs, backwards_input,
-                                  backwards_outputs, back_req, DispatchMode::kFCompute,
+      Imperative::Get()->InvokeOp(Context(),
+                                  backwards_attrs.attrs,
+                                  backwards_input,
+                                  backwards_outputs,
+                                  back_req,
+                                  DispatchMode::kFCompute,
                                   mxnet::OpStatePtr());
-      Imperative::Get()->InvokeOp(Context(), backwards_attrs.attrs, backwards_input,
-                                  backwards_ex_outputs, back_req, DispatchMode::kFComputeEx,
+      Imperative::Get()->InvokeOp(Context(),
+                                  backwards_attrs.attrs,
+                                  backwards_input,
+                                  backwards_ex_outputs,
+                                  back_req,
+                                  DispatchMode::kFComputeEx,
                                   mxnet::OpStatePtr());
       Engine::Get()->WaitForAll();
       VerifyCopyResult(backwards_outputs, backwards_ex_outputs);
@@ -1095,7 +1205,8 @@ void TestPoolingOp(const OpAttrs& forward_attrs, const OpAttrs& backwards_attrs)
 
     // can only pool only 3D and 4D inputs
     mxnet::TShape input_shape = in_arr.arr.shape();
-    if (input_shape.ndim() != kernel.ndim() + 2) continue;
+    if (input_shape.ndim() != kernel.ndim() + 2)
+      continue;
     // cannot pool if ndarray and mkldnn memory have different ndim
     if (in_arr.arr.IsView() ||
         in_arr.arr.GetMKLDNNData()->get_desc().data.ndims != in_arr.arr.shape().ndim())
@@ -1114,7 +1225,8 @@ void TestPoolingOp(const OpAttrs& forward_attrs, const OpAttrs& backwards_attrs)
       ex_out_arrs[i] = GetTestOutputArrays(in_arr.arr.shape(), mds, scale_vector);
     }
 
-    for (int i = 0; i < forward_attrs.num_inputs; i++) inputs[i] = &in_arr.arr;
+    for (int i = 0; i < forward_attrs.num_inputs; i++)
+      inputs[i] = &in_arr.arr;
 
     for (size_t output_i = 0; output_i < out_arrs[0].size(); output_i++) {
       for (int i = 0; i < forward_attrs.num_outputs; i++) {
@@ -1125,10 +1237,20 @@ void TestPoolingOp(const OpAttrs& forward_attrs, const OpAttrs& backwards_attrs)
       Imperative::Get()->set_is_training(true);
 
       PrintVerifyMsg(in_arr, out_arrs[0][output_i]);
-      Imperative::Get()->InvokeOp(Context(), forward_attrs.attrs, inputs, outputs, req,
-                                  DispatchMode::kFCompute, mxnet::OpStatePtr());
-      Imperative::Get()->InvokeOp(Context(), forward_attrs.attrs, inputs, ex_outputs, req,
-                                  DispatchMode::kFComputeEx, mxnet::OpStatePtr());
+      Imperative::Get()->InvokeOp(Context(),
+                                  forward_attrs.attrs,
+                                  inputs,
+                                  outputs,
+                                  req,
+                                  DispatchMode::kFCompute,
+                                  mxnet::OpStatePtr());
+      Imperative::Get()->InvokeOp(Context(),
+                                  forward_attrs.attrs,
+                                  inputs,
+                                  ex_outputs,
+                                  req,
+                                  DispatchMode::kFComputeEx,
+                                  mxnet::OpStatePtr());
       Engine::Get()->WaitForAll();
       VerifyCopyResult(outputs, ex_outputs);
 
@@ -1154,11 +1276,19 @@ void TestPoolingOp(const OpAttrs& forward_attrs, const OpAttrs& backwards_attrs)
       back_req[0]             = kWriteTo;
       std::cout << "Backwards: ";
       PrintVerifyMsg(out_arrs[0][output_i], tmp_output);
-      Imperative::Get()->InvokeOp(Context(), backwards_attrs.attrs, backwards_input,
-                                  backwards_outputs, back_req, DispatchMode::kFCompute,
+      Imperative::Get()->InvokeOp(Context(),
+                                  backwards_attrs.attrs,
+                                  backwards_input,
+                                  backwards_outputs,
+                                  back_req,
+                                  DispatchMode::kFCompute,
                                   mxnet::OpStatePtr());
-      Imperative::Get()->InvokeOp(Context(), backwards_attrs.attrs, backwards_input,
-                                  backwards_ex_outputs, back_req, DispatchMode::kFComputeEx,
+      Imperative::Get()->InvokeOp(Context(),
+                                  backwards_attrs.attrs,
+                                  backwards_input,
+                                  backwards_ex_outputs,
+                                  back_req,
+                                  DispatchMode::kFComputeEx,
                                   mxnet::OpStatePtr());
       Engine::Get()->WaitForAll();
       VerifyCopyResult(backwards_outputs, backwards_ex_outputs);
@@ -1237,7 +1367,8 @@ TEST(IMPERATIVE, PoolingOp) {
     for (int kernel = 1; kernel < 4; kernel++) {
       for (int stride = 1; stride < 3; stride++) {
         for (int pad = 0; pad < 2; pad++) {
-          if (kernel / 2. < pad) continue;
+          if (kernel / 2. < pad)
+            continue;
           OpAttrs forward_attrs   = GetPoolingOp(kernel, dim, stride, pad);
           OpAttrs backwards_attrs = GetPoolingBackwardsOp(kernel, dim, stride, pad);
           TestPoolingOp(forward_attrs, backwards_attrs);
@@ -1253,7 +1384,8 @@ TEST(IMPERATIVE, ConvOp) {
     for (size_t kernel = 1; kernel < 4; ++kernel) {
       for (size_t stride = 1; stride < 3; ++stride) {
         for (size_t pad = 0; pad < 2; ++pad) {
-          if (kernel / 2. < pad) continue;
+          if (kernel / 2. < pad)
+            continue;
           OpAttrs forward_attrs   = GetConvOp(kernel, num_filters, dim, stride, pad);
           OpAttrs backwards_attrs = GetConvBackwardOp(kernel, num_filters, dim, stride, pad);
           TestConvOp<mxnet::op::ConvolutionParam>(forward_attrs, backwards_attrs);
@@ -1269,7 +1401,8 @@ TEST(IMPERATIVE, DeconvOp) {
     for (size_t kernel = 1; kernel < 3; ++kernel) {
       for (size_t stride = 1; stride < 3; ++stride) {
         for (size_t pad = 0; pad < 2; ++pad) {
-          if (kernel / 2. < pad) continue;
+          if (kernel / 2. < pad)
+            continue;
           OpAttrs forward_attrs   = GetDeconvOp(kernel, num_filters, dim, stride, pad);
           OpAttrs backwards_attrs = GetDeconvBackwardOp(kernel, num_filters, dim, stride, pad);
           TestConvOp<mxnet::op::DeconvolutionParam>(forward_attrs, backwards_attrs, true);


### PR DESCRIPTION
## Description ##
This pull-request contains changes associated with a coding style. 
Contains: 
1. src/operator/nn/mkldnn/
2. include/mxnet/ndarray.h
3. src/ndarray/ndarray.cc
4. src/operator/operator_common.h
5. src/operator/quantization/mkldnn/
6. src/operator/subgraph/mkldnn/
7. src/operator/tensor/amp_cast.cc
8. src/operator/tensor/cast_storage-inl.h
9. tests/cpp/include/test_mkldnn.h
10. tests/cpp/operator/mkldnn_operator_test

.clang-format file: 
```cpp
---
Language: Cpp
BasedOnStyle: Google
ColumnLimit: 100
#AlignAfterOpenBracket: AlwaysBreak
AlignConsecutiveAssignments: true
AlignConsecutiveDeclarations: false
AlignConsecutiveMacros: true
DerivePointerAlignment: false
SortIncludes: true
MaxEmptyLinesToKeep: 1
PointerAlignment: Left
AllowAllParametersOfDeclarationOnNextLine: false
AllowShortBlocksOnASingleLine: false
AllowShortCaseLabelsOnASingleLine: false
AllowShortFunctionsOnASingleLine: Empty
AllowShortIfStatementsOnASingleLine: false
AllowShortLoopsOnASingleLine: false
AlwaysBreakAfterReturnType: None
AlwaysBreakBeforeMultilineStrings: true
AlwaysBreakTemplateDeclarations: true
BinPackArguments: false
BinPackParameters: false
```
## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
