### PR TITLE
[v1.9.x] Remove cpp-predict example due to licensing issues

### DIFF
--- a/tools/source-exclude-artifacts.txt
+++ b/tools/source-exclude-artifacts.txt
@@ -24,3 +24,4 @@ R-package
 3rdparty/mkldnn/doc
 3rdparty/googletest/ci
 docs
+example/image-classification/predict-cpp


### PR DESCRIPTION
This fixes https://github.com/apache/incubator-mxnet/issues/20515 - remove cpp example for image classification that is not compliant with Apache 2.0 license due to prior copyright.

This change removes the example from the release source archive.