### PR TITLE
[master] Remove .clang-format entry from .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,6 @@ tracker
 .vimrc
 .ycm_extra_conf.py
 .ycm_extra_conf.pyc
-.clang-format
 
 # Emacs
 .#*


### PR DESCRIPTION
## Description ##
To keep the same version of the file locally ~ the entry can be removed from  .gitignore' file

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
