### PR TITLE
[v1.9.x] Update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -292,6 +292,7 @@
     =======================================================================================
 
     3rdparty/dmlc-core/include/dmlc/concurrentqueue.h
+    include/dmlc/concurrentqueue.h (symlink to 3rdparty/dmlc-core/include/dmlc/concurrentqueue.h)
     3rdparty/onnx-tensorrt/third_party/onnx/third_party/pybind11/tools/FindEigen3.cmake  (Copy of the License available at licenses/BSD2)
     3rdparty/onnx-tensorrt/third_party/onnx/third_party/pybind11/tools/FindPythonLibsNew.cmake
     3rdparty/tvm/3rdparty/picojson/picojson.h
@@ -321,6 +322,7 @@
     =======================================================================================
 
     3rdparty/dmlc-core/include/dmlc/blockingconcurrentqueue.h
+    include/dmlc/blockingconcurrentqueue.h (symlink to 3rdparty/dmlc-core/include/dmlc/blockingconcurrentqueue.h)
 
     =======================================================================================
     Apache-2.0 license + 3-clause BSD license


### PR DESCRIPTION
Update LICENSE  to include symlinks in include/dmlc licensed under non-ASF-2.0 licenses.

Part of https://github.com/apache/incubator-mxnet/issues/20616