### PR TITLE
[v1.9.x] stop closing opened libs

### DIFF
--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -233,10 +233,11 @@ MXNET_DLL const char *MXGetLastError();
 /*!
  * \brief Load library dynamically
  * \param path to the library .so file
- * \param 0 for quiet, 1 for verbose
+ * \param verbose 0 for quiet, 1 for verbose
+ * \param lib handle to opened library
  * \return 0 when success, -1 when failure happens.
  */
-MXNET_DLL int MXLoadLib(const char *path, unsigned verbose);
+MXNET_DLL int MXLoadLib(const char *path, unsigned verbose, void** lib);
 
 /*!
  * \brief Get list of features supported on the runtime

--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -234,10 +234,9 @@ MXNET_DLL const char *MXGetLastError();
  * \brief Load library dynamically
  * \param path to the library .so file
  * \param verbose 0 for quiet, 1 for verbose
- * \param lib handle to opened library
  * \return 0 when success, -1 when failure happens.
  */
-MXNET_DLL int MXLoadLib(const char *path, unsigned verbose, void** lib);
+MXNET_DLL int MXLoadLib(const char *path, unsigned verbose);
 
 /*!
  * \brief Get list of features supported on the runtime

--- a/python/mxnet/library.py
+++ b/python/mxnet/library.py
@@ -37,7 +37,7 @@ def load(path, verbose=True):
 
     Returns
     ---------
-    ctypes.c_void_p : handle to opened library
+    None
     """
     #check if path exists
     if not os.path.exists(path):
@@ -53,8 +53,7 @@ def load(path, verbose=True):
     verbose_val = 1 if verbose else 0
     byt_obj = path.encode('utf-8')
     chararr = ctypes.c_char_p(byt_obj)
-    lib_ptr = ctypes.c_void_p(0)
-    check_call(_LIB.MXLoadLib(chararr, mx_uint(verbose_val), ctypes.byref(lib_ptr)))
+    check_call(_LIB.MXLoadLib(chararr, mx_uint(verbose_val)))
 
     #regenerate operators
     _init_op_module('mxnet', 'ndarray', _make_ndarray_function)
@@ -73,5 +72,3 @@ def load(path, verbose=True):
     for op in dir(mx_sym_op):
         func = getattr(mx_sym_op, op)
         setattr(mx_sym, op, func)
-
-    return lib_ptr

--- a/python/mxnet/library.py
+++ b/python/mxnet/library.py
@@ -37,7 +37,7 @@ def load(path, verbose=True):
 
     Returns
     ---------
-    void
+    ctypes.c_void_p : handle to opened library
     """
     #check if path exists
     if not os.path.exists(path):
@@ -53,7 +53,8 @@ def load(path, verbose=True):
     verbose_val = 1 if verbose else 0
     byt_obj = path.encode('utf-8')
     chararr = ctypes.c_char_p(byt_obj)
-    check_call(_LIB.MXLoadLib(chararr, mx_uint(verbose_val)))
+    lib_ptr = ctypes.c_void_p(0)
+    check_call(_LIB.MXLoadLib(chararr, mx_uint(verbose_val), ctypes.byref(lib_ptr)))
 
     #regenerate operators
     _init_op_module('mxnet', 'ndarray', _make_ndarray_function)
@@ -72,3 +73,5 @@ def load(path, verbose=True):
     for op in dir(mx_sym_op):
         func = getattr(mx_sym_op, op)
         setattr(mx_sym, op, func)
+
+    return lib_ptr

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -1514,16 +1514,19 @@ void registerPasses(void *lib, int verbose, mxnet::ext::msgSize_t msgSize,
 /*!
  * \brief Loads dynamic custom library and initializes it
  * \param path library path
+ * \param verbose 0 for quiet, 1 for verbose
+ * \param lib handle to opened library
+ * \return 0 when success, -1 when failure happens.
  */
