### PR TITLE
[v1.x] Backport  #20598

### DIFF
--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -1,0 +1,25 @@
+name: license check
+
+on: [push, pull_request]
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  licensecheck:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Update Submodules
+        run: |
+          git submodule update --init --recursive
+      - name: Check License Header
+        uses: apache/skywalking-eyes@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,0 +1,89 @@
+header:
+  license:
+    spdx-id: Apache-2.0
+    copyright-owner: Apache Software Foundation
+
+  paths-ignore:
+    - 'dist'
+    - 'licenses'
+    - '**/*.md'
+    - '**/*.ipynb'
+    - 'LICENSE'
+    - 'NOTICE'
+    - '3rdparty'
+    - '.gitignore'
+    - '.codecov.yml'
+    - '.gitattributes'
+    - '.github'
+    - '.gitmodules'
+    - '.licenserc.yaml'
+    - 'CODEOWNERS'
+    - 'DISCLAIMER'
+    - 'KEYS'
+    - 'python/mxnet/_cy3/README'
+    - 'tools/dependencies/LICENSE.binary.dependencies'
+    # files not distributed in source archive (listed in tools/source-exclude-artifacts.txt)
+    - 'docs'
+    - 'example/image-classification/predict-cpp/image-classification-predict.cc'
+    - 'R-package'
+    # files licensed under apache-2.0 license but do not include full license headers recognized by skywalking-eyes
+    - 'contrib/clojure-package/test'
+    - 'julia/src/runtime.jl'
+    - 'perl-package'
+    - 'python/mxnet/cython/ndarray.pyx'
+    - 'python/mxnet/cython/symbol.pyx'
+    - 'src/operator/contrib/deformable_convolution-inl.h'
+    - 'src/operator/contrib/deformable_convolution.cc'
+    - 'src/operator/contrib/deformable_convolution.cu'
+    - 'src/operator/contrib/deformable_psroi_pooling-inl.h'
+    - 'src/operator/contrib/deformable_psroi_pooling.cc'
+    - 'src/operator/contrib/deformable_psroi_pooling.cu'
+    - 'src/operator/contrib/multi_proposal-inl.h'
+    - 'src/operator/contrib/multi_proposal.cc'
+    - 'src/operator/contrib/multi_proposal.cu'
+    - 'src/operator/contrib/psroi_pooling.cc'
+    - 'src/operator/contrib/psroi_pooling.cu'
+    - 'src/operator/nn/mkldnn/mkldnn_base-inl.h'
+    - 'tests/python/unittest/test_contrib_text.py'
+    # files licensed under boost license
+    - 'cmake/Modules/FindJeMalloc.cmake'
+    # files licensed under bsd 2-clause
+    - 'example/ssd/dataset/pycocotools/coco.py'
+    # files licensed under bsd 3-clause
+    - 'cmake/upstream/FindCUDAToolkit.cmake'
+    - 'cmake/upstream/select_compute_arch.cmake'
+    - 'src/operator/contrib/erfinv-inl.h'
+    - 'src/operator/numpy/np_einsum_op-inl.h'
+    - 'src/operator/numpy/np_einsum_op.cc'
+    - 'src/operator/numpy/np_einsum_path_op-inl.h'
+    # files licensed under caffe/mit license
+    - 'src/operator/contrib/modulated_deformable_convolution-inl.h'
+    - 'src/operator/contrib/modulated_deformable_convolution.cc'
+    - 'src/operator/contrib/modulated_deformable_convolution.cu'
+    - 'src/operator/contrib/nn/deformable_im2col.cuh'
+    - 'src/operator/contrib/nn/deformable_im2col.h'
+    - 'src/operator/contrib/nn/modulated_deformable_im2col.cuh'
+    - 'src/operator/contrib/nn/modulated_deformable_im2col.h'
+    - 'src/operator/nn/im2col.cuh'
+    - 'src/operator/nn/im2col.h'
+    - 'src/operator/nn/pool.cuh'
+    - 'src/operator/nn/pool.h'
+    # symlinks
+    - 'include/dlpack' # symlink to 3rdparty/dlpack/include/dlpack
+    - 'include/dmlc' # symlink to 3rdparty/dmlc-core/include/dmlc
+    - 'include/mshadow' # symlink to 3rdparty/mshadow/mshadow
+    - 'include/mkldnn' # symlinks to 3rdparty/mkldnn
+    # test/build data
+    - 'contrib/clojure-package/examples/imclassification/test/test-symbol.json.ref'
+    - 'example/speech_recognition/resources/unicodemap_en_baidu.csv'
+    - 'example/ssd/dataset/names'
+    - 'julia/docs/src/tutorial/images/char-lstm-vis.svg' # tutorial include
+    - 'scala-package/.mvn/wrapper/maven-wrapper.properties'
+    - 'scala-package/init-native/src/main/native/org_apache_mxnet_init_native_c_api.h' # auto-generated file
+    - 'scala-package/native/src/main/native/org_apache_mxnet_native_c_api.h' # auto-generated file
+    - 'tests/python/mkl/data/test_mkldnn_test_mkldnn_model_model1.json'
+    - 'tests/python/unittest/save_000800.json'
+    - 'tools/accnn/config.json'
+    - 'tools/caffe_translator/build.gradle'
+
+  comment: on-failure

