### PR TITLE
[FEATURE] Add backend MXGetMaxSupportedArch() and frontend get_rtc_compile_opts() for CUDA enhanced compatibility

### DIFF
--- a/include/mxnet/c_api_test.h
+++ b/include/mxnet/c_api_test.h
@@ -91,6 +91,13 @@ MXNET_DLL int MXGetEnv(const char* name,
 MXNET_DLL int MXSetEnv(const char* name,
                        const char* value);
 
+/*!
+ * \brief Get the maximum SM architecture supported by the nvrtc compiler
+ * \param max_arch The maximum supported architecture (e.g. would be 80, if Ampere)
+ * \return 0 when success, -1 when failure happens.
+ */
+MXNET_DLL int MXGetMaxSupportedArch(uint32_t *max_arch);
+
 #ifdef __cplusplus
 }
 #endif  // __cplusplus

--- a/python/mxnet/test_utils.py
+++ b/python/mxnet/test_utils.py
@@ -50,6 +50,7 @@ from .ndarray.ndarray import _STORAGE_TYPE_STR_TO_ID
 from .symbol import Symbol
 from .symbol.numpy import _Symbol as np_symbol
 from .util import use_np, use_np_default_dtype, getenv, setenv  # pylint: disable=unused-import
+from .util import get_max_supported_compute_capability, get_rtc_compile_opts # pylint: disable=unused-import
 from .runtime import Features
 from .numpy_extension import get_cuda_compute_capability
 

