### PR TITLE
[v1.9.x] Update Dockerfile.build.ubuntu_cpu_jekyll

### DIFF
--- a/ci/docker/Dockerfile.build.ubuntu_cpu_jekyll
+++ b/ci/docker/Dockerfile.build.ubuntu_cpu_jekyll
@@ -16,36 +16,11 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Dockerfile to build and run MXNet on Ubuntu 18.04 for CPU
+# Dockerfile to build MXNet main website
 
-FROM ubuntu:18.04
+FROM ruby:2.6.5-buster
 
 WORKDIR /work/deps
-
-SHELL ["/bin/bash", "-l", "-c" ]
-
-RUN apt-get update && apt-get install -y \
-      build-essential \
-      git \
-      zlib1g-dev \
-      wget \
-      gnupg2 \
-      curl
-
-# Always last, except here to prevent conflicts with rvm
-ARG USER_ID=0
-ARG GROUP_ID=0
-COPY install/ubuntu_adduser.sh /work/
-RUN /work/ubuntu_adduser.sh
-
-RUN curl -sSL https://rvm.io/mpapis.asc | gpg2 --import - && \
-    curl -sSL https://rvm.io/pkuczynski.asc | gpg2 --import - && \
-    curl -sSL https://get.rvm.io | bash -s stable
-
-RUN source /etc/profile.d/rvm.sh && \
-    rvm requirements && \
-    rvm install 2.6.3 && \
-    rvm use 2.6.3 --default
 
 ENV BUNDLE_HOME=/work/deps/bundle
 ENV BUNDLE_APP_CONFIG=/work/deps/bundle
@@ -53,17 +28,18 @@ ENV BUNDLE_BIN=/work/deps/bundle/bin
 ENV GEM_BIN=/work/deps/gem/bin
 ENV GEM_HOME=/work/deps/gem
 
-RUN echo "gem: --no-ri --no-rdoc" > ~/.gemrc
-RUN yes | gem update --system
-RUN yes | gem install --force bundler
-RUN gem install jekyll
+RUN echo "gem: --no-ri --no-rdoc" > ~/.gemrc && \
+    yes | gem update --system && \
+    yes | gem install --force bundler && \
+    gem install jekyll
 
 ENV PATH=$BUNDLE_BIN:$GEM_BIN:$PATH
 
 COPY runtime_functions.sh /work/
 
-RUN chown -R jenkins_slave /work/ && \
-    chown -R jenkins_slave /usr/local/bin && \
-    chown -R jenkins_slave /usr/local/rvm
+ARG USER_ID=0
+ARG GROUP_ID=0
+COPY install/ubuntu_adduser.sh /work/
+RUN /work/ubuntu_adduser.sh
 
 WORKDIR /work/mxnet


### PR DESCRIPTION
## Description ##
The CI website pipeline is failing when installing Jekyll: https://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/mxnet-validation%2Fwebsite/detail/PR-20626/9/pipeline/. This PR updates the dockerfile in v1.9 to the one used in the master branch, trying to fix the issue.

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
