### PR TITLE
Port #20530 (license fixes) from v1.x.

### DIFF
--- a/tools/source-exclude-artifacts.txt
+++ b/tools/source-exclude-artifacts.txt
@@ -21,3 +21,6 @@
 #  restrictions.
 
 3rdparty/onednn/doc
+3rdparty/googletest/ci
+docs
+example/image-classification/predict-cpp


### PR DESCRIPTION
Just remove image classification CPP example from source tarball. (#20530)