--- a/LICENSE
+++ b/LICENSE
@@ -220,20 +220,37 @@
 
     3rdparty/ctc_include
     3rdparty/dlpack
+    include/dlpack (header symlinks to 3rdparty/dlpack/include/dlpack)
     3rdparty/dmlc-core
+    include/dmlc (header symlinks to 3rdparty/dmlc-core/include/dmlc)
     3rdparty/mshadow
+    include/mshadow (header symlinks to 3rdparty/mshadow/mshadow)
     3rdparty/tvm
     3rdparty/tvm/3rdparty/dmlc-core
     3rdparty/tvm/3rdparty/dlpack
+    include/nnvm (header symlinks to 3rdparty/tvm/nnvm/include/nnvm)
     3rdparty/ps-lite
     3rdparty/mkldnn
     include/mkldnn (header symlinks to 3rdparty/mkldnn)
     3rdparty/googletest/googlemock/scripts/generator
     3rdparty/onnx-tensorrt/third_party/onnx/third_party/benchmark
+    3rdparty/onnx-tensorrt/third_party/onnx/tools/protoc-gen-mypy.py
     3rdparty/mkldnn/tests/benchdnn (Copy of the License available at top of current file)
     src/operator/special_functions-inl.h Cephes Library Functions (Copy of the License available at top of current file)
     3rdparty/mkldnn/doc/assets/mathjax (Copy of the License available at top of current file)
     3rdparty/tvm/3rdparty/bfloat16/bfloat16.cc (Copy of the License available at top of current file)
+    src/operator/contrib/deformable_convolution-inl.h
+    src/operator/contrib/deformable_convolution.cc
+    src/operator/contrib/deformable_convolution.cu
+    src/operator/contrib/deformable_psroi_pooling-inl.h
+    src/operator/contrib/deformable_psroi_pooling.cc
+    src/operator/contrib/deformable_psroi_pooling.cu
+    src/operator/contrib/multi_proposal-inl.h
+    src/operator/contrib/multi_proposal.cc
+    src/operator/contrib/multi_proposal.cu
+    src/operator/contrib/psroi_pooling.cc
+    src/operator/contrib/psroi_pooling.cu
+    src/operator/nn/mkldnn/mkldnn_base-inl.h
 
     =======================================================================================
     MIT license
@@ -245,6 +262,9 @@
     3rdparty/onnx-tensorrt/third_party/onnx
     3rdparty/intgemm
     3rdparty/tvm/3rdparty/compiler-rt/builtin_fp16.h
+    src/operator/contrib/modulated_deformable_convolution-inl.h
+    src/operator/contrib/modulated_deformable_convolution.cc
+    src/operator/contrib/modulated_deformable_convolution.cu
 
     =======================================================================================
     3-clause BSD license
@@ -263,6 +283,9 @@
     cmake/upstream/FindCUDAToolkit.cmake
     cmake/upstream/select_compute_arch.cmake
     src/operator/contrib/erfinv-inl.h
+    src/operator/numpy/np_einsum_op-inl.h
+    src/operator/numpy/np_einsum_path_op-inl.h
+    src/operator/numpy/np_einsum_op.cc
 
     =======================================================================================
     2-clause BSD license
