### PR TITLE
[v1.x][submodule] Downgrade oneDNN to v2.2.4

### DIFF
--- a/tests/cpp/operator/mkldnn_test.cc
+++ b/tests/cpp/operator/mkldnn_test.cc
@@ -100,7 +100,7 @@ static void VerifyDefMem(const mkldnn::memory &mem) {
 
 TEST(MKLDNN_UTIL_FUNC, MemFormat) {
   // Check whether the number of format is correct.
-  CHECK_EQ(mkldnn_format_tag_last, 385);
+  CHECK_EQ(mkldnn_format_tag_last, 363);
   CHECK_EQ(mkldnn_nchw, 5);
   CHECK_EQ(mkldnn_oihw, 5);
 }


### PR DESCRIPTION
## Description ##
As a part of https://github.com/apache/incubator-mxnet/issues/20529 oneDNN on branch v1.x will be downgraded to v2.2.4 to unblock CI pipeline, until the problem with deconvolution primitive is fixed on branch v2.3 of onednn project.
