### PR TITLE
[v1.x] Fix docker cache build pipeline

### DIFF
--- a/ci/Jenkinsfile_docker_cache
+++ b/ci/Jenkinsfile_docker_cache
@@ -38,7 +38,7 @@ core_logic: {
         timeout(time: total_timeout, unit: 'MINUTES') {
           utils.init_git()
           sh "ci/docker_cache.py --docker-registry ${env.DOCKER_ECR_REGISTRY}"
-          sh "cd ci && $(aws ecr get-login --region ${env.DOCKER_ECR_REGION} --no-include-email) && docker-compose -f docker/docker-compose.yml build --parallel && docker-compose -f docker/docker-compose.yml push && docker logout"
+          sh "cd ci && $(aws ecr get-login --region ${env.DOCKER_ECR_REGION} --no-include-email) && DOCKER_CACHE_REGISTRY=${env.DOCKER_ECR_REGISTRY} docker-compose -f docker/docker-compose.yml build --parallel && DOCKER_CACHE_REGISTRY=${env.DOCKER_ECR_REGISTRY} docker-compose -f docker/docker-compose.yml push"
         }
       }
     }

--- a/ci/Jenkinsfile_docker_cache
+++ b/ci/Jenkinsfile_docker_cache
@@ -38,7 +38,7 @@ core_logic: {
         timeout(time: total_timeout, unit: 'MINUTES') {
           utils.init_git()
           sh "ci/docker_cache.py --docker-registry ${env.DOCKER_ECR_REGISTRY}"
-          sh "cd ci && python3 ./docker_login.py --secret-name ${env.DOCKERHUB_SECRET_NAME} && docker-compose -f docker/docker-compose.yml build --parallel && docker-compose -f docker/docker-compose.yml push && docker logout"
+          sh "cd ci && $(aws ecr get-login --region ${env.DOCKER_ECR_REGION} --no-include-email) && docker-compose -f docker/docker-compose.yml build --parallel && docker-compose -f docker/docker-compose.yml push && docker logout"
         }
       }
     }

