### PR TITLE
[v1.x] Enabling BRGEMM FullyConnected based on shapes

### DIFF
--- a/docs/static_site/src/pages/api/faq/env_var.md
+++ b/docs/static_site/src/pages/api/faq/env_var.md
@@ -300,7 +300,7 @@ If ctypes is used, it must be `mxnet._ctypes.ndarray.NDArrayBase`.
 
 * MXNET_MKLDNN_FORCE_FC_AB_FORMAT
   - Values: 0, 1 ```(default=0)```
-  - If set to true, FullyConnected will use only AB format for weights, thus MXNet won't use BRGEMM implementation of FC on machines with AVX512-VNNI support.
+  - If set to true, FullyConnected will use only AB format for weights, thus MXNet won't use BRGEMM implementation of FC on machines with AVX512-VNNI support which requires special weights format.
 
 * MXNET_ENFORCE_DETERMINISM
   - Values: 0(false) or 1(true) ```(default=0)```

--- a/docs/static_site/src/pages/api/faq/env_var.md
+++ b/docs/static_site/src/pages/api/faq/env_var.md
@@ -298,9 +298,9 @@ If ctypes is used, it must be `mxnet._ctypes.ndarray.NDArrayBase`.
   - Values: Int ```(default=-1)```
   - Flag to set num of elements that MKLDNN cache can hold. Default is -1 which means cache size is unbounded. Should only be set if your model has variable input shapes, as cache size may grow unbounded. The number represents the number of items in the cache and is proportional to the number of layers that use MKLDNN and different input shape.
 
-* MXNET_MKLDNN_DISABLE_BRGEMM_FC
-  - Values: 0, 1 ```(default=1)```
-  - Flag which disables BRGEMM kernels in FullyConnected executed with MKLDNN support - Should only be set to 0 if your model has constant input shapes or FullyConnected is calculated with large tensors. Supported on machines with AVX512-VNNI.
+* MXNET_MKLDNN_FORCE_FC_AB_FORMAT
+  - Values: 0, 1 ```(default=0)```
+  - If set to true, FullyConnected will use only AB format for weights, thus MXNet won't use BRGEMM implementation of FC on machines with AVX512-VNNI support.
 
 * MXNET_ENFORCE_DETERMINISM
   - Values: 0(false) or 1(true) ```(default=0)```

--- a/src/operator/nn/mkldnn/mkldnn_base-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_base-inl.h
@@ -306,6 +306,8 @@ inline static mkldnn::memory::desc GetMemDesc(const NDArray& arr, int dtype = -1
 }
 
 inline static bool SupportBRGEMMImpl(mkldnn::memory::dims weight_dims, size_t batch_size) {
+  // Conditions based on measurment results done on CLX8280
+  // https://github.com/apache/incubator-mxnet/pull/20533
   return weight_dims[0] % 64 == 0 && weight_dims[1] % 64 == 0 && weight_dims[0] >= 1024 &&
          weight_dims[1] >= 1024 && batch_size >= 2 << 13;
 }

--- a/src/operator/nn/mkldnn/mkldnn_base-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_base-inl.h
@@ -305,7 +305,7 @@ inline static mkldnn::memory::desc GetMemDesc(const NDArray& arr, int dtype = -1
   return mkldnn::memory::desc{dims, get_mkldnn_type(dtype), mkldnn::memory::format_tag::any};
 }
 
