### PR TITLE
Ignoring mass reformatting commits with git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Clang-formatter initial commit - /src directory is formatted
+e359bcd65e453d4bc86d3d8e5b1dee3916a2e426


### PR DESCRIPTION
## Description ##
Ignoring bulk change commits with git blame ~  Using --ignore-rev, one can specify a commit to be ignored by git blame.

We can call git blame with the --ignore-revs-file option to ignore all these commits at once:
```bash
git config blame.ignoreRevsFile .git-blame-ignore-revs
```
Before:
```cpp
e359bcd65e (mozga        2021-09-13 15:28:22 +0200  38)     .set_body([](runtime::MXNetArgs args, runtime::MXNetRetValue* ret) {
e359bcd65e (mozga        2021-09-13 15:28:22 +0200  39)       using namespace runtime;
e359bcd65e (mozga        2021-09-13 15:28:22 +0200  40)       if (args[0].type_code() == kDLInt) {
e359bcd65e (mozga        2021-09-13 15:28:22 +0200  41)         *ret = Integer(args[0].operator int64_t());
e359bcd65e (mozga        2021-09-13 15:28:22 +0200  42)       } else {
e359bcd65e (mozga        2021-09-13 15:28:22 +0200  43)         LOG(FATAL) << "only accept int";
e359bcd65e (mozga        2021-09-13 15:28:22 +0200  44)       }
e359bcd65e (mozga        2021-09-13 15:28:22 +0200  45)     });
```
After:
```cpp
3f0b049a30 (Haozheng Fan 2020-02-25 04:47:23 +0800  38)     .set_body([](runtime::MXNetArgs args, runtime::MXNetRetValue* ret) {
3f0b049a30 (Haozheng Fan 2020-02-25 04:47:23 +0800  39)       using namespace runtime;
3f0b049a30 (Haozheng Fan 2020-02-25 04:47:23 +0800  40)       if (args[0].type_code() == kDLInt) {
3f0b049a30 (Haozheng Fan 2020-02-25 04:47:23 +0800  41)         *ret = Integer(args[0].operator int64_t());
3f0b049a30 (Haozheng Fan 2020-02-25 04:47:23 +0800  42)       } else {
3f0b049a30 (Haozheng Fan 2020-02-25 04:47:23 +0800  43)         LOG(FATAL) << "only accept int";
3f0b049a30 (Haozheng Fan 2020-02-25 04:47:23 +0800  44)       }
3f0b049a30 (Haozheng Fan 2020-02-25 04:47:23 +0800  45)     });
```

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