-int MXLoadLib(const char *path, unsigned verbose) {
+int MXLoadLib(const char *path, unsigned verbose, void** lib) {
   API_BEGIN();
-  void *lib = LibraryInitializer::Get()->lib_load(path);
-  if (!lib)
+  *lib = LibraryInitializer::Get()->lib_load(path);
+  if (!*lib)
     LOG(FATAL) << "Unable to load library";
 
   // check that library and MXNet use same version of library API
   mxnet::ext::opVersion_t opVersion =
-    get_func<mxnet::ext::opVersion_t>(lib, const_cast<char*>(MXLIB_OPVERSION_STR));
+    get_func<mxnet::ext::opVersion_t>(*lib, const_cast<char*>(MXLIB_OPVERSION_STR));
   int libVersion =  opVersion();
   if (MX_LIBRARY_VERSION != libVersion)
     LOG(FATAL) << "Library version (" << libVersion << ") does not match MXNet version ("
@@ -1531,22 +1534,22 @@ int MXLoadLib(const char *path, unsigned verbose) {
 
   // get error messaging APIs
   mxnet::ext::msgSize_t msgSize =
-    get_func<mxnet::ext::msgSize_t>(lib, const_cast<char*>(MXLIB_MSGSIZE_STR));
+    get_func<mxnet::ext::msgSize_t>(*lib, const_cast<char*>(MXLIB_MSGSIZE_STR));
   mxnet::ext::msgGet_t msgGet =
-    get_func<mxnet::ext::msgGet_t>(lib, const_cast<char*>(MXLIB_MSGGET_STR));
+    get_func<mxnet::ext::msgGet_t>(*lib, const_cast<char*>(MXLIB_MSGGET_STR));
 
   // initialize library by passing MXNet version
   mxnet::ext::initialize_t initialize =
-    get_func<mxnet::ext::initialize_t>(lib, const_cast<char*>(MXLIB_INITIALIZE_STR));
+    get_func<mxnet::ext::initialize_t>(*lib, const_cast<char*>(MXLIB_INITIALIZE_STR));
   if (!initialize(static_cast<int>(MXNET_VERSION))) {
     std::string msgs = getExtensionMsgs(msgSize, msgGet);
     LOG(FATAL) << "Library failed to initialize" << msgs;
   }
 
   // find ops, partitioners, and passes in library
-  registerOperators(lib, verbose, msgSize, msgGet);
-  registerPartitioners(lib, verbose, msgSize, msgGet);
-  registerPasses(lib, verbose, msgSize, msgGet);
+  registerOperators(*lib, verbose, msgSize, msgGet);
+  registerPartitioners(*lib, verbose, msgSize, msgGet);
+  registerPasses(*lib, verbose, msgSize, msgGet);
   API_END();
 }
 

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -1520,7 +1520,7 @@ void registerPasses(void *lib, int verbose, mxnet::ext::msgSize_t msgSize,
 int MXLoadLib(const char *path, unsigned verbose) {
   API_BEGIN();
   void *lib = LibraryInitializer::Get()->lib_load(path);
-  if (!*lib)
+  if (!lib)
     LOG(FATAL) << "Unable to load library";
 
   // check that library and MXNet use same version of library API

--- a/src/initialize.cc
+++ b/src/initialize.cc
@@ -96,10 +96,6 @@ LibraryInitializer::LibraryInitializer()
   install_pthread_atfork_handlers();
 }
 
-LibraryInitializer::~LibraryInitializer() {
-  close_open_libs();
-}
-
 bool LibraryInitializer::lib_is_loaded(const std::string& path) const {
   return loaded_libs.count(path) > 0;
 }

--- a/src/initialize.h
+++ b/src/initialize.h
@@ -56,7 +56,7 @@ class LibraryInitializer {
    */
   LibraryInitializer();
 
-  ~LibraryInitializer();
+  ~LibraryInitializer() = default;
 
   /**
    * @return true if the current pid doesn't match the one that initialized the library


### PR DESCRIPTION
## Description ##
stop closing opened libs. fixes #20411 using portions already merged into master/2.0 in #19016. 

According to [[1]](https://pubs.opengroup.org/onlinepubs/009695399/functions/dlclose.html) 

> The dlclose() function shall inform the system that the object referenced by a handle returned from a previous dlopen() invocation is no longer needed by the application.

> The use of dlclose() reflects a statement of intent on the part of the process, but does not create any requirement upon the implementation, such as removal of the code or symbols referenced by handle.

So calling `dlclose` is just a suggestion to the OS that it could close the library. But the OS may not do anything (ie. and wait until the process exits to clean up any opened handles). Im thinking we might as well just let it be cleaned up anyway rather than calling `dlclose` at all. 

As suggested in [[2]](https://stackoverflow.com/a/26131259)

> If you only ever open one library, use it throughout your program, then calling dlclose just before you exit is probably not essential, but if you open a lot of libraries (e.g. using some sort of plugin in a long-running program that can/will use many different plugins, the program may run out of virtual address space if you don't call dlclose.

> (All shared libraries are closed on exit anyway, so leaving it open at exit should not be an issue)

So if a user was loading/unloading a bunch of libraries at runtime they might want to close some they dont need anymore. 

However, since MXNet registers components from the library (ie. operators, partitioners, graph passes, etc) and has NO capability to unregister them the references to the loaded library will live at least as long as MXNet (ie. libmxnet.so) does. MXNet already has quite a few components (or its dependencies like TVM/NNVM) that live forever and require the OS to clean them up when the process exits. So its not possible to close libmxnet.so and assume everything is cleaned up. We might as well do the same thing for custom libraries. 

This PR removes the code to close opened libraries in the destructor of the `LibraryInitializer` class with the caveat that MXNet will still have pointers to that library, so closing would not be recommended until process exit anyway.