--- a/python/mxnet/util.py
+++ b/python/mxnet/util.py
@@ -1176,3 +1176,27 @@ def setenv(name, value):
     """
     passed_value = None if value is None else c_str(value)
     check_call(_LIB.MXSetEnv(c_str(name), passed_value))
+
+
+def get_max_supported_compute_capability():
+    """Get the maximum compute capability (SM arch) supported by the nvrtc compiler
+    """
+    max_supported_cc = ctypes.c_int()
+    check_call(_LIB.MXGetMaxSupportedArch(ctypes.byref(max_supported_cc)))
+    return max_supported_cc.value
+
+
+def get_rtc_compile_opts(ctx):
+    """Get the compile ops suitable for the context, given the toolkit/driver config
+    """
+    device_cc = get_cuda_compute_capability(ctx)
+    max_supported_cc = get_max_supported_compute_capability()
+
+    # CUDA toolkits starting with 11.1 (first to support arch 86) can compile directly to SASS
+    can_compile_to_SASS = max_supported_cc >= 86
+    should_compile_to_SASS = can_compile_to_SASS and \
+                             device_cc <= max_supported_cc
+    device_cc_as_used = min(device_cc, max_supported_cc)
+    arch_opt = "--gpu-architecture={}_{}".format("sm" if should_compile_to_SASS else "compute",
+                                                 device_cc_as_used)
+    return [arch_opt]

--- a/python/mxnet/util.py
+++ b/python/mxnet/util.py
@@ -875,7 +875,7 @@ def get_cuda_compute_capability(ctx):
         raise ValueError('Expecting a gpu context to get cuda compute capability, '
                          'while received ctx {}'.format(str(ctx)))
 
-    libnames = ('libcuda.so', 'libcuda.dylib', 'cuda.dll')
+    libnames = ('libcuda.so', 'libcuda.dylib', 'nvcuda.dll', 'cuda.dll')
     for libname in libnames:
         try:
             cuda = ctypes.CDLL(libname)

--- a/src/c_api/c_api_test.cc
+++ b/src/c_api/c_api_test.cc
@@ -26,6 +26,7 @@
 #include <nnvm/pass.h>
 #include "./c_api_common.h"
 #include "../operator/subgraph/subgraph_property.h"
+#include "../common/cuda/rtc.h"
 
 int MXBuildSubgraphByOpNames(SymbolHandle sym_handle,
                               const char* prop_name,
@@ -125,6 +126,16 @@ int MXSetEnv(const char* name,
     unsetenv(name);
   else
     setenv(name, value, 1);
+#endif
+  API_END();
+}
+
+int MXGetMaxSupportedArch(uint32_t *max_arch) {
+  API_BEGIN();
+#if MXNET_USE_CUDA
+  *max_arch = static_cast<uint32_t>(mxnet::common::cuda::rtc::GetMaxSupportedArch());
+#else
+  LOG(FATAL) << "Compile with USE_CUDA=1 to have CUDA runtime compilation.";
 #endif
   API_END();
 }

--- a/src/common/cuda/rtc.h
+++ b/src/common/cuda/rtc.h
@@ -53,6 +53,8 @@ std::string to_string(OpReqType req);
 
 }  // namespace util
 
+int GetMaxSupportedArch();
+
 extern std::mutex lock;
 
 /*! \brief Compile and get the GPU kernel. Uses cache in order to

--- a/src/common/rtc.cc
+++ b/src/common/rtc.cc
@@ -44,8 +44,8 @@ CudaModule::Chunk::Chunk(
       << "For lower version of CUDA, please prepend your kernel defintiions "
       << "with extern \"C\" instead.";
 #endif
-  std::vector<const char*> c_options(options.size());
-  for (const auto& i : options) c_options.emplace_back(i.c_str());
+  std::vector<const char*> c_options;
+  for (const auto& i : options) c_options.push_back(i.c_str());
   nvrtcResult compile_res = nvrtcCompileProgram(prog_, c_options.size(), c_options.data());
   if (compile_res != NVRTC_SUCCESS) {
     size_t err_size;


### PR DESCRIPTION
## Description ##
This PR makes RTC (as invoked by our Python unittests and other model scripts) work with CUDA enhanced compatibility. 
 As such, it is an extension of PR https://github.com/apache/incubator-mxnet/pull/19364, which brought that functionality to the C++ backend.  This PR keeps test_operator_gpu.py::test_cuda_rtc from failing on systems that rely on CUDA enhanced compatibility, though those systems may not be part of upstream CI at present.
 
The changes of this PR are:
- break off the calculation of the max supported arch into a separate function GetMaxSupportedArch(), and enhance it to use nvrtcGetSupportedArchs() if CUDA_VERSION >= 11.2
- wrap GetMaxSupportedArch() as MXGetMaxSupportedArch() and add it to the C api
- use MXGetMaxSupportedArch() in a newly created Python utility function get_rtc_compile_opts(ctx)
- enhance test_cuda_rtc to use this new function

Our current approach to RTC in Python code, which might fail under CUDA enhanced compatibility:
```
module = mx.rtc.CudaModule(source)
```
With this PR, the new approach that succeeds under CUDA enhanced compatibility:
```
ctx = < some GPU context, e.g. mx.gpu(0) >
module = mx.rtc.CudaModule(source, options=get_rtc_compile_opts(ctx))
```
get_rtc_compile_opts() will return a list of options that is most appropriate for the system and the gpu context.  Currently this is a single option of the form `--gpu-architecture=compute_NN` or `--gpu-architecture=sm_NN` as needed.
## Background ##
Starting with CUDA 11.1, a user can accept minor release upgrades of the CUDA toolkit (potentially picking up support for a newer GPU arch) without upgrading the driver (per https://docs.nvidia.com/deploy/cuda-compatibility/index.html).  In such cases, the toolkit nvrtc compile toolchain should not only compile CUDA code to PTX, but also further translate the PTX to SASS, since the driver would be unable to JIT-compile to SASS for the newer GPU arch.  This is controlled by the nvrtc compiler option used: for example, to compile to SASS for the Ampere A100 the option is `--gpu-architecture=sm_80`.  To compile only to PTX, and so rely on the driver's ability to JIT-compile to SASS, the option is `--gpu-architecture=compute_80`.


## Checklist ##
### Essentials ###
- [X] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [~] All changes have test coverage [Verified privately, but ideally upstream's CI would have systems that stress this PR]
- [X] Code is well-documented

