### PR TITLE
[BUGFIX] Fix CI slowdown issue after removing 3rdparty/openmp

### DIFF
--- a/src/operator/tensor/broadcast_reduce-inl.h
+++ b/src/operator/tensor/broadcast_reduce-inl.h
@@ -372,7 +372,6 @@ void seq_reduce_compute(const size_t N, const size_t M, const bool addto,
           (idx, M, addto, big, small, bshape, sshape, rshape, rstride, true);
     }
   }
-
 }
 
 template <typename Reducer, int ndim, typename DType, typename OP>

--- a/src/operator/tensor/broadcast_reduce-inl.h
+++ b/src/operator/tensor/broadcast_reduce-inl.h
@@ -360,11 +360,19 @@ void seq_reduce_compute(const size_t N, const size_t M, const bool addto,
                         const Shape<ndim> sshape, const Shape<ndim> rshape,
                         const Shape<ndim> rstride) {
   const int thread_count = engine::OpenMP::Get()->GetRecommendedOMPThreadCount();
-  #pragma omp parallel for num_threads(thread_count) if (N >= thread_count)
-  for (index_t idx = 0; idx < static_cast<index_t>(N); ++idx) {
-    seq_reduce_assign<Reducer, ndim, AType, DType, OType, OP, IndexOP>
-        (idx, M, addto, big, small, bshape, sshape, rshape, rstride, N < thread_count);
+  if (N >= thread_count) {
+    #pragma omp parallel for num_threads(thread_count)
+    for (index_t idx = 0; idx < static_cast<index_t>(N); ++idx) {
+      seq_reduce_assign<Reducer, ndim, AType, DType, OType, OP, IndexOP>
+          (idx, M, addto, big, small, bshape, sshape, rshape, rstride, false);
+    }
+  } else {
+    for (index_t idx = 0; idx < static_cast<index_t>(N); ++idx) {
+      seq_reduce_assign<Reducer, ndim, AType, DType, OType, OP, IndexOP>
+          (idx, M, addto, big, small, bshape, sshape, rshape, rstride, true);
+    }
   }
+
 }
 
 template <typename Reducer, int ndim, typename DType, typename OP>


### PR DESCRIPTION
## Description ##
This PR fixes slowdown on CI (https://github.com/apache/incubator-mxnet/issues/20092) introduced after removing 3rdparty/openmp.

GOMP by default doesn't use OMP_DYNAMIC and OMP_NESTED which allows to run parallel regions inside other parallel region.
e.g.
```
#pragma omp parallel for
for(int i .....) {
    do_sth()...
    #pragma omp parallel for
    for(int i ....) {}
}
```
Even if there is "**if**" directive causing sequential run it's still treated as parallel region - setting OMP_DYNAMIC and OMP_NESTED somewhat helps, but seems that without "**if**" clause in GOMP we get even better performance and we don't need to set above env variables.

CC: @akarbown 

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented


