### PR TITLE
[FEATURE] MXIndexedRecordIO: avoid re-build index

### DIFF
--- a/python/mxnet/recordio.py
+++ b/python/mxnet/recordio.py
@@ -245,10 +245,11 @@ class MXIndexedRecordIO(MXRecordIO):
 
     def open(self):
         super(MXIndexedRecordIO, self).open()
-        self.idx = {}
-        self.keys = []
         self.fidx = open(self.idx_path, self.flag)
-        if not self.writable:
+        if self.writable:
+            self.idx = {}
+            self.keys = []
+        elif not self.idx:
             for line in iter(self.fidx.readline, ''):
                 line = line.strip().split('\t')
                 key = self.key_type(line[0])


### PR DESCRIPTION
## Description ##

When resetting, avoid re-build index for read-only instances to save time and memory (in case of forked, memory pages can be shared)

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [x] avoid reset index

## Comments ##

This can save ~30G memory for us when running with 16 forked workers.