### PR TITLE
[BUGFIX] Fix test_zero_sized_dim save/restore of np_shape state

### DIFF
--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -5333,19 +5333,21 @@ def test_boolean_mask():
     assert same(data.grad.asnumpy(), expected_grad)
 
     # test 0-size output
-    mx.set_np_shape(True)
-    data = mx.nd.array([[1, 2, 3],[4, 5, 6],[7, 8, 9]])
-    index = mx.nd.array([0, 0, 0])
-    data.attach_grad()
-    with mx.autograd.record():
-        out = mx.nd.contrib.boolean_mask(data, index)
-    out.backward()
-    data.grad.wait_to_read()
-    expected = np.zeros((0, 3))
-    expected_grad = np.array([[0, 0, 0], [0, 0, 0], [0, 0, 0]])
-    assert same(out.asnumpy(), expected)
-    assert same(data.grad.asnumpy(), expected_grad)
-    mx.set_np_shape(False)
+    prev_np_shape = mx.set_np_shape(True)
+    try:
+        data = mx.nd.array([[1, 2, 3],[4, 5, 6],[7, 8, 9]])
+        index = mx.nd.array([0, 0, 0])
+        data.attach_grad()
+        with mx.autograd.record():
+            out = mx.nd.contrib.boolean_mask(data, index)
+        out.backward()
+        data.grad.wait_to_read()
+        expected = np.zeros((0, 3))
+        expected_grad = np.array([[0, 0, 0], [0, 0, 0], [0, 0, 0]])
+        assert same(out.asnumpy(), expected)
+        assert same(data.grad.asnumpy(), expected_grad)
+    finally:
+        mx.set_np_shape(prev_np_shape)
 
     # test gradient
     shape = (100, 30)
@@ -9463,7 +9465,8 @@ def test_sldwin_selfatten_operators():
 
 def test_zero_sized_dim():
 
-    mx.util.set_np_shape(True)  # Must be done to prevent zero-sized dimension conversion to 'unknown'
+    # Must be done to prevent zero-sized dimension conversion to 'unknown'
+    prev_np_shape = mx.util.set_np_shape(True)
 
     def seq_last():
         """Test for issue: https://github.com/apache/incubator-mxnet/issues/18938"""
@@ -9483,9 +9486,12 @@ def test_zero_sized_dim():
         res = mx.nd.op.SequenceReverse(data)
         assert data.shape == res.shape
 
-    seq_last()
-    seq_reverse()
-    seq_mask()
+    try:
+        seq_last()
+        seq_reverse()
+        seq_mask()
+    finally:
+        mx.util.set_np_shape(prev_np_shape)
 
 def test_take_grads():
     # Test for https://github.com/apache/incubator-mxnet/issues/19817

--- a/tests/python/unittest/test_thread_local.py
+++ b/tests/python/unittest/test_thread_local.py
@@ -213,7 +213,7 @@ def test_np_array_scope():
 
 
 def test_np_global_shape():
-    set_np_shape(2)
+    prev_np_shape = set_np_shape(2)
     data = []
 
     def f():
@@ -229,4 +229,4 @@ def test_np_global_shape():
         assert_almost_equal(data[0].asnumpy(), np.ones(shape=()))
         assert_almost_equal(data[1].asnumpy(), np.ones(shape=(0, 1, 2)))
     finally:
-        set_np_shape(0)
+        set_np_shape(prev_np_shape)


### PR DESCRIPTION
## Description ##

Tensor shapes can be interpreted in one of two modes, depending on whether "numpy shape semantics" have been enabled.  There are unittests that test shape handling in both modes, but any one unittest should not make assumptions about the prevailing mode entering the test, nor should it permanently alter the mode for tests that follow (regardless of whether the test passes or fails).  **This PR fixes the test_operator.py::test_zero_sized_dim test, which was leaving numpy shape semantics set for follow-on tests.**  Running the test was found to cause failures in a following test_sparse_ndarray.py::def test_sparse_nd_pickle among other tests, as reported in issue https://github.com/apache/incubator-mxnet/issues/20337.  This PR also fixes test_operator.py::test_boolean_mask and test_thread_local.py::test_np_global_shape, which do not properly save and restore the pre-test shape interpretation mode.

When running pytest with xdist and multiple workers, I'm not sure if the same set of tests are run on the same workers.  If the assignment of tests to workers is non-deterministic, then failures of susceptible tests may be non-deterministic.  In that case, this PR may also fix the non-deterministic issue https://github.com/apache/incubator-mxnet/issues/19915.

Regarding implementation, I chose not to use the more elegant np_shape() or use_np_shape() decorators in fixing these tests.  Instead, I kept the use of set_np_shape() in order to retain some direct testing of this function from the unittests.

## Checklist ##
### Essentials ###
- [ X] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ X] Changes are complete (i.e. I finished coding on this PR)
- [ X] All changes have test coverage
- [X ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

