### PR TITLE
[master][ci] Avoid duplicate log output error when using clang-formatter

### DIFF
--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -718,7 +718,8 @@ sanity_cpp() {
 }
 
 sanity_clang() {
-    set -ex
+    set -e
+    set +x
     # .github/workgflows/greetings.yml passes BASE_SHA, GITHUB_RUN_ID, GITHUB_BASE_REF for pull requests.
     BASE_SHA="${GITHUB_PR_BASE_SHA}"
     GITHUB_RUN_ID="${GITHUB_PR_RUN_ID}"
@@ -741,14 +742,14 @@ sanity_clang() {
         git remote remove "${GITHUB_RUN_ID}" # temporary remote is removed
         exit 0
     fi
-    
+
     echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-    echo "| clang-format failures found! Run: "
-    echo "|    tool/lint/clang_format_ci.sh ${BASE_SHA} "
+    echo "| Clang-format failures found! Run: "
+    echo "|    tools/lint/clang_format_ci.sh ${BASE_SHA} "
     echo "| to fix this error. "
-    echo "| For more info, see: "
+    echo "| For more info, see: https://mxnet.apache.org/versions/master/community/clang_format_guide"
     echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-    
+
     echo "$GIT_DIFFERENCE"
     git remote remove "${GITHUB_RUN_ID}" # temporary remote is removed
     exit 1

--- a/tools/lint/clang_format_ci.sh
+++ b/tools/lint/clang_format_ci.sh
@@ -16,5 +16,5 @@
 # under the License.
 
 #!/bin/sh
-set -eux 
+set -eu 
     tools/lint/git-clang-format-13 --verbose "$1" --


### PR DESCRIPTION
## Description ##
Clang-format logs are duplicate because debug mode was enabled. This PR turns debugging information off.

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
