### PR TITLE
[master][bugfix] Remove exit 0 to avoid blocking in CI pipeline 

### DIFF
--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -752,6 +752,7 @@ sanity_clang() {
 
     echo "$GIT_DIFFERENCE"
     git remote remove "${GITHUB_RUN_ID}" # temporary remote is removed
+    exit 1
 }
 
 sanity_python() {


### PR DESCRIPTION
## Description ##
Exit 0, returns 'true' and then the CI is stopped; the 0 cannot be returned.

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
