### PR TITLE
Improve stack operator performance by oneDNN

### DIFF
--- a/python/mxnet/amp/lists/symbol_fp16.py
+++ b/python/mxnet/amp/lists/symbol_fp16.py
@@ -673,7 +673,6 @@ WIDEST_TYPE_CASTS = [
     '_npi_not_equal',
     '_npi_dstack',
     '_npi_hstack',
-    '_npi_stack',
     '_npi_tensordot',
     '_npi_tensordot_int_axes',
     '_npi_vstack',

--- a/python/mxnet/onnx/mx2onnx/_op_translations/_op_translations_opset12.py
+++ b/python/mxnet/onnx/mx2onnx/_op_translations/_op_translations_opset12.py
@@ -3191,7 +3191,6 @@ def convert_embedding(node, **kwargs):
 
 
 @mx_op.register("stack")
-@mx_op.register("_npi_stack")
 def convert_stack(node, **kwargs):
     """Map MXNet's stack operator to onnx operators.
     """

--- a/python/mxnet/onnx/mx2onnx/_op_translations/_op_translations_opset13.py
+++ b/python/mxnet/onnx/mx2onnx/_op_translations/_op_translations_opset13.py
@@ -551,7 +551,6 @@ def convert_expand_dims(node, **kwargs):
 
 
 @mx_op.register("stack", OPSET_VERSION)
-@mx_op.register("_npi_stack", OPSET_VERSION)
 def convert_stack(node, **kwargs):
     """Map MXNet's stack operator to onnx operators.
     """

--- a/src/operator/nn/dnnl/dnnl_base-inl.h
+++ b/src/operator/nn/dnnl/dnnl_base-inl.h
@@ -197,6 +197,7 @@ bool SupportDNNLTranspose(const NDArray& data);
 bool SupportDNNLBatchDot(const std::vector<NDArray>& inputs, const NDArray& output);
 bool SupportDNNLLayerNorm(const LayerNormParam& param, const std::vector<NDArray>& inputs);
 bool SupportDNNLReshape(const NDArray& input, const NDArray& output);
+bool SupportDNNLStack(const std::vector<NDArray>& inputs);
 }  // namespace op
 
 static int GetTypeSize(int dtype) {
@@ -607,9 +608,9 @@ class DNNLMemory {
       dnnl::memory::data_type data_type = dnnl::memory::data_type::undef) const {
     dnnl::memory::dims dims(desc.data.dims, desc.data.dims + desc.data.ndims);
     dnnl::memory::data_type cpp_type =
-        (data_type == dnnl::memory::data_type::undef)
-            ? static_cast<dnnl::memory::data_type>(desc.data.data_type)
-            : data_type;
+        (data_type == dnnl::memory::data_type::undef) ?
+            static_cast<dnnl::memory::data_type>(desc.data.data_type) :
+            data_type;
     dnnl::memory::desc data_md(dims, cpp_type, static_cast<dnnl::memory::format_tag>(format));
     return data_md;
   }

--- a/src/operator/nn/dnnl/dnnl_concat-inl.h
+++ b/src/operator/nn/dnnl/dnnl_concat-inl.h
@@ -52,13 +52,18 @@ class DNNLConcatFwd {
 
 static DNNLConcatFwd& GetConcatForward(int concat_dim,
                                        const std::vector<NDArray>& in_data,
-                                       const std::vector<dnnl::memory::desc>& data_md) {
+                                       const std::vector<dnnl::memory::desc>& data_md,
+                                       int cache_dim = -1) {
 #if DMLC_CXX11_THREAD_LOCAL
   static thread_local std::unordered_map<OpSignature, DNNLConcatFwd, OpHash> fwds;
 #else
   static MX_THREAD_LOCAL std::unordered_map<OpSignature, DNNLConcatFwd, OpHash> fwds;
 #endif
+  if (cache_dim == -1) {
+    cache_dim = concat_dim;
+  }
   OpSignature key;
+  key.AddSign(cache_dim);
   key.AddSign(concat_dim);
   key.AddSign(in_data);
 

--- a/src/operator/nn/dnnl/dnnl_concat-inl.h
+++ b/src/operator/nn/dnnl/dnnl_concat-inl.h
@@ -53,18 +53,16 @@ class DNNLConcatFwd {
 static DNNLConcatFwd& GetConcatForward(int concat_dim,
                                        const std::vector<NDArray>& in_data,
                                        const std::vector<dnnl::memory::desc>& data_md,
-                                       int cache_dim = -1) {
+                                       int stack_axis = -1 /*used only by stack op*/) {
 #if DMLC_CXX11_THREAD_LOCAL
   static thread_local std::unordered_map<OpSignature, DNNLConcatFwd, OpHash> fwds;
 #else
   static MX_THREAD_LOCAL std::unordered_map<OpSignature, DNNLConcatFwd, OpHash> fwds;
 #endif
-  if (cache_dim == -1) {
-    cache_dim = concat_dim;
-  }
+
   OpSignature key;
-  key.AddSign(cache_dim);
   key.AddSign(concat_dim);
+  key.AddSign(stack_axis);
   key.AddSign(in_data);
 
   auto it = fwds.find(key);

--- a/src/operator/nn/dnnl/dnnl_ops-inl.h
+++ b/src/operator/nn/dnnl/dnnl_ops-inl.h
@@ -180,6 +180,12 @@ void DNNLLayerNormBackward(const nnvm::NodeAttrs& attrs,
 
 void DNNLSum(const dnnl::memory& arr1, const dnnl::memory& arr2, const dnnl::memory& out);
 
+void DNNLStackForward(const nnvm::NodeAttrs& attrs,
+                      const OpContext& ctx,
+                      const std::vector<NDArray>& in_data,
+                      const std::vector<OpReqType>& req,
+                      const std::vector<NDArray>& out_data);
+
 template <class ParamType>
 void DNNLTransposeForward(const nnvm::NodeAttrs& attrs,
                           const OpContext& ctx,

--- a/src/operator/nn/dnnl/dnnl_stack.cc
+++ b/src/operator/nn/dnnl/dnnl_stack.cc
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file dnnl_stack.cc
+ */
+
+#include "./dnnl_base-inl.h"
+#include "./dnnl_concat-inl.h"
+#include "./dnnl_ops-inl.h"
+
+#include "../../tensor/matrix_op-inl.h"
+
+#if MXNET_USE_ONEDNN == 1
+namespace mxnet {
+namespace op {
+
+bool SupportDNNLStack(const std::vector<NDArray>& inputs) {
+  if (inputs[0].dtype() != mshadow::kFloat32 && inputs[0].dtype() != mshadow::kBfloat16)
+    return false;
+
+  int src_dtype = inputs[0].dtype();
+  for (auto& arr : inputs) {
+    if (arr.dtype() != src_dtype) {
+      return false;
+    }
+    // DO not support zero-size tensors.
+    if (arr.shape().Size() == 0)
+      return false;
+    int ndim = arr.shape().ndim();
+    if (ndim <= 0)
+      return false;
+  }
+  return true;
+}
+
+void DNNLStackForward(const nnvm::NodeAttrs& attrs,
+                      const OpContext& ctx,
+                      const std::vector<NDArray>& in_data,
+                      const std::vector<OpReqType>& req,
+                      const std::vector<NDArray>& out_data) {
+  TmpMemMgr::Get()->Init(ctx.requested[concat_enum::kTempSpace]);
+
+  const StackParam& param = dmlc::get<StackParam>(attrs.parsed);
+  const int axis          = CheckAxis(param.axis, out_data[0].shape().ndim());
+  const auto oshape       = out_data[0].shape();
+  const int src_dtype     = in_data[0].dtype();
+  const int dst_dtype     = out_data[0].dtype();
+  int leading             = 1;
+  int trailing            = 1;
+
+  for (int i = 0; i < axis; ++i) {
+    leading *= oshape[i];
+  }
+  for (int i = axis + 1; i < oshape.ndim(); ++i) {
+    trailing *= oshape[i];
+  }
+  int mid = oshape[axis];
+
+  std::vector<dnnl::memory::desc> data_md;
+  std::vector<dnnl::memory> data_mem;
+  dnnl::memory::desc in_md(
+      {leading, 1, trailing}, get_dnnl_type(src_dtype), dnnl::memory::format_tag::abc);
+  dnnl::memory::desc out_md(
+      {leading, mid, trailing}, get_dnnl_type(dst_dtype), dnnl::memory::format_tag::any);
+
+  const int num_in_data = in_data.size();
+  data_md.reserve(num_in_data);
+  data_mem.reserve(num_in_data);
+
+  MSHADOW_TYPE_SWITCH(src_dtype, DType, {
+    for (int i = 0; i < num_in_data; i++) {
+      NDArray tmp = in_data[i].IsDNNLData() ? in_data[i].Reorder2Default() : in_data[i];
+      dnnl::memory tmp_mem(in_md, CpuEngine::Get()->get_engine(), tmp.data().dptr<DType>());
+      data_mem.emplace_back(tmp_mem);
+      data_md.emplace_back(in_md);
+    }
+  });
+
+  auto& fwd = GetConcatForward(1, in_data, data_md, axis);
+  mxnet::dnnl_output_t out_mem =
+      CreateDNNLMem(out_data[concat_enum::kOut], fwd.fwd_pd.dst_desc(), req[concat_enum::kOut]);
+
+  std::unordered_map<int, dnnl::memory> net_args;
+  net_args.insert({DNNL_ARG_DST, *out_mem.second});
+  for (int i = 0; i < num_in_data; i++) {
+    net_args.insert({DNNL_ARG_MULTIPLE_SRC + i, data_mem[i]});
+  }
+
+  DNNLStream::Get()->RegisterPrimArgs(fwd.GetFwd(), net_args);
+  CommitOutput(out_data[concat_enum::kOut], out_mem);
+  DNNLStream::Get()->Submit();
+}
+
+}  // namespace op
+}  // namespace mxnet
+#endif

--- a/src/operator/nn/dnnl/dnnl_stack.cc
+++ b/src/operator/nn/dnnl/dnnl_stack.cc
@@ -61,8 +61,8 @@ void DNNLStackForward(const nnvm::NodeAttrs& attrs,
                       const std::vector<NDArray>& out_data) {
   TmpMemMgr::Get()->Init(ctx.requested[concat_enum::kTempSpace]);
 
-  // const value of new dimension to stack
-  // tensors with oneDNN concat primitive
+  // const value of artificial new dimension to
+  // stack tensors on using oneDNN concat primitive
   constexpr int stacking_dim = 1;
 
   const StackParam& param = dmlc::get<StackParam>(attrs.parsed);
@@ -96,7 +96,7 @@ void DNNLStackForward(const nnvm::NodeAttrs& attrs,
 
   MSHADOW_TYPE_SWITCH(src_dtype, DType, {
     for (int i = 0; i < num_in_data; i++) {
-      NDArray tmp = in_data[i].IsDNNLData() ? in_data[i].Reorder2Default() : in_data[i];
+      NDArray tmp = in_data[i].Reorder2Default();
       dnnl::memory tmp_mem(in_md, CpuEngine::Get()->get_engine(), tmp.data().dptr<DType>());
       data_mem.emplace_back(tmp_mem);
       data_md.emplace_back(in_md);

--- a/src/operator/numpy/np_matrix_op.cc
+++ b/src/operator/numpy/np_matrix_op.cc
@@ -638,46 +638,6 @@ struct NumpyConcatGrad {
     return MakeGradNode(op_name, n, heads, n->attrs.dict);
   }
 };
-NNVM_REGISTER_OP(_npi_stack)
-    .describe(R"code(Join a sequence of arrays along a new axis.
-
-The axis parameter specifies the index of the new axis in the dimensions of the
-result. For example, if axis=0 it will be the first dimension and if axis=-1 it
-will be the last dimension.
-
-Examples::
-
-  x = [1, 2]
-  y = [3, 4]
-
-  stack(x, y) = [[1, 2],
-                 [3, 4]]
-  stack(x, y, axis=1) = [[1, 3],
-                         [2, 4]]
-)code")
-    .set_num_inputs([](const nnvm::NodeAttrs& attrs) {
-      const StackParam& param = dmlc::get<StackParam>(attrs.parsed);
-      return static_cast<uint32_t>(param.num_args);
-    })
-    .set_num_outputs(1)
-    .set_attr_parser(ParamParser<StackParam>)
-    .set_attr<nnvm::FListInputNames>("FListInputNames",
-                                     [](const NodeAttrs& attrs) {
-                                       uint32_t num_args =
-                                           dmlc::get<StackParam>(attrs.parsed).num_args;
-                                       std::vector<std::string> ret;
-                                       for (uint32_t i = 0; i < num_args; ++i) {
-                                         ret.push_back(std::string("arg") + std::to_string(i));
-                                       }
-                                       return ret;
-                                     })
-    .set_attr<std::string>("key_var_num_args", "num_args")
-    .set_attr<mxnet::FInferShape>("FInferShape", StackOpShape)
-    .set_attr<nnvm::FInferType>("FInferType", ElemwiseType<-1, 1>)
-    .set_attr<FCompute>("FCompute<cpu>", StackOpForward<cpu>)
-    .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseNone{"_backward_stack"})
-    .add_argument("data", "NDArray-or-Symbol[]", "List of arrays to stack")
-    .add_arguments(StackParam::__FIELDS__());
 
 bool NumpyColumnStackType(const nnvm::NodeAttrs& attrs,
                           std::vector<int>* in_type,

--- a/src/operator/numpy/np_matrix_op.cu
+++ b/src/operator/numpy/np_matrix_op.cu
@@ -34,8 +34,6 @@ NNVM_REGISTER_OP(_np_reshape).set_attr<FCompute>("FCompute<gpu>", UnaryOp::Ident
 
 NNVM_REGISTER_OP(_npi_squeeze).set_attr<FCompute>("FCompute<gpu>", UnaryOp::IdentityCompute<gpu>);
 
-NNVM_REGISTER_OP(_npi_stack).set_attr<FCompute>("FCompute<gpu>", StackOpForward<gpu>);
-
 NNVM_REGISTER_OP(_npi_vstack).set_attr<FCompute>("FCompute<gpu>", NumpyVstackForward<gpu>);
 
 NNVM_REGISTER_OP(_backward_np_vstack).set_attr<FCompute>("FCompute<gpu>", NumpyVstackBackward<gpu>);

--- a/src/operator/tensor/matrix_op.cc
+++ b/src/operator/tensor/matrix_op.cc
@@ -930,7 +930,38 @@ NNVM_REGISTER_OP(_backward_reverse)
                                 })
     .set_attr<FCompute>("FCompute<cpu>", ReverseOpForward<cpu>);
 
+#if MXNET_USE_ONEDNN == 1
+static void StackForwardEx(const nnvm::NodeAttrs& attrs,
+                           const OpContext& op_ctx,
+                           const std::vector<NDArray>& inputs,
+                           const std::vector<OpReqType>& req,
+                           const std::vector<NDArray>& outputs) {
+  CHECK(!inputs.empty());
+  CHECK_EQ(outputs.size(), 1U);
+  CHECK_EQ(req.size(), 1U);
+  if (req[0] == kNullOp)
+    return;
+
+  if (SupportDNNLStack(inputs)) {
+    DNNL_OPCHECK_INIT(false, outputs.size(), inputs, outputs);
+    DNNLRun(DNNLStackForward, attrs, op_ctx, inputs, req, outputs);
+    DNNL_OPCHECK_RUN(StackOpForward<cpu>, attrs, op_ctx, inputs, req, outputs);
+  } else {
+    FallBackCompute(StackOpForward<cpu>, attrs, op_ctx, inputs, req, outputs);
+  }
+}
+
+inline static bool StackInferStorageType(const nnvm::NodeAttrs& attrs,
+                                         const int dev_mask,
+                                         DispatchMode* dispatch_mode,
+                                         std::vector<int>* in_attrs,
+                                         std::vector<int>* out_attrs) {
+  return DNNLStorageType(attrs, dev_mask, true, dispatch_mode, in_attrs, out_attrs);
+}
+#endif  // MXNET_USE_ONEDNN == 1
+
 NNVM_REGISTER_OP(stack)
+    .add_alias("_npi_stack")
     .describe(R"code(Join a sequence of arrays along a new axis.
 The axis parameter specifies the index of the new axis in the dimensions of the
 result. For example, if axis=0 it will be the first dimension and if axis=-1 it
@@ -965,6 +996,15 @@ Examples::
     .set_attr<mxnet::FInferShape>("FInferShape", StackOpShape)
     .set_attr<nnvm::FInferType>("FInferType", ElemwiseType<-1, 1>)
     .set_attr<FCompute>("FCompute<cpu>", StackOpForward<cpu>)
+#if MXNET_USE_ONEDNN == 1
+    .set_attr<FComputeEx>("FComputeEx<cpu>", StackForwardEx)
+    .set_attr<bool>("TIsDNNL", true)
+    .set_attr<FResourceRequest>("FResourceRequest",
+                                [](const NodeAttrs& n) {
+                                  return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
+                                })
+    .set_attr<FInferStorageType>("FInferStorageType", StackInferStorageType)
+#endif
     .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseNone{"_backward_stack"})
     .add_argument("data", "NDArray-or-Symbol[]", "List of arrays to stack")
     .add_arguments(StackParam::__FIELDS__());

--- a/src/operator/tensor/matrix_op.cc
+++ b/src/operator/tensor/matrix_op.cc
@@ -939,8 +939,9 @@ static void StackForwardEx(const nnvm::NodeAttrs& attrs,
   CHECK(!inputs.empty());
   CHECK_EQ(outputs.size(), 1U);
   CHECK_EQ(req.size(), 1U);
-  if (req[0] == kNullOp)
+  if (req[0] == kNullOp) {
     return;
+  }
 
   if (SupportDNNLStack(inputs)) {
     DNNL_OPCHECK_INIT(false, outputs.size(), inputs, outputs);

--- a/src/operator/tensor/matrix_op.cc
+++ b/src/operator/tensor/matrix_op.cc
@@ -140,7 +140,8 @@ bool ReshapeStorageType(const nnvm::NodeAttrs& attrs,
                         std::vector<int>* out_attrs) {
   CHECK_EQ(in_attrs->size(), 1U);
   CHECK_EQ(out_attrs->size(), 1U);
-  return DNNLStorageType(attrs, dev_mask, true, dispatch_mode, in_attrs, out_attrs);
+  return DNNLStorageType(
+      attrs, dev_mask, /*support_dnnl*/ true, dispatch_mode, in_attrs, out_attrs);
 }
 #endif
 
@@ -944,7 +945,7 @@ static void StackForwardEx(const nnvm::NodeAttrs& attrs,
   }
 
   if (SupportDNNLStack(inputs)) {
-    DNNL_OPCHECK_INIT(false, outputs.size(), inputs, outputs);
+    DNNL_OPCHECK_INIT(/*is backward*/ false, outputs.size(), inputs, outputs);
     DNNLRun(DNNLStackForward, attrs, op_ctx, inputs, req, outputs);
     DNNL_OPCHECK_RUN(StackOpForward<cpu>, attrs, op_ctx, inputs, req, outputs);
   } else {


### PR DESCRIPTION
## Description ##
Improves performance of stack operation. Performance results shows significant speedup on axis=0 (up to 7x faster).

Performance results collected on CLX8280 with `KMP_AFFINITY=granularity=fine,noduplicates,compact,1,0 OMP_NUM_THREADS=28 numactl --physcpubind=0-27 --membind=0`:
<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/bgawrych/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/bgawrych/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">
</head>

<body link="#0563C1" vlink="#954F72">



  |   | master | onednn
-- | -- | -- | --
shape | axis | time | time
(128, 128) | 0 | 0.007561 | 0.008217
(128, 128) | 1 | 0.004158 | 0.00457
(128, 512) | 0 | 0.014108 | 0.007263
(128, 512) | 1 | 0.004416 | 0.005567
(128, 1024) | 0 | 0.024753 | 0.009431
(128, 1024) | 1 | 0.0046 | 0.004892
(128, 4096) | 0 | 0.088938 | 0.025933
(128, 4096) | 1 | 0.006305 | 0.006167
(512, 128) | 0 | 0.012593 | 0.006721
(512, 128) | 1 | 0.004545 | 0.00462
(512, 512) | 0 | 0.043897 | 0.01301
(512, 512) | 1 | 0.005042 | 0.005218
(512, 1024) | 0 | 0.079853 | 0.016997
(512, 1024) | 1 | 0.006117 | 0.006382
(512, 4096) | 0 | 0.517834 | 0.097284
(512, 4096) | 1 | 0.070154 | 0.038691
(1024, 128) | 0 | 0.022151 | 0.008327
(1024, 128) | 1 | 0.004755 | 0.004991
(1024, 512) | 0 | 0.080592 | 0.017348
(1024, 512) | 1 | 0.006391 | 0.006452
(1024, 1024) | 0 | 0.205667 | 0.040287
(1024, 1024) | 1 | 0.013286 | 0.013144
(1024, 4096) | 0 | 1.159914 | 0.267409
(1024, 4096) | 1 | 0.174798 | 0.153152
(4096, 128) | 0 | 0.081543 | 0.017331
(4096, 128) | 1 | 0.006936 | 0.006952
(4096, 512) | 0 | 0.575121 | 0.079814
(4096, 512) | 1 | 0.084379 | 0.040853
(4096, 1024) | 0 | 1.244555 | 0.251577
(4096, 1024) | 1 | 0.1782 | 0.154799
(4096, 4096) | 0 | 5.169306 | 1.180926
(4096, 4096) | 1 | 0.766602 | 0.740192
(32, 128, 128) | 0 | 0.080957 | 0.017508
(32, 128, 128) | 1 | 0.00692 | 0.006721
(32, 128, 128) | 2 | 0.006921 | 0.006859
(32, 128, 512) | 0 | 0.555404 | 0.081633
(32, 128, 512) | 1 | 0.077143 | 0.037545
(32, 128, 512) | 2 | 0.083525 | 0.041425
(32, 128, 1024) | 0 | 1.225558 | 0.255515
(32, 128, 1024) | 1 | 0.190202 | 0.154146
(32, 128, 1024) | 2 | 0.177495 | 0.1549
(32, 128, 4096) | 0 | 5.006225 | 1.090737
(32, 128, 4096) | 1 | 0.831286 | 0.759118
(32, 128, 4096) | 2 | 0.765793 | 0.742179
(32, 512, 128) | 0 | 0.560635 | 0.090112
(32, 512, 128) | 1 | 0.076585 | 0.042584
(32, 512, 128) | 2 | 0.095465 | 0.04338
(32, 512, 512) | 0 | 2.536246 | 0.541157
(32, 512, 512) | 1 | 0.397728 | 0.341854
(32, 512, 512) | 2 | 0.407399 | 0.35051
(32, 512, 1024) | 0 | 5.034069 | 1.092211
(32, 512, 1024) | 1 | 0.830025 | 0.760654
(32, 512, 1024) | 2 | 0.772979 | 0.740602
(32, 512, 4096) | 0 | 20.72267 | 4.655413
(32, 512, 4096) | 1 | 3.503717 | 3.075174
(32, 512, 4096) | 2 | 3.02452 | 3.002688
(32, 1024, 128) | 0 | 1.196986 | 0.24314
(32, 1024, 128) | 1 | 0.190801 | 0.15396
(32, 1024, 128) | 2 | 0.220551 | 0.154176
(32, 1024, 512) | 0 | 5.024947 | 1.09671
(32, 1024, 512) | 1 | 0.828758 | 0.768377
(32, 1024, 512) | 2 | 0.842505 | 0.748963
(32, 1024, 1024) | 0 | 10.38974 | 2.242758
(32, 1024, 1024) | 1 | 1.869875 | 1.547855
(32, 1024, 1024) | 2 | 1.538614 | 1.496964
(32, 1024, 4096) | 0 | 41.49604 | 9.043207
(32, 1024, 4096) | 1 | 7.476183 | 6.120244
(32, 1024, 4096) | 2 | 6.035282 | 6.005883
(32, 4096, 128) | 0 | 5.003981 | 1.093519
(32, 4096, 128) | 1 | 0.826404 | 0.769504
(32, 4096, 128) | 2 | 0.926172 | 0.751195
(32, 4096, 512) | 0 | 20.09485 | 4.335339
(32, 4096, 512) | 1 | 3.502722 | 3.074266
(32, 4096, 512) | 2 | 3.359437 | 3.006657
(32, 4096, 1024) | 0 | 40.23293 | 8.423752
(32, 4096, 1024) | 1 | 7.462769 | 6.156365
(32, 4096, 1024) | 2 | 6.141823 | 6.012172
(32, 4096, 4096) | 0 | 154.2752 | 35.87757
(32, 4096, 4096) | 1 | 28.58106 | 24.12571
(32, 4096, 4096) | 2 | 24.46488 | 23.94641



</body>

</html>


```
import mxnet
import mxnet.gluon.nn as nn
import mxnet.numpy as np
import time

class TestStack(nn.HybridBlock):
    def __init__(self, axis=None):
        super(TestStack, self).__init__()
        self._axis = axis

    def forward(self, a, *args):
        return np.stack([a] + list(args), axis=self._axis)

dims = [128, 512, 1024, 4096]
print("shape;axis;time")
for ndim in range (2):
   for dim1 in dims:
     for dim2 in dims:
        shape = (dim1, dim2) if ndim == 0 else (32, dim1, dim2)
        a = np.random.uniform(-1.0, 1.0, shape).astype(np.float32)
        b = np.random.uniform(-1.0, 1.0, shape).astype(np.float32)
        c = np.random.uniform(-1.0, 1.0, shape).astype(np.float32)
        d = np.random.uniform(-1.0, 1.0, shape).astype(np.float32)
        for axis in range(2 + ndim):
            stack = TestStack(axis)
            stack.hybridize()
            tic = time.time()
            for i in range(100):
                out = np.stack([a, b, c, d], axis=axis)
                out.wait_to_read()
            toc = time.time()
            print(f"{shape};{axis};{toc-tic}")
```

