### PR TITLE
[BUGFIX] Fix accuracy issue due to reuse of primitives for MKLDNN-AArch64. Fixes #20265.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,6 +307,7 @@ if(USE_MKLDNN)
       # Also ACL_ROOT_DIR need to be set
       set(CMAKE_CXX_STANDARD 14)
       set(DNNL_AARCH64_USE_ACL ON CACHE INTERNAL "" FORCE)
+      add_definitions(-DDNNL_AARCH64_USE_ACL=1)
     endif()
     if (MKLDNN_USE_APL)
       # APL needs to be added to LD_LIBRARY_PATH

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -255,6 +255,7 @@ List of Contributors
 * [Zhaoqi Zhu](https://github.com/zha0q1)
 * [Harshit Sharma](https://github.com/harshitshrma)
 * [Andrzej Kotlowski](https://github.com/anko-intel)
+* [Crefeda Faviola Rodrigues](https://github.com/cfRod)
 
 Label Bot
 ---------

--- a/src/operator/operator_common.h
+++ b/src/operator/operator_common.h
@@ -620,6 +620,12 @@ class OpSignature {
       hash = hash * 2 + arr.dtype();
       eles.push_back(arr.dtype());
       AddSign(arr.shape());
+// Note:Temporary workaround for the accuracy issue noted here #20265.
+// Future releases of Compute Library will aim to fix this.
+#if DNNL_AARCH64_USE_ACL == 1
+      auto ival = reinterpret_cast<const uint64_t>(arr.storage_handle().dptr);
+      AddSign(ival);
+#endif
 #if MXNET_USE_MKLDNN == 1
     }
 #endif
@@ -639,6 +645,11 @@ class OpSignature {
   }
 
   void AddSign(int val) {
+    hash = hash * 2 + val;
+    eles.push_back(val);
+  }
+
+  void AddSign(uint64_t val) {
     hash = hash * 2 + val;
     eles.push_back(val);
   }


### PR DESCRIPTION
## Description ##

This fix is a workaround for the accuracy issue in the grouped convolution unit test observed when MXNet is built with Compute Library for Arm Architecture (ACL).
Fixes https://github.com/apache/incubator-mxnet/issues/20265
This change includes:
* Updating MXNet's existing AddSign function to generate unique hashes for MKLDNN-ACL backend.
* Adds a new AddSign overloaded function to generate hashes based on uint64_t type.
* Adding DNNL_AARCH64_USE_ACL definition to CMakeLists.txt
* Adding Crefeda Rodrigues to the contributors list

## Checklist ##
### Essentials ###
- [X] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
- [X] Code is well-documented

### Changes ###
- [X] Updating MXNet's existing AddSign function to generate unique hashes for MKLDNN-ACL backend.
- [X] Adds a new AddSign overloaded function to generate hashes based on uint64_t type.
- [X] Adding DNNL_AARCH64_USE_ACL definition to CMakeLists.txt
- [X] Adding Crefeda Rodrigues to the contributors list

## Comments ##
- This change is a workaround to resolve the accuracy issue seen test_operator.test_convolution_grouping until future releases of Compute library are compatible with reuse of MKLDNN/oneDNN primitives at the framework-level.