### PR TITLE
[BUGFIX] Prohibit the use of the BLA_VENDOR flag when using MKL

### DIFF
--- a/cmake/ChooseBlas.cmake
+++ b/cmake/ChooseBlas.cmake
@@ -132,6 +132,12 @@ elseif(BLAS STREQUAL "MKL" OR BLAS STREQUAL "mkl")
   cmake_dependent_option(BLA_STATIC "Use static libraries" ON "NOT MKL_USE_SINGLE_DYNAMIC_LIBRARY" OFF)
   cmake_dependent_option(MKL_MULTI_THREADED  "Use multi-threading"  ON "NOT MKL_USE_SINGLE_DYNAMIC_LIBRARY" OFF)
 
+  if(BLA_VENDOR)
+      message(FATAL_ERROR "Do not set BLA_VENDOR manually. MKL version (BLA_VENDOR) is selected based on MKL_USE_SINGLE_DYNAMIC_LIBRARY, "
+                          "MKL_MULTI_THREADED and USE_INT64_TENSOR_SIZE flags. If you want to select specific MKL library version "
+                          "please set the above-mentioned flags instead.")
+  endif()
+
   if(MKL_USE_SINGLE_DYNAMIC_LIBRARY)
     set(BLA_VENDOR Intel10_64_dyn)
     add_definitions(-DMKL_USE_SINGLE_DYNAMIC_LIBRARY=1)


### PR DESCRIPTION
## Description ##
MKL version (BLA_VENDOR) is chosen basing on three flags:
- MKL_USE_SINGLE_DYNAMIC_LIBRARY
- MKL_MULTI_THREADED
- USE_INT64_TENSOR_SIZE

This PR forbid use of BLA_VENDOR because it can cause incompatibility between those flags and chosen vendor like in issue: https://github.com/apache/incubator-mxnet/issues/20301 

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] Code is well-documented

