### PR TITLE
[DO NOT MERGE] CPU memory allocator using Transparent Huge Pages

### DIFF
--- a/include/mxnet/base.h
+++ b/include/mxnet/base.h
@@ -543,9 +543,7 @@ inline std::ostream& operator<<(std::ostream &out, const Context &ctx) {
 
 #if MXNET_USE_ONEDNN == 1 || MXNET_USE_INTGEMM == 1
 #ifdef __linux__
-  constexpr size_t kMKLDNNAlign = 1 << 21;
-#else
-  constexpr size_t kMKLDNNAlign = 4096ul;
+  constexpr size_t kMKLDNNAlign = 64;
 #endif
 #endif
 

--- a/include/mxnet/base.h
+++ b/include/mxnet/base.h
@@ -542,9 +542,7 @@ inline std::ostream& operator<<(std::ostream &out, const Context &ctx) {
 
 
 #if MXNET_USE_ONEDNN == 1 || MXNET_USE_INTGEMM == 1
-#ifdef __linux__
   constexpr size_t kMKLDNNAlign = 64;
-#endif
 #endif
 
 }  // namespace mxnet

--- a/include/mxnet/base.h
+++ b/include/mxnet/base.h
@@ -542,7 +542,11 @@ inline std::ostream& operator<<(std::ostream &out, const Context &ctx) {
 
 
 #if MXNET_USE_ONEDNN == 1 || MXNET_USE_INTGEMM == 1
-constexpr size_t kMKLDNNAlign = 64;
+#ifdef __linux__
+  constexpr size_t kMKLDNNAlign = 1 << 21;
+#else
+  constexpr size_t kMKLDNNAlign = 4096ul;
+#endif
 #endif
 
 }  // namespace mxnet

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -37,6 +37,7 @@
 #include <mxnet/graph_attr_types.h>
 #include <nnvm/graph_attr_types.h>
 
+#include <sys/mman.h>
 #include <memory>
 #include <vector>
 #include <type_traits>
@@ -958,14 +959,29 @@ MShadowTypeInfo mshadow_type_info(const int type_flag);
 inline bool AlignedMemAlloc(void** ptr, size_t size, size_t alignment) {
 #if _MSC_VER
   *ptr = _aligned_malloc(size, alignment);
-  if (*ptr == nullptr)
-    return false;
+  if (*ptr == nullptr) return false;
 #else
   int res = posix_memalign(ptr, alignment, size);
-  if (res != 0)
-    return false;
+  
+  constexpr size_t gHugePage2MB = 1 << 21;
+  if (size >= gHugePage2MB) {
+    res = posix_memalign(ptr, gHugePage2MB, size);
+    if (res == 0) {
+      madvise(ptr, size, MADV_HUGEPAGE);
+      return true;
+    } else {
+      res = posix_memalign(ptr, alignment, size);
+      if (res == 0) {
+        return true;
+      }
+    }
+  } else {
+    if (res == 0) {
+      return true;
+    }
+  }
 #endif
-  return true;
+  return false;
 }
 
 inline void AlignedMemFree(void* ptr) {


### PR DESCRIPTION
## Description ##
[Performance optimization] . This pull-request aims in the cpu-memory allocator. Typically, the size of a memory page is 4 KB. However, the modern operating system is able to support 2MB memory pages. This may improve performance results on a CPU in some scenarios. 

# How to measure? 
Basically: ways were used to measure the impact (a few of them), as following:
1. The first thing to measure is the number of TLB misses
2. The second thing to measure is the number of TLB misses
3. How much those misses cost for the CPU.

* Setting: Let’s turn the THP on.

# Result #
## After ##
### Perf: event aliases for dTLB ###
1. dTLB-loads and dTLB-load-misses (data loads) 
2. dTLB-stores and dTLB-store-misses for data stores hits and misses 
```
     35.957945866         5918306862      dTLB-loads
     35.957945866            3793195      dTLB-load-misses          #    0,03% of all dTLB cache hits
     35.957945866         1081002566      dTLB-stores
     35.957945866             831964      dTLB-store-misses
 = 1085627725 of TLB misses.
```
### Perf: event aliases for iTLB ###
1. iTLB-Load and iTLB-load-misses  
```
     35.518704631            5355733      iTLB-load
     35.518704631             346871      iTLB-load-misses          #    1,62% of all iTLB cache hits
 = 346871  of iTLB misses ~ 1,62% of all iTLB cache hits
 ```
 Let’s take a look at how much those misses cost for the CPU:
 ```
    35.569491823         5624072755      cycles
    35.569491823           48401471      dcycles
    35.569491823           13984776      icycles
 ```
 More than **90%** of CPU cycles were spent doing the page table walking
 
 ## Before ##
### Perf: event aliases for dTLB ###
1. dTLB-loads and dTLB-load-misses (data loads) 
2. dTLB-stores and dTLB-store-misses for data stores hits and misses 
```
    36.257627478        11048485906      dTLB-loads
    36.257627478            8580404      dTLB-load-misses          #    0,06% of all dTLB cache hits
    36.257627478         2244357468      dTLB-stores
    36.257627478            1529163      dTLB-store-misses
 = 2254467035 of TLB misses.
```
### Perf: event aliases for iTLB ###
1. iTLB-Load and iTLB-load-misses  
```
    35.004442377           17154527      iTLB-load
    35.004442377            1043883       iTLB-load-misses          #    4,75% of all iTLB cache hits
 = 1043883  of iTLB misses ~  4,75% of all iTLB cache hits
 ```
 Let’s take a look at how much those misses cost for the CPU:
 ```
    35.111981425        21648496310      cycles
    35.111981425          159387423      dcycles
    35.111981425           51165398      icycles
 ```
 More than 97% of CPU cycles were spent doing the page table walking
 
 
## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
