### PR TITLE
[v2.0] Add Optim Warning

### DIFF
--- a/python/mxnet/optimizer/adagrad.py
+++ b/python/mxnet/optimizer/adagrad.py
@@ -60,10 +60,13 @@ class AdaGrad(Optimizer):
         otherwise, fused_step is called.
 
     """
-    def __init__(self, learning_rate=0.01, epsilon=1e-6, use_fused_step=True, **kwargs):
+    def __init__(self, learning_rate=0.01, epsilon=1e-6, use_fused_step=True, eps=None, **kwargs):
         super(AdaGrad, self).__init__(learning_rate=learning_rate,
                                       use_fused_step=use_fused_step,
                                       **kwargs)
+        if eps is not None:
+            raise DeprecationWarning(
+                'parameter \'eps\' is deprecated. Please use \'epsilon\' instead...')
         self.epsilon = epsilon
 
     def create_state(self, index, weight):

--- a/python/mxnet/optimizer/adagrad.py
+++ b/python/mxnet/optimizer/adagrad.py
@@ -60,13 +60,13 @@ class AdaGrad(Optimizer):
         otherwise, fused_step is called.
 
     """
-    def __init__(self, learning_rate=0.01, epsilon=1e-6, use_fused_step=True, eps=None, **kwargs):
+    def __init__(self, learning_rate=0.01, epsilon=1e-6, use_fused_step=True, **kwargs):
+        if kwargs.get("eps") is not None:
+            raise DeprecationWarning(
+                'parameter \'eps\' is deprecated. Please use \'epsilon\' instead...')
         super(AdaGrad, self).__init__(learning_rate=learning_rate,
                                       use_fused_step=use_fused_step,
                                       **kwargs)
-        if eps is not None:
-            raise DeprecationWarning(
-                'parameter \'eps\' is deprecated. Please use \'epsilon\' instead...')
         self.epsilon = epsilon
 
     def create_state(self, index, weight):

--- a/python/mxnet/optimizer/rmsprop.py
+++ b/python/mxnet/optimizer/rmsprop.py
@@ -69,10 +69,16 @@ class RMSProp(Optimizer):
     """
     def __init__(self, learning_rate=0.001, rho=0.9, momentum=0.9,
                  epsilon=1e-8, centered=False, clip_weights=None,
-                 use_fused_step=True, **kwargs):
+                 use_fused_step=True, gamma1=None, gamma2=None, **kwargs):
         super(RMSProp, self).__init__(learning_rate=learning_rate,
                                       use_fused_step=use_fused_step,
                                       **kwargs)
+        if gamma1 is not None:
+            raise DeprecationWarning(
+                'parameter \'gamma1\' is deprecated. Please use \'rho\' instead...')
+        if gamma2 is not None:
+            raise DeprecationWarning(
+                'parameter \'gamma2\' is deprecated. Please use \'momentum\' instead...')
         self.rho = rho
         self.momentum = momentum
         self.centered = centered

--- a/python/mxnet/optimizer/rmsprop.py
+++ b/python/mxnet/optimizer/rmsprop.py
@@ -69,16 +69,16 @@ class RMSProp(Optimizer):
     """
     def __init__(self, learning_rate=0.001, rho=0.9, momentum=0.9,
                  epsilon=1e-8, centered=False, clip_weights=None,
-                 use_fused_step=True, gamma1=None, gamma2=None, **kwargs):
+                 use_fused_step=True, **kwargs):
+        if kwargs.get("gamma1") is not None:
+            raise DeprecationWarning(
+                'parameter \'gamma1\' is deprecated. Please use \'rho\' instead...')
+        if kwargs.get("gamma2") is not None:
+            raise DeprecationWarning(
+                'parameter \'gamma2\' is deprecated. Please use \'momentum\' instead...')
         super(RMSProp, self).__init__(learning_rate=learning_rate,
                                       use_fused_step=use_fused_step,
                                       **kwargs)
-        if gamma1 is not None:
-            raise DeprecationWarning(
-                'parameter \'gamma1\' is deprecated. Please use \'rho\' instead...')
-        if gamma2 is not None:
-            raise DeprecationWarning(
-                'parameter \'gamma2\' is deprecated. Please use \'momentum\' instead...')
         self.rho = rho
         self.momentum = momentum
         self.centered = centered


### PR DESCRIPTION
## Description ##
Optimizers in MXNet2.0 are refactored and some have new keyword name for the parameters, like adagrad(eps->epsilon), rmsprop(gamma1->rho, gamma2->momentum). It will be confusing for users who migrate from v1.x to find that using rmsprop could raise the following error: 
```
Traceback (most recent call last):
  File "optimizer_update.py", line 16, in <module>
    rmsprop_optimizer = optimizer.RMSProp(learning_rate=0.001, gamma1=0.9, gamma2=0.9, epsilon=1e-07, centered=False)
  File "/home/ubuntu/workspace/incubator-mxnet/python/mxnet/optimizer/rmsprop.py", line 73, in __init__
    super(RMSProp, self).__init__(learning_rate=learning_rate,
  File "/home/ubuntu/workspace/incubator-mxnet/python/mxnet/optimizer/optimizer.py", line 96, in __init__
    super(Optimizer, self).__init__(**kwargs)
TypeError: object.__init__() takes exactly one argument (the instance to initialize)
```
This PR will add warnings for deprecated parameters in the following optimizers: 
1. adagrad: 
    - eps -> epsilon
2. rmsprop:
    - gamma1 -> rho
    - gamma2 -> momentum   

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
