### PR TITLE
[CPU Parallel] Implementation of parallel_for with grain size

### DIFF
--- a/src/common/parallel_for.h
+++ b/src/common/parallel_for.h
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * Copyright (c) 2015 by Contributors
+ */
+
+#ifndef MXNET_COMMON_PARALLEL_FOR_H_
+#define MXNET_COMMON_PARALLEL_FOR_H_
+
+#include <algorithm>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+#include "../operator/mxnet_op.h"
+
+namespace {
+int64_t divup(int64_t x, int64_t y) {
+  return (x + y - 1) / y;
+}
+}  // namespace
+
+namespace mxnet {
+namespace common {
+namespace {
+
+struct DefaultGrainSizeT {
+  size_t grain_size;
+
+  DefaultGrainSizeT() {
+    auto var = std::getenv("MXNET_PARALLEL_FOR_GRAIN_SIZE");
+    grain_size = 1;
+    if (!var) {
+      grain_size = 1;
+    } else {
+      grain_size = std::stoul(var);
+      std::cout << grain_size << std::endl;
+    }
+  }
+
+  size_t operator()() {
+    return grain_size;
+  }
+};
+}  // namespace
+
+static DefaultGrainSizeT default_grain_size;
+
+template <typename F>
+void parallel_for(const size_t begin, const size_t end, const size_t grain_size, F&& f) {
+  if (begin >= end) {
+    return;
+  }
+#ifdef _OPENMP
+  if (!omp_in_parallel() && ((end - begin) > grain_size) &&
+      engine::OpenMP::Get()->GetRecommendedOMPThreadCount() > 1) {
+#pragma omp parallel
+    {
+      int64_t num_threads = omp_get_num_threads();
+      if (grain_size > 0) {
+        num_threads = std::min(num_threads, divup((end - begin), grain_size));
+      }
+      auto tid = omp_get_thread_num();
+      auto chunk_size = divup((end - begin), num_threads);
+      auto begin_tid = begin + tid * chunk_size;
+      if (begin_tid < end) {
+        auto end_tid = std::min(end, chunk_size + begin_tid);
+        f(begin_tid, end_tid);
+      }
+    }
+  } else {
+#endif
+    f(begin, end);
+  }
+}
+
+template <typename F>
+void parallel_for(const size_t begin, const size_t end, F&& f) {
+  parallel_for(begin, end, default_grain_size(), std::forward<F>(f));
+}
+}  // namespace common
+}  // namespace mxnet
+
+#endif  // MXNET_COMMON_PARALLEL_FOR_H_

--- a/src/operator/nn/batch_norm.cc
+++ b/src/operator/nn/batch_norm.cc
@@ -28,6 +28,7 @@
 
 #include "../elemwise_op_common.h"
 #include "../operator_common.h"
+#include "../../common/parallel_for.h"
 
 #include "batch_norm-inl.h"
 #if MXNET_USE_ONEDNN == 1
@@ -140,8 +141,8 @@ void BatchNormForwardImpl(mshadow::Stream<cpu>*,
   const size_t channelCount                = inputData.ChannelCount();
   const size_t itemCountPerChannel         = inputData.Size() / channelCount;
 
-#pragma omp parallel for
-  for (int channel = 0; channel < static_cast<int>(channelCount); ++channel) {
+  mxnet::common::parallel_for(0, static_cast<int>(channelCount), [=](size_t b, size_t e) {
+  for (int channel = b; channel < e; ++channel) {
     if (is_train_and_not_global_stats) {
       // compute mean per input
       mean[channel] = 0;
@@ -211,7 +212,7 @@ void BatchNormForwardImpl(mshadow::Stream<cpu>*,
                     });
       }
     }
-  }
+  }});
 }
 
 template <typename xpu, typename DType, typename AccReal>
@@ -254,9 +255,9 @@ void BatchNormBackwardImpl(mshadow::Stream<cpu>*,
   AccReal* gradBiasData            = gradBias.dptr<AccReal>();
 
   const bool is_train_and_not_global_stats = ctx.is_train && !param_.use_global_stats;
-
-#pragma omp parallel for
-  for (int channel = 0; channel < static_cast<int>(channelCount); ++channel) {
+  
+  mxnet::common::parallel_for(0, static_cast<int>(channelCount), [=](size_t b, size_t e) {
+  for (int channel = b; channel < e; ++channel) {
     const AccReal* weight = weights.dptr<AccReal>();
     const AccReal w       = !param_.fix_gamma ? weight[channel] : AccReal(1);
     AccReal mean, invstd;
@@ -365,7 +366,7 @@ void BatchNormBackwardImpl(mshadow::Stream<cpu>*,
     }
 
     KERNEL_ASSIGN(gradBiasData[channel], req[batchnorm::kBeta], scale * sumGradOut);
-  }
+  }});
 }
 
 DMLC_REGISTER_PARAMETER(BatchNormParam);


### PR DESCRIPTION
## Description ##
This PR implements parallel_for, a function wrapper that allows controlling the number of threads executing OpenMP parallel region by setting grain size.

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
