### PR TITLE
Update centos cu101 docker image to use cudnn8

### DIFF
--- a/ci/docker/docker-compose.yml
+++ b/ci/docker/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       dockerfile: Dockerfile.build.centos7
       target: base
       args:
-        BASE_IMAGE: nvidia/cuda:10.1-cudnn7-devel-centos7
+        BASE_IMAGE: nvidia/cuda:10.1-cudnn8-devel-centos7
       cache_from:
         - ${DOCKER_CACHE_REGISTRY}/build.centos7_gpu_cu101:latest
   centos7_gpu_cu102:


### PR DESCRIPTION
## Description ##
Update cu101 docker image to cudnn8. Attempt to fix CD test failure: https://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/restricted-mxnet-cd%2Fmxnet-cd-release-job/detail/mxnet-cd-release-job/3071/pipeline

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