@@ -306,22 +329,12 @@
     python/mxnet/onnx/mx2onnx/_export_onnx.py
     python/mxnet/onnx/mx2onnx/_op_translations/_op_translations_opset12.py
     python/mxnet/onnx/mx2onnx/_op_translations/_op_translations_opset13.py
-    src/operator/numpy/np_einsum_op-inl.h
-    src/operator/numpy/np_einsum_path_op-inl.h
-    src/operator/numpy/np_einsum_op.cc
 
     =======================================================================================
     Apache-2.0 license + MIT License
     =======================================================================================
 
-    3rdparty/onnx-tensorrt/third_party/onnx/tools/protoc-gen-mypy.py (Copy of the referenced AL2 License available at top of current file)
     src/operator/nn/layer_norm.cc (function LayerNormCPUKernel is adapated from MIT-licensed code)
-
-    =======================================================================================
-    Apache-2.0 license + Boost Software License, Version 1.0
-    =======================================================================================
-
-    cmake/Modules/FindJeMalloc.cmake
 
     =======================================================================================
     Boost Software License, Version 1.0
@@ -329,6 +342,7 @@
 
     3rdparty/intgemm/test/3rd_party/catch.hpp  (Copy of the License available at licenses/BOOST1_0)
     3rdparty/mkldnn/src/common/primitive_hashing.hpp
+    cmake/Modules/FindJeMalloc.cmake
 
     =======================================================================================
     LLVM Release License

--- a/rat-excludes
+++ b/rat-excludes
@@ -54,6 +54,7 @@ coco.py
 # Licenses
 licenses/*
 LICENSE.binary.dependencies
+.licenserc.yaml
 
 # Generated files during build
 .buildinfo
@@ -131,6 +132,9 @@ modulated_deformable_im2col.h
 FindCUDAToolkit.cmake
 FindJeMalloc.cmake
 select_compute_arch.cmake
+np_einsum_op-inl.h
+np_einsum_op.cc
+np_einsum_path_op-inl.h
 
 # AL2 License header not at the beginning of the file
 doap.rdf

--- a/src/operator/contrib/krprod.cc
+++ b/src/operator/contrib/krprod.cc
@@ -5,7 +5,7 @@
  * regarding copyright ownership.  The ASF licenses this file
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
-n * with the License.  You may obtain a copy of the License at
+ * with the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/operator/nn/mkldnn/mkldnn_batch_norm-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_batch_norm-inl.h
@@ -11,7 +11,7 @@
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY92
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.

--- a/src/operator/numpy/np_einsum_op-inl.h
+++ b/src/operator/numpy/np_einsum_op-inl.h
@@ -1,23 +1,4 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
-/*
  * Copyright (c) 2005-2019, NumPy Developers.
  *
  * All rights reserved.

--- a/src/operator/numpy/np_einsum_op.cc
+++ b/src/operator/numpy/np_einsum_op.cc
@@ -1,23 +1,4 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
-/*
  * Copyright (c) 2005-2019, NumPy Developers.
  * All rights reserved.
  *

--- a/src/operator/numpy/np_einsum_path_op-inl.h
+++ b/src/operator/numpy/np_einsum_path_op-inl.h
@@ -1,23 +1,4 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
-/*
  * Copyright (c) 2005-2019, NumPy Developers.
  * All rights reserved.
  * 

--- a/src/operator/subgraph/tensorrt/nnvm_to_onnx-inl.h
+++ b/src/operator/subgraph/tensorrt/nnvm_to_onnx-inl.h
@@ -1,5 +1,3 @@
-#ifndef MXNET_OPERATOR_SUBGRAPH_TENSORRT_NNVM_TO_ONNX_INL_H_
-#define MXNET_OPERATOR_SUBGRAPH_TENSORRT_NNVM_TO_ONNX_INL_H_
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -26,6 +24,8 @@
  * \author Marek Kolodziej, Clement Fuji Tsang
 */
 
+#ifndef MXNET_OPERATOR_SUBGRAPH_TENSORRT_NNVM_TO_ONNX_INL_H_
+#define MXNET_OPERATOR_SUBGRAPH_TENSORRT_NNVM_TO_ONNX_INL_H_
 #if MXNET_USE_TENSORRT
 
 #include <mxnet/operator.h>

