### PR TITLE
[v1.9.x] Test update to scipy to 1.4.1

### DIFF
--- a/ci/docker/install/requirements
+++ b/ci/docker/install/requirements
@@ -30,6 +30,6 @@ numpy>1.16.0,<1.19.0  # Restrict numpy version to < 1.19.0 due to https://github
 pylint==2.3.1  # pylint and astroid need to be aligned
 astroid==2.3.3  # pylint and astroid need to be aligned
 requests<2.19.0,>=2.18.4
-scipy==1.2.1
+scipy==1.4.1
 setuptools
 coverage

--- a/ci/docker/install/ubuntu_caffe.sh
+++ b/ci/docker/install/ubuntu_caffe.sh
@@ -55,5 +55,8 @@ ln -s /usr/lib/x86_64-linux-gnu/libhdf5_serial_hl.so.10.0.2 /usr/lib/x86_64-linu
 
 make all pycaffe -j$(nproc)
 
-cd python
-for req in $(cat requirements.txt); do pip3 install $req; done
+# do not install requirements from caffe's requirements.txt, as they are overwriting our specific versions in
+#  ci/docker/install/requirements. Instead, we need to add the required dependencies for caffe to 
+#  ci/docker/install/requirements
+# cd python
+# for req in $(cat requirements.txt); do pip3 install $req; done


### PR DESCRIPTION
Testing if updating scipy to 1.4.1 (master branch uses this version) to see if the rand unit tests that are failing will stabilize.