### PR TITLE
[v1.x][submodule] Upgrade oneDNN to v2.4.4

### DIFF
--- a/src/operator/nn/mkldnn/mkldnn_convolution.cc
+++ b/src/operator/nn/mkldnn/mkldnn_convolution.cc
@@ -113,16 +113,28 @@ std::shared_ptr<mkldnn::convolution_forward::primitive_desc> GetConvFwdImpl(
       [&param, &data, &weights, &output, &attr](const mkldnn::convolution_forward::desc& desc) {
         auto engine = CpuEngine::Get()->get_engine();
         try {
-          // MKL-DNN introduced padded formats since 0.15 which require more memory
-          // compared to the actual size of the tensor. Currently, MKL-DNN operators
-          // still reuse memory from memory planning, so here we need to select a
-          // suboptimal kernel for computation that has the expected memory size requirements
+          // MKLDNN introduced padded formats since 0.15 which require more
+          // memory compared to the actual size of the tensor. Currently, MKLDNN
+          // operators still reuse memory from memory planning, so here we need
+          // to select a suboptimal kernel for computation that has the expected
+          // memory size requirements
           auto conv_pd =
-              std::make_shared<mkldnn::convolution_forward::primitive_desc>(desc, attr, engine);
-          while (conv_pd->dst_desc().get_size() != GetArraySize(output) ||
-                 conv_pd->src_desc().get_size() != GetArraySize(data) ||
-                 (!param.mkldnn_param.quantized &&
-                  conv_pd->weights_desc().get_size() != GetArraySize(weights))) {
+              std::make_shared<mkldnn::convolution_forward::primitive_desc>(
+                  desc, attr, engine);
+          while (
+              conv_pd->dst_desc().get_size() != GetArraySize(output) ||
+              conv_pd->src_desc().get_size() != GetArraySize(data) ||
+              (!param.mkldnn_param.quantized &&
+               conv_pd->weights_desc().get_size() != GetArraySize(weights)) ||
+              // With the upgrade of MKLDNN to version 2.4+
+              // tests/python/mkl/test_subgraph.py::test_pos_conv_add
+              // started failing. Switching away from primitive with weight
+              // mkldnn::format_tag ABcd4b16a4b in order to temporairly fix
+              // the issue until full fix arrives. Tracking issue:
+              // https://github.com/apache/incubator-mxnet/issues/20826.
+              (param.mkldnn_param.quantized &&
+               conv_pd->weights_desc().dims()[1] < 4 &&
+               conv_pd->weights_desc().data.padded_dims[1] == 16)) {
             // next_impl() will visit desc and engine, please make sure they are still alive here.
             CHECK(conv_pd->next_impl()) << "No convolution implementation for this request.";
           }

--- a/src/operator/nn/mkldnn/mkldnn_convolution.cc
+++ b/src/operator/nn/mkldnn/mkldnn_convolution.cc
@@ -113,28 +113,23 @@ std::shared_ptr<mkldnn::convolution_forward::primitive_desc> GetConvFwdImpl(
       [&param, &data, &weights, &output, &attr](const mkldnn::convolution_forward::desc& desc) {
         auto engine = CpuEngine::Get()->get_engine();
         try {
-          // MKLDNN introduced padded formats since 0.15 which require more
-          // memory compared to the actual size of the tensor. Currently, MKLDNN
-          // operators still reuse memory from memory planning, so here we need
-          // to select a suboptimal kernel for computation that has the expected
-          // memory size requirements
+          // MKLDNN introduced padded formats since 0.15 which require more memory compared to the
+          // actual size of the tensor. Currently, MKLDNN operators still reuse memory from memory
+          // planning, so here we need to select a suboptimal kernel for computation that has the
+          // expected memory size requirements
           auto conv_pd =
-              std::make_shared<mkldnn::convolution_forward::primitive_desc>(
-                  desc, attr, engine);
-          while (
-              conv_pd->dst_desc().get_size() != GetArraySize(output) ||
-              conv_pd->src_desc().get_size() != GetArraySize(data) ||
-              (!param.mkldnn_param.quantized &&
-               conv_pd->weights_desc().get_size() != GetArraySize(weights)) ||
-              // With the upgrade of MKLDNN to version 2.4+
-              // tests/python/mkl/test_subgraph.py::test_pos_conv_add
-              // started failing. Switching away from primitive with weight
-              // mkldnn::format_tag ABcd4b16a4b in order to temporairly fix
-              // the issue until full fix arrives. Tracking issue:
-              // https://github.com/apache/incubator-mxnet/issues/20826.
-              (param.mkldnn_param.quantized &&
-               conv_pd->weights_desc().dims()[1] < 4 &&
-               conv_pd->weights_desc().data.padded_dims[1] == 16)) {
+              std::make_shared<mkldnn::convolution_forward::primitive_desc>(desc, attr, engine);
+          while (conv_pd->dst_desc().get_size() != GetArraySize(output) ||
+                 conv_pd->src_desc().get_size() != GetArraySize(data) ||
+                 (!param.mkldnn_param.quantized &&
+                  conv_pd->weights_desc().get_size() != GetArraySize(weights)) ||
+                 // With the upgrade of MKLDNN to version 2.4+
+                 // tests/python/mkl/test_subgraph.py::test_pos_conv_add started failing. Switching
+                 // away from primitive with weight mkldnn::format_tag ABcd4b16a4b in order to
+                 // temporairly fix the issue until full fix arrives. Tracking issue:
+                 // https://github.com/apache/incubator-mxnet/issues/20826.
+                 (param.mkldnn_param.quantized && conv_pd->weights_desc().dims()[1] < 4 &&
+                  conv_pd->weights_desc().data.padded_dims[1] == 16)) {
             // next_impl() will visit desc and engine, please make sure they are still alive here.
             CHECK(conv_pd->next_impl()) << "No convolution implementation for this request.";
           }

--- a/tests/cpp/operator/mkldnn_test.cc
+++ b/tests/cpp/operator/mkldnn_test.cc
@@ -101,7 +101,7 @@ static void VerifyDefMem(const mkldnn::memory& mem) {
 
 TEST(MKLDNN_UTIL_FUNC, MemFormat) {
   // Check whether the number of format is correct.
-  CHECK_EQ(mkldnn_format_tag_last, 385);
+  CHECK_EQ(mkldnn_format_tag_last, 495);
   CHECK_EQ(mkldnn_nchw, 5);
   CHECK_EQ(mkldnn_oihw, 5);
 }

--- a/tools/dependencies/README.md
+++ b/tools/dependencies/README.md
@@ -54,7 +54,7 @@ The dependencies could be categorized by several groups: BLAS libraries, CPU-bas
 | Dependencies  | MXNet Version |
 | :------------: |:-------------:| 
 |OpenBLAS| 0.3.3 |
-|MKLDNN| 0.19 | 
+|MKLDNN| 2.4.4 | 
 |CUDA| 10.1 |
 |cuDNN| 7.5.1 |
 |NCCL| 2.4.2 |


### PR DESCRIPTION
## Description ##
This change upgrades the version of oneDNN being used on v1.x branch to 2.4.4.

This is only temporary solution until the full fix arrives.

Problem tracking issue: https://github.com/apache/incubator-mxnet/issues/20826.

## Checklist ##
### Changes ###
- [x] Implement switching away from problematic primitive description

## Comment ##
With the upgrade of oneDNN to version 2.4+ tests/python/dnnl/subgraphs/test_conv_subgraph.py::test_pos_conv_add[True-data_shape1] starts failing. During investigation of the problem it turned out that it regards only cases with amount of input channels lower than 4 and switching away from primitive with weight dnnl::format_tag ABcd4b16a4b fixes the issue. This change implements the switch in MXNet.


