### PR TITLE
Enable float32 data type in linalg cholesky test

### DIFF
--- a/tests/python/unittest/test_numpy_interoperability.py
+++ b/tests/python/unittest/test_numpy_interoperability.py
@@ -527,12 +527,12 @@ def _add_workload_linalg_cholesky():
         for shape, dtype in itertools.product(shapes, dtypes):
             a = _np.random.randn(*shape)
 
-        t = list(range(len(shape)))
-        t[-2:] = -1, -2
+            t = list(range(len(shape)))
+            t[-2:] = -1, -2
 
-        a = _np.matmul(a.transpose(t).conj(), a)
+            a = _np.matmul(a.transpose(t).conj(), a)
 
-        OpArgMngr.add_workload('linalg.cholesky', np.array(a, dtype=dtype))
+            OpArgMngr.add_workload('linalg.cholesky', np.array(a, dtype=dtype))
 
     # test_0_size
     for dtype in dtypes:


### PR DESCRIPTION
## Description ##
Regarding #20505 . Running the Cholesky test on the current master uses only float64 data type. Checking Float32 data type is disabled. Is this intended or negligence? Here is a quick fix to check on float32 data type. 

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
