### PR TITLE
[BUGFIX] enable test_fc_subgraph.py::test_fc_eltwise

### DIFF
--- a/src/operator/subgraph/mkldnn/mkldnn_fc-inl.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_fc-inl.h
@@ -33,9 +33,13 @@ namespace op {
 static inline bool SupportMKLDNNFCEltwiseFusion(const std::string op_name) {
   if (op_name == "Activation" ||
       op_name == "square" ||
+      op_name == "_npi_square" ||
       op_name == "sqrt" ||
+      op_name == "_npi_sqrt" ||
       op_name == "exp" ||
+      op_name == "_npi_exp" ||
       op_name == "abs" ||
+      op_name == "_npi_absolute" ||
       op_name == "clip" ||
       op_name == "LeakyReLU") {
     return true;
@@ -45,13 +49,13 @@ static inline bool SupportMKLDNNFCEltwiseFusion(const std::string op_name) {
 }
 
 static inline mkldnn::algorithm GetMKLDNNEltwiseAlgo(const std::string op_name) {
-  if (op_name == "square")
+  if (op_name == "square" || op_name == "_npi_square")
     return mkldnn::algorithm::eltwise_square;
-  else if (op_name == "sqrt")
+  else if (op_name == "sqrt" || op_name == "_npi_sqrt")
     return mkldnn::algorithm::eltwise_sqrt;
-  else if (op_name == "exp")
+  else if (op_name == "exp" || op_name == "_npi_exp")
     return mkldnn::algorithm::eltwise_exp;
-  else if (op_name == "abs")
+  else if (op_name == "abs" || op_name == "_npi_absolute")
     return mkldnn::algorithm::eltwise_abs;
   else
     LOG(FATAL) << "Unsupported eltwise fusion op: " << op_name;

--- a/src/operator/subgraph/mkldnn/mkldnn_fc_property.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_fc_property.h
@@ -113,11 +113,11 @@ class SgMKLDNNFCSelector : public SubgraphSelector {
           }
         }
         if (!quantized_ && (new_node.op() == Op::Get("square") ||
-            new_node.op() == Op::Get("_npi_square") ||
-            new_node.op() == Op::Get("sqrt") ||
-            new_node.op() == Op::Get("_npi_sqrt") ||
-            new_node.op() == Op::Get("exp") ||
-            new_node.op() == Op::Get("_npi_exp"))) {
+                            new_node.op() == Op::Get("_npi_square") ||
+                            new_node.op() == Op::Get("sqrt") ||
+                            new_node.op() == Op::Get("_npi_sqrt") ||
+                            new_node.op() == Op::Get("exp") ||
+                            new_node.op() == Op::Get("_npi_exp"))) {
           matched_list_.push_back(&new_node);
           status_ = kSuccess;
           return true;

--- a/src/operator/subgraph/mkldnn/mkldnn_fc_property.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_fc_property.h
@@ -113,13 +113,17 @@ class SgMKLDNNFCSelector : public SubgraphSelector {
           }
         }
         if (!quantized_ && (new_node.op() == Op::Get("square") ||
+            new_node.op() == Op::Get("_npi_square") ||
             new_node.op() == Op::Get("sqrt") ||
-            new_node.op() == Op::Get("exp"))) {
+            new_node.op() == Op::Get("_npi_sqrt") ||
+            new_node.op() == Op::Get("exp") ||
+            new_node.op() == Op::Get("_npi_exp"))) {
           matched_list_.push_back(&new_node);
           status_ = kSuccess;
           return true;
         }
-        if (new_node.op() == Op::Get("abs")) {
+        if (new_node.op() == Op::Get("abs") ||
+            new_node.op() == Op::Get("_npi_absolute")) {
           matched_list_.push_back(&new_node);
           status_ = kSuccess;
           return true;

--- a/tests/python/mkl/subgraphs/subgraph_common.py
+++ b/tests/python/mkl/subgraphs/subgraph_common.py
@@ -79,8 +79,6 @@ class CustomNormalInit(mx.init.Initializer):
 
     def _init_weight(self, _, arr):
         mx.np.random.normal(self.mean, self.sigma, arr.shape, dtype=arr.dtype, out=arr)
-        # import pdb
-        # pdb.set_trace()
         if self.bounded:
             mx.np.abs(arr, out=arr)
 

--- a/tests/python/mkl/subgraphs/subgraph_common.py
+++ b/tests/python/mkl/subgraphs/subgraph_common.py
@@ -71,13 +71,18 @@ class CustomNormalInit(mx.init.Initializer):
     """Initializes weights with random values sampled from a normal distribution
     with a custom mean and standard deviation of `sigma`.
     """
-    def __init__(self, mean=0, sigma=0.01):
-        super(CustomNormalInit, self).__init__(mean=mean, sigma=sigma)
+    def __init__(self, mean=0, sigma=0.01, bounded=False):
+        super(CustomNormalInit, self).__init__(mean=mean, sigma=sigma, bounded=bounded)
         self.mean = mean
         self.sigma = sigma
+        self.bounded = bounded
 
     def _init_weight(self, _, arr):
         mx.np.random.normal(self.mean, self.sigma, arr.shape, dtype=arr.dtype, out=arr)
+        # import pdb
+        # pdb.set_trace()
+        if self.bounded:
+            mx.np.abs(arr, out=arr)
 
 
 def check_qsym_calibrated(qsym, out_type, name='conv'):


### PR DESCRIPTION
fix numpy activation after fc fuse into subgraph

## Description ##
Enables test_fc_eltwise

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage

## Comments ##
Fixes second part of issue https://github.com/apache/incubator-mxnet/issues/20354
Abs of input for square_root operation was introduced because otherwise nan's were in output and asserts wouldn't accept nans on the same positions to be equal even if assert_almost_equal_with_err equal_nan=True