### PR TITLE
[WIP][FEATURE][CONTRIB] Spatial parallel convolution support

### DIFF
--- a/3rdparty/mshadow/mshadow/base.h
+++ b/3rdparty/mshadow/mshadow/base.h
@@ -200,6 +200,10 @@ extern "C" {
   #include <cudnn.h>
 #endif
 
+#if MXNET_USE_NCCL == 1
+  #include <nccl.h>
+#endif
+
 #if MSHADOW_USE_CUTENSOR == 1
   #include <cutensor.h>
 #endif
@@ -380,6 +384,9 @@ struct DataType<float> {
   static const cudnnDataType_t kCudnnFlag = CUDNN_DATA_FLOAT;
   typedef float ScaleType;
 #endif
+#if MXNET_USE_NCCL
+  static const ncclDataType_t kNCCLFlag = ncclFloat32;
+#endif
 #endif
 };
 template<>
@@ -394,6 +401,9 @@ struct DataType<double> {
   static const cudnnDataType_t kCudnnFlag = CUDNN_DATA_DOUBLE;
   typedef double ScaleType;
 #endif
+#if MXNET_USE_NCCL
+  static const ncclDataType_t kNCCLFlag = ncclFloat64;
+#endif
 #endif
 };
 template<>
@@ -407,6 +417,9 @@ struct DataType<half::half_t> {
 #if MSHADOW_USE_CUDNN
   static const cudnnDataType_t kCudnnFlag = CUDNN_DATA_HALF;
   typedef float ScaleType;
+#endif
+#if MXNET_USE_NCCL
+  static const ncclDataType_t kNCCLFlag = ncclFloat16;
 #endif
 #endif
 };
@@ -428,6 +441,9 @@ struct DataType<uint8_t> {
   static const cudnnDataType_t kCudnnFlag = CUDNN_DATA_INT8;
   typedef uint8_t ScaleType;
 #endif
+#if MXNET_USE_NCCL
+  static const ncclDataType_t kNCCLFlag = ncclUint8;
+#endif
 #endif
 };
 template<>
@@ -441,6 +457,9 @@ struct DataType<int8_t> {
 #if (MSHADOW_USE_CUDNN == 1 && CUDNN_MAJOR >= 6)
   static const cudnnDataType_t kCudnnFlag = CUDNN_DATA_INT8;
   typedef int8_t ScaleType;
+#endif
+#if MXNET_USE_NCCL
+  static const ncclDataType_t kNCCLFlag = ncclInt8;
 #endif
 #endif
 };
@@ -456,12 +475,18 @@ struct DataType<int32_t> {
   static const cudnnDataType_t kCudnnFlag = CUDNN_DATA_INT32;
   typedef int32_t ScaleType;
 #endif
+#if MXNET_USE_NCCL
+  static const ncclDataType_t kNCCLFlag = ncclInt32;
+#endif
 #endif
 };
 template<>
 struct DataType<int64_t> {
   static const int kFlag = kInt64;
   static const int kLanes = 1;
+#if MXNET_USE_NCCL
+  static const ncclDataType_t kNCCLFlag = ncclInt64;
+#endif
 };
 template<>
 struct DataType<bool> {

--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -502,6 +502,14 @@ MXNET_DLL int MXEngineSetBulkSize(int bulk_size, int* prev_bulk_size);
 MXNET_DLL int MXGetGPUCount(int* out);
 
 /*!
+ * \brief Get the compute capability of a given GPU.
+ * \param dev the GPU number to query
+ * \param out pointer to integer that will hold the compute capability of the queried GPU.
+ * \return 0 when success, -1 when failure happens.
+ */
+MXNET_DLL int MXGetGPUSMArch(int dev, int* out);
+
+/*!
  * \brief get the free and total available memory on a GPU
  *  Note: Deprecated, use MXGetGPUMemoryInformation64 instead.
  * \param dev the GPU number to query

--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -529,6 +529,21 @@ MXNET_DLL int MXGetGPUMemoryInformation(int dev, int *free_mem, int *total_mem);
 MXNET_DLL int MXGetGPUMemoryInformation64(int dev, uint64_t *free_mem, uint64_t *total_mem);
 
 /*!
+ * \brief Get the size of the NCCL unique id (in bytes).
+ * \param size pointer to integer that will hold the NCCL unique id size.
+ * \return 0 when success, -1 when failure happens.
+ */
+MXNET_DLL int MXNCCLGetUniqueIdSize(int* size);
+
+/*!
+ * \brief Get the NCCL unique id.
+ * \param out pointer to an array that will hold the NCCL unique id. It has to be at least of the
+ *            size returned by MXNCCLGetUniqueIdSize.
+ * \return 0 when success, -1 when failure happens.
+ */
+MXNET_DLL int MXNCCLGetUniqueId(void* out);
+
+/*!
  * \brief get the MXNet library version as an integer
  * \param pointer to the integer holding the version number
  * \return 0 when success, -1 when failure happens

--- a/include/mxnet/resource.h
+++ b/include/mxnet/resource.h
@@ -40,16 +40,22 @@ struct ResourceRequest {
   /*! \brief Resource type, indicating what the pointer type is */
   enum Type {
     /*! \brief mshadow::Random<xpu> object */
-    kRandom,
+    kRandom = 0,
     /*! \brief A dynamic temp space that can be arbitrary size */
-    kTempSpace,
+    kTempSpace = 1,
     /*! \brief common::RandGenerator<xpu> object, which can be used in GPU kernel functions */
-    kParallelRandom
+    kParallelRandom = 2
 #if MXNET_USE_CUDNN == 1
     ,
     /*! \brief cudnnDropoutDescriptor_t object for GPU dropout kernel functions */
-    kCuDNNDropoutDesc
+    kCuDNNDropoutDesc = 3
 #endif  // MXNET_USE_CUDNN == 1
+#if MXNET_USE_CUDA
+    ,
+    /*! \brief Resource indicating the usage of multi GPU communication, used to prevent
+     *         multiple ops of doing it at the same time */
+    kMultiGPUComm = 4
+#endif  // MXNET_USE_CUDA == 1
   };
   /*! \brief type of resources */
   Type type;

--- a/python/mxnet/context.py
+++ b/python/mxnet/context.py
@@ -245,6 +245,23 @@ def num_gpus():
     check_call(_LIB.MXGetGPUCount(ctypes.byref(count)))
     return count.value
 
+def gpu_sm_arch(device_id=0):
+    """Query CUDA for the GPU's streaming multiprocessor (SM) architecture.
+
+    Raises
+    ------
+    Will raise an exception on any CUDA error.
+
+    Returns
+    -------
+    sm_arch : int (= 10 * compute_capability_major + compute_capability_minor)
+        The SM arch, e.g. 70 for Volta.
+
+    """
+    arch = ctypes.c_int()
+    dev_id = ctypes.c_int(device_id)
+    check_call(_LIB.MXGetGPUSMArch(dev_id, ctypes.byref(arch)))
+    return arch.value
 
 def gpu_memory_info(device_id=0):
     """Query CUDA for the free and total bytes of GPU global memory.

--- a/python/mxnet/gluon/contrib/nn/__init__.py
+++ b/python/mxnet/gluon/contrib/nn/__init__.py
@@ -16,10 +16,11 @@
 # under the License.
 
 # coding: utf-8
-"""Contrib neural network module."""
+# pylint: disable=wildcard-import
+"""Contributed neural network modules."""
 
-from . import data
+from . import conv_layers
 
-from . import estimator
+from .conv_layers import *
 
-from . import nn
+__all__ = conv_layers.__all__

--- a/python/mxnet/gluon/contrib/nn/conv_layers.py
+++ b/python/mxnet/gluon/contrib/nn/conv_layers.py
@@ -1,0 +1,461 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# coding: utf-8
+# pylint: disable= arguments-differ
+"""Custom convolutional neural network layers."""
+
+__all__ = ['SpatialParallelConv2D', 'SpatialParallelConv3D',
+           'SpatialParallelSplit', 'SpatialParallelAllgather']
+
+from ...block import HybridBlock
+from .... import symbol
+from ....base import numeric_types, check_call, _LIB
+from ...nn.activations import Activation
+from ....util import is_np_array
+
+def _infer_weight_shape(op_name, data_shape, kwargs):
+    data = symbol.var('data', shape=data_shape)
+    if is_np_array():
+        op = getattr(symbol.npx, op_name)
+        data = data.as_np_ndarray()
+    else:
+        op = getattr(symbol, op_name)
+    sym = op(data, **kwargs)
+    return sym.infer_shape_partial()[0]
+
+class _SpatialParallelHelper(object):
+    _init = False
+    nccl_id = None
+    num_gpus = None
+    rank = None
+
+    @staticmethod
+    def init(num_gpus):
+        """Communicate the NCCL unique id"""
+        cls = _SpatialParallelHelper
+        if not cls._init:
+            cls._init = True
+            import ctypes
+            try:
+                from mpi4py import MPI
+            except:
+                raise ImportError("Spatial parallel modules require mpi4py package.")
+            import numpy as np
+            nccl_id_size = ctypes.c_int()
+            check_call(_LIB.MXNCCLGetUniqueIdSize(ctypes.byref(nccl_id_size)))
+            nccl_id_size = nccl_id_size.value
+            cls.nccl_id = np.zeros(nccl_id_size, np.byte)
+            check_call(_LIB.MXNCCLGetUniqueId(
+                cls.nccl_id.ctypes.data_as(ctypes.c_void_p)))
+            global_comm = MPI.COMM_WORLD
+            rank = global_comm.rank
+            color = rank / num_gpus
+            comm = global_comm.Split(color, rank)
+            comm.Bcast([cls.nccl_id, nccl_id_size, MPI.BYTE], root=0)
+            cls.num_gpus = num_gpus
+            cls.rank = rank % num_gpus
+        assert num_gpus == cls.num_gpus, ("All of the spatial parallel "
+                                          "operations need to span the same number of GPUs")
+
+
+
+class _SpatialParallelConv(HybridBlock):
+    """Abstract nD spatial convolution layer (private, used as implementation base).
+    It requires launching the script using MPI and single GPU per process.
+
+    This layer creates a convolution kernel that is convolved
+    with the layer input residing on multiple GPUs to produce a tensor of outputs.
+    If `use_bias` is `True`, a bias vector is created and added to the outputs.
+    Finally, if `activation` is not `None`,
+    it is applied to the outputs as well.
+
+    Parameters
+    ----------
+    num_gpus : int
+        Specify the number of GPUs participating to compute the single convolution.
+    channels : int
+        The dimensionality of the output space
+        i.e. the number of output channels in the convolution.
+    kernel_size : int or tuple/list of n ints
+        Specifies the dimensions of the convolution window.
+    strides: int or tuple/list of n ints,
+        Specifies the strides of the convolution.
+    padding : int or tuple/list of n ints,
+        If padding is non-zero, then the input is implicitly zero-padded
+        on both sides for padding number of points
+    groups : int
+        Controls the connections between inputs and outputs.
+        At groups=1, all inputs are convolved to all outputs.
+        At groups=2, the operation becomes equivalent to having two convolution
+        layers side by side, each seeing half the input channels, and producing
+        half the output channels, and both subsequently concatenated.
+    layout : str,
+        Dimension ordering of data and weight. Can be 'NWC',
+        'NHWC', 'NDHWC', etc. 'N', 'C', 'H', 'W', 'D' stands for
+        batch, channel, height, width and depth dimensions respectively.
+        Convolution is performed over 'D', 'H', and 'W' dimensions.
+        The spatial partitioning across different GPUs happens on the
+        outermost dimension (e.g. 'H' in 2D case or 'D' in the 3D case).
+    in_channels : int, default 0
+        The number of input channels to this layer. If not specified,
+        initialization will be deferred to the first time `forward` is called
+        and `in_channels` will be inferred from the shape of input data.
+    activation : str
+        Activation function to use. See :func:`~mxnet.ndarray.Activation`.
+        If you don't specify anything, no activation is applied
+        (ie. "linear" activation: `a(x) = x`).
+    use_bias: bool
+        Whether the layer uses a bias vector.
+    weight_initializer : str or `Initializer`
+        Initializer for the `weight` weights matrix.
+    bias_initializer: str or `Initializer`
+        Initializer for the bias vector.
+    cudnn_algo_fwd: int, default '-1'
+        The cuDNN Convolution algorithm for forward computation.
+        Value of '0' denotes the implicit GEMM algorithm. For
+        more details refer to cuDNN documentation on cudnnConvolutionFwdAlgo_t.
+    cudnn_algo_bwd_data: int, default '-1'
+        The cuDNN Convolution algorithm for backward computation for data.
+    cudnn_algo_bwd_filter: int, default '-1'
+        The cuDNN Convolution algorithm for backward computation for filter.
+    cudnn_tensor_core_only: bool, default False
+        Whether to force cuDNN Convolution algorithm to use tensor cores.
+    cudnn_algo_verbose : boolean, optional, default=False
+        Verboseness of algo selection. 1 = output selection, 0 = no output
+    cudnn_algo_fwd_prec : {'None', 'float16', 'float32', 'float64'}, optional, default='None'
+        Precision of the computation of the forward convolution kernel.
+        Default is the tensor data type, or float32 if the tensor data
+        type is float16.
+    cudnn_algo_bwd_prec : {'None', 'float16', 'float32', 'float64'}, optional, default='None'
+        Precision of the computation of the back-prop kernels.
+        Default is the tensor data type, or float32 if the tensor data
+        type is float16.
+    workspace: int, default 1024
+         Maximum temporary workspace allowed (MB) in convolution.
+         This parameter has two usages. When CUDNN is not used, it determines
+         the effective batch size of the convolution kernel. When CUDNN is used,
+         it controls the maximum temporary storage used for tuning the best CUDNN
+         kernel when limited_workspace strategy is used. A large number leads to
+         more (GPU) memory usage but may improve the performance.
+    """
+    def __init__(self, num_gpus, channels, kernel_size, strides, padding,
+                 groups, layout, in_channels=0, activation=None, use_bias=True,
+                 weight_initializer=None, bias_initializer='zeros',
+                 op_name='SpatialParallelConvolution', adj=None, prefix=None, params=None,
+                 cudnn_algo_fwd=-1, cudnn_algo_bwd_data=-1, cudnn_algo_bwd_filter=-1,
+                 cudnn_tensor_core_only=False, cudnn_algo_verbose=False,
+                 cudnn_algo_fwd_prec='None', cudnn_algo_bwd_prec='None',
+                 workspace=1024):
+        super(_SpatialParallelConv, self).__init__(prefix=prefix, params=params)
+        helper = _SpatialParallelHelper
+
+        helper.init(num_gpus)
+        with self.name_scope():
+            self._channels = channels
+            self._in_channels = in_channels
+            if isinstance(strides, numeric_types):
+                strides = (strides,)*len(kernel_size)
+            if isinstance(padding, numeric_types):
+                padding = (padding,)*len(kernel_size)
+            assert kernel_size[0] % 2 != 0, \
+                "Only supports odd values for the kernel_size[0] for now."
+            assert padding[0] == int((kernel_size[0] - 1) / 2), \
+                "Only supports padding[0] equal to the half of kernel_size[0] - 1 for now."
+            self._op_name = op_name
+            self._kwargs = {
+                'kernel': kernel_size, 'stride': strides,
+                'pad': padding, 'num_filter': channels, 'num_group': groups,
+                'no_bias': not use_bias, 'layout': layout,
+                'num_gpus': num_gpus,
+                'rank': helper.rank,
+                'cudnn_algo_fwd': cudnn_algo_fwd,
+                'cudnn_algo_bwd_data': cudnn_algo_bwd_data,
+                'cudnn_algo_bwd_filter': cudnn_algo_bwd_filter,
+                'cudnn_tensor_core_only': cudnn_tensor_core_only,
+                'cudnn_algo_verbose': cudnn_algo_verbose,
+                'cudnn_algo_fwd_prec': cudnn_algo_fwd_prec,
+                'cudnn_algo_bwd_prec': cudnn_algo_bwd_prec,
+                'workspace': workspace,
+                'nccl_unique_id': helper.nccl_id.ctypes.data}
+            if adj is not None:
+                self._kwargs['adj'] = adj
+
+            if is_np_array():
+                dshape = [-1]*(len(kernel_size) + 2)
+            else:
+                dshape = [0]*(len(kernel_size) + 2)
+
+            dshape[layout.find('N')] = 1
+            dshape[layout.find('C')] = in_channels
+            wshapes = _infer_weight_shape(op_name, dshape, self._kwargs)
+            if kernel_size in [(1, 1), (1, 1, 1)]:
+                self._spatial = False
+                self._op_name = self._op_name.replace("SpatialParallel", "")
+                self._kwargs.pop('num_gpus')
+                self._kwargs.pop('nccl_unique_id')
+                self._kwargs.pop('rank')
+            else:
+                self._spatial = True
+            self.weight = self.params.get('weight', shape=wshapes[1],
+                                          init=weight_initializer,
+                                          allow_deferred_init=True)
+            if use_bias:
+                self.bias = self.params.get('bias', shape=wshapes[2],
+                                            init=bias_initializer,
+                                            allow_deferred_init=True)
+            else:
+                self.bias = None
+
+            if activation is not None:
+                self.act = Activation(activation, prefix=activation+'_')
+            else:
+                self.act = None
+
+    def hybrid_forward(self, F, x, weight, bias=None):
+        if is_np_array():
+            F = F.npx
+        if bias is None:
+            act = getattr(F, self._op_name)(x, weight=weight, name='fwd', **self._kwargs)
+        else:
+            act = getattr(F, self._op_name)(x, weight=weight, bias=bias, name='fwd', **self._kwargs)
+        if self.act is not None:
+            act = self.act(act)
+        return act
+
+    def _alias(self):
+        return 'spatialparallelconv'
+
+    def __repr__(self):
+        s = '{name}({mapping}, num_gpus={num_gpus}, kernel_size={kernel}, stride={stride}'
+        len_kernel_size = len(self._kwargs['kernel'])
+        if self._kwargs['pad'] != (0,) * len_kernel_size:
+            s += ', padding={pad}'
+        if hasattr(self, 'out_pad') and self.out_pad != (0,) * len_kernel_size:
+            s += ', output_padding={out_pad}'.format(out_pad=self.out_pad)
+        if self._kwargs['num_group'] != 1:
+            s += ', groups={num_group}'
+        if self.bias is None:
+            s += ', bias=False'
+        if self.act:
+            s += ', {}'.format(self.act)
+        s += ')'
+        shape = self.weight.shape
+        return s.format(name=self.__class__.__name__,
+                        mapping='{0} -> {1}'.format(shape[1] if shape[1] else None, shape[0]),
+                        **self._kwargs)
+
+class SpatialParallelConv2D(_SpatialParallelConv):
+    r"""2D convolution layer (e.g. spatial convolution over images),
+    spatially distributed across multiple GPUs.
+
+    This layer creates a convolution kernel that is convolved
+    with the layer input to produce a tensor of
+    outputs. If `use_bias` is True,
+    a bias vector is created and added to the outputs. Finally, if
+    `activation` is not `None`, it is applied to the outputs as well.
+
+    If `in_channels` is not specified, `Parameter` initialization will be
+    deferred to the first time `forward` is called and `in_channels` will be
+    inferred from the shape of input data.
+
+    Parameters
+    ----------
+    num_gpus : int
+        Specify the number of GPUs participating to compute the single convolution.
+    channels : int
+        The dimensionality of the output space, i.e. the number of output
+        channels (filters) in the convolution.
+    kernel_size :int or tuple/list of 2 int
+        Specifies the dimensions of the convolution window.
+    strides : int or tuple/list of 2 int,
+        Specify the strides of the convolution.
+    padding : int or a tuple/list of 2 int,
+        If padding is non-zero, then the input is implicitly zero-padded
+        on both sides for padding number of points
+    dilation : int or tuple/list of 2 int
+        Specifies the dilation rate to use for dilated convolution.
+    groups : int
+        Controls the connections between inputs and outputs.
+        At groups=1, all inputs are convolved to all outputs.
+        At groups=2, the operation becomes equivalent to having two conv
+        layers side by side, each seeing half the input channels, and producing
+        half the output channels, and both subsequently concatenated.
+    layout : str, default 'NHWC'
+        Dimension ordering of data and weight. Only supports 'NHWC'
+        layout for now. 'N', 'C', 'H', 'W' stands for batch, channel, height,
+        and width dimensions respectively. Convolution is applied on the 'H' and
+        'W' dimensions.
+    in_channels : int, default 0
+        The number of input channels to this layer. If not specified,
+        initialization will be deferred to the first time `forward` is called
+        and `in_channels` will be inferred from the shape of input data.
+    activation : str
+        Activation function to use. See :func:`~mxnet.ndarray.Activation`.
+        If you don't specify anything, no activation is applied
+        (ie. "linear" activation: `a(x) = x`).
+    use_bias : bool
+        Whether the layer uses a bias vector.
+    weight_initializer : str or `Initializer`
+        Initializer for the `weight` weights matrix.
+    bias_initializer : str or `Initializer`
+        Initializer for the bias vector.
+
+
+    Inputs:
+        - **data**: 4D input tensor with shape
+          `(batch_size, height, width, in_channels)` when `layout` is `NHWC`.
+          For other layouts shape is permuted accordingly.
+
+    Outputs:
+        - **out**: 4D output tensor with shape
+          `(batch_size, out_height, out_width, channels)` when `layout` is `NHWC`.
+          out_height and out_width are calculated as::
+
+              out_height = floor((height+2*padding[0]-dilation[0]*(kernel_size[0]-1)-1)/stride[0])+1
+              out_width = floor((width+2*padding[1]-dilation[1]*(kernel_size[1]-1)-1)/stride[1])+1
+    """
+    def __init__(self, num_gpus, channels, kernel_size, strides=(1, 1), padding=(0, 0),
+                 groups=1, layout='NHWC',
+                 activation=None, use_bias=True, weight_initializer=None,
+                 bias_initializer='zeros', in_channels=0, **kwargs):
+        assert layout in ('NHWC'), "Only supports 'NHWC' layout for now"
+        if isinstance(kernel_size, numeric_types):
+            kernel_size = (kernel_size,)*2
+        assert len(kernel_size) == 2, "kernel_size must be a number or a list of 2 ints"
+        op_name = kwargs.pop('op_name', 'SpatialParallelConvolution')
+        if is_np_array():
+            op_name = 'spatial_parallel_convolution'
+        super(SpatialParallelConv2D, self).__init__(
+            num_gpus, channels, kernel_size, strides, padding, groups, layout,
+            in_channels, activation, use_bias, weight_initializer, bias_initializer,
+            op_name, **kwargs)
+
+class SpatialParallelConv3D(_SpatialParallelConv):
+    """3D convolution layer (e.g. spatial convolution over volumes),
+    spatially distributed across multiple GPUs.
+
+    This layer creates a convolution kernel that is convolved
+    with the layer input to produce a tensor of
+    outputs. If `use_bias` is `True`,
+    a bias vector is created and added to the outputs. Finally, if
+    `activation` is not `None`, it is applied to the outputs as well.
+
+    If `in_channels` is not specified, `Parameter` initialization will be
+    deferred to the first time `forward` is called and `in_channels` will be
+    inferred from the shape of input data.
+
+    Parameters
+    ----------
+    num_gpus : int
+        Specify the number of GPUs participating to compute the single convolution.
+    channels : int
+        The dimensionality of the output space, i.e. the number of output
+        channels (filters) in the convolution.
+    kernel_size :int or tuple/list of 3 int
+        Specifies the dimensions of the convolution window.
+    strides : int or tuple/list of 3 int,
+        Specify the strides of the convolution.
+    padding : int or a tuple/list of 3 int,
+        If padding is non-zero, then the input is implicitly zero-padded
+        on both sides for padding number of points
+    groups : int
+        Controls the connections between inputs and outputs.
+        At groups=1, all inputs are convolved to all outputs.
+        At groups=2, the operation becomes equivalent to having two conv
+        layers side by side, each seeing half the input channels, and producing
+        half the output channels, and both subsequently concatenated.
+    layout : str, default 'NDHWC'
+        Dimension ordering of data and weight. Only supports 'NDHWC'
+        layout for now. 'N', 'C', 'H', 'W', 'D' stands for batch, channel, height,
+        width and depth dimensions respectively. Convolution is applied on the 'D',
+        'H' and 'W' dimensions. The spatial partitioning across different GPUs
+        happens on the outermost dimension ('D').
+    in_channels : int, default 0
+        The number of input channels to this layer. If not specified,
+        initialization will be deferred to the first time `forward` is called
+        and `in_channels` will be inferred from the shape of input data.
+    activation : str
+        Activation function to use. See :func:`~mxnet.ndarray.Activation`.
+        If you don't specify anything, no activation is applied
+        (ie. "linear" activation: `a(x) = x`).
+    use_bias : bool
+        Whether the layer uses a bias vector.
+    weight_initializer : str or `Initializer`
+        Initializer for the `weight` weights matrix.
+    bias_initializer : str or `Initializer`
+        Initializer for the bias vector.
+
+
+    Inputs:
+        - **data**: 5D input tensor with shape
+          `(batch_size, depth, height, width, in_channels)` when `layout` is `NDHWC`.
+          For other layouts shape is permuted accordingly.
+
+    Outputs:
+        - **out**: 5D output tensor with shape
+          `(batch_size, out_depth, out_height, out_width, channels)` when `layout` is `NDHWC`.
+          out_depth, out_height and out_width are calculated as::
+
+              out_depth = floor((depth+2*padding[0]-dilation[0]*(kernel_size[0]-1)-1)/stride[0])+1
+              out_height = floor((height+2*padding[1]-dilation[1]*(kernel_size[1]-1)-1)/stride[1])+1
+              out_width = floor((width+2*padding[2]-dilation[2]*(kernel_size[2]-1)-1)/stride[2])+1
+    """
+    def __init__(self, num_gpus, channels, kernel_size,
+                 strides=(1, 1, 1), padding=(0, 0, 0),
+                 groups=1, layout='NDHWC', activation=None,
+                 use_bias=True, weight_initializer=None, bias_initializer='zeros',
+                 in_channels=0, **kwargs):
+        assert layout in ('NDHWC'), "Only supports 'NDHWC' layout for now"
+        if isinstance(kernel_size, numeric_types):
+            kernel_size = (kernel_size,)*3
+        assert len(kernel_size) == 3, "kernel_size must be a number or a list of 3 ints"
+        op_name = kwargs.pop('op_name', 'SpatialParallelConvolution')
+        if is_np_array():
+            op_name = 'spatial_parallel_convolution'
+        super(SpatialParallelConv3D, self).__init__(num_gpus, channels, kernel_size, strides,
+                                                    padding, groups, layout, in_channels,
+                                                    activation, use_bias, weight_initializer,
+                                                    bias_initializer, op_name, **kwargs)
+
+class SpatialParallelSplit(HybridBlock):
+    """Spatial parallel split"""
+    def __init__(self, num_gpus, prefix=None, **kwargs):
+        super(SpatialParallelSplit, self).__init__(prefix=prefix, **kwargs)
+        helper = _SpatialParallelHelper
+        helper.init(num_gpus)
+        self._kwargs = {
+            'num_gpus': num_gpus,
+            'rank': helper.rank,
+            'nccl_unique_id': helper.nccl_id.ctypes.data}
+
+    def hybrid_forward(self, F, x):
+        return F.contrib.SpatialParallelSplit(x, **self._kwargs)
+
+class SpatialParallelAllgather(HybridBlock):
+    """Spatial parallel allgather"""
+    def __init__(self, num_gpus, prefix=None, **kwargs):
+        super(SpatialParallelAllgather, self).__init__(prefix=prefix, **kwargs)
+        helper = _SpatialParallelHelper
+        helper.init(num_gpus)
+        self._kwargs = {
+            'num_gpus': num_gpus,
+            'rank': helper.rank,
+            'nccl_unique_id': helper.nccl_id.ctypes.data}
+
+    def hybrid_forward(self, F, x):
+        return F.contrib.SpatialParallelAllgather(x, **self._kwargs)

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -61,6 +61,9 @@
 #include "../serialization/cnpy.h"
 #include "miniz.h"
 #include "nnvm/pass_functions.h"
+#if MXNET_USE_CUDA
+#include "../common/cuda/utils.h"
+#endif
 
 using namespace mxnet;
 
@@ -1610,6 +1613,16 @@ int MXEngineSetBulkSize(int bulk_size, int* prev_bulk_size) {
 int MXGetGPUCount(int* out) {
   API_BEGIN();
   *out = Context::GetGPUCount();
+  API_END();
+}
+
+int MXGetGPUSMArch(int dev, int* out) {
+  API_BEGIN();
+#if MXNET_USE_CUDA == 1
+  *out = SMArch(dev);
+#else
+  LOG(FATAL) << "Compile with USE_CUDA=1 to query CUDA device properties.";
+#endif
   API_END();
 }
 

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -64,6 +64,9 @@
 #if MXNET_USE_CUDA
 #include "../common/cuda/utils.h"
 #endif
+#if MXNET_USE_NCCL
+#include <nccl.h>
+#endif
 
 using namespace mxnet;
 
@@ -1640,6 +1643,29 @@ int MXGetGPUMemoryInformation(int dev, int *free_mem, int *total_mem) {
 int MXGetGPUMemoryInformation64(int dev, uint64_t *free_mem, uint64_t *total_mem) {
   API_BEGIN();
   Context::GetGPUMemoryInformation(dev, free_mem, total_mem);
+  API_END();
+}
+
+int MXNCCLGetUniqueIdSize(int* size) {
+  API_BEGIN();
+#if MXNET_USE_CUDA && MXNET_USE_NCCL
+  *size = sizeof(ncclUniqueId);
+#else
+  LOG(FATAL) << "Compile with USE_CUDA=1 and USE_NCCL=1 to have NCCL support.";
+#endif
+  API_END();
+}
+
+int MXNCCLGetUniqueId(void* out) {
+  API_BEGIN();
+#if MXNET_USE_CUDA && MXNET_USE_NCCL
+  auto ret = ncclGetUniqueId(reinterpret_cast<ncclUniqueId*>(out));
+  if (ret != ncclSuccess) {
+    LOG(FATAL) << "Failed to get the NCCL unique id";
+  }
+#else
+  LOG(FATAL) << "Compile with USE_CUDA=1 and USE_NCCL=1 to have NCCL support.";
+#endif
   API_END();
 }
 

--- a/src/imperative/attach_op_resource_pass.cc
+++ b/src/imperative/attach_op_resource_pass.cc
@@ -88,6 +88,12 @@ void AttachOpResources(
             break;
           }
 #endif  // MXNET_USE_CUDNN == 1
+#if MXNET_USE_CUDA == 1
+          case ResourceRequest::kMultiGPUComm: {
+            requested.push_back(ResourceManager::Get()->Request(ctx, req));
+            break;
+          }
+#endif  // MXNET_USE_CUDNN == 1
           default:
             LOG(FATAL) << "resource type " << req.type << " is not yet supported";
         }

--- a/src/operator/contrib/nn/cudnn/cudnn_spatial_parallel_convolution-inl.h
+++ b/src/operator/contrib/nn/cudnn/cudnn_spatial_parallel_convolution-inl.h
@@ -1,0 +1,1596 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * Copyright (c) 2015 by Contributors
+ * \file cudnn_convolution-inl.h
+ * \brief
+ * \author Bing Xu
+*/
+#ifndef MXNET_OPERATOR_CONTRIB_NN_CUDNN_CUDNN_SPATIAL_PARALLEL_CONVOLUTION_INL_H_
+#define MXNET_OPERATOR_CONTRIB_NN_CUDNN_CUDNN_SPATIAL_PARALLEL_CONVOLUTION_INL_H_
+
+#include <mshadow/base.h>
+#include <mxnet/storage.h>
+#include <dmlc/parameter.h>
+#include <mxnet/tuple.h>
+#if MXNET_USE_NCCL
+#include <nccl.h>
+#endif
+#include <algorithm>
+#include <vector>
+#include <set>
+#include <mutex>
+#include <string>
+#include <iostream>
+#include <sstream>
+#include <iomanip>
+#include <utility>
+#include "../spatial_parallel_convolution-inl.h"
+#include "../../../nn/cudnn/cudnn_algoreg-inl.h"
+#include "../../../../common/cuda/utils.h"
+#include "../../../nn/cublas_fully_connected-inl.h"
+#include "../../spatial_parallel_support.h"
+
+namespace mxnet {
+namespace op {
+#if MXNET_USE_CUDNN == 1 && MXNET_USE_NCCL == 1
+
+typedef CuDNNAlgoReg<SpatialParallelConvolutionParam> CuDNNSPConvAlgoReg;
+
+// Equivalent algo performance threshhold (e.g. 1.01 == 1% performance difference)
+// Used to prune Tensor Core algos with no appreciable performance benefit.
+#define ALGO_PERF_THRESHOLD 1.01
+
+namespace {
+
+template <typename DType>
+__global__ void ExtractHaloFilter_kernel(DType* out, const DType* in, const index_t slice_begin,
+                                  const index_t slice_end, const index_t stride,
+                                  const index_t out_dim, const index_t in_dim,
+                                  const index_t slice_offset, const index_t N) {
+  const index_t tid = blockIdx.x * blockDim.x + threadIdx.x;
+  if (tid >= N) return;
+  const index_t my_slice = (tid / stride) % out_dim;
+  DType val = 0;
+  if (my_slice >= slice_begin && my_slice < slice_end) {
+    const index_t base_x = tid % stride;
+    const index_t base_y = tid / (stride * out_dim);
+    const index_t base = base_x + (my_slice + slice_offset + base_y * in_dim) * stride;
+    val = in[base];
+  }
+  out[tid] = val;
+}
+
+template <typename DType>
+void ExtractHaloFilter(mshadow::Stream<gpu>* s, DType* out, const DType* in,
+                       const index_t slice_begin, const index_t slice_end,
+                       const index_t slice_offset, const mxnet::TShape& halo_wshape,
+                       const mxnet::TShape& wshape) {
+    index_t n_elements = halo_wshape.Size();
+    const int threads = 512;
+    const index_t blocks = common::div_round(n_elements, threads);
+    cudaStream_t stream = Stream<gpu>::GetStream(s);
+    index_t stride = wshape.Size() / (wshape[0] * wshape[1]);
+    const index_t filter_halo_dim = halo_wshape.ndim() == wshape.ndim() ? halo_wshape[1] : 1;
+    ExtractHaloFilter_kernel<<<blocks, threads, 0, stream>>>(out, in, slice_begin, slice_end,
+                                                             stride, filter_halo_dim, wshape[1],
+                                                             slice_offset, n_elements);
+}
+
+template <typename DType>
+__global__ void AddHaloWGrad_kernel(const DType* in, DType* out, const index_t slice_begin,
+                                    const index_t slice_end, const index_t stride,
+                                    const index_t in_dim, const index_t out_dim,
+                                    const index_t slice_offset, const index_t N) {
+  const index_t tid = blockIdx.x * blockDim.x + threadIdx.x;
+  if (tid >= N) return;
+  const index_t my_slice = (tid / stride) % in_dim;
+  if (my_slice >= slice_begin && my_slice < slice_end) {
+    const index_t base_x = tid % stride;
+    const index_t base_y = tid / (stride * in_dim);
+    const index_t base = base_x + (my_slice + slice_offset + base_y * out_dim) * stride;
+    out[base] += in[tid];
+  }
+}
+
+template <typename DType>
+void AddHaloWGrad(mshadow::Stream<gpu>* s, DType* out, const DType* in,
+                  const index_t slice_begin, const index_t slice_end,
+                  const index_t slice_offset, const mxnet::TShape& halo_wshape,
+                  const mxnet::TShape& wshape) {
+    index_t n_elements = halo_wshape.Size();
+    const int threads = 512;
+    const index_t blocks = common::div_round(n_elements, threads);
+    cudaStream_t stream = Stream<gpu>::GetStream(s);
+    index_t stride = wshape.Size() / (wshape[0] * wshape[1]);
+    const index_t filter_halo_dim = halo_wshape.ndim() == wshape.ndim() ? halo_wshape[1] : 1;
+    AddHaloWGrad_kernel<<<blocks, threads, 0, stream>>>(in, out, slice_begin, slice_end, stride,
+                                                        filter_halo_dim, wshape[1], slice_offset,
+                                                        n_elements);
+}
+
+void SetTensorDescriptor(cudnnTensorDescriptor_t desc,
+                         cudnnDataType_t dtype,
+                         const mxnet::TShape& shape,
+                         const mxnet::TShape& strides) {
+  std::vector<int> shape_buffer(shape.ndim());
+  nnvm::ShapeTypeCast(shape.begin(), shape.end(), shape_buffer.data());
+  std::vector<int> stride_buffer(strides.ndim());
+  nnvm::ShapeTypeCast(strides.begin(), strides.end(), stride_buffer.data());
+
+  CUDNN_CALL(cudnnSetTensorNdDescriptor(desc,
+                                        dtype,
+                                        static_cast<int>(shape.ndim()),
+                                        shape_buffer.data(),
+                                        stride_buffer.data()));
+}
+
+int *CastTShapeToIntPtr(const mxnet::TShape& s, std::vector<int> *buffer) {
+  buffer->resize(s.ndim());
+  nnvm::ShapeTypeCast(s.begin(), s.end(), buffer->data());
+  return buffer->data();
+}
+
+// Converts a mxnet::TShape to a Shape<> of strides.
+// e.g. {shape[0], shape[1], shape[2]} -> {shape[1]*shape[2], shape[2], 1}
+template <int dim>
+inline Shape<dim> Strides(const mxnet::TShape &s) {
+  int ndim = s.ndim();
+  mxnet::TShape strides(ndim, -1);
+  for (int i = 0; i != ndim; ++i)
+    strides[i] = s.ProdShape(i+1, ndim);
+  return strides.get<dim>();
+}
+
+}  // namespace
+
+/*!
+ * \brief The Operator used to perform convolution using cuDNN kernels.
+ */
+template<typename DType>
+class CuDNNSPConvolutionOp {
+  STATIC_ASSERT_CUDNN_VERSION_GE(7000);
+
+  struct CUDNNConvolution {
+   public:
+    cudnnConvolutionDescriptor_t forward_desc_;
+    // Convolution descriptor for back-prop operations to the data
+    cudnnConvolutionDescriptor_t dgrad_desc_;
+    // Convolution descriptor for back-prop operations to the weights
+    cudnnConvolutionDescriptor_t wgrad_desc_;
+    cudnnTensorDescriptor_t in_desc_;
+    cudnnTensorDescriptor_t out_desc_;
+    cudnnTensorDescriptor_t bias_desc_;
+    cudnnFilterDescriptor_t filter_desc_;
+
+    // Algorithm for the forward inference operation
+    CuDNNAlgo<cudnnConvolutionFwdAlgo_t> forward_algo_;
+    // Algorithm for the back-prop operation to the data
+    CuDNNAlgo<cudnnConvolutionBwdDataAlgo_t> dgrad_algo_;
+    // Algorithm for the back-prop operation to the weights
+    CuDNNAlgo<cudnnConvolutionBwdFilterAlgo_t> wgrad_algo_;
+    // Temp workspace size in bytes needed for Forward() operation.
+    size_t forward_workspace_byte_;
+    // Temp workspace size in bytes needed for Backward() dgrad (data gradient) operation.
+    size_t dgrad_workspace_byte_;
+    // Temp workspace size in bytes needed for Backward() wgrad (weight gradient) operation.
+    size_t wgrad_workspace_byte_;
+    // Temp workspace size in bytes needed for Backward() bgrad (bias gradient) operation.
+    size_t bias_workspace_byte_;
+
+
+    CUDNNConvolution() {
+      CUDNN_CALL(cudnnCreateTensorDescriptor(&in_desc_));
+      CUDNN_CALL(cudnnCreateTensorDescriptor(&out_desc_));
+      CUDNN_CALL(cudnnCreateTensorDescriptor(&bias_desc_));
+      CUDNN_CALL(cudnnCreateFilterDescriptor(&filter_desc_));
+      CUDNN_CALL(cudnnCreateConvolutionDescriptor(&forward_desc_));
+      CUDNN_CALL(cudnnCreateConvolutionDescriptor(&dgrad_desc_));
+      CUDNN_CALL(cudnnCreateConvolutionDescriptor(&wgrad_desc_));
+      bias_workspace_byte_ = 0;
+      forward_workspace_byte_ = 0;
+      dgrad_workspace_byte_ = 0;
+      wgrad_workspace_byte_ = 0;
+    }
+
+    ~CUDNNConvolution() {
+      CUDNN_CALL(cudnnDestroyTensorDescriptor(in_desc_));
+      CUDNN_CALL(cudnnDestroyTensorDescriptor(out_desc_));
+      CUDNN_CALL(cudnnDestroyTensorDescriptor(bias_desc_));
+      CUDNN_CALL(cudnnDestroyFilterDescriptor(filter_desc_));
+      CUDNN_CALL(cudnnDestroyConvolutionDescriptor(forward_desc_));
+      CUDNN_CALL(cudnnDestroyConvolutionDescriptor(wgrad_desc_));
+      CUDNN_CALL(cudnnDestroyConvolutionDescriptor(dgrad_desc_));
+    }
+
+    void Init(const mxnet::TShape& original_dshape,
+              const mxnet::TShape& original_wshape,
+              const mxnet::TShape& original_oshape,
+              const mshadow::LayoutFlag original_layout,
+              const cudnnDataType_t dtype,
+              const mxnet::TShape& stride_shape,
+              const mxnet::TShape& dilate_shape,
+              const mxnet::TShape& pad_shape,
+              const cudnnDataType_t forward_compute_type,
+              const cudnnDataType_t backward_compute_type,
+              const bool cudnn_tensor_core) {
+      mxnet::TShape dstride, ostride;
+      mxnet::TShape dshape_channel_first, oshape_channel_first;
+      std::vector<int> stride, dilate, pad;
+      CastTShapeToIntPtr(stride_shape, &stride);
+      CastTShapeToIntPtr(dilate_shape, &dilate);
+      CastTShapeToIntPtr(pad_shape, &pad);
+      auto layout = original_layout;
+      auto dshape = original_dshape;
+      auto wshape = original_wshape;
+      auto oshape = original_oshape;
+      if (pad.size() == 1) {
+        // Convert 1D conv to 2D with first dimension being 1
+        switch (layout) {
+          case mshadow::kNCW:
+          case mshadow::kCWN:
+            LOG(FATAL) << "Only channels-last layouts are supported for now!";
+            break;
+          case mshadow::kNWC:
+            layout = mshadow::kNHWC;
+            pad = {0, pad[0]};
+            dilate = {1, dilate[0]};
+            stride = {1, stride[0]};
+            dshape = mxnet::TShape{dshape[0], 1, dshape[1], dshape[2]};
+            wshape = mxnet::TShape{wshape[0], 1, wshape[1], wshape[2]};
+            oshape = mxnet::TShape{oshape[0], 1, oshape[1], oshape[2]};
+          default: break;
+        }
+      }
+      cudnnTensorFormat_t format;
+      MSHADOW_LAYOUT_SWITCH(layout, Layout, {
+        format = LayoutType<Layout>::kCudnnFlag;
+      });
+      CHECK_GE(dshape.ndim(), 4) << "Only 2D and 3D convolutions are supported for now!";
+      if (dshape.ndim() == 4) {
+        // 1d or 2d conv
+        CUDNN_CALL(cudnnSetConvolution2dDescriptor(forward_desc_,
+                                                   pad[0],
+                                                   pad[1],
+                                                   stride[0],
+                                                   stride[1],
+                                                   dilate[0],
+                                                   dilate[1],
+                                                   CUDNN_CROSS_CORRELATION,
+                                                   forward_compute_type));
+        CUDNN_CALL(cudnnSetConvolution2dDescriptor(dgrad_desc_,
+                                                   pad[0],
+                                                   pad[1],
+                                                   stride[0],
+                                                   stride[1],
+                                                   dilate[0],
+                                                   dilate[1],
+                                                   CUDNN_CROSS_CORRELATION,
+                                                   backward_compute_type));
+        CUDNN_CALL(cudnnSetConvolution2dDescriptor(wgrad_desc_,
+                                                   pad[0],
+                                                   pad[1],
+                                                   stride[0],
+                                                   stride[1],
+                                                   dilate[0],
+                                                   dilate[1],
+                                                   CUDNN_CROSS_CORRELATION,
+                                                   backward_compute_type));
+        auto wshape_channel_first = ConvertLayout(wshape.get<4>(), layout, kNCHW);
+        dstride = ConvertLayout(Strides<4>(dshape), layout, kNCHW);
+        dshape_channel_first = ConvertLayout(dshape.get<4>(), layout, kNCHW);
+        ostride = ConvertLayout(Strides<4>(oshape), layout, kNCHW);
+        oshape_channel_first = ConvertLayout(oshape.get<4>(), layout, kNCHW);
+        CUDNN_CALL(cudnnSetFilter4dDescriptor(filter_desc_,
+                                              dtype,
+                                              format,
+                                              wshape_channel_first[0],
+                                              wshape_channel_first[1],
+                                              wshape_channel_first[2],
+                                              wshape_channel_first[3]));
+        auto kernel_h = wshape_channel_first[2];
+        auto kernel_w = wshape_channel_first[3];
+        // The 5x5 non-fused Winograd kernel is fast, but because of its reduced numerical
+        // accuracy compared to other algos, users must opt-in to its use.
+        bool exclude_nonfused_winograd_5x5 =
+          !dmlc::GetEnv("MXNET_CUDNN_ENABLE_WINOGRAD_NONFUSED_5X5", false);
+        if (exclude_nonfused_winograd_5x5 && kernel_h == 5 && kernel_w == 5) {
+          // excluded_forward_algos_.insert(CUDNN_CONVOLUTION_FWD_ALGO_WINOGRAD_NONFUSED);
+          // excluded_back_algos_.insert(CUDNN_CONVOLUTION_BWD_DATA_ALGO_WINOGRAD_NONFUSED);
+          // excluded_back_algos_w_.insert(CUDNN_CONVOLUTION_BWD_FILTER_ALGO_WINOGRAD_NONFUSED);
+        }
+      } else if (dshape.ndim() == 5) {
+        // 3d conv
+        std::vector<int> wshape_buffer(wshape.ndim());
+        mxnet::TShape wshape_channel_first = ConvertLayout(wshape.get<5>(), layout, kNCDHW);
+
+        CUDNN_CALL(cudnnSetFilterNdDescriptor(filter_desc_,
+                                              dtype,
+                                              format,
+                                              static_cast<int>(wshape.ndim()),
+                                              CastTShapeToIntPtr(wshape_channel_first,
+                                                                 &wshape_buffer)));
+        CUDNN_CALL(cudnnSetConvolutionNdDescriptor(forward_desc_,
+                                                   3,
+                                                   pad.data(),
+                                                   stride.data(),
+                                                   dilate.data(),
+                                                   CUDNN_CROSS_CORRELATION,
+                                                   forward_compute_type));
+
+        CUDNN_CALL(cudnnSetConvolutionNdDescriptor(dgrad_desc_,
+                                                   3,
+                                                   pad.data(),
+                                                   stride.data(),
+                                                   dilate.data(),
+                                                   CUDNN_CROSS_CORRELATION,
+                                                   backward_compute_type));
+
+        CUDNN_CALL(cudnnSetConvolutionNdDescriptor(wgrad_desc_,
+                                                   3,
+                                                   pad.data(),
+                                                   stride.data(),
+                                                   dilate.data(),
+                                                   CUDNN_CROSS_CORRELATION,
+                                                   backward_compute_type));
+
+        dstride = ConvertLayout(Strides<5>(dshape), layout, kNCDHW);
+        dshape_channel_first = ConvertLayout(dshape.get<5>(), layout, kNCDHW);
+
+        ostride = ConvertLayout(Strides<5>(oshape), layout, kNCDHW);
+        oshape_channel_first = ConvertLayout(oshape.get<5>(), layout, kNCDHW);
+      }
+      // Set "allow tensor core" flag in convolution descriptors, if available.
+      cudnnMathType_t math_type = cudnn_tensor_core ? CUDNN_TENSOR_OP_MATH
+                                                    : CUDNN_DEFAULT_MATH;
+#if CUDNN_VERSION >= 7200
+      if (GetEnvAllowTensorCore() && GetEnvAllowTensorCoreConversion() &&
+          (DataType<DType>::kFlag != kFloat16))
+        math_type = CUDNN_TENSOR_OP_MATH_ALLOW_CONVERSION;
+#endif
+      CUDNN_CALL(cudnnSetConvolutionMathType(forward_desc_, math_type));
+      CUDNN_CALL(cudnnSetConvolutionMathType(dgrad_desc_, math_type));
+      CUDNN_CALL(cudnnSetConvolutionMathType(wgrad_desc_, math_type));
+      CUDNN_CALL(cudnnSetConvolutionGroupCount(forward_desc_, 1));
+      CUDNN_CALL(cudnnSetConvolutionGroupCount(dgrad_desc_, 1));
+      CUDNN_CALL(cudnnSetConvolutionGroupCount(wgrad_desc_, 1));
+
+      SetTensorDescriptor(in_desc_, dtype, dshape_channel_first, dstride);
+      SetTensorDescriptor(out_desc_, dtype, oshape_channel_first, ostride);
+    }
+
+    void InitBias(const mxnet::TShape& bias,
+                  const int ndim,
+                  const cudnnDataType_t dtype) {
+      int bias_dim = static_cast<int>(bias[0]);
+      std::vector<int> bias_shape(ndim, 1);
+      std::vector<int> bias_stride(ndim, bias_dim);
+      bias_shape[1] = bias_dim;
+      bias_stride[1] = 1;
+      CUDNN_CALL(cudnnSetTensorNdDescriptor(bias_desc_,
+                                            dtype,
+                                            static_cast<int>(bias_shape.size()),
+                                            bias_shape.data(),
+                                            bias_stride.data()));
+    }
+
+    void GetWorkspaceSize(const RunContext& rctx) {
+      mshadow::Stream<gpu> *s = rctx.get_stream<gpu>();
+      CUDNN_CALL(cudnnGetConvolutionBackwardDataWorkspaceSize(s->dnn_handle_,
+                                                              filter_desc_,
+                                                              out_desc_,
+                                                              dgrad_desc_,
+                                                              in_desc_,
+                                                              dgrad_algo_.AlgoNumber(),
+                                                              &dgrad_workspace_byte_));
+      CUDNN_CALL(cudnnGetConvolutionBackwardFilterWorkspaceSize(s->dnn_handle_,
+                                                                in_desc_,
+                                                                out_desc_,
+                                                                wgrad_desc_,
+                                                                filter_desc_,
+                                                                wgrad_algo_.AlgoNumber(),
+                                                                &wgrad_workspace_byte_));
+
+      CUDNN_CALL(cudnnGetConvolutionForwardWorkspaceSize(s->dnn_handle_,
+                                                         in_desc_,
+                                                         filter_desc_,
+                                                         forward_desc_,
+                                                         out_desc_,
+                                                         forward_algo_.AlgoNumber(),
+                                                         &forward_workspace_byte_));
+    }
+
+    template <typename ScaleType>
+    void Forward(mshadow::Stream<gpu>* s, ScaleType alpha, void* input,
+                 void* filter, void* wsp, ScaleType beta, void* output) {
+      CUDNN_CALL(cudnnConvolutionForward(s->dnn_handle_, &alpha, in_desc_,
+                                         input, filter_desc_, filter,
+                                         forward_desc_, forward_algo_.AlgoNumber(),
+                                         wsp, forward_workspace_byte_,
+                                         &beta, out_desc_, output));
+    }
+
+    template <typename ScaleType>
+    void DGrad(mshadow::Stream<gpu>* s, ScaleType alpha, void* input,
+                 void* filter, void* wsp, ScaleType beta, void* output) {
+      CUDNN_CALL(cudnnConvolutionBackwardData(s->dnn_handle_, &alpha, filter_desc_,
+                                              filter, out_desc_, input, dgrad_desc_,
+                                              dgrad_algo_.AlgoNumber(), wsp,
+                                              dgrad_workspace_byte_, &beta,
+                                              in_desc_, output));
+    }
+
+    template <typename ScaleType>
+    void WGrad(mshadow::Stream<gpu>* s, ScaleType alpha, void* input,
+                 void* in_grad, void* wsp, ScaleType beta, void* dfilter) {
+      CUDNN_CALL(cudnnConvolutionBackwardFilter(s->dnn_handle_, &alpha, in_desc_,
+                                                input, out_desc_, in_grad, wgrad_desc_,
+                                                wgrad_algo_.AlgoNumber(), wsp,
+                                                wgrad_workspace_byte_, &beta,
+                                                filter_desc_, dfilter));
+    }
+  };
+
+ public:
+  CuDNNSPConvolutionOp() : back_bias_get_workspace_performed_(false) {
+    parallelize_backward_kernels_ = Context::GetGPUStreamsPerWorker() >= 2;
+  }
+
+  void Init(const SpatialParallelConvolutionParam& param,
+            int forward_compute_type,
+            int backward_compute_type,
+            const mxnet::ShapeVector& in_shape,
+            const mxnet::ShapeVector& out_shape,
+            const RunContext& rctx,
+            bool add_to_weight) {
+    using namespace mshadow;
+    this->param_ = param;
+    // If no local setting for TensorCore use policy, look to global policy.
+    if (!param_.cudnn_tensor_core.has_value())
+      param_.cudnn_tensor_core = GetEnvAllowTensorCore();
+    this->add_to_weight_ = add_to_weight;
+    auto cudnn_forward_compute_type = convertToCuDNNDataType(forward_compute_type);
+    auto cudnn_backward_compute_type = convertToCuDNNDataType(backward_compute_type);
+    // convert MB to words
+    param_.workspace = (param_.workspace << 20) / sizeof(DType);
+
+    // Double check to make sure this class supports the operation
+    if (!Supports(param, forward_compute_type, backward_compute_type, rctx.ctx.dev_id))
+      LOG(FATAL) << "Convolution parameters not supported by cuDNN implementation.";
+
+    InitDescriptors(in_shape, out_shape,
+                    cudnn_forward_compute_type, cudnn_backward_compute_type);
+
+    if (!param_.cudnn_tune) {
+      param_.cudnn_tune = dmlc::GetEnv("MXNET_CUDNN_AUTOTUNE_DEFAULT", 1);
+    }
+
+    // In cuDNN_v6, dilated convolution descriptors are compatible with only a
+    // single convolution algorithm.  Despite this, we go through the algorithm
+    // selection process, which will return the only algorithm supported.  This
+    // approach keeps the treatment of convolution cases uniform and will
+    // naturally respond to more algorithms supporting dilated convolutions in
+    // future cuDNN releases.
+    SelectMainAlgo(rctx, in_shape, out_shape,
+                   cudnn_forward_compute_type, cudnn_backward_compute_type);
+    mxnet::ShapeVector halo_in_shape(2);
+    const index_t input_halo_dim = (param_.kernel[0] - 1) / 2;
+    const index_t output_halo_dim = (input_halo_dim + 2 * param_.pad[0] - param_.kernel[0])
+                                    / param_.stride[0] + 1;
+    const bool reduced_dim = param_.kernel[0] == 3;
+    halo_in_shape[0] = GetHaloShape(in_shape[0], input_halo_dim, reduced_dim);
+    halo_in_shape[1] = GetHaloFilterShape(in_shape[1], param.kernel[0]);
+    mxnet::ShapeVector halo_out_shape(1);
+    halo_out_shape[0] = GetHaloShape(out_shape[0], output_halo_dim, reduced_dim);
+
+    SelectHaloAlgo(rctx, halo_in_shape, halo_out_shape,
+                   cudnn_forward_compute_type, cudnn_backward_compute_type);
+    GetTempSize(rctx);
+    SpatialParallelParam p;
+    p.num_gpus = param_.num_gpus;
+    p.rank = param_.rank;
+    p.nccl_unique_id = param_.nccl_unique_id;
+    NCCLCommContainer::Init(p);
+  }
+
+  ~CuDNNSPConvolutionOp() {}
+
+  void Forward(const OpContext &ctx,
+               const std::vector<TBlob> &in_data,
+               const std::vector<OpReqType> &req,
+               const std::vector<TBlob> &out_data) {
+    using namespace mshadow;
+    size_t expected = param_.no_bias ? 2 : 3;
+    CHECK_EQ(in_data.size(), expected);
+    CHECK_EQ(out_data.size(), 1U);
+    Stream<gpu> *s = ctx.get_stream<gpu>();
+    auto dshape = in_data[0].shape_;
+    auto oshape = out_data[0].shape_;
+    const index_t input_halo_dim = (param_.kernel[0] - 1) / 2;
+    const index_t output_halo_dim = (input_halo_dim + 2 * param_.pad[0] - param_.kernel[0])
+                                    / param_.stride[0] + 1;
+    const bool reduced_dim = param_.kernel[0] == 3;
+    auto halo_dshape = GetHaloShape(dshape, input_halo_dim, reduced_dim);
+    size_t halo_size = halo_dshape.Size() * sizeof(DType);
+    mxnet::TShape wshape = in_data[spconv::kWeight].shape_;
+    mxnet::TShape halo_wshape = GetHaloFilterShape(wshape, param_.kernel[0]);
+    size_t halo_filter_size = halo_wshape.Size() * sizeof(DType);
+
+    // I/O's should have 2 more dims than the kernel dim
+    DType *data_ptr = GetNdPtr(in_data[spconv::kData], param_.kernel.ndim() + 2, s);
+    DType *wmat_ptr = GetNdPtr(in_data[spconv::kWeight], param_.kernel.ndim() + 2, s);
+    DType *out_ptr = GetNdPtr(out_data[spconv::kOut], param_.kernel.ndim() + 2, s);
+
+    typename DataType<DType>::ScaleType alpha = 1.0f;
+    typename DataType<DType>::ScaleType beta = 0.0f;
+    typename DataType<DType>::ScaleType beta_add = 1.0f;
+
+    index_t first_index = param_.rank * dshape[1];
+    index_t last_index = (param_.rank + 1) * dshape[1] - 1;
+    const bool needs_recv_previous_halo = param_.rank > 0 && (param_.pad[0] > 0);
+    const bool needs_recv_next_halo = (param_.rank < param_.num_gpus - 1) &&
+                                      ((param_.kernel[0] - 1)/2 >
+                                       ((last_index - first_index + param_.pad[0] -
+                                         (param_.kernel[0] - 1) / 2)
+                                        % param_.stride[0]));
+    const bool needs_send_first_halo = param_.rank > 0 &&
+                                       ((param_.kernel[0] - 1)/2 >
+                                        ((last_index - first_index + param_.pad[0] -
+                                          (param_.kernel[0] - 1) / 2)
+                                         % param_.stride[0]));
+    const bool needs_send_last_halo = (param_.rank < param_.num_gpus - 1) &&
+                                      (param_.pad[0] > 0);
+    const bool needs_communicate = needs_recv_next_halo || needs_recv_previous_halo ||
+                                   needs_send_first_halo || needs_send_last_halo;
+
+    const index_t input_slice_size = RemoveFirstSpatialDim(dshape).Size();
+    const index_t output_slice_size = RemoveFirstSpatialDim(oshape).Size();
+
+    std::vector<std::vector<size_t>> stages;
+    using WorkspaceType = mshadow::Tensor<gpu, 1, DType>;
+    WorkspaceType previous_halo_data;
+    WorkspaceType next_halo_data;
+    WorkspaceType main_fwd_wsp;
+    WorkspaceType halo_prev_fwd_wsp;
+    WorkspaceType halo_next_fwd_wsp;
+    WorkspaceType halo_prev_filter;
+    WorkspaceType halo_next_filter;
+    if (needs_communicate) {
+      size_t prev_halo_size = needs_recv_previous_halo ? halo_size : 0;
+      size_t next_halo_size = needs_recv_next_halo ? halo_size : 0;
+      if (parallelize_backward_kernels_) {
+        std::pair<size_t, size_t> prev_halo_wsp_size = needs_recv_previous_halo
+          ? std::make_pair(halo_conv_.forward_workspace_byte_, halo_filter_size)
+          : std::make_pair(0ul, 0ul);
+        std::pair<size_t, size_t> next_halo_wsp_size = needs_recv_next_halo
+          ? std::make_pair(halo_conv_.forward_workspace_byte_, halo_filter_size)
+          : std::make_pair(0ul, 0ul);
+        stages = {{prev_halo_size, next_halo_size, main_conv_.forward_workspace_byte_},
+                  {prev_halo_size, next_halo_size,
+                   prev_halo_wsp_size.first, prev_halo_wsp_size.second,
+                   next_halo_wsp_size.first, next_halo_wsp_size.second}};
+        auto workspace_stages = AllocateTempWorkspaces(ctx, stages);
+        previous_halo_data = workspace_stages[0][0];
+        next_halo_data = workspace_stages[0][1];
+        main_fwd_wsp = workspace_stages[0][2];
+        halo_prev_fwd_wsp = workspace_stages[1][2];
+        halo_prev_filter = workspace_stages[1][3];
+        halo_next_fwd_wsp = workspace_stages[1][4];
+        halo_next_filter = workspace_stages[1][5];
+      } else {
+        stages = {{prev_halo_size, next_halo_size, halo_filter_size,
+                   std::max(main_conv_.forward_workspace_byte_,
+                            halo_conv_.forward_workspace_byte_)}};
+        auto workspace_stages = AllocateTempWorkspaces(ctx, stages);
+        previous_halo_data = workspace_stages[0][0];
+        next_halo_data = workspace_stages[0][1];
+        halo_prev_filter = workspace_stages[0][2];
+        halo_next_filter = workspace_stages[0][2];
+        main_fwd_wsp = workspace_stages[0][3];
+        halo_prev_fwd_wsp = workspace_stages[0][3];
+        halo_next_fwd_wsp = workspace_stages[0][3];
+      }
+    } else {
+      stages = {{main_conv_.forward_workspace_byte_}};
+      auto workspace_stages = AllocateTempWorkspaces(ctx, stages);
+      main_fwd_wsp = workspace_stages[0][0];
+    }
+    if (needs_communicate) {
+      {
+        // First phase: Fwd + NCCL
+        SyncedGPUAuxStream s_nccl = ctx.get_gpu_aux_stream();
+        main_conv_.Forward(s, alpha, data_ptr, wmat_ptr, main_fwd_wsp.dptr_,
+                           req[spconv::kOut] == kAddTo ? beta_add : beta,
+                           out_ptr);
+        {
+          cudaStream_t nccl_stream = Stream<gpu>::GetStream(s_nccl.GetStream());
+          std::lock_guard<std::mutex> l(Storage::Get()->GetMutex(Context::kGPU));
+          ncclComm_t comm = *(NCCLCommContainer::comm_map.at(param_.num_gpus));
+          ncclGroupStart();
+          if (needs_recv_previous_halo) {
+            ncclRecv(previous_halo_data.dptr_, halo_dshape.Size(), DataType<DType>::kNCCLFlag,
+                     param_.rank - 1, comm, nccl_stream);
+          }
+          if (needs_recv_next_halo) {
+            ncclRecv(next_halo_data.dptr_, halo_dshape.Size(), DataType<DType>::kNCCLFlag,
+                     param_.rank + 1, comm, nccl_stream);
+          }
+          if (needs_send_first_halo) {
+            ncclSend(data_ptr, halo_dshape.Size(), DataType<DType>::kNCCLFlag,
+                     param_.rank - 1, comm, nccl_stream);
+          }
+          if (needs_send_last_halo) {
+            ncclSend(data_ptr + dshape.Size() - halo_dshape.Size(),
+                     halo_dshape.Size(), DataType<DType>::kNCCLFlag,
+                     param_.rank + 1, comm, nccl_stream);
+          }
+          ncclGroupEnd();
+        }
+      }
+      {
+        // Second phase - halo convolutions
+        SyncedGPUAuxStream s_aux = ctx.get_gpu_aux_stream();
+        if (needs_recv_previous_halo) {
+          ExtractHaloFilter(s, halo_prev_filter.dptr_, wmat_ptr, input_halo_dim - 1,
+                            2 * input_halo_dim - 1, 1 - input_halo_dim, halo_wshape, wshape);
+          halo_conv_.Forward(s, alpha, previous_halo_data.dptr_, halo_prev_filter.dptr_,
+                             halo_prev_fwd_wsp.dptr_, beta_add, out_ptr);
+        }
+        if (needs_recv_next_halo) {
+          const index_t stride_adjustment = (param_.stride[0] -
+                                             (input_halo_dim % param_.stride[0])) %
+                                            param_.stride[0];
+          // If the output regions do not overlap use the secondary stream
+          mshadow::Stream<gpu>* second_stream =
+            oshape.Size() >= 2 * output_slice_size * output_halo_dim ? s_aux.GetStream() : s;
+          ExtractHaloFilter(second_stream, halo_next_filter.dptr_, wmat_ptr, 0,
+                            input_halo_dim - stride_adjustment,
+                            input_halo_dim + 1 + stride_adjustment,
+                            halo_wshape, wshape);
+          halo_conv_.Forward(second_stream, alpha, next_halo_data.dptr_, halo_next_filter.dptr_,
+                             halo_next_fwd_wsp.dptr_, beta_add,
+                             out_ptr + oshape.Size() - output_slice_size * output_halo_dim);
+        }
+      }
+    } else {
+      main_conv_.Forward(s, alpha, data_ptr, wmat_ptr, main_fwd_wsp.dptr_,
+                         req[spconv::kOut] == kAddTo? beta_add : beta, out_ptr);
+    }
+
+    bool perform_forward_bias = !param_.no_bias;
+    bool perform_cuda_forward_bias = perform_forward_bias &&
+                                     FeaturesLastLayout() &&
+                                     dmlc::GetEnv("MXNET_CONV_CUDA_FORWARD_BIAS", true);
+    if (perform_forward_bias) {
+      if (perform_cuda_forward_bias) {
+        int output_features = static_cast<int>(Features(out_data[spconv::kOut].shape_));
+        Tensor<gpu, 1, DType> bias =
+          in_data[spconv::kBias].get_with_shape<gpu, 1, DType>(Shape1(output_features), s);
+        Tensor<gpu, 2, DType> out = FlattenAs2DHead<gpu, DType>(out_data[spconv::kOut], ctx);
+        auto &data = out;  // Only data.shape_[0] is used by AddBias()
+        AddBias(bias, data, out, s);
+      } else {
+        Tensor<gpu, 1, DType> bias = in_data[spconv::kBias].get<gpu, 1, DType>(s);
+        CUDNN_CALL(cudnnAddTensor(s->dnn_handle_,
+                                  &alpha,
+                                  main_conv_.bias_desc_,
+                                  bias.dptr_,
+                                  &beta_add,
+                                  main_conv_.out_desc_,
+                                  out_ptr));
+      }
+    }
+  }
+
+  void Backward(const OpContext &ctx,
+                const std::vector<TBlob> &out_grad,
+                const std::vector<TBlob> &in_data,
+                const std::vector<OpReqType> &req,
+                const std::vector<TBlob> &in_grad) {
+    using namespace mshadow;
+    using namespace mshadow::expr;
+    size_t expected = param_.no_bias == 0 ? 3 : 2;
+    CHECK_EQ(out_grad.size(), 1U);
+    CHECK_EQ(in_data.size(), expected);
+    CHECK_EQ(in_grad.size(), expected);
+    Stream<gpu> *s = ctx.get_stream<gpu>();
+    const index_t output_halo_dim = (param_.kernel[0] - 1) / 2;
+    const index_t input_halo_dim = (output_halo_dim + 2 * param_.pad[0] - param_.kernel[0])
+                                   / param_.stride[0] + 1;
+    const auto& dshape = out_grad[spconv::kOut].shape_;
+    const bool reduced_dim = param_.kernel[0] == 3;
+    const auto& halo_dshape = GetHaloShape(dshape, input_halo_dim, reduced_dim);
+    const auto& oshape = in_grad[spconv::kData].shape_;
+    const size_t halo_size = halo_dshape.Size() * sizeof(DType);
+    mxnet::TShape wshape = in_data[spconv::kWeight].shape_;
+    mxnet::TShape halo_wshape = GetHaloFilterShape(wshape, param_.kernel[0]);
+    size_t halo_filter_size = halo_wshape.Size() * sizeof(DType);
+
+    // I/O's should have 2 more dims than the kernel dim
+    DType *grad_ptr = GetNdPtr(out_grad[spconv::kOut], param_.kernel.ndim() + 2, s);
+    DType *wmat_ptr = GetNdPtr(in_data[spconv::kWeight], param_.kernel.ndim() + 2, s);
+    DType *gwmat_ptr = GetNdPtr(in_grad[spconv::kWeight], param_.kernel.ndim() + 2, s);
+    DType *data_ptr = GetNdPtr(in_data[spconv::kData], param_.kernel.ndim() + 2, s);
+    DType *gdata_ptr = GetNdPtr(in_grad[spconv::kData], param_.kernel.ndim() + 2, s);
+
+    bool perform_backward_bias = !param_.no_bias && (req[spconv::kBias] != kNullOp);
+    bool perform_cuda_backward_bias = perform_backward_bias &&
+                                      FeaturesLastLayout() &&
+                                      dmlc::GetEnv("MXNET_CONV_CUDA_BACKWARD_BIAS", true);
+    if (perform_cuda_backward_bias && !back_bias_get_workspace_performed_) {
+      auto y_grad = FlattenAs2DHead<gpu, DType>(out_grad[spconv::kOut], ctx);
+      int output_features = static_cast<int>(Features(out_grad[spconv::kOut].shape_));
+      main_conv_.bias_workspace_byte_ = AddBiasGradWorkspaceSizeBytes(in_grad[spconv::kBias],
+                                                                      y_grad,
+                                                                      req[spconv::kBias],
+                                                                      output_features, ctx);
+      back_bias_get_workspace_performed_ = true;
+    }
+
+    index_t first_index = param_.rank * dshape[1];
+    index_t last_index = (param_.rank + 1) * dshape[1] - 1;
+    const bool needs_recv_previous_halo = param_.rank > 0 &&
+                                          ((param_.kernel[0] - 1)/2 >
+                                           ((last_index - first_index + param_.pad[0] -
+                                             (param_.kernel[0] - 1) / 2)
+                                            % param_.stride[0]));
+    const bool needs_recv_next_halo = (param_.rank < param_.num_gpus - 1) &&
+                                      (param_.pad[0] > 0);
+    const bool needs_send_first_halo = param_.rank > 0 && (param_.pad[0] > 0);
+    const bool needs_send_last_halo = (param_.rank < param_.num_gpus - 1) &&
+                                      ((param_.kernel[0] - 1)/2 >
+                                       ((last_index - first_index + param_.pad[0] -
+                                         (param_.kernel[0] - 1) / 2)
+                                        % param_.stride[0]));
+    bool needs_communicate = needs_recv_next_halo || needs_recv_previous_halo ||
+                             needs_send_first_halo || needs_send_last_halo;
+
+    const index_t output_slice_size = RemoveFirstSpatialDim(oshape).Size();
+    std::vector<std::vector<size_t>> stages;
+    using WorkspaceType = mshadow::Tensor<gpu, 1, DType>;
+    WorkspaceType previous_halo_data;
+    WorkspaceType next_halo_data;
+    WorkspaceType main_dgrad_wsp;
+    WorkspaceType main_wgrad_wsp;
+    WorkspaceType main_bias_wsp;
+    WorkspaceType halo_dgrad_wsp;
+    WorkspaceType halo_wgrad_wsp;
+    WorkspaceType halo_dfilter;
+    WorkspaceType halo_filter;
+    if (needs_communicate) {
+      size_t prev_halo_size = needs_recv_previous_halo ? halo_size : 0;
+      size_t next_halo_size = needs_recv_next_halo ? halo_size : 0;
+      if (parallelize_backward_kernels_) {
+        stages = {{prev_halo_size, next_halo_size, std::max(main_conv_.dgrad_workspace_byte_,
+                                                            main_conv_.wgrad_workspace_byte_)},
+                  {prev_halo_size, next_halo_size, std::max(halo_conv_.wgrad_workspace_byte_,
+                                                            main_conv_.bias_workspace_byte_),
+                   halo_filter_size, halo_conv_.dgrad_workspace_byte_, halo_filter_size}};
+        CHECK_EQ(stages[0][0], prev_halo_size);
+        CHECK_EQ(stages[0][1], next_halo_size);
+        const auto& workspace_stages = AllocateTempWorkspaces(ctx, stages);
+        previous_halo_data = workspace_stages[0][0];
+        next_halo_data = workspace_stages[0][1];
+        main_dgrad_wsp = workspace_stages[0][2];
+        main_wgrad_wsp = workspace_stages[0][2];
+        main_bias_wsp = workspace_stages[1][2];
+        halo_wgrad_wsp = workspace_stages[1][2];
+        halo_dfilter = workspace_stages[1][3];
+        halo_dgrad_wsp = workspace_stages[1][4];
+        halo_filter = workspace_stages[1][5];
+      } else {
+        stages = {{prev_halo_size, next_halo_size, halo_filter_size,
+                   std::max({main_conv_.dgrad_workspace_byte_,
+                             main_conv_.wgrad_workspace_byte_,
+                             main_conv_.bias_workspace_byte_,
+                             halo_conv_.dgrad_workspace_byte_,
+                             halo_conv_.wgrad_workspace_byte_})}};
+        const auto& workspace_stages = AllocateTempWorkspaces(ctx, stages);
+        previous_halo_data = workspace_stages[0][0];
+        next_halo_data = workspace_stages[0][1];
+        halo_dfilter = workspace_stages[0][2];
+        halo_filter = workspace_stages[0][2];
+        main_dgrad_wsp = workspace_stages[0][3];
+        main_wgrad_wsp = workspace_stages[0][3];
+        main_bias_wsp = workspace_stages[0][3];
+        halo_wgrad_wsp = workspace_stages[0][3];
+        halo_dgrad_wsp = workspace_stages[0][3];
+      }
+    } else {
+      if (parallelize_backward_kernels_) {
+        stages = {{std::max(main_conv_.wgrad_workspace_byte_, main_conv_.bias_workspace_byte_),
+                   main_conv_.dgrad_workspace_byte_}};
+        const auto& workspace_stages = AllocateTempWorkspaces(ctx, stages);
+        main_wgrad_wsp = workspace_stages[0][0];
+        main_bias_wsp = workspace_stages[0][0];
+        main_dgrad_wsp = workspace_stages[0][1];
+      } else {
+        stages = {{std::max({main_conv_.dgrad_workspace_byte_,
+                             main_conv_.wgrad_workspace_byte_,
+                             main_conv_.bias_workspace_byte_})}};
+        const auto& workspace_stages = AllocateTempWorkspaces(ctx, stages);
+        main_dgrad_wsp = workspace_stages[0][0];
+        main_wgrad_wsp = workspace_stages[0][0];
+        main_bias_wsp = workspace_stages[0][0];
+      }
+    }
+
+    if (needs_communicate) {
+      typename DataType<DType>::ScaleType alpha = 1.0f;
+      typename DataType<DType>::ScaleType beta = 0.0f;
+      typename DataType<DType>::ScaleType beta_add = 1.0f;
+      {
+        SyncedGPUAuxStream aux_stream = ctx.get_gpu_aux_stream();
+        // First stage: [dgrad, wgrad] + [NCCL]
+        if (req[spconv::kData] != kNullOp) {
+          main_conv_.DGrad(s, alpha, grad_ptr, wmat_ptr, main_dgrad_wsp.dptr_,
+                           req[spconv::kData] == kAddTo? beta_add : beta, gdata_ptr);
+        }
+        if (req[spconv::kWeight] != kNullOp) {
+          CHECK_EQ(add_to_weight_, req[spconv::kWeight] == kAddTo);
+          main_conv_.WGrad(s, alpha, data_ptr, grad_ptr, main_wgrad_wsp.dptr_,
+                           req[spconv::kWeight] == kAddTo? beta_add : beta,
+                           gwmat_ptr);
+        }
+        {
+          cudaStream_t nccl_stream = Stream<gpu>::GetStream(aux_stream.GetStream());
+          std::lock_guard<std::mutex> l(Storage::Get()->GetMutex(Context::kGPU));
+          ncclComm_t comm = *(NCCLCommContainer::comm_map.at(param_.num_gpus));
+          ncclGroupStart();
+          if (needs_recv_previous_halo) {
+            ncclRecv(previous_halo_data.dptr_, halo_dshape.Size(), DataType<DType>::kNCCLFlag,
+                     param_.rank - 1, comm, nccl_stream);
+          }
+          if (needs_recv_next_halo) {
+            ncclRecv(next_halo_data.dptr_, halo_dshape.Size(), DataType<DType>::kNCCLFlag,
+                     param_.rank + 1, comm, nccl_stream);
+          }
+          if (needs_send_first_halo) {
+            ncclSend(grad_ptr, halo_dshape.Size(), DataType<DType>::kNCCLFlag,
+                     param_.rank - 1, comm, nccl_stream);
+          }
+          if (needs_send_last_halo) {
+            ncclSend(grad_ptr + dshape.Size() - halo_dshape.Size(),
+                     halo_dshape.Size(), DataType<DType>::kNCCLFlag,
+                     param_.rank + 1, comm, nccl_stream);
+          }
+          ncclGroupEnd();
+        }
+      }
+      {
+        // Second stage: [halo_wgrad, halo_wgrad, bgrad] + [halo_dgrad, halo_dgrad]
+        SyncedGPUAuxStream aux_stream = ctx.get_gpu_aux_stream();
+        const index_t filter_halo_dim = halo_wshape.ndim() == wshape.ndim() ? halo_wshape[1] : 1;
+        if (req[spconv::kWeight] != kNullOp) {
+          if (needs_recv_previous_halo) {
+            halo_conv_.WGrad(s, alpha, data_ptr, previous_halo_data.dptr_, halo_wgrad_wsp.dptr_,
+                             beta, halo_dfilter.dptr_);
+            const index_t stride_adjustment = (param_.stride[0] -
+                                               (output_halo_dim % param_.stride[0])) %
+                                              param_.stride[0];
+            AddHaloWGrad(s, gwmat_ptr, halo_dfilter.dptr_, 0, output_halo_dim - stride_adjustment,
+                         output_halo_dim + 1 + stride_adjustment, halo_wshape, wshape);
+          }
+          if (needs_recv_next_halo) {
+            halo_conv_.WGrad(s, alpha, data_ptr + oshape.Size() -
+                                                  output_slice_size * output_halo_dim,
+                             next_halo_data.dptr_, halo_wgrad_wsp.dptr_, beta, halo_dfilter.dptr_);
+            AddHaloWGrad(s, gwmat_ptr, halo_dfilter.dptr_, output_halo_dim - 1,
+                         2 * output_halo_dim - 1, 1 - output_halo_dim, halo_wshape, wshape);
+          }
+        }
+        if (perform_backward_bias) {
+          if (perform_cuda_backward_bias) {
+            auto y_grad = FlattenAs2DHead<gpu, DType>(out_grad[spconv::kOut], ctx);
+            int output_features = static_cast<int>(Features(out_grad[spconv::kOut].shape_));
+            Tensor<gpu, 1, uint8_t> workspace(reinterpret_cast<uint8_t*>(main_bias_wsp.dptr_),
+                                              Shape1(main_bias_wsp.shape_.Size() * sizeof(DType)));
+            AddBiasGrad(in_grad[spconv::kBias], y_grad, req[spconv::kBias], output_features,
+                        ctx, spconv::kTempSpace, &workspace);
+          } else {
+            Tensor<gpu, 1, DType> gbias = in_grad[spconv::kBias].get<gpu, 1, DType>(s);
+            CUDNN_CALL(cudnnConvolutionBackwardBias(s->dnn_handle_,
+                                                &alpha,
+                                                main_conv_.out_desc_,
+                                                grad_ptr,
+                                                req[spconv::kBias] == kAddTo ? &beta_add : &beta,
+                                                main_conv_.bias_desc_,
+                                                gbias.dptr_));
+          }
+        }
+        if (needs_recv_previous_halo && req[spconv::kData] != kNullOp) {
+          const index_t stride_adjustment = (param_.stride[0] -
+                                             (output_halo_dim % param_.stride[0])) %
+                                            param_.stride[0];
+          ExtractHaloFilter(aux_stream.GetStream(), halo_filter.dptr_, wmat_ptr, 0,
+                            output_halo_dim - stride_adjustment,
+                            output_halo_dim + 1 + stride_adjustment,
+                            halo_wshape, wshape);
+          halo_conv_.DGrad(aux_stream.GetStream(), alpha, previous_halo_data.dptr_,
+                           halo_filter.dptr_, halo_dgrad_wsp.dptr_, beta_add, gdata_ptr);
+        }
+        if (needs_recv_next_halo && req[spconv::kData] != kNullOp) {
+          ExtractHaloFilter(aux_stream.GetStream(), halo_filter.dptr_, wmat_ptr,
+                            output_halo_dim - 1, 2 * output_halo_dim - 1, 1 - output_halo_dim,
+                            halo_wshape, wshape);
+          halo_conv_.DGrad(aux_stream.GetStream(), alpha, next_halo_data.dptr_,
+                           halo_filter.dptr_, halo_dgrad_wsp.dptr_, beta_add,
+                           gdata_ptr + oshape.Size() - output_slice_size * output_halo_dim);
+        }
+      }
+    } else {
+      SyncedGPUAuxStream aux_stream = ctx.get_gpu_aux_stream();
+      DType *workspace_dptr_wgrad = main_wgrad_wsp.dptr_;
+      DType *workspace_dptr_dgrad = main_dgrad_wsp.dptr_;
+      typename DataType<DType>::ScaleType alpha = 1.0f;
+      typename DataType<DType>::ScaleType beta = 0.0f;
+      typename DataType<DType>::ScaleType beta_add = 1.0f;
+      if (req[spconv::kData] != kNullOp) {
+        main_conv_.DGrad(aux_stream.GetStream(), alpha, grad_ptr, wmat_ptr, workspace_dptr_dgrad,
+                         req[spconv::kData] == kAddTo? beta_add : beta, gdata_ptr);
+      }
+      if (req[spconv::kWeight] != kNullOp) {
+          CHECK_EQ(add_to_weight_, req[spconv::kWeight] == kAddTo);
+          main_conv_.WGrad(s, alpha, data_ptr, grad_ptr, workspace_dptr_wgrad,
+                           req[spconv::kWeight] == kAddTo? beta_add : beta, gwmat_ptr);
+      }
+      if (perform_backward_bias) {
+        if (perform_cuda_backward_bias) {
+          auto y_grad = FlattenAs2DHead<gpu, DType>(out_grad[spconv::kOut], ctx);
+          int output_features = static_cast<int>(Features(out_grad[spconv::kOut].shape_));
+          Tensor<gpu, 1, uint8_t> workspace(reinterpret_cast<uint8_t*>(main_bias_wsp.dptr_),
+                                            Shape1(main_bias_wsp.shape_.Size() * sizeof(DType)));
+          // Will use the beginning of the workspace (so the one shared with wgrad)
+          AddBiasGrad(in_grad[spconv::kBias], y_grad, req[spconv::kBias], output_features,
+                      ctx, spconv::kTempSpace, &workspace);
+        } else {
+          Tensor<gpu, 1, DType> gbias = in_grad[spconv::kBias].get<gpu, 1, DType>(s);
+          CUDNN_CALL(cudnnConvolutionBackwardBias(s->dnn_handle_,
+                                              &alpha,
+                                              main_conv_.out_desc_,
+                                              grad_ptr,
+                                              req[spconv::kBias] == kAddTo ? &beta_add : &beta,
+                                              main_conv_.bias_desc_,
+                                              gbias.dptr_));
+        }
+      }
+    }
+  }
+
+/*!
+ * \brief Returns whether the cuDNN library version supports the convolution
+ * operation described by `param`: cuDNN v5 and earlier does not support
+ * dilated convolutions.  Dilation only enabled after v6.0.20.
+ */
+  static bool Supports(SpatialParallelConvolutionParam param,
+                       int forward_compute_type,
+                       int backward_compute_type,
+                       int dev_id) {
+    using namespace mshadow;
+
+    // NDHWC, NHWC, NHC not supported in true fp16
+    auto layout_val = param.layout.value();
+    auto true_fp16 = DataType<DType>::kFlag == kFloat16 &&
+      (forward_compute_type == kFloat16 || backward_compute_type == kFloat16);
+    if (true_fp16 &&
+        (layout_val == kNDHWC || layout_val == kNHWC || layout_val == kNWC))
+      return false;
+
+    // Permits graceful fallback to pseudo-fp16 on heterogenous systems
+    if (!SupportsFloat16Compute(dev_id) &&
+        (forward_compute_type == kFloat16 || backward_compute_type == kFloat16)) {
+      return false;
+    }
+
+    return true;
+  }
+
+ private:
+/*!
+ * \brief Translate an mxnet datatype to the corresponding cudnnDataType_t.
+ */
+  cudnnDataType_t convertToCuDNNDataType(int dtype) {
+    cudnnDataType_t converted = CUDNN_DATA_FLOAT;
+    // The following will always assign to `converted` or throw an exception.
+    MSHADOW_REAL_TYPE_SWITCH(dtype, mxDType, {
+      converted = mshadow::DataType<mxDType>::kCudnnFlag;
+    })
+    return converted;
+  }
+
+  void InitDescriptors(const mxnet::ShapeVector& in_shape,
+                       const mxnet::ShapeVector& out_shape,
+                       cudnnDataType_t cudnn_forward_compute_type,
+                       cudnnDataType_t cudnn_backward_compute_type) {
+    using namespace mshadow;
+    size_t expected = param_.no_bias ? 2 : 3;
+    CHECK_EQ(in_shape.size(), expected);
+    CHECK_EQ(out_shape.size(), 1U);
+
+    mxnet::TShape dshape = in_shape[spconv::kData];
+    mxnet::TShape wshape = in_shape[spconv::kWeight];
+    mxnet::TShape oshape = out_shape[spconv::kOut];
+
+    CHECK(param_.layout.value() == kNDHWC ||
+          param_.layout.value() == kNHWC) << "Supports only NHWC and NDHWC for now.";
+
+    mxnet::TShape halo_wshape = GetHaloFilterShape(wshape, param_.kernel[0]);
+    const index_t input_halo_dim = (param_.kernel[0] - 1) / 2;
+    const index_t output_halo_dim = (input_halo_dim + 2 * param_.pad[0] - param_.kernel[0])
+                                    / param_.stride[0] + 1;
+    const bool reduced_dim = param_.kernel[0] == 3;
+    mxnet::TShape halo_dshape = GetHaloShape(dshape, input_halo_dim, reduced_dim);
+    mxnet::TShape halo_oshape = GetHaloShape(oshape, output_halo_dim, reduced_dim);
+
+    CHECK_EQ(param_.num_group, 1) << "Does not support grouped convolutions for now.";
+    auto dtype = DataType<DType>::kCudnnFlag;
+    main_conv_.Init(dshape, wshape, oshape, mshadow::LayoutFlag(param_.layout.value()),
+                    dtype, param_.stride, param_.dilate,
+                    param_.pad, cudnn_forward_compute_type,
+                    cudnn_backward_compute_type,
+                    param_.cudnn_tensor_core.value());
+    if (!param_.no_bias) {
+      main_conv_.InitBias(in_shape[spconv::kBias], dshape.ndim(), dtype);
+    }
+    int ndim = param_.stride.ndim();
+    if (reduced_dim) ndim -= 1;
+    mxnet::TShape halo_stride(ndim, -1), halo_dilate(ndim, -1), halo_pad(ndim, -1);
+    int count = 0;
+    for (int i = 0; i < param_.stride.ndim(); ++i) {
+      if (reduced_dim && i == 0) continue;
+      halo_stride[count] = param_.stride[i];
+      halo_dilate[count] = param_.dilate[i];
+      if (!reduced_dim && i == 0) {
+        halo_pad[count] = param_.pad[i] - 1;
+      } else {
+        halo_pad[count] = param_.pad[i];
+      }
+      ++count;
+    }
+    auto halo_layout = mshadow::LayoutFlag(param_.layout.value());
+    if (reduced_dim) {
+      switch (param_.layout.value()) {
+        case mshadow::kNDHWC: halo_layout = mshadow::kNHWC; break;
+        case mshadow::kNHWC: halo_layout = mshadow::kNWC; break;
+        default: LOG(FATAL) << "Layout not supported!";
+      }
+    }
+    halo_conv_.Init(halo_dshape, halo_wshape, halo_oshape, halo_layout,
+                    dtype, halo_stride, halo_dilate, halo_pad,
+                    cudnn_forward_compute_type,
+                    cudnn_backward_compute_type,
+                    param_.cudnn_tensor_core.value());
+  }
+
+  void CuDNNAlgoSetter(const RunContext& rctx,
+                  const mxnet::ShapeVector& in_shape,
+                  const mxnet::ShapeVector& out_shape,
+                  cudnnDataType_t cudnn_forward_compute_type,
+                  cudnnDataType_t cudnn_backward_compute_type,
+                  CuDNNAlgo<cudnnConvolutionFwdAlgo_t> *fwd,
+                  CuDNNAlgo<cudnnConvolutionBwdDataAlgo_t> *bwd,
+                  CuDNNAlgo<cudnnConvolutionBwdFilterAlgo_t> *flt) {
+    // Not in algo registry, must determine via *Get*() or *Find*()
+    mshadow::Stream<gpu> *s = rctx.get_stream<gpu>();
+    CHECK_EQ(s->dnn_handle_ownership_, mshadow::Stream<gpu>::OwnHandle);
+    size_t workspace_byte = static_cast<size_t>(param_.workspace * sizeof(DType));
+
+    // Since the function signature of *Get*_v7() matches that of *Find*(),
+    // we can unify the find-vs-get logic by using function pointers.
+
+    // Forward Algorithm Find/Get() v7
+    std::vector<cudnnConvolutionFwdAlgoPerf_t> fwd_results(MaxForwardAlgos(s->dnn_handle_));
+    int actual_fwd_algos = 0;
+    auto fwd_algo_discoverer =
+      param_.cudnn_tune.value() == spconv::kOff ? cudnnGetConvolutionForwardAlgorithm_v7
+                                              : cudnnFindConvolutionForwardAlgorithm;
+    CUDNN_CALL((*fwd_algo_discoverer)(s->dnn_handle_,
+                                      main_conv_.in_desc_,
+                                      main_conv_.filter_desc_,
+                                      main_conv_.forward_desc_,
+                                      main_conv_.out_desc_,
+                                      fwd_results.size(),
+                                      &actual_fwd_algos,
+                                      fwd_results.data()));
+    fwd_results.resize(actual_fwd_algos);
+    AlgoFinalSelect<cudnnConvolutionFwdAlgoPerf_t,
+                    cudnnConvolutionFwdAlgo_t>(fwd_results, "forward",
+                                               param_.cudnn_algo_fwd, workspace_byte,
+                                               fwd, excluded_forward_algos_);
+
+    // Backprop-to-Filter Algorithm Find/Get() v7
+    auto max_bwd_filt_algos = MaxBackwardFilterAlgos(s->dnn_handle_);
+    std::vector<cudnnConvolutionBwdFilterAlgoPerf_t> bwd_filt_results(max_bwd_filt_algos);
+    int actual_bwd_filter_algos = 0;
+    // In cudnn v7.1.4, find() returned wgrad algos that could fail for large c if we
+    // were summing into the output (i.e. beta != 0).  Get() returned OK algos though.
+    auto bwd_filter_algo_discoverer =
+      param_.cudnn_tune.value() == spconv::kOff ? cudnnGetConvolutionBackwardFilterAlgorithm_v7
+                                              : cudnnFindConvolutionBackwardFilterAlgorithm;
+    CUDNN_CALL((*bwd_filter_algo_discoverer)(s->dnn_handle_,
+                                             main_conv_.in_desc_,
+                                             main_conv_.out_desc_,
+                                             main_conv_.wgrad_desc_,
+                                             main_conv_.filter_desc_,
+                                             bwd_filt_results.size(),
+                                             &actual_bwd_filter_algos,
+                                             bwd_filt_results.data()));
+    bwd_filt_results.resize(actual_bwd_filter_algos);
+    AlgoFinalSelect<cudnnConvolutionBwdFilterAlgoPerf_t,
+                    cudnnConvolutionBwdFilterAlgo_t>(bwd_filt_results, "backprop-to-filter",
+                                                     param_.cudnn_algo_bwd_filter, workspace_byte,
+                                                     flt, excluded_back_algos_w_);
+
+    // Backprop-to-Data Algorithm Find/Get() v7
+    auto max_bwd_data_algos = MaxBackwardDataAlgos(s->dnn_handle_);
+    std::vector<cudnnConvolutionBwdDataAlgoPerf_t> bwd_data_results(max_bwd_data_algos);
+    int actual_bwd_data_algos = 0;
+    auto bwd_data_algo_discoverer =
+      param_.cudnn_tune.value() == spconv::kOff ? cudnnGetConvolutionBackwardDataAlgorithm_v7
+                                              : cudnnFindConvolutionBackwardDataAlgorithm;
+    CUDNN_CALL((*bwd_data_algo_discoverer)(s->dnn_handle_,
+                                           main_conv_.filter_desc_,
+                                           main_conv_.out_desc_,
+                                           main_conv_.dgrad_desc_,
+                                           main_conv_.in_desc_,
+                                           bwd_data_results.size(),
+                                           &actual_bwd_data_algos,
+                                           bwd_data_results.data()));
+    bwd_data_results.resize(actual_bwd_data_algos);
+    AlgoFinalSelect<cudnnConvolutionBwdDataAlgoPerf_t,
+                    cudnnConvolutionBwdDataAlgo_t>(bwd_data_results, "backprop-to-data",
+                                                   param_.cudnn_algo_bwd_data, workspace_byte,
+                                                   bwd, excluded_back_algos_);
+
+    // Fix for issue #11241
+    int cudnn_find_issue_max_features = 64 * 1024;
+    if (add_to_weight_ && Features(in_shape[spconv::kData]) >= cudnn_find_issue_max_features) {
+      flt->Set(CUDNN_CONVOLUTION_BWD_FILTER_ALGO_1, true);
+    }
+
+    if (param_.cudnn_algo_verbose) {
+      std::string key = CuDNNSPConvAlgoReg::Get()->ToString(param_, in_shape, out_shape,
+                                                            DataType<DType>::kCudnnFlag,
+                                                            cudnn_forward_compute_type,
+                                                            cudnn_backward_compute_type,
+                                                            SMArch(rctx.ctx.dev_id));
+      LOG(INFO) << "Algo selection for convolution: " << key;
+      LOG(INFO) << "            forward : " << fwd->AlgoNumber() <<
+                TensorCoreStr(rctx.ctx, fwd->IsTensorCoreAlgo());
+      LOG(INFO) << "    backprop-to-data: " << bwd->AlgoNumber() <<
+                TensorCoreStr(rctx.ctx, bwd->IsTensorCoreAlgo());
+      LOG(INFO) << "  backprop-to-filter: " << flt->AlgoNumber() <<
+                TensorCoreStr(rctx.ctx, flt->IsTensorCoreAlgo());
+      LOG(INFO) << "";
+    }
+  }
+
+  void SelectMainAlgo(const RunContext& rctx,
+                      const mxnet::ShapeVector& in_shape,
+                      const mxnet::ShapeVector& out_shape,
+                      cudnnDataType_t cudnn_forward_compute_type,
+                      cudnnDataType_t cudnn_backward_compute_type) {
+    SelectAlgo(rctx, in_shape, out_shape, cudnn_forward_compute_type,
+               cudnn_backward_compute_type, param_, DataType<DType>::kCudnnFlag, add_to_weight_,
+               &main_conv_.forward_algo_, &main_conv_.dgrad_algo_, &main_conv_.wgrad_algo_,
+               main_conv_.forward_desc_, main_conv_.dgrad_desc_, main_conv_.wgrad_desc_);
+  }
+
+  void SelectHaloAlgo(const RunContext& rctx,
+                      const mxnet::ShapeVector& in_shape,
+                      const mxnet::ShapeVector& out_shape,
+                      cudnnDataType_t cudnn_forward_compute_type,
+                      cudnnDataType_t cudnn_backward_compute_type) {
+    SpatialParallelConvolutionParam halo_param = param_;
+    if (param_.kernel[0] > 3) {
+      halo_param.kernel[0] -= 2;
+      halo_param.pad[0] -= 1;
+    } else {
+      halo_param.kernel = mxnet::TShape(param_.kernel.begin() + 1, param_.kernel.end());
+      halo_param.stride = mxnet::TShape(param_.stride.begin() + 1, param_.stride.end());
+      halo_param.dilate = mxnet::TShape(param_.dilate.begin() + 1, param_.dilate.end());
+      halo_param.pad = mxnet::TShape(param_.pad.begin() + 1, param_.pad.end());
+    }
+    SelectAlgo(rctx, in_shape, out_shape, cudnn_forward_compute_type,
+               cudnn_backward_compute_type, halo_param, DataType<DType>::kCudnnFlag, add_to_weight_,
+               &halo_conv_.forward_algo_, &halo_conv_.dgrad_algo_, &halo_conv_.wgrad_algo_,
+               halo_conv_.forward_desc_, halo_conv_.dgrad_desc_, halo_conv_.wgrad_desc_);
+  }
+
+  void SelectAlgo(const RunContext& rctx,
+                  const mxnet::ShapeVector& in_shape,
+                  const mxnet::ShapeVector& out_shape,
+                  cudnnDataType_t cudnn_forward_compute_type,
+                  cudnnDataType_t cudnn_backward_compute_type,
+                  const SpatialParallelConvolutionParam& param,
+                  cudnnDataType_t dtype,
+                  bool add_to_weight,
+                  CuDNNAlgo<cudnnConvolutionFwdAlgo_t>* forward_algo,
+                  CuDNNAlgo<cudnnConvolutionBwdDataAlgo_t>* back_algo,
+                  CuDNNAlgo<cudnnConvolutionBwdFilterAlgo_t>* back_algo_w,
+                  cudnnConvolutionDescriptor_t forward_conv_desc,
+                  cudnnConvolutionDescriptor_t back_conv_desc,
+                  cudnnConvolutionDescriptor_t back_conv_desc_w) {
+    auto algo_setter = [&](CuDNNAlgo<cudnnConvolutionFwdAlgo_t> *fwd,
+                           CuDNNAlgo<cudnnConvolutionBwdDataAlgo_t> *bwd,
+                           CuDNNAlgo<cudnnConvolutionBwdFilterAlgo_t> *flt) {
+      if (param_.cudnn_tune.value() == spconv::kOff) {
+        // The routine will only be calling cudnnGet, so no need to grab the Storage lock.
+        this->CuDNNAlgoSetter(rctx, in_shape, out_shape,
+                              cudnn_forward_compute_type,
+                              cudnn_backward_compute_type,
+                              fwd, bwd, flt);
+      } else {
+        // One potential problem is that cudnnFind() uses cudaMalloc() to directly allocate
+        // I/O and workspace areas, and these allocations may result in an out-of-memory
+        // error even though the StorageMangager free pool is not empty.  Ideally, cudnnFind
+        // would use MXNet's storage allocator for its I/O and workspace areas, instead of using
+        // the area carved out by MXNET_GPU_MEM_POOL_RESERVE.
+        // To get somewhat the same effect as this, we can pre-allocate the areas needed for the
+        // I/Os (possibly triggering a desirable StorageManager::ReleaseAll()), followed by a
+        // DirectFree(), which makes these areas available for cudnn's subsequent cudaMalloc().
+
+        // Allocate for x (or dx), w (or dw) and y (or dy).
+        ReserveElements({in_shape[spconv::kData].Size(),
+                         in_shape[spconv::kWeight].Size(),
+                         out_shape[spconv::kOut].Size()});
+
+        // We're about to call cudnnFind so we need to quiet the system by grabbing
+        // the Storage lock.  Concurrent cudaMalloc's can disrupt the accurate timing
+        // measurements of the algos, and can prevent the cuda driver's proper freeing
+        // of cudnnFind's internal temporary allocations.  Grabbing the lock might also
+        // impede other threads from launching work on the GPU.
+        std::lock_guard<std::mutex> lock(Storage::Get()->GetMutex(Context::kGPU));
+        this->CuDNNAlgoSetter(rctx, in_shape, out_shape,
+                              cudnn_forward_compute_type,
+                              cudnn_backward_compute_type,
+                              fwd, bwd, flt);
+      }
+    };
+
+    CuDNNSPConvAlgoReg::Get()->FindOrElseRegister(param, in_shape, out_shape, dtype,
+                                                  cudnn_forward_compute_type,
+                                                  cudnn_backward_compute_type,
+                                                  SMArch(rctx.ctx.dev_id), add_to_weight,
+                                                  forward_algo, back_algo,
+                                                  back_algo_w, algo_setter);
+
+    // If we're allowing Tensor Core variants of the algos to be considered in
+    // *Find*() or *Get*(), but a non-Tensor-Core algo variant is the fastest,
+    // we must change the descriptor to preclude Tensor Core.  Simplest is to
+    // once again set the mathType in all cases.
+    CUDNN_CALL(cudnnSetConvolutionMathType(forward_conv_desc, forward_algo->MathType()));
+    CUDNN_CALL(cudnnSetConvolutionMathType(back_conv_desc, back_algo->MathType()));
+    CUDNN_CALL(cudnnSetConvolutionMathType(back_conv_desc_w, back_algo_w->MathType()));
+  }
+
+  // Convert the `is_tensor_core_algo` flag to a string for verbose-mode output
+  std::string TensorCoreStr(const Context& ctx, bool is_tensor_core_algo) {
+    // GPU's before Volta (sm_70) would not be expected to run Tensor Core algos,
+    // so we don't report whether the algo is/is-not Tensor Core in that case.
+    if (!SupportsTensorCore(ctx.dev_id))
+      return std::string("");
+    else if (is_tensor_core_algo)
+      return std::string(" (Tensor Core)");
+    else
+      return std::string(" (not Tensor Core)");
+  }
+
+  std::string FixedFormat(float f, int width, int precision) {
+    std::stringstream ss;
+    ss << std::fixed << std::setprecision(precision) << std::setw(width) << f;
+    return ss.str();
+  }
+
+  // Look over the results from *Find*() or *Get*() and pick the fastest algo given possible
+  // workspace constraints and a possible user algo preference.
+  template <typename PerfType, typename AlgoType>
+  void AlgoFinalSelect(const std::vector<PerfType> &perf_results, std::string kernel_name,
+                       int32_t algo_preference, size_t workspace_byte, CuDNNAlgo<AlgoType> *algo,
+                       const std::set<AlgoType> &excluded_algos) {
+    // Determine the fastest acceptable algo that matches the algo_preference (-1 = any),
+    // regardless of mathType.
+    auto mode = param_.cudnn_tune.value() == spconv::kOff ? " get " : " find ";
+    if (param_.cudnn_algo_verbose && dmlc::GetEnv("MXNET_CUDNN_ALGO_VERBOSE_LEVEL", 1) >= 2) {
+      LOG(INFO) << "Full results of algo" << mode << kernel_name << ":";
+      for (const auto &result : perf_results) {
+        auto math_type_str = "-";
+          if (result.mathType == CUDNN_TENSOR_OP_MATH)
+            math_type_str = "+";
+        LOG(INFO) << "    algo: " << result.algo <<
+                     ", TC" << math_type_str <<
+                     ", time: " << FixedFormat(result.time, 7, 3) << "ms" <<
+                     ", wksp = " << result.memory <<
+                     ", status = " << result.status;
+      }
+    }
+
+    bool enforce_determinism = dmlc::GetEnv("MXNET_ENFORCE_DETERMINISM", false);
+    for (decltype(perf_results.size()) i = 0; i != perf_results.size(); ++i) {
+      const auto &result = perf_results[i];
+      bool algo_is_tensor_core = result.mathType == CUDNN_TENSOR_OP_MATH;
+      bool algo_exclusion =
+          param_.cudnn_tensor_core_only && !algo_is_tensor_core ||
+          (result.algo != algo_preference) && (excluded_algos.count(result.algo) != 0);
+      if (result.status == CUDNN_STATUS_SUCCESS &&
+          (!enforce_determinism || result.determinism == cudnnDeterminism_t::CUDNN_DETERMINISTIC) &&
+          (param_.cudnn_tune.value() == spconv::kFastest || result.memory <= workspace_byte) &&
+          (algo_preference == -1 || algo_preference == result.algo) &&
+          !algo_exclusion) {
+        // Fix for a current cuDNNv7 behavior where algos are reported twice
+        // with equivalent performance (both as Tensor Core and not Tensor Core).
+        if ((result.mathType == CUDNN_TENSOR_OP_MATH) &&
+             (i != perf_results.size() - 1) &&
+             !param_.cudnn_tensor_core_only) {
+          const auto &next_result = perf_results[i+1];
+          if (next_result.status == CUDNN_STATUS_SUCCESS &&
+              next_result.algo == result.algo &&
+              next_result.memory == result.memory &&
+              next_result.mathType != CUDNN_TENSOR_OP_MATH &&
+              next_result.time < ALGO_PERF_THRESHOLD * result.time) {
+              // Skip over this result- it's not really a Tensor Core algo.
+              // Prefer instead the next equivalent non-Tensor Core algo.
+                continue;
+          }
+        }
+        algo->Set(result.algo, algo_is_tensor_core);
+        return;
+      }
+    }
+    if (algo_preference != -1)
+      LOG(FATAL) << "Failed to" << mode << kernel_name
+                 << " convolution algorithm " << algo_preference
+                 << " with workspace size of " << workspace_byte << " bytes,"
+                 << " please consider reducing batch/model size or increasing the workspace size";
+    else
+      LOG(FATAL) << "Failed to" << mode << "any " << kernel_name << " convolution algorithm"
+                 << " with workspace size of " << workspace_byte << " bytes,"
+                 << " please consider reducing batch/model size or increasing the workspace size";
+  }
+
+
+  void GetTempSize(const RunContext& rctx) {
+    main_conv_.GetWorkspaceSize(rctx);
+    halo_conv_.GetWorkspaceSize(rctx);
+  }
+
+  // Converts a TBlob to a dptr, checking for the expected dim and that it's contiguous.
+  DType *GetNdPtr(const TBlob& tb, int dim, Stream<gpu> *s) {
+    DType *data_ptr = nullptr;
+    if (dim == 3) {
+      Tensor<gpu, 3, DType> data = tb.get<gpu, 3, DType>(s);
+      CHECK_EQ(data.CheckContiguous(), true);
+      data_ptr = data.dptr_;
+    } else if (dim == 4) {
+      Tensor<gpu, 4, DType> data = tb.get<gpu, 4, DType>(s);
+      CHECK_EQ(data.CheckContiguous(), true);
+      data_ptr = data.dptr_;
+    } else if (dim == 5) {
+      Tensor<gpu, 5, DType> data = tb.get<gpu, 5, DType>(s);
+      CHECK_EQ(data.CheckContiguous(), true);
+      data_ptr = data.dptr_;
+    } else {
+      LOG(FATAL) << "Unexpected Tensor size " << dim << ", supporting only 3, 4 or 5.";
+    }
+    return data_ptr;
+  }
+
+  // Round a value 'x' up to the next multiple of 'multiple'
+  static size_t RoundToMultiple(size_t x, size_t multiple) {
+    size_t retVal = ((x + multiple - 1) / multiple) * multiple;
+    return retVal;
+  }
+
+  std::vector<std::vector<mshadow::Tensor<gpu, 1, DType>>>
+  AllocateTempWorkspaces(const OpContext &ctx,
+                         const std::vector<std::vector<size_t>> &sizes_bytes_stages) {
+    mshadow::Stream<gpu> *s = ctx.get_stream<gpu>();
+    size_t max_total_size = 0;
+    std::vector<std::vector<mshadow::Tensor<gpu, 1, DType>>> ret;
+    std::vector<std::vector<size_t>> rounded_sizes_in_words_stages;
+    // Get maximum size
+    for (const auto& sizes_bytes : sizes_bytes_stages) {
+      rounded_sizes_in_words_stages.emplace_back();
+      auto& rounded_sizes_in_words = rounded_sizes_in_words_stages.back();
+      std::transform(sizes_bytes.cbegin(), sizes_bytes.cend(),
+                     std::back_inserter(rounded_sizes_in_words),
+                     [](const size_t s) -> std::size_t {
+                       const size_t dptr_alignment = 512 / sizeof(DType);
+                       size_t size_in_words = std::max<size_t>(1,
+                                                RoundToMultiple(s, sizeof(DType)) /
+                                                sizeof(DType));
+                       size_t aligned = RoundToMultiple(size_in_words, dptr_alignment);
+                       return aligned;
+                     });
+      size_t total_size = 0;
+      for (const size_t s : rounded_sizes_in_words) {
+        total_size += s;
+      }
+      max_total_size = std::max(max_total_size, total_size);
+    }
+    auto total_storage = ctx.requested[spconv::kTempSpace].get_space_typed<gpu, 1, DType>(
+        mshadow::Shape1(max_total_size), s);
+    for (const auto& rounded_sizes_in_words : rounded_sizes_in_words_stages) {
+      ret.emplace_back();
+      auto& current = ret.back();
+      DType *ptr = total_storage.dptr_;
+      std::transform(rounded_sizes_in_words.cbegin(), rounded_sizes_in_words.cend(),
+                     std::back_inserter(current),
+                     [&ptr](const size_t s) -> mshadow::Tensor<gpu, 1, DType> {
+                       mshadow::Tensor<gpu, 1, DType> t(ptr, mshadow::Shape1(s));
+                       ptr += s;
+                       return t;
+                     });
+    }
+    return ret;
+  }
+
+  // Returns the size in bytes of the 1D Tensor of words.
+  size_t TensorSizeBytes(const mshadow::Tensor<gpu, 1, DType> &tensor) {
+    return tensor.MSize() * sizeof(DType);
+  }
+
+  // Given a tensor shape of this operation, return the number of features 'c'
+  int64_t Features(const mxnet::TShape &dshape) {
+    int c = 0;
+    switch (dshape.ndim()) {
+      case 3: c = ConvertLayout(dshape.get<3>(), param_.layout.value(), kNCW)[1]; break;
+      case 4: c = ConvertLayout(dshape.get<4>(), param_.layout.value(), kNCHW)[1]; break;
+      case 5: c = ConvertLayout(dshape.get<5>(), param_.layout.value(), kNCDHW)[1]; break;
+      default:
+        LOG(FATAL) << "Unexpected convolution data dimension " << dshape.ndim();
+    }
+    return c;
+  }
+
+  // Does the operation's data layout have the features dimension 'c' last?
+  bool FeaturesLastLayout() {
+    return param_.layout.value() == kNWC ||
+           param_.layout.value() == kNHWC ||
+           param_.layout.value() == kNDHWC;
+  }
+
+    // Give a tensor shape of this operation, return the N * H * W
+  int64_t GetNHW(const TShape &dshape) {
+    int nhw = 0;
+    switch (dshape.ndim()) {
+      case 3:
+      {
+         auto tmp = ConvertLayout(dshape.get<3>(), param_.layout.value(), kNCW);
+         nhw = tmp[0] * tmp[2];
+         break;
+      }
+      case 4:
+      {
+        auto tmp = ConvertLayout(dshape.get<4>(), param_.layout.value(), kNCHW);
+        nhw = tmp[0] * tmp[2] * tmp[3];
+        break;
+      }
+      case 5:
+      {
+        auto tmp = ConvertLayout(dshape.get<5>(), param_.layout.value(), kNCDHW);
+        nhw = tmp[0] * tmp[3] * tmp[4];
+        break;
+      }
+      default:
+        LOG(FATAL) << "Unexpected convolution data dimension " << dshape.ndim();
+    }
+    return nhw;
+  }
+
+  // Make a number of allocations and directly free them, ensuring room for an equivalent set of
+  // cudaMalloc() calls by (say) cudnnFind().  `elements` spec the alloc size in DTypes, not bytes.
+  void ReserveElements(const std::vector<size_t> &elements) {
+    std::vector<Storage::Handle> handles;
+    for (size_t alloc_element : elements)
+        handles.push_back(Storage::Get()->Alloc(alloc_element * sizeof(DType), Context::GPU()));
+    for (auto &handle : handles)
+        Storage::Get()->DirectFree(handle);
+  }
+
+  // Log that no suitable algo was found that met the workspace constraints, then exit.
+  void LogNoSuitableAlgoAndExit(int num_algos_tried, size_t min_memory_needs,
+                                size_t workspace_byte, std::string algo_kind) {
+    LOG(FATAL) << num_algos_tried << " " << algo_kind << " with minimum memory requirement "
+               << min_memory_needs << " bytes have been tried. Workspace size is set to "
+               << workspace_byte << " bytes, please consider reducing the batch/model size, "
+               << "or increasing workspace size.";
+  }
+
+  mxnet::TShape RemoveFirstSpatialDim(const mxnet::TShape& shape) {
+    mxnet::TShape ret(shape.ndim() - 1, -1);
+
+    for (int i = 0, count = 0; i < shape.ndim(); ++i) {
+      // Remove D or H
+      if (i != 1) {
+        ret[count] = shape[i];
+        ++count;
+      }
+    }
+
+    return ret;
+  }
+
+  mxnet::TShape GetHaloShape(const mxnet::TShape& shape, const int halo_dim,
+                             const bool reduced_dim) {
+    const int ndim = reduced_dim ? shape.ndim() - 1 : shape.ndim();
+    mxnet::TShape ret(ndim, -1);
+
+    for (int i = 0, count = 0; i < shape.ndim(); ++i) {
+      if (i != 1) {
+        ret[count] = shape[i];
+        ++count;
+      } else {
+        if (!reduced_dim) {
+          CHECK_LE(halo_dim, shape[i])
+            << "Tensor split into too many GPUs - the halo dimension (" << halo_dim
+            << ") is larger than the per-GPU tensor dimension (" << shape[1] << ").";
+          ret[count] = halo_dim;
+          ++count;
+        }
+      }
+    }
+
+    return ret;
+  }
+
+  mxnet::TShape GetHaloFilterShape(const mxnet::TShape& shape, const int kernel_size) {
+    const int ndim = kernel_size > 3 ? shape.ndim() : shape.ndim() - 1;
+    mxnet::TShape ret(ndim, -1);
+
+    for (int i = 0, count = 0; i < shape.ndim(); ++i) {
+      if (i != 1) {
+        ret[count] = shape[i];
+        ++count;
+      } else {
+        if (kernel_size > 3) {
+          ret[count] = kernel_size - 2;
+          ++count;
+        }
+      }
+    }
+
+    return ret;
+  }
+
+  // If backward bias is needed, has the workspace size been requested
+  bool back_bias_get_workspace_performed_;
+
+  CUDNNConvolution main_conv_;
+  CUDNNConvolution halo_conv_;
+
+  // Should dgrad and wgrad be launched into separate streams
+  bool parallelize_backward_kernels_;
+  SpatialParallelConvolutionParam param_;
+  // Is req[kWeight] == spconv::kAddTo ?
+  bool add_to_weight_;
+  // forward algos that should be avoided to work-around possible cuDNN issues.
+  std::set<cudnnConvolutionFwdAlgo_t> excluded_forward_algos_;
+  // dgrad algos that should be avoided to work-around possible cuDNN issues.
+  std::set<cudnnConvolutionBwdDataAlgo_t> excluded_back_algos_;
+  // wgrad algos that should be avoided to work-around possible cuDNN issues.
+  std::set<cudnnConvolutionBwdFilterAlgo_t> excluded_back_algos_w_;
+};
+
+#endif  // CUDNN && NCCL
+}  // namespace op
+}  // namespace mxnet
+
+#endif  // MXNET_OPERATOR_CONTRIB_NN_CUDNN_CUDNN_SPATIAL_PARALLEL_CONVOLUTION_INL_H_

--- a/src/operator/contrib/nn/spatial_parallel_convolution-inl.h
+++ b/src/operator/contrib/nn/spatial_parallel_convolution-inl.h
@@ -1,0 +1,232 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * Copyright (c) 2020 by Contributors
+ * \file spatial_parallel_convolution-inl.h
+ * \brief Spatial parallel convolution
+ * \author Przemyslaw Tredak
+*/
+#ifndef MXNET_OPERATOR_CONTRIB_NN_SPATIAL_PARALLEL_CONVOLUTION_INL_H_
+#define MXNET_OPERATOR_CONTRIB_NN_SPATIAL_PARALLEL_CONVOLUTION_INL_H_
+
+#include <mxnet/operator.h>
+#include <mxnet/op_attr_types.h>
+#include <dmlc/logging.h>
+#include <dmlc/optional.h>
+#include <algorithm>
+#include <map>
+#include <vector>
+#include <string>
+#include <utility>
+#include "../../operator_common.h"
+
+
+namespace mxnet {
+namespace op {
+
+namespace spconv {
+enum ConvolutionOpInputs {kData, kWeight, kBias};
+enum ConvolutionOpOutputs {kOut};
+enum ConvolutionOpResource {kTempSpace};
+enum ConvolutionOpCudnnTune {kOff, kLimited, kFastest};
+}
+
+struct SpatialParallelConvolutionParam : public dmlc::Parameter<SpatialParallelConvolutionParam> {
+  mxnet::TShape kernel;
+  mxnet::TShape stride;
+  mxnet::TShape dilate;
+  mxnet::TShape pad;
+  uint32_t num_filter;
+  uint32_t num_group;
+  uint64_t workspace;
+  bool no_bias;
+  dmlc::optional<int> cudnn_tune;
+  bool cudnn_off;
+  dmlc::optional<bool> cudnn_tensor_core;
+  bool cudnn_tensor_core_only;
+  dmlc::optional<int> layout;
+  bool cudnn_algo_verbose;
+  int32_t cudnn_algo_fwd;
+  int32_t cudnn_algo_bwd_data;
+  int32_t cudnn_algo_bwd_filter;
+  int32_t cudnn_algo_fwd_prec;
+  int32_t cudnn_algo_bwd_prec;
+  int32_t num_gpus;
+  int32_t rank;
+  uintptr_t nccl_unique_id;
+  DMLC_DECLARE_PARAMETER(SpatialParallelConvolutionParam) {
+    DMLC_DECLARE_FIELD(kernel).describe("Convolution kernel size: (w,), (h, w) or (d, h, w)");
+    DMLC_DECLARE_FIELD(stride).set_default(mxnet::TShape(0, 0))
+    .describe("Convolution stride: (w,), (h, w) or (d, h, w). Defaults to 1 for each dimension.");
+    DMLC_DECLARE_FIELD(dilate).set_default(mxnet::TShape(0, 0))
+    .describe("Convolution dilate: (w,), (h, w) or (d, h, w). Defaults to 1 for each dimension.");
+    DMLC_DECLARE_FIELD(pad).set_default(mxnet::TShape(0, 0))
+    .describe("Zero pad for convolution: (w,), (h, w) or (d, h, w). Defaults to no padding.");
+    DMLC_DECLARE_FIELD(num_filter).set_lower_bound(1)
+    .describe("Convolution filter(channel) number");
+    DMLC_DECLARE_FIELD(num_group).set_default(1)
+    .describe("Number of group partitions.");
+    DMLC_DECLARE_FIELD(workspace).set_default(1024).set_lower_bound(0)
+    .describe("Maximum temporary workspace allowed (MB) in convolution."
+              "This parameter has two usages. When CUDNN is not used, it determines the "
+              "effective batch size of the convolution kernel. When CUDNN is used, it controls "
+              "the maximum temporary storage used for tuning the best CUDNN kernel when "
+              "`limited_workspace` strategy is used.");
+    DMLC_DECLARE_FIELD(no_bias).set_default(false)
+    .describe("Whether to disable bias parameter.");
+    DMLC_DECLARE_FIELD(cudnn_tune)
+    .add_enum("off", spconv::kOff)
+    .add_enum("limited_workspace", spconv::kLimited)
+    .add_enum("fastest", spconv::kFastest)
+    .set_default(dmlc::optional<int>())
+        .describe("Whether to pick convolution algo by running performance test.");
+    DMLC_DECLARE_FIELD(cudnn_off).set_default(false)
+    .describe("Turn off cudnn for this layer.");
+    DMLC_DECLARE_FIELD(cudnn_tensor_core)
+    .set_default(dmlc::optional<bool>())
+    .describe("Allow Tensor Core math within the algos.");
+    DMLC_DECLARE_FIELD(cudnn_tensor_core_only).set_default(false)
+        .describe("Require Tensor Core math within the algos.");
+    DMLC_DECLARE_FIELD(layout)
+    .add_enum("NCW", mshadow::kNCW)
+    .add_enum("NCHW", mshadow::kNCHW)
+    .add_enum("NCDHW", mshadow::kNCDHW)
+    .add_enum("NWC", mshadow::kNWC)
+    .add_enum("NHWC", mshadow::kNHWC)
+    .add_enum("NDHWC", mshadow::kNDHWC)
+    .set_default(dmlc::optional<int>())
+    .describe("Set layout for input, output and weight. Empty for\n    "
+              "default layout: NWC for 1d, NHWC for 2d and NDHWC for 3d.");
+    DMLC_DECLARE_FIELD(cudnn_algo_verbose).set_default(0)
+    .describe("Verboseness of algo selection. 1 = output selection, 0 = no output");
+    DMLC_DECLARE_FIELD(cudnn_algo_fwd).set_default(-1)
+    .describe("Specified Forward Algorithm.");
+    DMLC_DECLARE_FIELD(cudnn_algo_bwd_data).set_default(-1)
+    .describe("Specified Backprop-to-Data Algorithm.");
+    DMLC_DECLARE_FIELD(cudnn_algo_bwd_filter).set_default(-1)
+    .describe("Specified Backprop-to-Filter Algorithm.");
+    DMLC_DECLARE_FIELD(cudnn_algo_fwd_prec)
+    .add_enum("None", -1)
+    .add_enum("float32", mshadow::kFloat32)
+    .add_enum("float64", mshadow::kFloat64)
+    .add_enum("float16", mshadow::kFloat16)
+    .set_default(-1)
+    .describe("Precision of the computation of the forward convolution kernel.\n    "
+              "Default is the tensor data type, or float32 if the tensor data\n    "
+              "type is float16.");
+    DMLC_DECLARE_FIELD(cudnn_algo_bwd_prec)
+    .add_enum("None", -1)
+    .add_enum("float32", mshadow::kFloat32)
+    .add_enum("float64", mshadow::kFloat64)
+    .add_enum("float16", mshadow::kFloat16)
+    .set_default(-1)
+    .describe("Precision of the computation of the back-prop kernels.\n    "
+              "Default is the tensor data type, or float32 if the tensor data\n    "
+              "type is float16.");
+    DMLC_DECLARE_FIELD(num_gpus).describe("Number of GPUs per sample.");
+    DMLC_DECLARE_FIELD(rank).describe("Rank inside a group");
+    DMLC_DECLARE_FIELD(nccl_unique_id).describe("NCCL unique ID");
+  }
+  // Adjusts kernel size for effects of dilation in the dimension `dim`.
+  index_t DilatedKernelSize(int dim) const {
+    return 1 + (kernel[dim] - 1) * dilate[dim];
+  }
+
+  bool operator==(const SpatialParallelConvolutionParam& other) const {
+    return this->kernel == other.kernel &&
+           this->stride == other.stride &&
+           this->dilate == other.dilate &&
+           this->pad == other.pad &&
+           this->num_filter == other.num_filter &&
+           this->num_group == other.num_group &&
+           this->workspace == other.workspace &&
+           this->no_bias == other.no_bias &&
+           this->cudnn_tune == other.cudnn_tune &&
+           this->cudnn_off == other.cudnn_off &&
+           this->layout == other.layout &&
+           // cudnn_algo_verbose omitted since it can't affect algo choice.
+           this->cudnn_tensor_core == other.cudnn_tensor_core &&
+           this->cudnn_tensor_core_only == other.cudnn_tensor_core_only &&
+           this->cudnn_algo_fwd == other.cudnn_algo_fwd &&
+           this->cudnn_algo_bwd_data == other.cudnn_algo_bwd_data &&
+           this->cudnn_algo_bwd_filter == other.cudnn_algo_bwd_filter &&
+           this->cudnn_algo_fwd_prec == other.cudnn_algo_fwd_prec &&
+           this->cudnn_algo_bwd_prec == other.cudnn_algo_bwd_prec &&
+           this->num_gpus == other.num_gpus;
+  }
+};
+
+void SPConvolutionParamParser(nnvm::NodeAttrs* attrs);
+
+using SPConvSignature = ParamOpSign<SpatialParallelConvolutionParam>;
+}  // namespace op
+}  // namespace mxnet
+
+namespace std {
+template<>
+struct hash<mxnet::op::SpatialParallelConvolutionParam> {
+  size_t operator()(const mxnet::op::SpatialParallelConvolutionParam& val) {
+    size_t ret = 0;
+    ret = dmlc::HashCombine(ret, val.kernel);
+    ret = dmlc::HashCombine(ret, val.stride);
+    ret = dmlc::HashCombine(ret, val.dilate);
+    ret = dmlc::HashCombine(ret, val.pad);
+    ret = dmlc::HashCombine(ret, val.num_filter);
+    ret = dmlc::HashCombine(ret, val.num_group);
+    ret = dmlc::HashCombine(ret, val.workspace);
+    ret = dmlc::HashCombine(ret, val.no_bias);
+    ret = dmlc::HashCombine(ret, val.cudnn_tune);
+    ret = dmlc::HashCombine(ret, val.cudnn_off);
+    ret = dmlc::HashCombine(ret, val.layout);
+    // cudnn_algo_verbose omitted since it can't affect algo choice.
+    ret = dmlc::HashCombine(ret, val.cudnn_tensor_core);
+    ret = dmlc::HashCombine(ret, val.cudnn_tensor_core_only);
+    ret = dmlc::HashCombine(ret, val.cudnn_algo_fwd);
+    ret = dmlc::HashCombine(ret, val.cudnn_algo_bwd_data);
+    ret = dmlc::HashCombine(ret, val.cudnn_algo_bwd_filter);
+    ret = dmlc::HashCombine(ret, val.cudnn_algo_fwd_prec);
+    ret = dmlc::HashCombine(ret, val.cudnn_algo_bwd_prec);
+    ret = dmlc::HashCombine(ret, val.num_gpus);
+    ret = dmlc::HashCombine(ret, val.rank);
+
+    return ret;
+  }
+};
+}  // namespace std
+
+namespace mxnet {
+namespace op {
+
+template<typename xpu>
+void SPConvolutionCompute(const nnvm::NodeAttrs& attrs,
+                          const OpContext& ctx, const std::vector<TBlob>& inputs,
+                          const std::vector<OpReqType>& req,
+                          const std::vector<TBlob>& outputs) {
+}
+
+template<typename xpu>
+void SPConvolutionGradCompute(const nnvm::NodeAttrs& attrs,
+                              const OpContext& ctx, const std::vector<TBlob>& inputs,
+                              const std::vector<OpReqType>& req,
+                              const std::vector<TBlob>& outputs) {}
+
+}  // namespace op
+}  // namespace mxnet
+#endif  // MXNET_OPERATOR_CONTRIB_NN_SPATIAL_PARALLEL_CONVOLUTION_INL_H_

--- a/src/operator/contrib/nn/spatial_parallel_convolution-inl.h
+++ b/src/operator/contrib/nn/spatial_parallel_convolution-inl.h
@@ -59,15 +59,7 @@ struct SpatialParallelConvolutionParam : public dmlc::Parameter<SpatialParallelC
   bool no_bias;
   dmlc::optional<int> cudnn_tune;
   bool cudnn_off;
-  dmlc::optional<bool> cudnn_tensor_core;
-  bool cudnn_tensor_core_only;
   dmlc::optional<int> layout;
-  bool cudnn_algo_verbose;
-  int32_t cudnn_algo_fwd;
-  int32_t cudnn_algo_bwd_data;
-  int32_t cudnn_algo_bwd_filter;
-  int32_t cudnn_algo_fwd_prec;
-  int32_t cudnn_algo_bwd_prec;
   int32_t num_gpus;
   int32_t rank;
   uintptr_t nccl_unique_id;
@@ -99,11 +91,6 @@ struct SpatialParallelConvolutionParam : public dmlc::Parameter<SpatialParallelC
         .describe("Whether to pick convolution algo by running performance test.");
     DMLC_DECLARE_FIELD(cudnn_off).set_default(false)
     .describe("Turn off cudnn for this layer.");
-    DMLC_DECLARE_FIELD(cudnn_tensor_core)
-    .set_default(dmlc::optional<bool>())
-    .describe("Allow Tensor Core math within the algos.");
-    DMLC_DECLARE_FIELD(cudnn_tensor_core_only).set_default(false)
-        .describe("Require Tensor Core math within the algos.");
     DMLC_DECLARE_FIELD(layout)
     .add_enum("NCW", mshadow::kNCW)
     .add_enum("NCHW", mshadow::kNCHW)
@@ -114,32 +101,6 @@ struct SpatialParallelConvolutionParam : public dmlc::Parameter<SpatialParallelC
     .set_default(dmlc::optional<int>())
     .describe("Set layout for input, output and weight. Empty for\n    "
               "default layout: NWC for 1d, NHWC for 2d and NDHWC for 3d.");
-    DMLC_DECLARE_FIELD(cudnn_algo_verbose).set_default(0)
-    .describe("Verboseness of algo selection. 1 = output selection, 0 = no output");
-    DMLC_DECLARE_FIELD(cudnn_algo_fwd).set_default(-1)
-    .describe("Specified Forward Algorithm.");
-    DMLC_DECLARE_FIELD(cudnn_algo_bwd_data).set_default(-1)
-    .describe("Specified Backprop-to-Data Algorithm.");
-    DMLC_DECLARE_FIELD(cudnn_algo_bwd_filter).set_default(-1)
-    .describe("Specified Backprop-to-Filter Algorithm.");
-    DMLC_DECLARE_FIELD(cudnn_algo_fwd_prec)
-    .add_enum("None", -1)
-    .add_enum("float32", mshadow::kFloat32)
-    .add_enum("float64", mshadow::kFloat64)
-    .add_enum("float16", mshadow::kFloat16)
-    .set_default(-1)
-    .describe("Precision of the computation of the forward convolution kernel.\n    "
-              "Default is the tensor data type, or float32 if the tensor data\n    "
-              "type is float16.");
-    DMLC_DECLARE_FIELD(cudnn_algo_bwd_prec)
-    .add_enum("None", -1)
-    .add_enum("float32", mshadow::kFloat32)
-    .add_enum("float64", mshadow::kFloat64)
-    .add_enum("float16", mshadow::kFloat16)
-    .set_default(-1)
-    .describe("Precision of the computation of the back-prop kernels.\n    "
-              "Default is the tensor data type, or float32 if the tensor data\n    "
-              "type is float16.");
     DMLC_DECLARE_FIELD(num_gpus).describe("Number of GPUs per sample.");
     DMLC_DECLARE_FIELD(rank).describe("Rank inside a group");
     DMLC_DECLARE_FIELD(nccl_unique_id).describe("NCCL unique ID");
@@ -161,14 +122,6 @@ struct SpatialParallelConvolutionParam : public dmlc::Parameter<SpatialParallelC
            this->cudnn_tune == other.cudnn_tune &&
            this->cudnn_off == other.cudnn_off &&
            this->layout == other.layout &&
-           // cudnn_algo_verbose omitted since it can't affect algo choice.
-           this->cudnn_tensor_core == other.cudnn_tensor_core &&
-           this->cudnn_tensor_core_only == other.cudnn_tensor_core_only &&
-           this->cudnn_algo_fwd == other.cudnn_algo_fwd &&
-           this->cudnn_algo_bwd_data == other.cudnn_algo_bwd_data &&
-           this->cudnn_algo_bwd_filter == other.cudnn_algo_bwd_filter &&
-           this->cudnn_algo_fwd_prec == other.cudnn_algo_fwd_prec &&
-           this->cudnn_algo_bwd_prec == other.cudnn_algo_bwd_prec &&
            this->num_gpus == other.num_gpus;
   }
 };
@@ -195,14 +148,6 @@ struct hash<mxnet::op::SpatialParallelConvolutionParam> {
     ret = dmlc::HashCombine(ret, val.cudnn_tune);
     ret = dmlc::HashCombine(ret, val.cudnn_off);
     ret = dmlc::HashCombine(ret, val.layout);
-    // cudnn_algo_verbose omitted since it can't affect algo choice.
-    ret = dmlc::HashCombine(ret, val.cudnn_tensor_core);
-    ret = dmlc::HashCombine(ret, val.cudnn_tensor_core_only);
-    ret = dmlc::HashCombine(ret, val.cudnn_algo_fwd);
-    ret = dmlc::HashCombine(ret, val.cudnn_algo_bwd_data);
-    ret = dmlc::HashCombine(ret, val.cudnn_algo_bwd_filter);
-    ret = dmlc::HashCombine(ret, val.cudnn_algo_fwd_prec);
-    ret = dmlc::HashCombine(ret, val.cudnn_algo_bwd_prec);
     ret = dmlc::HashCombine(ret, val.num_gpus);
     ret = dmlc::HashCombine(ret, val.rank);
 

--- a/src/operator/contrib/nn/spatial_parallel_convolution.cu
+++ b/src/operator/contrib/nn/spatial_parallel_convolution.cu
@@ -1,0 +1,246 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * Copyright (c) 2017 by Contributors
+ * \file convolution.cu
+ * \brief
+ * \author Bing Xu, Jun Wu, Da Zheng
+*/
+
+#include "./spatial_parallel_convolution-inl.h"
+#include <vector>
+#if MXNET_USE_CUDNN == 1
+#include "./cudnn/cudnn_spatial_parallel_convolution-inl.h"
+#endif  // MXNET_USE_CUDNN
+
+namespace mxnet {
+namespace op {
+
+#if MXNET_USE_CUDNN == 1
+template<>
+CuDNNAlgoReg<SpatialParallelConvolutionParam> *
+CuDNNAlgoReg<SpatialParallelConvolutionParam>::Get() {
+  static CuDNNAlgoReg<SpatialParallelConvolutionParam> inst;
+  return &inst;
+}
+
+template<typename DType>
+static CuDNNSPConvolutionOp<DType>& GetCuDNNSPConvOp(const SpatialParallelConvolutionParam& param,
+                                                     int forward_compute_type,
+                                                     int backward_compute_type,
+                                                     const mxnet::ShapeVector& in_shape,
+                                                     const mxnet::ShapeVector& out_shape,
+                                                     const RunContext& rctx,
+                                                     bool add_to_weight) {
+#if DMLC_CXX11_THREAD_LOCAL
+  static thread_local std::unordered_map<SPConvSignature,
+                                         std::shared_ptr<CuDNNSPConvolutionOp<DType> >,
+                                         OpHash> ops;
+#else
+  static MX_THREAD_LOCAL std::unordered_map<SPConvSignature,
+                                            std::shared_ptr<CuDNNSPConvolutionOp<DType> >,
+                                            OpHash> ops;
+#endif
+  SPConvSignature key(param);
+  size_t ndim = 0;
+  for (auto &s : in_shape)
+    ndim += s.ndim();
+  for (auto &s : out_shape)
+    ndim += s.ndim();
+  key.Reserve(1 /* for forward_compute_type */ +
+              1 /* for backward_compute_type */ +
+              ndim /* for in and out shapes */ +
+              1 /* for dev_id */ +
+              1 /* for add_to_weight */);
+
+  key.AddSign(forward_compute_type);
+  key.AddSign(backward_compute_type);
+  key.AddSign(in_shape);
+  key.AddSign(out_shape);
+  key.AddSign(rctx.ctx.dev_id);
+  key.AddSign(add_to_weight ? 1 : 0);
+
+  auto it = ops.find(key);
+  if (it == ops.end()) {
+    std::shared_ptr<CuDNNSPConvolutionOp<DType>> op(new CuDNNSPConvolutionOp<DType>());
+    auto ins_ret = ops.insert(std::pair<SPConvSignature,
+                                        std::shared_ptr<CuDNNSPConvolutionOp<DType>>>(
+                              key, op));
+    CHECK(ins_ret.second);
+    it = ins_ret.first;
+    it->second->Init(param, forward_compute_type, backward_compute_type, in_shape,
+                     out_shape, rctx, add_to_weight);
+  }
+  return *it->second;
+}
+#endif
+
+template<>
+void SPConvolutionCompute<gpu>(const nnvm::NodeAttrs& attrs,
+                               const OpContext& ctx,
+                               const std::vector<TBlob>& inputs,
+                               const std::vector<OpReqType>& req,
+                               const std::vector<TBlob>& outputs) {
+  const SpatialParallelConvolutionParam& param =
+      nnvm::get<SpatialParallelConvolutionParam>(attrs.parsed);
+  int dtype = inputs[spconv::kData].type_flag_;
+#if MXNET_USE_CUDNN == 0 || MXNET_USE_NCCL == 0
+  LOG(FATAL) << "Spatial parallel convolution works only with cuDNN and NCCL support enabled. "
+             << "Please compile MXNet with USE_CUDNN and USE_NCCL options enabled.";
+#endif
+
+#if MXNET_USE_CUDNN == 1
+  STATIC_ASSERT_CUDNN_VERSION_GE(7000);
+  // On fp16-I/O instances, use fp32 compute (i.e. pseudo-fp16).
+  int desired_forward_compute_type =
+    (dtype == mshadow::kFloat16) ? mshadow::kFloat32 : dtype;
+  int desired_backward_compute_type =
+    (dtype == mshadow::kFloat16) ? mshadow::kFloat32 : dtype;
+
+  MSHADOW_REAL_TYPE_SWITCH(dtype, DType, {
+    if (param.cudnn_off) {
+      LOG(FATAL) << "Spatial parallel convolution needs cuDNN support!";
+    } else {
+      int forward_compute_type = desired_forward_compute_type;
+      int backward_compute_type = desired_backward_compute_type;
+      bool convolutionIsSupported = CuDNNSPConvolutionOp<DType>::Supports(param,
+                                          forward_compute_type,
+                                          backward_compute_type, ctx.run_ctx.ctx.dev_id);
+      // If cuDNN can't handle this case with fp16 backprop kernels, try fp32 backprop.
+      if (!convolutionIsSupported && backward_compute_type == mshadow::kFloat16) {
+        backward_compute_type = mshadow::kFloat32;
+        convolutionIsSupported = CuDNNSPConvolutionOp<DType>::Supports(param,
+                                          forward_compute_type,
+                                          backward_compute_type, ctx.run_ctx.ctx.dev_id);
+      }
+
+      // If cuDNN can't handle this case with fp16 forward kernels, try fp32
+      if (!convolutionIsSupported && forward_compute_type == mshadow::kFloat16) {
+        forward_compute_type = mshadow::kFloat32;
+        convolutionIsSupported = CuDNNSPConvolutionOp<DType>::Supports(param,
+                                          forward_compute_type,
+                                          backward_compute_type, ctx.run_ctx.ctx.dev_id);
+      }
+      if (!convolutionIsSupported) {
+        LOG(FATAL) << "This convolution is not supported by cuDNN and spatial parallel convolution "
+                   << "needs cuDNN support!";
+      } else {
+        if (forward_compute_type != desired_forward_compute_type)
+          LOG(WARNING) << "Requested forward compute precision not supported, using fp32.";
+        if (backward_compute_type != desired_backward_compute_type)
+          LOG(WARNING) << "Requested backward compute precision not supported, using fp32.";
+        mxnet::ShapeVector in_shape(inputs.size());
+        mxnet::ShapeVector out_shape(1, outputs[0].shape_);
+        for (size_t i = 0; i < in_shape.size(); i++)
+          in_shape[i] = inputs[i].shape_;
+        // req[conv::kWeight] is only set for backward, so assume the typical 'write' for now.
+        auto add_to_weight = false;
+        CuDNNSPConvolutionOp<DType> &op = GetCuDNNSPConvOp<DType>(param,
+          forward_compute_type, backward_compute_type, in_shape, out_shape, ctx.run_ctx,
+          add_to_weight);
+        op.Forward(ctx, inputs, req, outputs);
+      }
+    }
+  })
+#endif  // MXNET_USE_CUDNN
+}
+
+template<>
+void SPConvolutionGradCompute<gpu>(const nnvm::NodeAttrs& attrs,
+                                   const OpContext& ctx,
+                                   const std::vector<TBlob>& inputs,
+                                   const std::vector<OpReqType>& req,
+                                   const std::vector<TBlob>& outputs) {
+  const SpatialParallelConvolutionParam& param =
+      nnvm::get<SpatialParallelConvolutionParam>(attrs.parsed);
+  std::vector<TBlob> in_data(inputs.begin() + 1, inputs.end());
+  const TBlob &out_grad = inputs[0];
+  const std::vector<TBlob> &in_grad = outputs;
+  int dtype = out_grad.type_flag_;
+#if MXNET_USE_CUDNN == 0 || MXNET_USE_NCCL == 0
+  LOG(FATAL) << "Spatial parallel convolution works only with cuDNN and NCCL support enabled. "
+             << "Please compile MXNet with USE_CUDNN and USE_NCCL options enabled.";
+#endif
+
+#if MXNET_USE_CUDNN == 1
+  STATIC_ASSERT_CUDNN_VERSION_GE(7000);
+  // On fp16-I/O instances, use fp32 compute (i.e. pseudo-fp16).
+  int desired_forward_compute_type =
+    (dtype == mshadow::kFloat16) ? mshadow::kFloat32 : dtype;
+  int desired_backward_compute_type =
+    (dtype == mshadow::kFloat16) ? mshadow::kFloat32 : dtype;
+
+  MSHADOW_REAL_TYPE_SWITCH(dtype, DType, {
+    if (param.cudnn_off) {
+      LOG(FATAL) << "Spatial parallel convolution needs cuDNN support!";
+    } else {
+      int forward_compute_type = desired_forward_compute_type;
+      int backward_compute_type = desired_backward_compute_type;
+      bool convolutionIsSupported = CuDNNSPConvolutionOp<DType>::Supports(param,
+                                          forward_compute_type,
+                                          backward_compute_type, ctx.run_ctx.ctx.dev_id);
+      // If cuDNN can't handle this case with fp16 backprop kernels, try fp32 backprop.
+      if (!convolutionIsSupported && backward_compute_type == mshadow::kFloat16) {
+        backward_compute_type = mshadow::kFloat32;
+        convolutionIsSupported = CuDNNSPConvolutionOp<DType>::Supports(param,
+                                          forward_compute_type,
+                                          backward_compute_type, ctx.run_ctx.ctx.dev_id);
+      }
+
+      // If cuDNN can't handle this case with fp16 forward kernels, try fp32
+      if (!convolutionIsSupported && forward_compute_type == mshadow::kFloat16) {
+        forward_compute_type = mshadow::kFloat32;
+        convolutionIsSupported = CuDNNSPConvolutionOp<DType>::Supports(param,
+                                          forward_compute_type,
+                                          backward_compute_type, ctx.run_ctx.ctx.dev_id);
+      }
+      if (!convolutionIsSupported) {
+        LOG(FATAL) << "This convolution is not supported by cuDNN and spatial parallel convolution "
+                   << "needs cuDNN support!";
+      } else {
+        if (forward_compute_type != desired_forward_compute_type)
+          LOG(WARNING) << "Requested forward compute precision not supported, using fp32.";
+        if (backward_compute_type != desired_backward_compute_type)
+          LOG(WARNING) << "Requested backward compute precision not supported, using fp32.";
+        // The first element stores out grad.
+        mxnet::ShapeVector in_shape(in_data.size());
+        mxnet::ShapeVector out_shape(1, out_grad.shape_);
+        for (size_t i = 0; i < in_shape.size(); i++)
+          in_shape[i] = in_data[i].shape_;
+        auto add_to_weight = req[conv::kWeight] == kAddTo;
+        CuDNNSPConvolutionOp<DType> &op = GetCuDNNSPConvOp<DType>(param,
+          forward_compute_type, backward_compute_type, in_shape, out_shape, ctx.run_ctx,
+          add_to_weight);
+        op.Backward(ctx, std::vector<TBlob>{out_grad}, in_data, req, in_grad);
+      }
+    }
+  })
+#endif  // MXNET_USE_CUDNN
+}
+
+NNVM_REGISTER_OP(SpatialParallelConvolution)
+.set_attr<FCompute>("FCompute<gpu>", SPConvolutionCompute<gpu>);
+
+NNVM_REGISTER_OP(_backward_SPConvolution)
+.set_attr<FCompute>("FCompute<gpu>", SPConvolutionGradCompute<gpu>);
+
+}  // namespace op
+}  // namespace mxnet
+

--- a/src/operator/contrib/spatial_parallel_support.cc
+++ b/src/operator/contrib/spatial_parallel_support.cc
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * Copyright (c) 2020 by Contributors
+ * \file spatial_parallel_support.cc
+ * \brief Support operators for spatial parallelism
+ * \author Przemyslaw Tredak
+*/
+
+#include "spatial_parallel_support.h"
+#include <mxnet/base.h>
+#include <mxnet/storage.h>
+#include <mutex>
+#include <string>
+#include <utility>
+#include <vector>
+#include "../operator_common.h"
+#include "../elemwise_op_common.h"
+
+namespace mxnet {
+namespace op {
+
+void NCCLCommContainer::Init(const SpatialParallelParam& param) {
+  std::lock_guard<std::mutex> l(Storage::Get()->GetMutex(Context::kGPU));
+  if (NCCLCommContainer::comm_map.count(param.num_gpus) == 0) {
+    auto [it, inserted] = NCCLCommContainer::comm_map.emplace(param.num_gpus, // NOLINT(*)
+        std::make_unique<ncclComm_t>());
+    CHECK(inserted) << "Could not insert new NCCL communicator!";
+    ncclComm_t* comm = it->second.get();
+    ncclUniqueId id = *(reinterpret_cast<ncclUniqueId*>(
+          reinterpret_cast<void*>(param.nccl_unique_id)));
+    auto result = ncclCommInitRank(comm, param.num_gpus, id, param.rank);
+    CHECK_EQ(result, ncclSuccess) << "ncclCommInitRank failed!";
+  }
+}
+
+DMLC_REGISTER_PARAMETER(SpatialParallelParam);
+
+namespace {
+
+bool SpatialParallelSplitShape(const nnvm::NodeAttrs& attrs,
+                               std::vector<mxnet::TShape>* in_attrs,
+                               std::vector<mxnet::TShape>* out_attrs) {
+  CHECK_EQ(in_attrs->size(), 1U);
+  CHECK_EQ(out_attrs->size(), 1U);
+
+  mxnet::TShape& in = (*in_attrs)[0];
+  mxnet::TShape& out = (*out_attrs)[0];
+
+  if (!mxnet::ndim_is_known(in)) return false;
+
+  const SpatialParallelParam& param = nnvm::get<SpatialParallelParam>(attrs.parsed);
+
+  mxnet::TShape desired_shape(in.ndim(), -1);
+  desired_shape[0] = 1;
+  SHAPE_ASSIGN_CHECK(&desired_shape, 0, in);
+  if (desired_shape[1] != -1) {
+    CHECK(desired_shape[1] % param.num_gpus == 0) <<
+      "The outermost spatial dimension needs to be divisible by the number of GPUs!";
+    desired_shape[1] /= param.num_gpus;
+  }
+
+  SHAPE_ASSIGN_CHECK(&desired_shape, 0, out);
+  SHAPE_ASSIGN_CHECK(*out_attrs, 0, desired_shape);
+
+  if (desired_shape[1] >= 0)
+    desired_shape[1] *= param.num_gpus;
+
+  SHAPE_ASSIGN_CHECK(*in_attrs, 0, desired_shape);
+
+  return shape_is_known(in) && shape_is_known(out);
+}
+
+bool SpatialParallelAllgatherShape(const nnvm::NodeAttrs& attrs,
+                                   std::vector<mxnet::TShape>* in_attrs,
+                                   std::vector<mxnet::TShape>* out_attrs) {
+  CHECK_EQ(in_attrs->size(), 1U);
+  CHECK_EQ(out_attrs->size(), 1U);
+
+  mxnet::TShape& in = (*in_attrs)[0];
+  mxnet::TShape& out = (*out_attrs)[0];
+
+  if (!mxnet::ndim_is_known(in)) return false;
+
+  const SpatialParallelParam& param = nnvm::get<SpatialParallelParam>(attrs.parsed);
+
+  mxnet::TShape desired_shape(in.ndim(), -1);
+  desired_shape[0] = 1;
+  SHAPE_ASSIGN_CHECK(&desired_shape, 0, in);
+  if (desired_shape[1] != -1) {
+    desired_shape[1] *= param.num_gpus;
+  }
+
+  SHAPE_ASSIGN_CHECK(&desired_shape, 0, out);
+  SHAPE_ASSIGN_CHECK(*out_attrs, 0, desired_shape);
+
+  if (desired_shape[1] >= 0)
+    desired_shape[1] /= param.num_gpus;
+
+  SHAPE_ASSIGN_CHECK(*in_attrs, 0, desired_shape);
+
+  return shape_is_known(in) && shape_is_known(out);
+}
+
+}  // namespace
+
+NNVM_REGISTER_OP(_contrib_SpatialParallelSplit)
+.describe(R"code(Split the input so that each GPU in the
+in the group gets an equal part.
+
+)code" ADD_FILELINE)
+.set_num_inputs(1)
+.set_num_outputs(1)
+.set_attr_parser(ParamParser<SpatialParallelParam>)
+.set_attr<nnvm::FListOutputNames>("FListOutputNames",
+    [](const NodeAttrs& attrs) {
+    return std::vector<std::string>{"output"};
+})
+.set_attr<nnvm::FInplaceOption>("FInplaceOption", [](const NodeAttrs& attrs){
+  return std::vector<std::pair<int, int> >{{0, 0}};
+})
+.set_attr<nnvm::FInplaceIdentity>("FInplaceIdentity",
+  [](const NodeAttrs& attrs){
+    const SpatialParallelParam& param = nnvm::get<SpatialParallelParam>(attrs.parsed);
+    if (param.num_gpus == 1) {
+      return std::vector<bool>{true};
+    } else {
+      return std::vector<bool>{false};
+    }
+  })
+.set_attr<mxnet::FInferShape>("FInferShape", SpatialParallelSplitShape)
+.set_attr<nnvm::FInferType>("FInferType", ElemwiseType<1, 1>)
+.set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseNone{"_contrib_SpatialParallelAllgather"})
+.set_attr<FResourceRequest>("FResourceRequest", [](const NodeAttrs& n) {
+  return std::vector<ResourceRequest>{ResourceRequest::kMultiGPUComm};
+})
+.add_argument("data", "NDArray-or-Symbol", "Data")
+.add_arguments(SpatialParallelParam::__FIELDS__());
+
+NNVM_REGISTER_OP(_contrib_SpatialParallelAllgather)
+.describe(R"code(Gather the input so that each GPU in the
+in the group gets the full sample.
+
+)code" ADD_FILELINE)
+.set_num_inputs(1)
+.set_num_outputs(1)
+.set_attr_parser(ParamParser<SpatialParallelParam>)
+.set_attr<nnvm::FListOutputNames>("FListOutputNames",
+    [](const NodeAttrs& attrs) {
+    return std::vector<std::string>{"output"};
+})
+.set_attr<nnvm::FInplaceOption>("FInplaceOption", [](const NodeAttrs& attrs){
+  return std::vector<std::pair<int, int> >{{0, 0}};
+})
+.set_attr<nnvm::FInplaceIdentity>("FInplaceIdentity",
+  [](const NodeAttrs& attrs){
+    const SpatialParallelParam& param = nnvm::get<SpatialParallelParam>(attrs.parsed);
+    if (param.num_gpus == 1) {
+      return std::vector<bool>{true};
+    } else {
+      return std::vector<bool>{false};
+    }
+  })
+.set_attr<mxnet::FInferShape>("FInferShape", SpatialParallelAllgatherShape)
+.set_attr<nnvm::FInferType>("FInferType", ElemwiseType<1, 1>)
+.set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseNone{"_contrib_SpatialParallelSplit"})
+.set_attr<FResourceRequest>("FResourceRequest", [](const NodeAttrs& n) {
+  return std::vector<ResourceRequest>{ResourceRequest::kMultiGPUComm};
+})
+.add_argument("data", "NDArray-or-Symbol", "Data")
+.add_arguments(SpatialParallelParam::__FIELDS__());
+
+}  // namespace op
+}  // namespace mxnet

--- a/src/operator/contrib/spatial_parallel_support.cu
+++ b/src/operator/contrib/spatial_parallel_support.cu
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * Copyright (c) 2020 by Contributors
+ * \file spatial_parallel_support.cu
+ * \brief Support operators for spatial parallelism
+ * \author Przemyslaw Tredak
+*/
+
+#include "spatial_parallel_support.h"
+#include <mxnet/base.h>
+#include <mxnet/storage.h>
+#include <mutex>
+#include <vector>
+#include "../operator_common.h"
+#include "../../common/utils.h"
+#include "../tensor/elemwise_binary_op.h"
+
+namespace mxnet {
+namespace op {
+
+void SpatialParallelSplitCompute(const nnvm::NodeAttrs& attrs,
+                                 const OpContext& ctx,
+                                 const std::vector<TBlob>& inputs,
+                                 const std::vector<OpReqType>& req,
+                                 const std::vector<TBlob>& outputs) {
+  if (req[0] == OpReqType::kNullOp) return;
+  const SpatialParallelParam& param = nnvm::get<SpatialParallelParam>(attrs.parsed);
+  if (param.num_gpus == 1 && req[0] == OpReqType::kWriteInplace) return;
+  const auto& in = inputs[0];
+  const auto& out = outputs[0];
+  CHECK(param.num_gpus == 1 || in.shape_[0] == 1) <<
+    "SpatialParallelSplit supports only a single sample when number of GPUs is greater than 1.";
+  CHECK(in.shape_[1] % param.num_gpus == 0) <<
+    "The outermost spatial dimension needs to be divisible by the number of GPUs.";
+  const index_t stride = in.shape_.Size() / in.shape_[1];
+  const index_t dim_per_gpu = in.shape_[1] / param.num_gpus;
+  const index_t type_size = common::mshadow_type_info(in.type_flag_).size;
+  const index_t size = dim_per_gpu * stride * type_size;
+  const index_t start = param.rank * size;
+  if (req[0] != OpReqType::kAddTo) {
+    cudaStream_t stream = mshadow::Stream<gpu>::GetStream(ctx.get_stream<gpu>());
+    cudaMemcpyAsync(out.dptr_,
+                    reinterpret_cast<uint8_t*>(in.dptr_) + start,
+                    size,
+                    cudaMemcpyDeviceToDevice,
+                    stream);
+  } else {
+    TBlob new_in(reinterpret_cast<uint8_t*>(in.dptr_) + start, out.shape_,
+                 in.dev_mask(), in.type_flag_, in.dev_id());
+    ElemwiseBinaryRTCCompute {"add"}(attrs, ctx, {new_in, out}, {kWriteInplace}, {out});
+  }
+}
+
+void SpatialParallelAllgatherCompute(const nnvm::NodeAttrs& attrs,
+                                     const OpContext& ctx,
+                                     const std::vector<TBlob>& inputs,
+                                     const std::vector<OpReqType>& req,
+                                     const std::vector<TBlob>& outputs) {
+  const SpatialParallelParam& param = nnvm::get<SpatialParallelParam>(attrs.parsed);
+  if (req[0] == OpReqType::kNullOp) return;
+  if (param.num_gpus == 1 && req[0] == OpReqType::kWriteInplace) return;
+
+  NCCLCommContainer::Init(param);
+
+  std::lock_guard<std::mutex> l(Storage::Get()->GetMutex(Context::kGPU));
+  ncclComm_t comm = *(NCCLCommContainer::comm_map.at(param.num_gpus));
+  const index_t size = inputs[0].shape_.Size() *
+                       common::mshadow_type_info(inputs[0].type_flag_).size;
+  if (req[0] != OpReqType::kAddTo) {
+    ncclResult_t result = ncclAllGather(inputs[0].dptr_,
+                                        outputs[0].dptr_,
+                                        size, ncclInt8,
+                                        comm,
+                                        mshadow::Stream<gpu>::GetStream(ctx.get_stream<gpu>()));
+    CHECK_EQ(result, ncclSuccess) << "NCCL Allgather failed!";
+  } else {
+    LOG(FATAL) << "kAddTo not supported yet!";
+  }
+}
+
+NNVM_REGISTER_OP(_contrib_SpatialParallelSplit)
+.set_attr<FCompute>("FCompute<gpu>", SpatialParallelSplitCompute);
+
+NNVM_REGISTER_OP(_contrib_SpatialParallelAllgather)
+.set_attr<FCompute>("FCompute<gpu>", SpatialParallelAllgatherCompute);
+
+}  // namespace op
+}  // namespace mxnet

--- a/src/operator/contrib/spatial_parallel_support.h
+++ b/src/operator/contrib/spatial_parallel_support.h
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * Copyright (c) 2020 by Contributors
+ * \file spatial_parallel_support.h
+ * \brief Declarations needed for spatial parallelism
+ * \author Przemyslaw Tredak
+*/
+
+#ifndef MXNET_OPERATOR_CONTRIB_SPATIAL_PARALLEL_SUPPORT_H_
+#define MXNET_OPERATOR_CONTRIB_SPATIAL_PARALLEL_SUPPORT_H_
+
+#include <mxnet/base.h>
+
+#if MXNET_USE_NCCL
+#include <nccl.h>
+#include <unordered_map>
+#include <memory>
+
+namespace mxnet {
+namespace op {
+
+struct SpatialParallelParam : public dmlc::Parameter<SpatialParallelParam> {
+  int32_t num_gpus;
+  int32_t rank;
+  uintptr_t nccl_unique_id;
+
+  DMLC_DECLARE_PARAMETER(SpatialParallelParam) {
+    DMLC_DECLARE_FIELD(num_gpus).describe("Number of GPUs per sample.");
+    DMLC_DECLARE_FIELD(rank).describe("Rank inside a group");
+    DMLC_DECLARE_FIELD(nccl_unique_id).describe("NCCL unique ID");
+  }
+};
+
+class NCCLCommContainer {
+ public:
+  static inline std::unordered_map<int, std::unique_ptr<ncclComm_t>> comm_map;
+
+  static void Init(const SpatialParallelParam& param);
+};
+
+}  // namespace op
+}  // namespace mxnet
+
+#else
+static_assert(false, "You need to compile with NCCL support to use spatial parallelism!");
+#endif  // MXNET_USE_NCCL
+
+#endif  // MXNET_OPERATOR_CONTRIB_SPATIAL_PARALLEL_SUPPORT_H_

--- a/src/resource.cc
+++ b/src/resource.cc
@@ -166,6 +166,17 @@ class ResourceManagerImpl : public ResourceManager {
           })->GetNext();
         }
 #endif  // MXNET_USE_CUDNN == 1
+#if MXNET_USE_CUDA
+        case ResourceRequest::kMultiGPUComm: {
+          return *gpu_comm_.Get(ctx.dev_id, []() {
+              Resource* res = new Resource;
+              res->var = Engine::Get()->NewVariable();
+              res->ptr_ = nullptr;
+              res->req = ResourceRequest(ResourceRequest::kMultiGPUComm);
+              return res;
+            });
+        }
+#endif
         default: LOG(FATAL) << "Unknown supported type " << req.type;
       }
 #else
@@ -464,6 +475,8 @@ class ResourceManagerImpl : public ResourceManager {
   common::LazyAllocArray<ResourceTempSpace<ResourceRequest::kTempSpace>> gpu_space_;
   /*! \brief GPU parallel (on device) random number resources */
   common::LazyAllocArray<ResourceParallelRandom<gpu> > gpu_parallel_rand_;
+  /*! \brief Resource for tracking multi GPU communication */
+  common::LazyAllocArray<Resource> gpu_comm_;
 #if MXNET_USE_CUDNN == 1
   /*! \brief number of copies in GPU cudnn dropout descriptor resources */
   int gpu_cudnn_dropout_state_copy_;


### PR DESCRIPTION
## Description ##
This PR introduces Gluon blocks enabling spatial parallel convolutions (convolutions spanning multiple GPUs). This functionality was used in the NVIDIA's UNet-3D submission for MLPerf 1.0.

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [x] SpatialParallelConv2D module
- [x] SpatialParallelConv3D module
- [x] SpatialParallelSplit module
- [x] SpatialParallelAllgather module 

## Comments ##
- Currently the code has multiple restrictions: supports only the channels last format (NHWC and NDHWC) and requires that the filter/padding in first spatial dimension (D in 3D case, H in 2D case) fulfill `pad = (filter - 1)/2` equation (so e.g. for filter size 3, pad has to be 1).
- In order to bootstrap NCCL communicator I use out of band MPI communication via mpi4py, which is why I submit it to contrib module
