### PR TITLE
[v1.x] More docker cache fixes

### DIFF
--- a/ci/Jenkinsfile_docker_cache
+++ b/ci/Jenkinsfile_docker_cache
@@ -38,7 +38,7 @@ core_logic: {
         timeout(time: total_timeout, unit: 'MINUTES') {
           utils.init_git()
           sh "ci/docker_cache.py --docker-registry ${env.DOCKER_ECR_REGISTRY}"
-          sh "cd ci && $(aws ecr get-login --region ${env.DOCKER_ECR_REGION} --no-include-email) && DOCKER_CACHE_REGISTRY=${env.DOCKER_ECR_REGISTRY} docker-compose -f docker/docker-compose.yml build --parallel && DOCKER_CACHE_REGISTRY=${env.DOCKER_ECR_REGISTRY} docker-compose -f docker/docker-compose.yml push"
+          sh "cd ci && DOCKER_CACHE_REGISTRY=${env.DOCKER_ECR_REGISTRY} docker-compose -f docker/docker-compose.yml build --parallel && DOCKER_CACHE_REGISTRY=${env.DOCKER_ECR_REGISTRY} docker-compose -f docker/docker-compose.yml push"
         }
       }
     }

--- a/ci/docker_cache.py
+++ b/ci/docker_cache.py
@@ -119,7 +119,12 @@ def _ecr_login(registry):
     assert(regionMatch)
     region = regionMatch.group(1)
     logging.info("Logging into ECR region %s using aws-cli..", region)
-    os.system("$(aws ecr get-login --region "+region+" --no-include-email)")
+    # first check version of aws-cli
+    aws_cli_output = subprocess.check_output(["aws","--version"])
+    if aws_cli_output.decode('utf-8').startswith("aws-cli/2"):
+        os.system("aws ecr get-login-password --region "+region+" | docker login --username AWS --password-stdin "+registry)
+    else:
+        os.system("$(aws ecr get-login --region "+region+" --no-include-email)")
     ECR_LOGGED_IN = True
 
 def _upload_image(registry, docker_tag, image_id) -> None:


### PR DESCRIPTION
Add support for awscli v2, use docker credentials already saved from docker_cache.py run for docker-compose based images.