### PR TITLE
[FEATURE] Add oneDNN support for numpy concatenate operator

### DIFF
--- a/cpp-package/example/charRNN.cpp
+++ b/cpp-package/example/charRNN.cpp
@@ -125,7 +125,8 @@ Symbol LSTMUnroll(int num_lstm_layer, int sequence_length, int input_dim,
     hidden_all.push_back(hidden);
   }
 
-  auto hidden_concat = isTrain? Concat(hidden_all, hidden_all.size(), 0) : hidden_all[0];
+  auto hidden_concat =
+      isTrain ? Concat(hidden_all, hidden_all.size(), dmlc::optional<int>(0)) : hidden_all[0];
   auto cls_weight = Symbol::Variable("cls_weight");
   auto cls_bias = Symbol::Variable("cls_bias");
   auto pred = FullyConnected("pred", hidden_concat, cls_weight, cls_bias, input_dim);

--- a/python/mxnet/amp/lists/symbol_fp16.py
+++ b/python/mxnet/amp/lists/symbol_fp16.py
@@ -641,7 +641,6 @@ WIDEST_TYPE_CASTS = [
     '_mod',
     '_not_equal',
     '_npi_column_stack',
-    '_npi_concatenate',
     '_npi_copysign',
     '_npi_cross',
     '_npi_dot',

--- a/src/api/operator/numpy/np_matrix_op.cc
+++ b/src/api/operator/numpy/np_matrix_op.cc
@@ -139,17 +139,17 @@ MXNET_REGISTER_API("_npi.concatenate")
       using namespace runtime;
       const nnvm::Op* op = Op::Get("_npi_concatenate");
       nnvm::NodeAttrs attrs;
-      op::NumpyConcatenateParam param;
+      op::ConcatParam param;
       int arg_size   = args.num_args;
       param.num_args = arg_size - 2;
       if (args[arg_size - 2].type_code() == kNull) {
-        param.axis = dmlc::nullopt;
+        param.dim = dmlc::nullopt;
       } else {
-        param.axis = args[arg_size - 2].operator int();
+        param.dim = args[arg_size - 2].operator int();
       }
       attrs.parsed = param;
       attrs.op     = op;
-      SetAttrDict<op::NumpyConcatenateParam>(&attrs);
+      SetAttrDict<op::ConcatParam>(&attrs);
       int num_inputs = arg_size - 2;
       std::vector<NDArray*> inputs;
       inputs.reserve(num_inputs);

--- a/src/operator/nn/concat.cc
+++ b/src/operator/nn/concat.cc
@@ -200,7 +200,7 @@ inline static bool ConcatForwardInferStorageType(const nnvm::NodeAttrs& attrs,
   auto& out_stype          = out_attrs->at(0);
   bool dispatched          = false;
   const ConcatParam& param = nnvm::get<ConcatParam>(attrs.parsed);
-  int param_dim = param.dim.has_value() ? param.dim.value() : 0;
+  int param_dim            = param.dim.has_value() ? param.dim.value() : 0;
   if (!dispatched && common::ContainsOnlyStorage(*in_attrs, kCSRStorage) && param_dim == 0) {
     dispatched =
         storage_type_assign(&out_stype, kCSRStorage, dispatch_mode, DispatchMode::kFComputeEx);

--- a/src/operator/nn/concat.cc
+++ b/src/operator/nn/concat.cc
@@ -39,12 +39,18 @@ bool ConcatShape(const nnvm::NodeAttrs& attrs,
   CHECK_EQ(in_shape->size(), static_cast<size_t>(param_.num_args));
   mxnet::TShape dshape;
   dim_t size                = 0;
+  int param_dim             = param_.dim.has_value() ? param_.dim.value() : 0;
   bool has_unknown_dim_size = false;
   int axis                  = -1;
+  if (!param_.dim.has_value()) {
+    for (int i = 0; i < param_.num_args; ++i) {
+      (*in_shape)[i] = Shape1((*in_shape)[i].Size());
+    }
+  }
   for (int i = 0; i < param_.num_args; ++i) {
     mxnet::TShape tmp = (*in_shape)[i];
     if (tmp.ndim() > 0) {
-      axis                 = CheckAxis(param_.dim, tmp.ndim());
+      axis                 = CheckAxis(param_dim, tmp.ndim());
       has_unknown_dim_size = !mxnet::dim_size_is_known(tmp, axis) || has_unknown_dim_size;
       size += tmp[axis];
       tmp[axis] = -1;
@@ -54,7 +60,7 @@ bool ConcatShape(const nnvm::NodeAttrs& attrs,
 
   mxnet::TShape tmp = (*out_shape)[0];
   if (tmp.ndim() > 0) {
-    axis      = CheckAxis(param_.dim, tmp.ndim());
+    axis      = CheckAxis(param_dim, tmp.ndim());
     tmp[axis] = -1;
     shape_assign(&dshape, tmp);
   }
@@ -89,11 +95,12 @@ static bool RNNParamConcatShape(const nnvm::NodeAttrs& attrs,
   mxnet::TShape dshape;
   index_t size = 0;
   std::vector<int> zero_indices;
-  int axis = -1;
+  int axis      = -1;
+  int param_dim = param_.dim.has_value() ? param_.dim.value() : 0;
   for (int i = 0; i < param_.num_args; ++i) {
     mxnet::TShape tmp = (*in_shape)[i];
     if (tmp.ndim() > 0) {
-      axis = CheckAxis(param_.dim, tmp.ndim());
+      axis = CheckAxis(param_dim, tmp.ndim());
       if (!mxnet::dim_size_is_known(tmp, axis)) {
         zero_indices.emplace_back(i);
       } else {
@@ -107,7 +114,7 @@ static bool RNNParamConcatShape(const nnvm::NodeAttrs& attrs,
 
   mxnet::TShape tmp = (*out_shape)[0];
   if (tmp.ndim() > 0) {
-    axis      = CheckAxis(param_.dim, tmp.ndim());
+    axis      = CheckAxis(param_dim, tmp.ndim());
     tmp[axis] = -1;
     shape_assign(&dshape, tmp);
   }
@@ -193,13 +200,14 @@ inline static bool ConcatForwardInferStorageType(const nnvm::NodeAttrs& attrs,
   auto& out_stype          = out_attrs->at(0);
   bool dispatched          = false;
   const ConcatParam& param = nnvm::get<ConcatParam>(attrs.parsed);
-  if (!dispatched && common::ContainsOnlyStorage(*in_attrs, kCSRStorage) && param.dim == 0) {
+  int param_dim = param.dim.has_value() ? param.dim.value() : 0;
+  if (!dispatched && common::ContainsOnlyStorage(*in_attrs, kCSRStorage) && param_dim == 0) {
     dispatched =
         storage_type_assign(&out_stype, kCSRStorage, dispatch_mode, DispatchMode::kFComputeEx);
   }
 #if MXNET_USE_ONEDNN == 1
   if (!dispatched && dev_mask == mshadow::cpu::kDevMask &&
-      common::ContainsOnlyStorage(*in_attrs, kDefaultStorage) && param.dim > 0) {
+      common::ContainsOnlyStorage(*in_attrs, kDefaultStorage)) {
     dispatched =
         storage_type_assign(&out_stype, kDefaultStorage, dispatch_mode, DispatchMode::kFComputeEx);
   }
@@ -225,10 +233,8 @@ inline static bool BackwardConcatStorageType(const nnvm::NodeAttrs& attrs,
                                              std::vector<int>* out_attrs) {
   DispatchMode wanted_mode;
 #if MXNET_USE_ONEDNN == 1
-  const ConcatParam& param = nnvm::get<ConcatParam>(attrs.parsed);
   CHECK_EQ(out_attrs->size(), in_attrs->size() - 1);
-  if (dev_mask == mshadow::cpu::kDevMask &&
-      common::ContainsOnlyStorage(*in_attrs, kDefaultStorage) && param.dim > 0)
+  if (dev_mask == mshadow::cpu::kDevMask && common::ContainsOnlyStorage(*in_attrs, kDefaultStorage))
     wanted_mode = DispatchMode::kFComputeEx;
   else
 #endif  // MXNET_USE_ONEDNN == 1
@@ -251,8 +257,9 @@ bool SupportDNNLConcat(const std::vector<NDArray>& arrs) {
       return false;
     int ndim               = arr.shape().ndim();
     const int dnnl_ndims   = arr.GetDNNLData()->get_desc().data.ndims;
-    if (!(ndim == 2 || ndim == 4) || ndim != dnnl_ndims)
+    if ((ndim != 2 && ndim != 4) || ndim != dnnl_ndims) {
       return false;
+    }
   }
   return true;
 }
@@ -347,12 +354,14 @@ DMLC_REGISTER_PARAMETER(ConcatParam);
 NNVM_REGISTER_OP(Concat)
 MXNET_ADD_SPARSE_OP_ALIAS(concat)
     .add_alias("concat")
+    .add_alias("_npi_concatenate")
     .describe(R"code(Joins input arrays along a given axis.
 
 .. note:: `Concat` is deprecated. Use `concat` instead.
 
 The dimensions of the input arrays should be the same except the axis along
-which they will be concatenated.
+which they will be concatenated. With dimension parameter ``None`` input 
+arrays are flattened before concatenating them along axis 0.
 The dimension of the output array along the concatenated axis will be equal
 to the sum of the corresponding dimensions of the input arrays.
 
@@ -376,6 +385,11 @@ Example::
                           [ 7.,  7.],
                           [ 8.,  8.]]
 
+   concat(x,y,z,dim=None) = [1., 1., 2., 2., 
+                             3., 3., 4., 4.,
+                             5., 5., 6., 6.,
+                             7., 7., 8., 8.]
+
    Note that you cannot concat x,y,z along dimension 1 since dimension
    0 is not the same for all the input arrays.
 
@@ -397,6 +411,7 @@ Example::
     .add_arguments(ConcatParam::__FIELDS__());
 
 NNVM_REGISTER_OP(_backward_Concat)
+    .add_alias("_backward_np_concat")
     .set_num_inputs([](const NodeAttrs& attrs) {
 #if MXNET_USE_ONEDNN == 1
       const ConcatParam& params = nnvm::get<ConcatParam>(attrs.parsed);

--- a/src/operator/nn/concat.cu
+++ b/src/operator/nn/concat.cu
@@ -47,6 +47,7 @@ static void ConcatComputeExGPU(const nnvm::NodeAttrs& attrs,
 }
 
 NNVM_REGISTER_OP(Concat)
+    .add_alias("_npi_concatenate")
     .set_attr<FCompute>("FCompute<gpu>", ConcatCompute<gpu>)
     .set_attr<FComputeEx>("FComputeEx<gpu>", ConcatComputeExGPU);
 
@@ -54,7 +55,9 @@ NNVM_REGISTER_OP(_rnn_param_concat)
     .set_attr<FCompute>("FCompute<gpu>", ConcatCompute<gpu>)
     .set_attr<FComputeEx>("FComputeEx<gpu>", ConcatComputeExGPU);
 
-NNVM_REGISTER_OP(_backward_Concat).set_attr<FCompute>("FCompute<gpu>", ConcatGradCompute<gpu>);
+NNVM_REGISTER_OP(_backward_Concat)
+    .add_alias("_backward_np_concat")
+    .set_attr<FCompute>("FCompute<gpu>", ConcatGradCompute<gpu>);
 
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/numpy/np_matrix_op.cu
+++ b/src/operator/numpy/np_matrix_op.cu
@@ -34,12 +34,6 @@ NNVM_REGISTER_OP(_np_reshape).set_attr<FCompute>("FCompute<gpu>", UnaryOp::Ident
 
 NNVM_REGISTER_OP(_npi_squeeze).set_attr<FCompute>("FCompute<gpu>", UnaryOp::IdentityCompute<gpu>);
 
-NNVM_REGISTER_OP(_npi_concatenate)
-    .set_attr<FCompute>("FCompute<gpu>", NumpyConcatenateForward<gpu>);
-
-NNVM_REGISTER_OP(_backward_np_concat)
-    .set_attr<FCompute>("FCompute<gpu>", NumpyConcatenateBackward<gpu>);
-
 NNVM_REGISTER_OP(_npi_stack).set_attr<FCompute>("FCompute<gpu>", StackOpForward<gpu>);
 
 NNVM_REGISTER_OP(_npi_vstack).set_attr<FCompute>("FCompute<gpu>", NumpyVstackForward<gpu>);

--- a/src/operator/quantization/dnnl/dnnl_quantized_concat.cc
+++ b/src/operator/quantization/dnnl/dnnl_quantized_concat.cc
@@ -95,8 +95,8 @@ static void DNNLQuantizedConcatForward(const nnvm::NodeAttrs& attrs,
       data_md.push_back(mem_desc);
     }
   }
-  int param_dim                  = param_.dim.has_value() ? param_.dim.value() : 0;
-  param_dim                      = CheckAxis(param_dim, in_data[concat_enum::kData0].shape().ndim());
+  int param_dim                = param_.dim.has_value() ? param_.dim.value() : 0;
+  param_dim                    = CheckAxis(param_dim, in_data[concat_enum::kData0].shape().ndim());
   DNNLConcatFwd& fwd           = GetConcatForward(param_dim, in_data, data_md);
   mxnet::dnnl_output_t out_mem = CreateDNNLMem(
       out_data[quantized_concat_enum::kOut], fwd.fwd_pd.dst_desc(), req[concat_enum::kOut]);

--- a/src/operator/quantization/dnnl/dnnl_quantized_concat.cc
+++ b/src/operator/quantization/dnnl/dnnl_quantized_concat.cc
@@ -95,7 +95,9 @@ static void DNNLQuantizedConcatForward(const nnvm::NodeAttrs& attrs,
       data_md.push_back(mem_desc);
     }
   }
-  DNNLConcatFwd& fwd           = GetConcatForward(param_.dim, in_data, data_md);
+  int param_dim                  = param_.dim.has_value() ? param_.dim.value() : 0;
+  param_dim                      = CheckAxis(param_dim, in_data[concat_enum::kData0].shape().ndim());
+  DNNLConcatFwd& fwd           = GetConcatForward(param_dim, in_data, data_md);
   mxnet::dnnl_output_t out_mem = CreateDNNLMem(
       out_data[quantized_concat_enum::kOut], fwd.fwd_pd.dst_desc(), req[concat_enum::kOut]);
   dnnl_args_map_t net_args;

--- a/src/operator/quantization/quantized_concat.cc
+++ b/src/operator/quantization/quantized_concat.cc
@@ -147,10 +147,10 @@ If any input holds int8, then the output will be int8. Otherwise output will be 
     .add_arguments(ConcatParam::__FIELDS__());
 
 NNVM_REGISTER_OP(Concat).set_attr<FQuantizedOp>("FQuantizedOp", [](const NodeAttrs& attrs) {
-  nnvm::ObjectPtr node     = nnvm::Node::Create();
-  node->attrs.op   = Op::Get("_contrib_quantized_concat");
-  node->attrs.name = "quantized_" + attrs.name;
-  node->attrs.dict = attrs.dict;
+  nnvm::ObjectPtr node = nnvm::Node::Create();
+  node->attrs.op       = Op::Get("_contrib_quantized_concat");
+  node->attrs.name     = "quantized_" + attrs.name;
+  node->attrs.dict     = attrs.dict;
   if (node->op() != nullptr && node->op()->attr_parser != nullptr) {
     node->op()->attr_parser(&(node->attrs));
   }

--- a/src/operator/subgraph/tensorrt/nnvm_to_onnx.cc
+++ b/src/operator/subgraph/tensorrt/nnvm_to_onnx.cc
@@ -669,13 +669,14 @@ void ConvertConcatenate(GraphProto* graph_proto,
   NodeProto* node_proto = graph_proto->add_node();
   node_proto->set_name(node_name);
   const auto& _param = nnvm::get<ConcatParam>(attrs.parsed);
+  const int param_dim = _param.dim.has_value() ? _param.dim.value() : 0;
   node_proto->set_op_type("Concat");
   node_proto->set_name(attrs.name);
   // axis
   AttributeProto* const axis = node_proto->add_attribute();
   axis->set_name("axis");
   axis->set_type(AttributeProto::INT);
-  axis->set_i(static_cast<int64_t>(_param.dim));
+  axis->set_i(static_cast<int64_t>(param_dim));
   DefaultConnectInputsOutputs(node_proto, inputs, ig, node_name);
 }
 

--- a/src/operator/subgraph/tensorrt/tensorrt-inl.h
+++ b/src/operator/subgraph/tensorrt/tensorrt-inl.h
@@ -193,7 +193,8 @@ class TensorrtSelector : public SubgraphSelector {
 
     if (op_name == "Concat") {
       const auto& param = nnvm::get<ConcatParam>(n.attrs.parsed);
-      return (param.dim != 0);
+      const int param_dim = param.dim.has_value() ? param.dim.value() : 0;
+      return (param_dim != 0);
     }
 
     if (op_name == "Dropout") {

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -3973,7 +3973,7 @@ def test_np_concat():
 
     shapes = [(0, 0), (2, 3), (2, 1, 3)]
     hybridizes = [True, False]
-    axes = [0, 1, None]
+    axes = [0, 1, -1, None]
     grad_reqs = ['write', 'add', 'null']
     dtypes = [np.float32, np.float64, np.bool]
     combinations = itertools.product(shapes, hybridizes, axes, grad_reqs, dtypes)


### PR DESCRIPTION
## Description ##
Function concatenate() from module mxnet.numpy will now be executed by oneDNN primitives as it is done in module mxnet.ndarray. Additionally concat from mxnet.ndarray will gain numpy fuctionality which is flattening input arrays when parameter dim=None.

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] Code is well-documented

### Changes ###
- [x] Merge NNVM_REGISTER_OP(_npi_concatenate) with NNVM_REGISTER_OP(concatenate)

## Comments ##
It was possible to merge both ndarray and numpy concatenate operators into one NNVM_REGISTER_OP, additional functionality was added to ndarray concatenate by this process.
Performance tests from mxnet profiler with 10 warmup runs and 50 test runs of this operator are given below:
![image](https://user-images.githubusercontent.com/59651240/136538384-76578db3-4731-4033-89ee-11e999596382.png)
Numpy concatenate was about 9 times faster in those tests