--- a/src/operator/subgraph/tensorrt/onnx_to_tensorrt.h
+++ b/src/operator/subgraph/tensorrt/onnx_to_tensorrt.h
@@ -1,5 +1,3 @@
-#ifndef MXNET_OPERATOR_SUBGRAPH_TENSORRT_ONNX_TO_TENSORRT_H_
-#define MXNET_OPERATOR_SUBGRAPH_TENSORRT_ONNX_TO_TENSORRT_H_
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -26,6 +24,8 @@
  * \author Marek Kolodziej, Clement Fuji Tsang, Serge Panev
  */
 
+#ifndef MXNET_OPERATOR_SUBGRAPH_TENSORRT_ONNX_TO_TENSORRT_H_
+#define MXNET_OPERATOR_SUBGRAPH_TENSORRT_ONNX_TO_TENSORRT_H_
 #if MXNET_USE_TENSORRT
 
 #include <onnx-tensorrt/NvOnnxParser.h>

--- a/src/operator/subgraph/tensorrt/tensorrt-inl.h
+++ b/src/operator/subgraph/tensorrt/tensorrt-inl.h
@@ -1,5 +1,3 @@
-#ifndef MXNET_OPERATOR_SUBGRAPH_TENSORRT_TENSORRT_INL_H_
-#define MXNET_OPERATOR_SUBGRAPH_TENSORRT_TENSORRT_INL_H_
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -26,6 +24,8 @@
  * \author Marek Kolodziej, Clement Fuji Tsang, Serge Panev
 */
 
+#ifndef MXNET_OPERATOR_SUBGRAPH_TENSORRT_TENSORRT_INL_H_
+#define MXNET_OPERATOR_SUBGRAPH_TENSORRT_TENSORRT_INL_H_
 #if MXNET_USE_TENSORRT
 
 #include <onnx-tensorrt/NvOnnxParser.h>

--- a/src/operator/subgraph/tensorrt/tensorrt_int8_calibrator.h
+++ b/src/operator/subgraph/tensorrt/tensorrt_int8_calibrator.h
@@ -1,5 +1,3 @@
-#ifndef MXNET_OPERATOR_SUBGRAPH_TENSORRT_TENSORRT_INT8_CALIBRATOR_H_
-#define MXNET_OPERATOR_SUBGRAPH_TENSORRT_TENSORRT_INT8_CALIBRATOR_H_
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -26,6 +24,8 @@
  * \author Serge Panev
 */
 
+#ifndef MXNET_OPERATOR_SUBGRAPH_TENSORRT_TENSORRT_INT8_CALIBRATOR_H_
+#define MXNET_OPERATOR_SUBGRAPH_TENSORRT_TENSORRT_INT8_CALIBRATOR_H_
 #if MXNET_USE_TENSORRT
 
 #include <cuda_runtime_api.h>


### PR DESCRIPTION
Backport #20598 from v1.9.x to v1.x.


Fix the first 3 items in #20616

* Remove ASF2.0 license and properly list under 3-clause BSD files in LICENSE for np_einsum files.
* Fix license category for deformable_convolution files.
* Update list of Apache-2.0 licensed files.
* Add files to LICENSE that fall under Apache 2.0 license.
* Add include symlinks and other ASF2 files to LICENSE.
* Remove extra line.
* Add numpy einsum files (licensed under bsd 3-clause) to rat-excludes.
* Mention include/nnvm in LICENSE file.
* Remove files from LICENSE with clear ASF-2.0 license headers, added by accident based on skywalking-eyes faulty results.
* Move header guards to below license header section, so skywalking-eyes tool recognizes ASF-2.0 header.
* Fix formatting with license header.
* Fix license section for FindJeMalloc.cmake, move protoc-gen-mypy.py to Apache-2.0 licensed files.
* Clearly indicate caffe subdirectory's licensing model in LICENSE.
* Add skywalking-eyes config to repo.
* Add skywalking-eyes config (.licenserv.yaml) to rat-excludes.
* Add skywalking-eyes license checker into Github workflow.
* Remove caffe subdir from LICENSE and license-check config whitelist, since it is no longer in the repo.
* Remove duplicate entries in LICENSE - leave in Caffe license section.
