### PR TITLE
[BUGFIX] fix issue in elemwise_add

### DIFF
--- a/python/mxnet/executor.py
+++ b/python/mxnet/executor.py
@@ -121,7 +121,7 @@ class Executor:
                         with self._ctx:
                             self._args[i].attach_grad(req, stype=g.stype)
                             self._args[i].grad[:] = g
-        self._cached_op = ndarray.CachedOp(sym)
+        self._cached_op = ndarray.CachedOp(sym, flags=[("static_alloc", True)])
 
     def get_optimized_symbol(self):
         """Get an optimized version of the symbol from the executor.

--- a/src/operator/tensor/elemwise_binary_op_basic.cc
+++ b/src/operator/tensor/elemwise_binary_op_basic.cc
@@ -108,7 +108,7 @@ The storage type of ``elemwise_add`` output depends on storage types of inputs
    - otherwise, ``elemwise_add`` generates output with default storage
 
 )code")
-.set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseNone{"_backward_add"});
+.set_attr<nnvm::FGradient>("FGradient", CloneGradient{"_backward_add"});
 
 // specialized gradient add function to do add to optimization
 // this must differ from elemwise_add to prevent add to optimization in forward pass.

--- a/src/operator/tensor/elemwise_binary_op_basic.cc
+++ b/src/operator/tensor/elemwise_binary_op_basic.cc
@@ -108,7 +108,7 @@ The storage type of ``elemwise_add`` output depends on storage types of inputs
    - otherwise, ``elemwise_add`` generates output with default storage
 
 )code")
-.set_attr<nnvm::FGradient>("FGradient", CloneGradient{"_backward_add"});
+.set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseNone{"_backward_add"});
 
 // specialized gradient add function to do add to optimization
 // this must differ from elemwise_add to prevent add to optimization in forward pass.

--- a/src/operator/tensor/elemwise_binary_op_basic.cc
+++ b/src/operator/tensor/elemwise_binary_op_basic.cc
@@ -108,7 +108,16 @@ The storage type of ``elemwise_add`` output depends on storage types of inputs
    - otherwise, ``elemwise_add`` generates output with default storage
 
 )code")
-.set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseNone{"_backward_add"});
+.set_attr<nnvm::FGradient>("FGradient",
+  [](const nnvm::ObjectPtr& n, const std::vector<nnvm::NodeEntry>& ograds) {
+    std::vector<nnvm::NodeEntry> ret;
+    const size_t input_count = n->inputs.size();
+    ret.reserve(input_count);
+    for (size_t i = 0; i < input_count; ++i) {
+      ret.emplace_back(MakeNode("ones_like", n->attrs.name + "_grad_ones", {n->inputs[i]}, nullptr, &n));
+    }
+    return ret;
+});
 
 // specialized gradient add function to do add to optimization
 // this must differ from elemwise_add to prevent add to optimization in forward pass.

--- a/tests/python/unittest/test_autograd.py
+++ b/tests/python/unittest/test_autograd.py
@@ -508,14 +508,14 @@ def test_sparse_dot_grad():
     dns.attach_grad(stype='row_sparse')
     check_sparse_dot_grad(dns)
 
-def test_gradient():
-    x = mx.nd.ones((1,))
-    x.attach_grad()
+# def test_gradient():
+#     x = mx.nd.ones((1,))
+#     x.attach_grad()
 
-    with mx.autograd.record():
-        z = mx.nd.elemwise_add(mx.nd.exp(x), x)
-    dx, = mx.autograd.grad(z, [x], create_graph=True)
-    assert abs(dx.asscalar() - 3.71828175) < 1e-7
-    dx.backward()
-    assert abs(x.grad.asscalar() - 2.71828175) < 1e-7
+#     with mx.autograd.record():
+#         z = mx.nd.elemwise_add(mx.nd.exp(x), x)
+#     dx, = mx.autograd.grad(z, [x], create_graph=True)
+#     assert abs(dx.asscalar() - 3.71828175) < 1e-7
+#     dx.backward()
+#     assert abs(x.grad.asscalar() - 2.71828175) < 1e-7
 

--- a/tests/python/unittest/test_autograd.py
+++ b/tests/python/unittest/test_autograd.py
@@ -508,14 +508,13 @@ def test_sparse_dot_grad():
     dns.attach_grad(stype='row_sparse')
     check_sparse_dot_grad(dns)
 
-# def test_gradient():
-#     x = mx.nd.ones((1,))
-#     x.attach_grad()
+def test_gradient():
+    x = mx.nd.ones((1,))
+    x.attach_grad()
 
-#     with mx.autograd.record():
-#         z = mx.nd.elemwise_add(mx.nd.exp(x), x)
-#     dx, = mx.autograd.grad(z, [x], create_graph=True)
-#     assert abs(dx.asscalar() - 3.71828175) < 1e-7
-#     dx.backward()
-#     assert abs(x.grad.asscalar() - 2.71828175) < 1e-7
-
+    with mx.autograd.record():
+        z = mx.nd.elemwise_add(mx.nd.exp(x), x)
+    dx, = mx.autograd.grad(z, [x], create_graph=True)
+    assert abs(dx.asscalar() - 3.71828175) < 1e-7
+    dx.backward()
+    assert abs(x.grad.asscalar() - 2.71828175) < 1e-7

--- a/tests/python/unittest/test_autograd.py
+++ b/tests/python/unittest/test_autograd.py
@@ -508,14 +508,14 @@ def test_sparse_dot_grad():
     dns.attach_grad(stype='row_sparse')
     check_sparse_dot_grad(dns)
 
-# def test_gradient():
-#     x = mx.nd.ones((1,))
-#     x.attach_grad()
+def test_gradient():
+    x = mx.nd.ones((1,))
+    x.attach_grad()
 
-#     with mx.autograd.record():
-#         z = mx.nd.elemwise_add(mx.nd.exp(x), x)
-#     dx, = mx.autograd.grad(z, [x], create_graph=True)
-#     assert abs(dx.asscalar() - 3.71828175) < 1e-7
-#     dx.backward()
-#     assert abs(x.grad.asscalar() - 2.71828175) < 1e-7
+    with mx.autograd.record():
+        z = mx.nd.elemwise_add(mx.nd.exp(x), x)
+    dx, = mx.autograd.grad(z, [x], create_graph=True)
+    assert abs(dx.asscalar() - 3.71828175) < 1e-7
+    dx.backward()
+    assert abs(x.grad.asscalar() - 2.71828175) < 1e-7
 

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -9570,3 +9570,49 @@ def test_take_grads():
 
     for i in range(len(grads1)):
         assert_almost_equal(grads1[i], grads2[i])
+
+
+def test_elemwise_add():
+    json = """
+        {  
+            "nodes": [ 
+                {
+                    \"op\":\"null\",
+                    \"name\":\".Inputs.Input1\",
+                    \"inputs\":[]
+                },
+                {
+                    \"op\":\"null\",
+                    \"name\":\".Inputs.Input2\",
+                    \"inputs\":[]
+                },
+                {
+                    \"op\":\"elemwise_add\",
+                    \"name\":\".$0\",
+                    \"inputs\":[[0,0,0],[1,0,0]]
+                },
+                {
+                    \"op\":\"_copy\",
+                    \"name\":\".Outputs.Output\",
+                    \"inputs\":[[2,0,0]]
+                }
+            ],
+            \"arg_nodes\":[0,1],
+            \"heads\":[[3,0,0]]
+        }
+        """
+    sym = mx.symbol.fromjson(json)
+
+    ex = sym._bind(
+        mx.cpu(), 
+        {'.Inputs.Input1': mx.nd.array([0.4]), '.Inputs.Input2': mx.nd.array([0.5])},
+        args_grad={
+            '.Inputs.Input1': mx.ndarray.zeros((1)), 
+            '.Inputs.Input2': mx.ndarray.zeros((1))
+        },
+        grad_req={'.Inputs.Input1': 'null', '.Inputs.Input2': 'write'}
+    )
+
+    ex.forward(is_train=True)
+    ex.backward(out_grads=mx.nd.array([2021]))
+    assert ex.grad_arrays[1] == 2021


### PR DESCRIPTION
## Description ##
Thie PR is created to fix the issue #20293, where operator `elemwise_add `has bug when `CachedOp ` uses static_alloc.

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ]  Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
