### PR TITLE
Remove static keyword from a thread_local std::unordered_map 

### DIFF
--- a/src/operator/nn/mkldnn/mkldnn_act.cc
+++ b/src/operator/nn/mkldnn/mkldnn_act.cc
@@ -132,7 +132,7 @@ MKLDNNActForward& GetActForward(const MKLDNNActParam& param,
                                 const NDArray& in_data,
                                 const mkldnn::memory& in_mem) {
 #if DMLC_CXX11_THREAD_LOCAL
-  static thread_local std::unordered_map<MKLDNNActSignature, MKLDNNActForward, OpHash> fwds;
+  thread_local std::unordered_map<MKLDNNActSignature, MKLDNNActForward, OpHash> fwds;
 #else
   static MX_THREAD_LOCAL std::unordered_map<MKLDNNActSignature, MKLDNNActForward, OpHash> fwds;
 #endif

--- a/src/operator/nn/mkldnn/mkldnn_batch_dot.cc
+++ b/src/operator/nn/mkldnn/mkldnn_batch_dot.cc
@@ -49,7 +49,7 @@ MKLDNNBatchDotFwd& MKLDNNBatchDotFwd::GetCached(const DotParam& param,
                                                 const std::vector<NDArray>& outputs) {
   using batch_dot_fwd_map = std::unordered_map<BatchDotSignature, MKLDNNBatchDotFwd, OpHash>;
 #if DMLC_CXX11_THREAD_LOCAL
-  static thread_local batch_dot_fwd_map fwds;
+  thread_local batch_dot_fwd_map fwds;
 #else
   static MX_THREAD_LOCAL batch_dot_fwd_map fwds;
 #endif

--- a/src/operator/nn/mkldnn/mkldnn_batch_norm-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_batch_norm-inl.h
@@ -128,7 +128,7 @@ static MKLDNNBNForward& GetBNForward(const BatchNormParam& param,
                                      const mkldnn::memory* data_mem,
                                      mkldnn::normalization_flags flags) {
 #if DMLC_CXX11_THREAD_LOCAL
-  static thread_local std::unordered_map<MKLDNNBNSignature, MKLDNNBNForward, OpHash> fwds;
+  thread_local std::unordered_map<MKLDNNBNSignature, MKLDNNBNForward, OpHash> fwds;
 #else
   static MX_THREAD_LOCAL std::unordered_map<MKLDNNBNSignature, MKLDNNBNForward, OpHash> fwds;
 #endif

--- a/src/operator/nn/mkldnn/mkldnn_concat-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_concat-inl.h
@@ -55,7 +55,7 @@ static MKLDNNConcatFwd& GetConcatForward(int concat_dim,
                                          const std::vector<NDArray>& in_data,
                                          const std::vector<mkldnn::memory::desc>& data_md) {
 #if DMLC_CXX11_THREAD_LOCAL
-  static thread_local std::unordered_map<OpSignature, MKLDNNConcatFwd, OpHash> fwds;
+  thread_local std::unordered_map<OpSignature, MKLDNNConcatFwd, OpHash> fwds;
 #else
   static MX_THREAD_LOCAL std::unordered_map<OpSignature, MKLDNNConcatFwd, OpHash> fwds;
 #endif

--- a/src/operator/nn/mkldnn/mkldnn_convolution.cc
+++ b/src/operator/nn/mkldnn/mkldnn_convolution.cc
@@ -446,7 +446,7 @@ MKLDNNConvForward& GetConvFwd(const MKLDNNConvFullParam& param,
                               const NDArray& output) {
   using conv_fwd_map = std::unordered_map<MKLDNNConvSignature, MKLDNNConvForward, OpHash>;
 #if DMLC_CXX11_THREAD_LOCAL
-  static thread_local conv_fwd_map fwds;
+  thread_local conv_fwd_map fwds;
 #else
   static MX_THREAD_LOCAL conv_fwd_map fwds;
 #endif

--- a/src/operator/nn/mkldnn/mkldnn_deconvolution.cc
+++ b/src/operator/nn/mkldnn/mkldnn_deconvolution.cc
@@ -292,7 +292,7 @@ MKLDNNDeconvForward& GetDeconvFwd(const nnvm::NodeAttrs& attrs,
                                   const NDArray* bias,
                                   const NDArray& output) {
 #if DMLC_CXX11_THREAD_LOCAL
-  static thread_local std::unordered_map<DeconvSignature, MKLDNNDeconvForward, OpHash> fwds;
+  thread_local std::unordered_map<DeconvSignature, MKLDNNDeconvForward, OpHash> fwds;
 #else
   static MX_THREAD_LOCAL std::unordered_map<DeconvSignature, MKLDNNDeconvForward, OpHash> fwds;
 #endif
@@ -459,8 +459,7 @@ static inline MKLDNNDeconvBackwardWeights& GetDeconvBwdWeights(
     const NDArray& output,
     const mkldnn::convolution_forward::primitive_desc& bwd_data_pd) {
 #if DMLC_CXX11_THREAD_LOCAL
-  static thread_local std::unordered_map<MKLDNNDeconvSignature, MKLDNNDeconvBackwardWeights, OpHash>
-      bwds;
+  thread_local std::unordered_map<MKLDNNDeconvSignature, MKLDNNDeconvBackwardWeights, OpHash> bwds;
 #else
   static MX_THREAD_LOCAL
       std::unordered_map<MKLDNNDeconvSignature, MKLDNNDeconvBackwardWeights, OpHash>

--- a/src/operator/nn/mkldnn/mkldnn_fully_connected.cc
+++ b/src/operator/nn/mkldnn/mkldnn_fully_connected.cc
@@ -126,9 +126,8 @@ MKLDNNFullyConnectedForward& GetFCFwd(const FullyConnectedParam& param,
                                       const NDArray* bias,
                                       const mkldnn::memory::desc& out_md) {
 #if DMLC_CXX11_THREAD_LOCAL
-  static thread_local std::
-      unordered_map<MKLDNNFullyconSignature, MKLDNNFullyConnectedForward, OpHash>
-          fcFwds;
+  thread_local std::unordered_map<MKLDNNFullyconSignature, MKLDNNFullyConnectedForward, OpHash>
+      fcFwds;
 #else
   static MX_THREAD_LOCAL
       std::unordered_map<MKLDNNFullyconSignature, MKLDNNFullyConnectedForward, OpHash>

--- a/src/operator/nn/mkldnn/mkldnn_log_softmax.cc
+++ b/src/operator/nn/mkldnn/mkldnn_log_softmax.cc
@@ -96,7 +96,7 @@ static MKLDNNLogSoftmaxFwd& GetLogSoftmaxFwd(const SoftmaxParam& param,
                                              const NDArray& data,
                                              const NDArray& output) {
 #if DMLC_CXX11_THREAD_LOCAL
-  static thread_local std::unordered_map<MKLDNNSoftmaxSignature, MKLDNNLogSoftmaxFwd, OpHash> fwds;
+  thread_local std::unordered_map<MKLDNNSoftmaxSignature, MKLDNNLogSoftmaxFwd, OpHash> fwds;
 #else
   static MX_THREAD_LOCAL std::unordered_map<MKLDNNSoftmaxSignature, MKLDNNLogSoftmaxFwd, OpHash>
       fwds;
@@ -162,7 +162,7 @@ static MKLDNNLogSoftmaxBwd& GetLogSoftmaxBwd(const SoftmaxParam& param,
                                              const std::vector<NDArray>& data,
                                              const std::vector<NDArray>& output) {
 #if DMLC_CXX11_THREAD_LOCAL
-  static thread_local std::unordered_map<MKLDNNSoftmaxSignature, MKLDNNLogSoftmaxBwd, OpHash> bwds;
+  thread_local std::unordered_map<MKLDNNSoftmaxSignature, MKLDNNLogSoftmaxBwd, OpHash> bwds;
 #else
   static MX_THREAD_LOCAL std::unordered_map<MKLDNNSoftmaxSignature, MKLDNNLogSoftmaxBwd, OpHash>
       bwds;

--- a/src/operator/nn/mkldnn/mkldnn_lrn-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_lrn-inl.h
@@ -148,7 +148,7 @@ static MKLDNNLRNFwd& GetLRNFwd(const LRNParam& param,
                                const OpContext& ctx,
                                const NDArray& in_data) {
 #if DMLC_CXX11_THREAD_LOCAL
-  static thread_local std::unordered_map<MKLDNNLRNSignature, MKLDNNLRNFwd, OpHash> lrn_fwds;
+  thread_local std::unordered_map<MKLDNNLRNSignature, MKLDNNLRNFwd, OpHash> lrn_fwds;
 #else
   static MX_THREAD_LOCAL std::unordered_map<MKLDNNLRNSignature, MKLDNNLRNFwd, OpHash> lrn_fwds;
 #endif
@@ -223,7 +223,7 @@ static MKLDNNLRNBwd& GetLRNBwd(const LRNParam& param,
                                const NDArray& in_grad,
                                const NDArray& out_grad) {
 #if DMLC_CXX11_THREAD_LOCAL
-  static thread_local std::unordered_map<MKLDNNLRNSignature, MKLDNNLRNBwd, OpHash> lrn_bwds;
+  thread_local std::unordered_map<MKLDNNLRNSignature, MKLDNNLRNBwd, OpHash> lrn_bwds;
 #else
   static MX_THREAD_LOCAL std::unordered_map<MKLDNNLRNSignature, MKLDNNLRNBwd, OpHash> lrn_bwds;
 #endif

--- a/src/operator/nn/mkldnn/mkldnn_pooling.cc
+++ b/src/operator/nn/mkldnn/mkldnn_pooling.cc
@@ -261,8 +261,7 @@ MKLDNNPoolingFwd& GetPoolingFwd(const PoolingParam& param,
                                 const NDArray& data,
                                 const NDArray& output) {
 #if DMLC_CXX11_THREAD_LOCAL
-  static thread_local std::unordered_map<MKLDNNPoolingSignature, MKLDNNPoolingFwd, OpHash>
-      pooling_fwds;
+  thread_local std::unordered_map<MKLDNNPoolingSignature, MKLDNNPoolingFwd, OpHash> pooling_fwds;
 #else
   static MX_THREAD_LOCAL std::unordered_map<MKLDNNPoolingSignature, MKLDNNPoolingFwd, OpHash>
       pooling_fwds;
@@ -321,8 +320,7 @@ MKLDNNPoolingBwd& GetPoolingBwd(const PoolingParam& param,
                                 const NDArray& in_grad,
                                 const NDArray& out_grad) {
 #if DMLC_CXX11_THREAD_LOCAL
-  static thread_local std::unordered_map<MKLDNNPoolingSignature, MKLDNNPoolingBwd, OpHash>
-      pooling_bwds;
+  thread_local std::unordered_map<MKLDNNPoolingSignature, MKLDNNPoolingBwd, OpHash> pooling_bwds;
 #else
   static MX_THREAD_LOCAL std::unordered_map<MKLDNNPoolingSignature, MKLDNNPoolingBwd, OpHash>
       pooling_bwds;

--- a/src/operator/nn/mkldnn/mkldnn_reshape.cc
+++ b/src/operator/nn/mkldnn/mkldnn_reshape.cc
@@ -100,7 +100,7 @@ MKLDNNReshapeFwd& GetReshapeForward(const OpReqType& req,
                                     const NDArray& input,
                                     const NDArray& output) {
 #if DMLC_CXX11_THREAD_LOCAL
-  static thread_local std::unordered_map<MKLDNNReshapeSignature, MKLDNNReshapeFwd, OpHash> fwds;
+  thread_local std::unordered_map<MKLDNNReshapeSignature, MKLDNNReshapeFwd, OpHash> fwds;
 #else
   static MX_THREAD_LOCAL std::unordered_map<MKLDNNReshapeSignature, MKLDNNReshapeFwd, OpHash> fwds;
 #endif

--- a/src/operator/nn/mkldnn/mkldnn_rnn.cc
+++ b/src/operator/nn/mkldnn/mkldnn_rnn.cc
@@ -470,7 +470,7 @@ void MKLDNNRnnForward::SetNewDataMem(void* x,
 
 inline void MKLDNNMemoryReorder(const mkldnn::memory& src, const mkldnn::memory& dst) {
 #if DMLC_CXX11_THREAD_LOCAL
-  static thread_local std::unordered_map<OpSignature, mkldnn::reorder, OpHash> reorderPrimitives;
+  thread_local std::unordered_map<OpSignature, mkldnn::reorder, OpHash> reorderPrimitives;
 #else
   static MX_THREAD_LOCAL std::unordered_map<OpSignature, mkldnn::reorder, OpHash> reorderPrimitives;
 #endif

--- a/src/operator/nn/mkldnn/mkldnn_slice.cc
+++ b/src/operator/nn/mkldnn/mkldnn_slice.cc
@@ -74,7 +74,7 @@ MKLDNNSliceFwd& GetSliceForward(const SliceParam& param,
                                 const NDArray& in_data,
                                 const NDArray& out_data) {
 #if DMLC_CXX11_THREAD_LOCAL
-  static thread_local std::unordered_map<MKLDNNSliceSignature, MKLDNNSliceFwd, OpHash> fwds;
+  thread_local std::unordered_map<MKLDNNSliceSignature, MKLDNNSliceFwd, OpHash> fwds;
 #else
   static MX_THREAD_LOCAL std::unordered_map<MKLDNNSliceSignature, MKLDNNSliceFwd, OpHash> fwds;
 #endif

--- a/src/operator/nn/mkldnn/mkldnn_softmax.cc
+++ b/src/operator/nn/mkldnn/mkldnn_softmax.cc
@@ -98,7 +98,7 @@ static MKLDNNSoftmaxFwd& GetSoftmaxFwd(const SoftmaxParam& param,
                                        const NDArray& data,
                                        const NDArray& output) {
 #if DMLC_CXX11_THREAD_LOCAL
-  static thread_local std::unordered_map<MKLDNNSoftmaxSignature, MKLDNNSoftmaxFwd, OpHash> fwds;
+  thread_local std::unordered_map<MKLDNNSoftmaxSignature, MKLDNNSoftmaxFwd, OpHash> fwds;
 #else
   static MX_THREAD_LOCAL std::unordered_map<MKLDNNSoftmaxSignature, MKLDNNSoftmaxFwd, OpHash> fwds;
 #endif

--- a/src/operator/nn/mkldnn/mkldnn_softmax_output.cc
+++ b/src/operator/nn/mkldnn/mkldnn_softmax_output.cc
@@ -24,9 +24,10 @@
  */
 
 #if MXNET_USE_ONEDNN == 1
-#include "../../softmax_output-inl.h"
 #include "./mkldnn_base-inl.h"
 #include "./mkldnn_ops-inl.h"
+
+#include "../../softmax_output-inl.h"
 namespace mxnet {
 namespace op {
 
@@ -67,9 +68,7 @@ static MKLDNNSoftmaxOutputFwd& GetSoftmaxOutputForward(const SoftmaxOutputParam&
                                                        const OpContext& ctx,
                                                        const NDArray& in_data) {
 #if DMLC_CXX11_THREAD_LOCAL
-  static thread_local std::
-      unordered_map<MKLDNNSoftmaxOuputSignature, MKLDNNSoftmaxOutputFwd, OpHash>
-          fwds;
+  thread_local std::unordered_map<MKLDNNSoftmaxOuputSignature, MKLDNNSoftmaxOutputFwd, OpHash> fwds;
 #else
   static MX_THREAD_LOCAL
       std::unordered_map<MKLDNNSoftmaxOuputSignature, MKLDNNSoftmaxOutputFwd, OpHash>

--- a/src/operator/nn/mkldnn/mkldnn_sum.cc
+++ b/src/operator/nn/mkldnn/mkldnn_sum.cc
@@ -82,7 +82,7 @@ static MKLDNNSumFwd& GetSumForward(const std::vector<float>& scales,
                                    const std::vector<NDArray>& in_data,
                                    const std::vector<mkldnn::memory::desc>& data_md) {
 #if DMLC_CXX11_THREAD_LOCAL
-  static thread_local std::unordered_map<OpSignature, MKLDNNSumFwd, OpHash> fwds;
+  thread_local std::unordered_map<OpSignature, MKLDNNSumFwd, OpHash> fwds;
 #else
   static MX_THREAD_LOCAL std::unordered_map<OpSignature, MKLDNNSumFwd, OpHash> fwds;
 #endif

--- a/src/operator/nn/mkldnn/mkldnn_transpose.cc
+++ b/src/operator/nn/mkldnn/mkldnn_transpose.cc
@@ -117,8 +117,7 @@ class MKLDNNTransposeForward {
 static MKLDNNTransposeForward& GetTransposeForward(const TransposeParam& param,
                                                    const NDArray& data) {
 #if DMLC_CXX11_THREAD_LOCAL
-  static thread_local std::unordered_map<MKLDNNTransposeSignature, MKLDNNTransposeForward, OpHash>
-      fwds;
+  thread_local std::unordered_map<MKLDNNTransposeSignature, MKLDNNTransposeForward, OpHash> fwds;
 #else
   static MX_THREAD_LOCAL
       std::unordered_map<MKLDNNTransposeSignature, MKLDNNTransposeForward, OpHash>


### PR DESCRIPTION
## Description ##
Following the [doc](https://timsong-cpp.github.io/cppwp/n3337/dcl.stc), 

> The thread_local specifier indicates that the named entity has thread storage duration ([basic.stc.thread]). It shall be applied only to the names of variables of namespace or block scope and to the names of static data members. When thread_local is applied to a variable of block scope the storage-class-specifier static is implied if it does not appear explicitly. 

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
