### PR TITLE
[Master] The size of a stack needs to be greater than 4

### DIFF
--- a/include/mxnet/tuple.h
+++ b/include/mxnet/tuple.h
@@ -383,7 +383,7 @@ class Tuple {
 
  protected:
   // stack cache size
-  static const int kStackCache = 4;
+  static const int kStackCache = 8;
   /*! \brief number of dimension of the tuple */
   int ndim_{0};
   /*! \brief number of cells allocated in data_heap_ */


### PR DESCRIPTION
## Description ##
The size of a stack is always 4.  A new optional<T> ([#658](https://github.com/dmlc/dmlc-core/pull/658)) structure is used to indicate that an object t may be "moved from" ~ allowing the efficient transfer of resources from t to another object. If an old value is moved into a new object, then the size is not enough and a blind value is reading out of the memory ~ hence:  a double corruption error shows up. The size of the stack needs to be greater to avoid double corruption errors.  The issue comes from #20560.

In this scenario: if a previous container is moved into a new buffer, then an address of a buffer is the same.

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