-inline static bool SupportBRGEMMImpl(mkldnn::memory::dims weight_dims, size_t batch_size) {
+inline static bool ChooseBRGEMMImpl(mkldnn::memory::dims weight_dims, size_t batch_size) {
   // Conditions based on measurment results done on CLX8280
   // https://github.com/apache/incubator-mxnet/pull/20533
   return weight_dims[0] % 64 == 0 && weight_dims[1] % 64 == 0 && weight_dims[0] >= 1024 &&
@@ -324,7 +324,7 @@ inline static mkldnn::memory::desc GetFCWeightDesc(const NDArray& arr,
   // for batch 256 alexnet benchmark test
   const bool force_fc_ab_format = dmlc::GetEnv("MXNET_MKLDNN_FORCE_FC_AB_FORMAT", false);
   if (dims.size() == 2) {
-    if (force_fc_ab_format || !SupportBRGEMMImpl(dims, batch_size)) {
+    if (force_fc_ab_format || !ChooseBRGEMMImpl(dims, batch_size)) {
       format = mkldnn::memory::format_tag::ab;
     }
   }

--- a/src/operator/nn/mkldnn/mkldnn_base-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_base-inl.h
@@ -305,7 +305,7 @@ inline static mkldnn::memory::desc GetMemDesc(const NDArray& arr, int dtype = -1
   return mkldnn::memory::desc{dims, get_mkldnn_type(dtype), mkldnn::memory::format_tag::any};
 }
 
-inline static bool ChooseBRGEMMImpl(mkldnn::memory::dims& weight_dims, size_t batch_size) {
+inline static bool ChooseBRGEMMImpl(const mkldnn::memory::dims& weight_dims, size_t batch_size) {
   // Conditions based on measurement results done on CLX8280
   // https://github.com/apache/incubator-mxnet/pull/20533
   return weight_dims[0] >= 1024 && weight_dims[1] >= 1024 && batch_size >= 16384 &&

--- a/src/operator/nn/mkldnn/mkldnn_base-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_base-inl.h
@@ -305,7 +305,14 @@ inline static mkldnn::memory::desc GetMemDesc(const NDArray& arr, int dtype = -1
   return mkldnn::memory::desc{dims, get_mkldnn_type(dtype), mkldnn::memory::format_tag::any};
 }
 
-inline static mkldnn::memory::desc GetFCWeightDesc(const NDArray& arr, int dtype = -1) {
+inline static bool SupportBRGEMMImpl(mkldnn::memory::dims weight_dims, size_t batch_size) {
+  return weight_dims[0] % 64 == 0 && weight_dims[1] % 64 == 0 && weight_dims[0] >= 1024 &&
+         weight_dims[1] >= 1024 && batch_size >= 2 << 13;
+}
+
+inline static mkldnn::memory::desc GetFCWeightDesc(const NDArray& arr,
+                                                   size_t batch_size,
+                                                   int dtype = -1) {
   int ndim = arr.shape().ndim();
   mkldnn::memory::dims dims(ndim);
   dtype = (dtype == -1) ? arr.dtype() : dtype;
@@ -313,9 +320,11 @@ inline static mkldnn::memory::desc GetFCWeightDesc(const NDArray& arr, int dtype
     dims[i] = arr.shape()[i];
   auto format = mkldnn::memory::format_tag::any;
   // for batch 256 alexnet benchmark test
-  const bool brgemm_disabled = dmlc::GetEnv("MXNET_MKLDNN_DISABLE_BRGEMM_FC", true);
-  if (dims.size() == 2 && brgemm_disabled) {
-    format = mkldnn::memory::format_tag::ab;
+  const bool force_fc_ab_format = dmlc::GetEnv("MXNET_MKLDNN_FORCE_FC_AB_FORMAT", false);
+  if (dims.size() == 2) {
+    if (force_fc_ab_format || !SupportBRGEMMImpl(dims, batch_size)) {
+      format = mkldnn::memory::format_tag::ab;
+    }
   }
 
   return mkldnn::memory::desc{dims, get_mkldnn_type(dtype), format};

--- a/src/operator/nn/mkldnn/mkldnn_base-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_base-inl.h
@@ -306,7 +306,7 @@ inline static mkldnn::memory::desc GetMemDesc(const NDArray& arr, int dtype = -1
 }
 
 inline static bool ChooseBRGEMMImpl(mkldnn::memory::dims weight_dims, size_t batch_size) {
-  // Conditions based on measurment results done on CLX8280
+  // Conditions based on measurement results done on CLX8280
   // https://github.com/apache/incubator-mxnet/pull/20533
   return weight_dims[0] % 64 == 0 && weight_dims[1] % 64 == 0 && weight_dims[0] >= 1024 &&
          weight_dims[1] >= 1024 && batch_size >= 2 << 13;

--- a/src/operator/nn/mkldnn/mkldnn_base-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_base-inl.h
@@ -305,11 +305,11 @@ inline static mkldnn::memory::desc GetMemDesc(const NDArray& arr, int dtype = -1
   return mkldnn::memory::desc{dims, get_mkldnn_type(dtype), mkldnn::memory::format_tag::any};
 }
 
-inline static bool ChooseBRGEMMImpl(mkldnn::memory::dims weight_dims, size_t batch_size) {
+inline static bool ChooseBRGEMMImpl(mkldnn::memory::dims& weight_dims, size_t batch_size) {
   // Conditions based on measurement results done on CLX8280
   // https://github.com/apache/incubator-mxnet/pull/20533
-  return weight_dims[0] % 64 == 0 && weight_dims[1] % 64 == 0 && weight_dims[0] >= 1024 &&
-         weight_dims[1] >= 1024 && batch_size >= 2 << 13;
+  return weight_dims[0] >= 1024 && weight_dims[1] >= 1024 && batch_size >= 16384 &&
+         weight_dims[0] % 64 == 0 && weight_dims[1] % 64 == 0;
 }
 
 inline static mkldnn::memory::desc GetFCWeightDesc(const NDArray& arr,

--- a/src/operator/nn/mkldnn/mkldnn_fully_connected.cc
+++ b/src/operator/nn/mkldnn/mkldnn_fully_connected.cc
@@ -42,8 +42,8 @@ mkldnn::inner_product_forward::primitive_desc GetFCFwdImpl(const MKLDNNFCFullPar
                                                            const NDArray* bias,
                                                            const mkldnn::memory::desc& out_md) {
   auto data_md   = GetMemDesc(data);
-  auto weight_md = full_param.mkldnn_param.quantized ? GetFCWeightDesc(weight, mshadow::kInt8)
-                                                     : GetFCWeightDesc(weight);
+  auto weight_md = full_param.mkldnn_param.quantized ? GetFCWeightDesc(weight, data.shape()[0], mshadow::kInt8)
+                                                     : GetFCWeightDesc(weight, data.shape()[0]);
   auto engine    = CpuEngine::Get()->get_engine();
   auto propagation =
       is_train ? mkldnn::prop_kind::forward_training : mkldnn::prop_kind::forward_scoring;
@@ -107,7 +107,7 @@ inline static mkldnn::inner_product_backward_data::primitive_desc GetFCBwdData(
     const NDArray& output,
     mkldnn::inner_product_forward::primitive_desc fwd_pd) {
   auto data_md   = GetMemDesc(data);
-  auto weight_md = GetFCWeightDesc(weight);
+  auto weight_md = GetFCWeightDesc(weight, data.shape()[0]);
   auto out_md    = GetMemDesc(output);
   auto engine    = CpuEngine::Get()->get_engine();
   mkldnn::inner_product_backward_data::desc desc(data_md, weight_md, out_md);
@@ -121,7 +121,7 @@ inline static mkldnn::inner_product_backward_weights::primitive_desc GetFCBwdWei
     const NDArray& output,
     mkldnn::inner_product_forward::primitive_desc fwd_pd) {
   auto data_md   = GetMemDesc(data);
-  auto weight_md = GetFCWeightDesc(weight);
+  auto weight_md = GetFCWeightDesc(weight, data.shape()[0]);
   auto out_md    = GetMemDesc(output);
   auto engine    = CpuEngine::Get()->get_engine();
   if (bias) {

--- a/src/operator/nn/mkldnn/mkldnn_fully_connected.cc
+++ b/src/operator/nn/mkldnn/mkldnn_fully_connected.cc
@@ -41,11 +41,11 @@ mkldnn::inner_product_forward::primitive_desc GetFCFwdImpl(const MKLDNNFCFullPar
                                                            const NDArray& weight,
                                                            const NDArray* bias,
                                                            const mkldnn::memory::desc& out_md) {
+  auto engine    = CpuEngine::Get()->get_engine();
   auto data_md   = GetMemDesc(data);
   auto weight_md = full_param.mkldnn_param.quantized
                        ? GetFCWeightDesc(weight, data.shape()[0], mshadow::kInt8)
                        : GetFCWeightDesc(weight, data.shape()[0]);
-  auto engine = CpuEngine::Get()->get_engine();
   auto propagation =
       is_train ? mkldnn::prop_kind::forward_training : mkldnn::prop_kind::forward_scoring;
 

--- a/src/operator/nn/mkldnn/mkldnn_fully_connected.cc
+++ b/src/operator/nn/mkldnn/mkldnn_fully_connected.cc
@@ -42,9 +42,10 @@ mkldnn::inner_product_forward::primitive_desc GetFCFwdImpl(const MKLDNNFCFullPar
                                                            const NDArray* bias,
                                                            const mkldnn::memory::desc& out_md) {
   auto data_md   = GetMemDesc(data);
-  auto weight_md = full_param.mkldnn_param.quantized ? GetFCWeightDesc(weight, data.shape()[0], mshadow::kInt8)
-                                                     : GetFCWeightDesc(weight, data.shape()[0]);
-  auto engine    = CpuEngine::Get()->get_engine();
+  auto weight_md = full_param.mkldnn_param.quantized
+                       ? GetFCWeightDesc(weight, data.shape()[0], mshadow::kInt8)
+                       : GetFCWeightDesc(weight, data.shape()[0]);
+  auto engine = CpuEngine::Get()->get_engine();
   auto propagation =
       is_train ? mkldnn::prop_kind::forward_training : mkldnn::prop_kind::forward_scoring;
 


### PR DESCRIPTION
## Description ##
This PR is continuation of https://github.com/apache/incubator-mxnet/pull/20450, where enabling BRGEMM automatically was requested. 


Following script was used to benchmark - only single iteration was benchmarked to avoid measuring performance with cached reordered weights for BRGEMM.

```
import mxnet as mx
from mxnet import nd
from mxnet.gluon import nn
import time

class CalibIter(mx.io.DataIter):
    def __init__(self, batch, data_shape, batch_size):
        super(CalibIter, self).__init__(batch_size)
        self.label_shape = (batch_size,)
        self.data_shape = data_shape
        if isinstance(data_shape, tuple):
          self.provide_data = [('data', data_shape)]
        else:
          self.provide_data = data_shape
        self.provide_label = []
        self.batch = batch

    def __iter__(self):
        yield self.batch

def test_qfc():
    results = dict()
    N  = [1, 8, 16, 32, 64, 128, 256, 512, 1024, 2048,
          4096, 8192, 9216, 10240, 11264, 12288, 13312,
          14336, 15360, 16384, 32768, 65536, 131072]
    IC = [32, 64, 128, 256, 512, 1024, 2048, 4096]
    OC = [32, 64, 128, 256, 512, 1024, 2048, 4096]

    for ic in IC:
        for oc in OC:
            net = nn.Dense(units=oc, flatten=True,
                           weight_initializer=mx.init.Normal(),
                           bias_initializer=mx.init.Normal())
            net.initialize()
            net.hybridize(static_alloc=True, static_shape=True)
            x = mx.nd.random_uniform(shape=(1, ic), low=-1.0, high=1.0)
            net(x)
            batch = mx.io.DataBatch([x])
            calib_data = CalibIter(batch, [mx.io.DataDesc("data", shape=(1, ic), dtype='float32')], 1)
            net_quantized = mx.contrib.quant.quantize_net_v2(net, quantized_dtype='auto',
                                                             exclude_layers=None,
                                                             exclude_layers_match=None,
                                                             calib_data=calib_data,
                                                             calib_mode='naive',
                                                             num_calib_examples=1,
                                                             ctx=mx.current_context())
            net_quantized.hybridize(static_alloc=True, static_shape=True)
            mx.nd.waitall()
            total = 0
            for bs in N:
                x = mx.nd.random_uniform(shape=(bs, ic), low=-1.0, high=1.0)
                mx.nd.waitall()
                tic = time.time()
                o = net_quantized(x)
                o.wait_to_read()
                total = time.time() - tic
                results[(bs, ic, oc)] = total

    for k,v in results.items():
        print(f"{k[0]};{k[1]};{k[2]};{v}")

test_qfc()
```
Attaching spreadsheet with results on CLX8280 (before this change). 
[brgemm_igemm_cmp.xlsx](https://github.com/apache/incubator-mxnet/files/7000191/brgemm_igemm_cmp.xlsx)