--- a/ci/Jenkinsfile_utils.groovy
+++ b/ci/Jenkinsfile_utils.groovy
@@ -148,7 +148,7 @@ def collect_test_results_windows(original_file_name, new_file_name) {
 
 
 def docker_run(platform, function_name, use_nvidia, shared_mem = '500m', env_vars = "", build_args = "") {
-  def command = "ci/build.py %ENV_VARS% %BUILD_ARGS% --docker-registry ${env.DOCKER_CACHE_REGISTRY} %USE_NVIDIA% --platform %PLATFORM% --docker-build-retries 3 --shm-size %SHARED_MEM% /work/runtime_functions.sh %FUNCTION_NAME%"
+  def command = "ci/build.py %ENV_VARS% %BUILD_ARGS% --docker-registry ${env.DOCKER_ECR_REGISTRY} %USE_NVIDIA% --platform %PLATFORM% --docker-build-retries 3 --shm-size %SHARED_MEM% /work/runtime_functions.sh %FUNCTION_NAME%"
   command = command.replaceAll('%ENV_VARS%', env_vars.length() > 0 ? "-e ${env_vars}" : '')
   command = command.replaceAll('%BUILD_ARGS%', env_vars.length() > 0 ? "${build_args}" : '')
   command = command.replaceAll('%USE_NVIDIA%', use_nvidia ? '--nvidiadocker' : '')

--- a/ci/build.py
+++ b/ci/build.py
@@ -297,7 +297,11 @@ def load_docker_cache(platform, tag, docker_registry) -> None:
             env = os.environ.copy()
             env["DOCKER_CACHE_REGISTRY"] = docker_registry
             if "dkr.ecr" in docker_registry:
-                docker_cache._ecr_login(docker_registry)
+                try:
+                    import docker_cache
+                    docker_cache._ecr_login(docker_registry)
+                except Exception:
+                    logging.exception('Unable to login to ECR...')
             cmd = ['docker-compose', '-f', 'docker/docker-compose.yml', 'pull', platform]
             logging.info("Running command: 'DOCKER_CACHE_REGISTRY=%s %s'", docker_registry, ' '.join(cmd))
             check_call(cmd, env=env)

--- a/ci/build.py
+++ b/ci/build.py
@@ -296,6 +296,8 @@ def load_docker_cache(platform, tag, docker_registry) -> None:
         if platform in DOCKER_COMPOSE_WHITELIST:
             env = os.environ.copy()
             env["DOCKER_CACHE_REGISTRY"] = docker_registry
+            if "dkr.ecr" in docker_registry:
+                docker_cache._ecr_login(docker_registry)
             cmd = ['docker-compose', '-f', 'docker/docker-compose.yml', 'pull', platform]
             logging.info("Running command: 'DOCKER_CACHE_REGISTRY=%s %s'", docker_registry, ' '.join(cmd))
             check_call(cmd, env=env)

--- a/ci/docker/docker-compose.yml
+++ b/ci/docker/docker-compose.yml
@@ -30,8 +30,8 @@ services:
   centos7_cpu:
     # The resulting image will be named build.centos7_cpu:latest and will be
     # pushed to the dockerhub user specified in the environment variable
-    # ${DOCKER_ECR_REGISTRY} (typicall "mxnetci") under this name
-    image: ${DOCKER_ECR_REGISTRY}/build.centos7_cpu:latest
+    # ${DOCKER_CACHE_REGISTRY} (typicall "mxnetci") under this name
+    image: ${DOCKER_CACHE_REGISTRY}/build.centos7_cpu:latest
     build:
       context: .
       dockerfile: Dockerfile.build.centos7
@@ -41,9 +41,9 @@ services:
         # BASE_IMAGE is used to dynamically specify the FROM image in Dockerfile.build.centos7
         BASE_IMAGE: centos:7
       cache_from:
-        - ${DOCKER_ECR_REGISTRY}/build.centos7_cpu:latest
+        - ${DOCKER_CACHE_REGISTRY}/build.centos7_cpu:latest
   centos7_gpu_cu100:
-    image: ${DOCKER_ECR_REGISTRY}/build.centos7_gpu_cu100:latest
+    image: ${DOCKER_CACHE_REGISTRY}/build.centos7_gpu_cu100:latest
     build:
       context: .
       dockerfile: Dockerfile.build.centos7
@@ -51,9 +51,9 @@ services:
       args:
         BASE_IMAGE: nvidia/cuda:10.0-cudnn7-devel-centos7
       cache_from:
-        - ${DOCKER_ECR_REGISTRY}/build.centos7_gpu_cu100:latest
+        - ${DOCKER_CACHE_REGISTRY}/build.centos7_gpu_cu100:latest
   centos7_gpu_cu101:
-    image: ${DOCKER_ECR_REGISTRY}/build.centos7_gpu_cu101:latest
+    image: ${DOCKER_CACHE_REGISTRY}/build.centos7_gpu_cu101:latest
     build:
       context: .
       dockerfile: Dockerfile.build.centos7
@@ -61,9 +61,9 @@ services:
       args:
         BASE_IMAGE: nvidia/cuda:10.1-cudnn7-devel-centos7
       cache_from:
-        - ${DOCKER_ECR_REGISTRY}/build.centos7_gpu_cu101:latest
+        - ${DOCKER_CACHE_REGISTRY}/build.centos7_gpu_cu101:latest
   centos7_gpu_cu102:
-    image: ${DOCKER_ECR_REGISTRY}/build.centos7_gpu_cu102:latest
+    image: ${DOCKER_CACHE_REGISTRY}/build.centos7_gpu_cu102:latest
     build:
       context: .
       dockerfile: Dockerfile.build.centos7
@@ -71,9 +71,9 @@ services:
       args:
         BASE_IMAGE: nvidia/cuda:10.2-cudnn8-devel-centos7
       cache_from:
-        - ${DOCKER_ECR_REGISTRY}/build.centos7_gpu_cu102:latest
+        - ${DOCKER_CACHE_REGISTRY}/build.centos7_gpu_cu102:latest
   centos7_gpu_cu110:
-    image: ${DOCKER_ECR_REGISTRY}/build.centos7_gpu_cu110:latest
+    image: ${DOCKER_CACHE_REGISTRY}/build.centos7_gpu_cu110:latest
     build:
       context: .
       dockerfile: Dockerfile.build.centos7
@@ -81,9 +81,9 @@ services:
       args:
         BASE_IMAGE: nvidia/cuda:11.0-cudnn8-devel-centos7
       cache_from:
-        - ${DOCKER_ECR_REGISTRY}/build.centos7_gpu_cu110:latest
+        - ${DOCKER_CACHE_REGISTRY}/build.centos7_gpu_cu110:latest
   centos7_gpu_cu112:
-    image: ${DOCKER_ECR_REGISTRY}/build.centos7_gpu_cu112:latest
+    image: ${DOCKER_CACHE_REGISTRY}/build.centos7_gpu_cu112:latest
     build:
       context: .
       dockerfile: Dockerfile.build.centos7
@@ -91,4 +91,4 @@ services:
       args:
         BASE_IMAGE: nvidia/cuda:11.2.1-cudnn8-devel-centos7
       cache_from:
-        - ${DOCKER_ECR_REGISTRY}/build.centos7_gpu_cu112:latest
+        - ${DOCKER_CACHE_REGISTRY}/build.centos7_gpu_cu112:latest

--- a/ci/docker/docker-compose.yml
+++ b/ci/docker/docker-compose.yml
@@ -30,8 +30,8 @@ services:
   centos7_cpu:
     # The resulting image will be named build.centos7_cpu:latest and will be
     # pushed to the dockerhub user specified in the environment variable
-    # ${DOCKER_CACHE_REGISTRY} (typicall "mxnetci") under this name
-    image: ${DOCKER_CACHE_REGISTRY}/build.centos7_cpu:latest
+    # ${DOCKER_ECR_REGISTRY} (typicall "mxnetci") under this name
+    image: ${DOCKER_ECR_REGISTRY}/build.centos7_cpu:latest
     build:
       context: .
       dockerfile: Dockerfile.build.centos7
@@ -41,9 +41,9 @@ services:
         # BASE_IMAGE is used to dynamically specify the FROM image in Dockerfile.build.centos7
         BASE_IMAGE: centos:7
       cache_from:
-        - ${DOCKER_CACHE_REGISTRY}/build.centos7_cpu:latest
+        - ${DOCKER_ECR_REGISTRY}/build.centos7_cpu:latest
   centos7_gpu_cu100:
-    image: ${DOCKER_CACHE_REGISTRY}/build.centos7_gpu_cu100:latest
+    image: ${DOCKER_ECR_REGISTRY}/build.centos7_gpu_cu100:latest
     build:
       context: .
       dockerfile: Dockerfile.build.centos7
@@ -51,9 +51,9 @@ services:
       args:
         BASE_IMAGE: nvidia/cuda:10.0-cudnn7-devel-centos7
       cache_from:
-        - ${DOCKER_CACHE_REGISTRY}/build.centos7_gpu_cu100:latest
+        - ${DOCKER_ECR_REGISTRY}/build.centos7_gpu_cu100:latest
   centos7_gpu_cu101:
-    image: ${DOCKER_CACHE_REGISTRY}/build.centos7_gpu_cu101:latest
+    image: ${DOCKER_ECR_REGISTRY}/build.centos7_gpu_cu101:latest
     build:
       context: .
       dockerfile: Dockerfile.build.centos7
@@ -61,9 +61,9 @@ services:
       args:
         BASE_IMAGE: nvidia/cuda:10.1-cudnn7-devel-centos7
       cache_from:
-        - ${DOCKER_CACHE_REGISTRY}/build.centos7_gpu_cu101:latest
+        - ${DOCKER_ECR_REGISTRY}/build.centos7_gpu_cu101:latest
   centos7_gpu_cu102:
-    image: ${DOCKER_CACHE_REGISTRY}/build.centos7_gpu_cu102:latest
+    image: ${DOCKER_ECR_REGISTRY}/build.centos7_gpu_cu102:latest
     build:
       context: .
       dockerfile: Dockerfile.build.centos7
@@ -71,9 +71,9 @@ services:
       args:
         BASE_IMAGE: nvidia/cuda:10.2-cudnn8-devel-centos7
       cache_from:
-        - ${DOCKER_CACHE_REGISTRY}/build.centos7_gpu_cu102:latest
+        - ${DOCKER_ECR_REGISTRY}/build.centos7_gpu_cu102:latest
   centos7_gpu_cu110:
-    image: ${DOCKER_CACHE_REGISTRY}/build.centos7_gpu_cu110:latest
+    image: ${DOCKER_ECR_REGISTRY}/build.centos7_gpu_cu110:latest
     build:
       context: .
       dockerfile: Dockerfile.build.centos7
@@ -81,9 +81,9 @@ services:
       args:
         BASE_IMAGE: nvidia/cuda:11.0-cudnn8-devel-centos7
       cache_from:
-        - ${DOCKER_CACHE_REGISTRY}/build.centos7_gpu_cu110:latest
+        - ${DOCKER_ECR_REGISTRY}/build.centos7_gpu_cu110:latest
   centos7_gpu_cu112:
-    image: ${DOCKER_CACHE_REGISTRY}/build.centos7_gpu_cu112:latest
+    image: ${DOCKER_ECR_REGISTRY}/build.centos7_gpu_cu112:latest
     build:
       context: .
       dockerfile: Dockerfile.build.centos7
@@ -91,4 +91,4 @@ services:
       args:
         BASE_IMAGE: nvidia/cuda:11.2.1-cudnn8-devel-centos7
       cache_from:
-        - ${DOCKER_CACHE_REGISTRY}/build.centos7_gpu_cu112:latest
+        - ${DOCKER_ECR_REGISTRY}/build.centos7_gpu_cu112:latest

--- a/ci/docker/install/ubuntu_core.sh
+++ b/ci/docker/install/ubuntu_core.sh
@@ -45,7 +45,6 @@ apt-get install -y \
     libopencv-dev \
     libjpeg-turbo8-dev \
     libjpeg8-dev \
-    libturbojpeg0-dev \
     libzmq3-dev \
     libtinfo-dev \
     zlib1g-dev \
@@ -62,6 +61,11 @@ apt-get install -y \
 
 # Use libturbojpeg package as it is correctly compiled with -fPIC flag
 # https://github.com/HaxeFoundation/hashlink/issues/147
+#  libturbojpeg0-dev is not available on 16.04
+source /etc/os-release
+if [[ "$VERSION_ID" == "18.04" ]]; then
+    apt-get install -y libturbojpeg0-dev
+fi
 
 
 # CMake 3.13.2+ is required

--- a/ci/docker/install/ubuntu_core.sh
+++ b/ci/docker/install/ubuntu_core.sh
@@ -63,7 +63,7 @@ apt-get install -y \
 # https://github.com/HaxeFoundation/hashlink/issues/147
 #  libturbojpeg0-dev is not available on 16.04
 source /etc/os-release
-if [[ "$VERSION_ID" == "18.04" ]]; then
+if [[ "$VERSION_ID" != "16.04" ]]; then
     apt-get install -y libturbojpeg0-dev
 fi
 

--- a/ci/docker_cache.py
+++ b/ci/docker_cache.py
@@ -77,6 +77,8 @@ def _build_save_container(platform, registry, load_cache) -> Optional[str]:
     """
     # docker-compose
     if platform in build_util.DOCKER_COMPOSE_WHITELIST:
+        if "dkr.ecr" in registry:
+            _ecr_login(registry)
         build_util.build_docker(platform=platform, registry=registry, num_retries=10, no_cache=False)
         push_cmd = ['docker-compose', 'push', platform]
         subprocess.check_call(push_cmd)


### PR DESCRIPTION
The docker cache refresh pipeline is failing because one of our install scripts is attempting to install the `libturbojpeg0-dev` package on Ubuntu 16.04, and it is only provided on Ubuntu 18.04 and 20.04.

This PR checks the Ubuntu version and only installs if the ubuntu version is not 16.04.