### PR TITLE
[BUGFIX] fix log_sigmoid bugs

### DIFF
--- a/src/common/cuda/rtc/backward_functions-inl.h
+++ b/src/common/cuda/rtc/backward_functions-inl.h
@@ -47,7 +47,7 @@ backward_sigmoid(const DTypeGrad grad, const DType val) {
 template <typename DType, typename DTypeGrad>
 __device__ inline mixed_type<DTypeGrad, DType>
 backward_log_sigmoid(const DTypeGrad grad, const DType val) {
-  return grad * 1 / (1 + op::exp(val));
+  return grad * (1 - op::exp(val));
 }
 
 template <typename DType, typename DTypeGrad>

--- a/src/operator/mshadow_op.h
+++ b/src/operator/mshadow_op.h
@@ -413,7 +413,7 @@ MXNET_UNARY_MATH_OP(sigmoid_grad, math::id(a) * (1.0f - math::id(a)));
 
 MXNET_UNARY_MATH_OP(log_sigmoid, math::log(1.0f / (1.0f + math::exp(-a))));
 
-MXNET_UNARY_MATH_OP(log_sigmoid_grad, 1.0f / (1.0f + math::exp(a)));
+MXNET_UNARY_MATH_OP(log_sigmoid_grad, 1.0f - math::exp(a));
 
 struct mish : public mxnet_op::tunable {
   template<typename DType>

--- a/src/operator/nn/activation.cu
+++ b/src/operator/nn/activation.cu
@@ -56,12 +56,15 @@ void ActivationCompute<gpu>(const nnvm::NodeAttrs& attrs,
   const ActivationParam& param = nnvm::get<ActivationParam>(attrs.parsed);
   const int act_type = param.act_type;
 
-  // SoftReLU, kSoftSign and Mish are not supported by CUDNN yet
+  // SoftReLU, SoftSign, Log_Sigmoid and Mish are not supported by CUDNN yet
   if (act_type == activation::kSoftReLU) {
     ActivationForward<gpu, mshadow_op::softrelu, mshadow_op::softrelu_grad>(ctx,
       inputs[0], req[0], outputs[0]);
   } else if (act_type == activation::kSoftSign) {
     ActivationForward<gpu, mshadow_op::softsign, mshadow_op::softsign_grad>(ctx,
+      inputs[0], req[0], outputs[0]);
+  } else if (act_type == activation::kLogSigmoid) {
+    ActivationForward<gpu, mshadow_op::log_sigmoid, mshadow_op::log_sigmoid_grad>(ctx,
       inputs[0], req[0], outputs[0]);
   } else if (act_type == activation::kMish) {
     ActivationForward<gpu, mshadow_op::mish, mshadow_op::mish_grad>(ctx,
@@ -87,9 +90,12 @@ void ActivationGradCompute<gpu>(const nnvm::NodeAttrs& attrs,
 
   bool do_memory_opt = dmlc::GetEnv("MXNET_MEMORY_OPT", 0);
 
-  // SoftReLU, SoftSign and Mish not supported by CUDNN yet
+  // SoftReLU, SoftSign, Log_Sigmoid and Mish not supported by CUDNN yet
   if (act_type == activation::kSoftReLU) {
     ActivationBackward<gpu, mshadow_op::softrelu, mshadow_op::softrelu_grad>(
+      ctx, inputs.at(0), inputs.at(1), req[0], outputs[0]);
+  } else if (act_type == activation::kLogSigmoid) {
+    ActivationBackward<gpu, mshadow_op::log_sigmoid, mshadow_op::log_sigmoid_grad>(
       ctx, inputs.at(0), inputs.at(1), req[0], outputs[0]);
   } else if (act_type == activation::kMish) {
     ActivationBackward<gpu, mshadow_op::mish, mshadow_op::mish_grad>(
@@ -120,9 +126,6 @@ void ActivationGradCompute<gpu>(const nnvm::NodeAttrs& attrs,
           ctx, inputs.at(0), inputs.at(1), req[0], outputs[0]);
       } else if (act_type == activation::kSigmoid) {
         ActivationBackward<gpu, mshadow_op::sigmoid, mshadow_op::sigmoid_grad>(
-          ctx, inputs.at(0), inputs.at(1), req[0], outputs[0]);
-      } else if (act_type == activation::kLogSigmoid) {
-        ActivationBackward<gpu, mshadow_op::log_sigmoid, mshadow_op::log_sigmoid_grad>(
           ctx, inputs.at(0), inputs.at(1), req[0], outputs[0]);
       } else {
         LOG(FATAL) << "unknown activation type";

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -3460,8 +3460,8 @@ def test_npx_activation_log_sigmoid():
         def __init__(self):
             super(TestLogSigmoid, self).__init__()
 
-        def hybrid_forward(self, F, a):
-            return F.npx.activation(a, act_type='log_sigmoid')
+        def forward(self, a):
+            return npx.activation(a, act_type='log_sigmoid')
 
     shapes = [(), (2, 3, 4)]
     for hybridize in [True, False]:
@@ -3499,8 +3499,8 @@ def test_npx_activation_mish():
         def __init__(self):
             super(TestMish, self).__init__()
 
-        def hybrid_forward(self, F, a):
-            return F.npx.activation(a, act_type='mish')
+        def forward(self, a):
+            return npx.activation(a, act_type='mish')
 
     shapes = [(), (2, 3, 4)]
     for hybridize in [True, False]:


### PR DESCRIPTION
## Description ##
Solve https://github.com/apache/incubator-mxnet/issues/20371

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [ ] Code is well-documented

## Comments ##
- When the input's shape=(), the backward log_sigmoid activation is incorrect

    - Reason: For `y = log_sigmoid(x)`, the inputs for `log_sigmoid_grad` is `(dy, y)`. This problem is similar to https://github.com/apache/incubator-mxnet/issues/10868

- There is an error when run the log_sigmoid in gpu.

    - Reason: There is no cudnn log_sigmoid implement in `cudnn_activation-inl.h`
https://github.com/apache/incubator-mxnet/blob/da4ff3a4dc0bd6a54af3d75c492021d18ba1867b/src/operator/nn/cudnn/cudnn_activation-inl.h#L48-L65