### PR TITLE
[v1.9.x][submodule] Upgrade oneDNN to v2.2.4

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -258,7 +258,7 @@
     3rdparty/mkldnn/src/cpu/x64/xbyak
     3rdparty/mkldnn/tests/gtests/gtest
     3rdparty/mkldnn/cmake/FindOpenCL.cmake (Copy of the License available at licenses/BSD3-cmake)
-    3rdparty/mkldnn/src/cpu/x64/jit_utils/jitprofiling/
+    3rdparty/mkldnn/src/common/ittnotify/
     3rdparty/onnx-tensorrt/third_party/onnx/third_party/pybind11/tools/FindPythonLibsNew.cmake
     3rdparty/ctc_include/contrib/moderngpu
     3rdparty/nvidia_cub

--- a/src/operator/nn/mkldnn/mkldnn_convolution.cc
+++ b/src/operator/nn/mkldnn/mkldnn_convolution.cc
@@ -430,8 +430,7 @@ void MKLDNNConvolutionForwardFullFeature(const MKLDNNConvFullParam &param, const
       weight.MKLDNNDataReorderAsync(fwd->GetPd().weights_desc());
       weight_mem = GetWeights(weight, fwd->GetPd().weights_desc(), param.conv_param.num_group);
     } else {
-      weight_mem = weight.GetMKLDNNData();
-      CHECK(weight_mem->get_desc() == fwd->GetPd().weights_desc());
+      weight_mem = weight.GetMKLDNNDataReorder(fwd->GetPd().weights_desc());
     }
   }
   mkldnn_output_t out_mem;

--- a/tests/cpp/operator/mkldnn_test.cc
+++ b/tests/cpp/operator/mkldnn_test.cc
@@ -100,7 +100,7 @@ static void VerifyDefMem(const mkldnn::memory &mem) {
 
 TEST(MKLDNN_UTIL_FUNC, MemFormat) {
   // Check whether the number of format is correct.
-  CHECK_EQ(mkldnn_format_tag_last, 222);
+  CHECK_EQ(mkldnn_format_tag_last, 363);
   CHECK_EQ(mkldnn_nchw, 5);
   CHECK_EQ(mkldnn_oihw, 5);
 }


### PR DESCRIPTION
## Description ##
This change simply upgrades the oneDNN used on v1.9.x branch to v2.2.4.