### PR TITLE
Revert "[v1.x][submodule] Downgrade oneDNN to v2.2.4"

### DIFF
--- a/tests/cpp/operator/mkldnn_test.cc
+++ b/tests/cpp/operator/mkldnn_test.cc
@@ -101,7 +101,7 @@ static void VerifyDefMem(const mkldnn::memory& mem) {
 
 TEST(MKLDNN_UTIL_FUNC, MemFormat) {
   // Check whether the number of format is correct.
-  CHECK_EQ(mkldnn_format_tag_last, 363);
+  CHECK_EQ(mkldnn_format_tag_last, 385);
   CHECK_EQ(mkldnn_nchw, 5);
   CHECK_EQ(mkldnn_oihw, 5);
 }


### PR DESCRIPTION
Reverts apache/incubator-mxnet#20556

As there is no "next_impl()" function call in deconvolution implementation anymore, oneDNN in version 2.3 and above should not break the CI.