### PR TITLE
[WIP][API] Add data type functions

### DIFF
--- a/python/mxnet/numpy/__init__.py
+++ b/python/mxnet/numpy/__init__.py
@@ -27,6 +27,7 @@ from ._op import *  # pylint: disable=wildcard-import
 from .utils import *  # pylint: disable=wildcard-import
 from .function_base import *  # pylint: disable=wildcard-import
 from .stride_tricks import *  # pylint: disable=wildcard-import
+from .type_functions import *  # pylint: disable=wildcard-import
 from .io import *  # pylint: disable=wildcard-import
 from .arrayprint import *  # pylint: disable=wildcard-import
 

--- a/python/mxnet/numpy/fallback.py
+++ b/python/mxnet/numpy/fallback.py
@@ -94,7 +94,6 @@ fallbacks = [
     'pv',
     'rate',
     'real',
-    'result_type',
     'roots',
     'searchsorted',
     'select',

--- a/python/mxnet/numpy/type_functions.py
+++ b/python/mxnet/numpy/type_functions.py
@@ -1,0 +1,176 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Type functions for the numpy module."""
+
+
+import numpy as onp
+from typing import NamedTuple
+from multiarray import ndarray
+from utils import _type_promotion_table
+
+
+__all__ = ['can_cast', 'finfo', 'iinfo', 'result_type']
+
+class finfo_obj(NamedTuple):
+    bits: int
+    eps: float
+    max: float
+    min: float
+    smallest_normal: float
+
+
+class iinfo_obj(NamedTuple):
+    bits: int
+    max: int
+    min: int
+
+
+def can_cast(from_, to):
+    """
+    Returns True if cast between data types can occur according to
+    the casting rule. If from is a scalar or array scalar,
+    also returns True if the scalar value can be cast without
+    overflow or truncation to an integer.
+
+    Parameters
+    ----------
+    from_ : dtype, ndarray or scalar
+        Data type, scalar, or array to cast from.
+    to : dtype
+        Data type to cast to.
+
+    Returns
+    -------
+    out : bool
+        True if cast can occur according to the casting rule.
+    """
+    if isinstance(from_, ndarray):
+        from_ = from_.asnumpy()
+    return onp.can_cast(from_, to)
+
+
+def finfo(dtype):
+    """
+    Machine limits for floating-point data types.
+
+    Notes 
+    ----- 
+    `finfo` is a standard API in 
+    https://data-apis.org/array-api/latest/API_specification/data_type_functions.html#finfo-type
+    instead of an official NumPy operator.
+
+    Parameters
+    ----------
+    dtype : ndarray, float or dtype
+        Kind of floating point data-type about which to get information.
+
+    Returns
+    -------
+    out : finfo object
+        an object having the following attributes:
+            - bits : int
+                number of bits occupied by the floating-point data type.
+            - eps : float
+                difference between 1.0 and the next smallest representable floating-point
+                number larger than 1.0 according to the IEEE-754 standard.
+            - max : float
+                largest representable number.
+            - min : float
+                smallest representable number.
+            - smallest_normal : float
+                smallest positive floating-point number with full precision.
+    """
+    f_info = onp.finfo(dtype)
+    return finfo_obj(f_info.bits, float(f_info.eps),
+                     float(f_info.max), float(f_info.min), float(f_info.smallest_normal))
+
+
+def iinfo(dtype):
+    """
+    Machine limits for floating-point data types.
+
+    Notes 
+    ----- 
+    `iinfo` is a standard API in 
+    https://data-apis.org/array-api/latest/API_specification/data_type_functions.html#iinfo-type
+    instead of an official NumPy operator.
+
+    Parameters
+    ----------
+    dtype : ndarray, integer or dtype
+        The kind of integer data type to get information about.
+
+    Returns
+    -------
+    out : iinfo object
+        an object having the following attributes:
+            - bits : int
+                number of bits occupied by the type
+            - max : int
+                largest representable number.
+            - min : int
+                smallest representable number.
+    """
+    i_info = onp.iinfo(dtype)
+    return iinfo_obj(i_info.bits, i_info.max, i_info.min)
+
+
+def _get_dtype(array_or_dtype):
+    """Utility function for result_type"""
+    if isinstance(array_or_dtype, (ndarray, onp.ndarray)):
+        return array_or_dtype.dtype
+    elif isinstance(d, onp.dtype):
+        return array_or_dtype
+    else:
+        raise ValueError("Inputs of result_type must be ndarrays or dtypes")
+
+
+def result_type(*arrays_and_dtypes):
+    """
+    Returns the dtype that results from applying the type promotion rules to the arguments.
+
+    Notes 
+    ----- 
+    `result_type` is a standard API in 
+    https://data-apis.org/array-api/latest/API_specification/data_type_functions.html#result-type-arrays-and-dtypes
+    instead of an official NumPy operator.
+
+    Parameters
+    ----------
+    arrays_and_dtypes : mixed ndarrays and dtypes
+        an arbitrary number of input arrays and/or dtypes.
+
+    Returns
+    -------
+    out : dtype
+        the dtype resulting from an operation involving the input arrays and dtypes.
+    """
+    if len(arrays_and_dtypes) == 0:
+        raise ValueError("at least one array or dtype is required")
+    else:
+        ret = _get_dtype(arrays_and_dtypes[0])
+        for d in arrays_and_dtypes[1:]:
+            dd = _get_dtype(arrays_and_dtypes[d])
+            if (ret, dd) in _type_promotion_table:
+                ret = _type_promotion_table[ret, dd]
+            elif (dd, ret) in _type_promotion_table:
+                ret = _type_promotion_table[dd, ret]
+            else:
+                raise TypeError("Unknown type promotion between {} and {}".format(ret, dd))
+        return ret
+

--- a/python/mxnet/numpy/type_functions.py
+++ b/python/mxnet/numpy/type_functions.py
@@ -17,11 +17,11 @@
 
 """Type functions for the numpy module."""
 
+from typing import NamedTuple
 
 import numpy as onp
-from typing import NamedTuple
-from multiarray import ndarray
-from utils import _type_promotion_table
+from .multiarray import ndarray
+from .utils import _type_promotion_table
 
 
 __all__ = ['can_cast', 'finfo', 'iinfo', 'result_type']
@@ -68,9 +68,9 @@ def finfo(dtype):
     """
     Machine limits for floating-point data types.
 
-    Notes 
-    ----- 
-    `finfo` is a standard API in 
+    Notes
+    -----
+    `finfo` is a standard API in
     https://data-apis.org/array-api/latest/API_specification/data_type_functions.html#finfo-type
     instead of an official NumPy operator.
 
@@ -104,9 +104,9 @@ def iinfo(dtype):
     """
     Machine limits for floating-point data types.
 
-    Notes 
-    ----- 
-    `iinfo` is a standard API in 
+    Notes
+    -----
+    `iinfo` is a standard API in
     https://data-apis.org/array-api/latest/API_specification/data_type_functions.html#iinfo-type
     instead of an official NumPy operator.
 
@@ -134,7 +134,7 @@ def _get_dtype(array_or_dtype):
     """Utility function for result_type"""
     if isinstance(array_or_dtype, (ndarray, onp.ndarray)):
         return array_or_dtype.dtype
-    elif isinstance(d, onp.dtype):
+    elif isinstance(array_or_dtype, onp.dtype):
         return array_or_dtype
     else:
         raise ValueError("Inputs of result_type must be ndarrays or dtypes")
@@ -144,9 +144,9 @@ def result_type(*arrays_and_dtypes):
     """
     Returns the dtype that results from applying the type promotion rules to the arguments.
 
-    Notes 
-    ----- 
-    `result_type` is a standard API in 
+    Notes
+    -----
+    `result_type` is a standard API in
     https://data-apis.org/array-api/latest/API_specification/data_type_functions.html#result-type-arrays-and-dtypes
     instead of an official NumPy operator.
 
@@ -160,9 +160,7 @@ def result_type(*arrays_and_dtypes):
     out : dtype
         the dtype resulting from an operation involving the input arrays and dtypes.
     """
-    if len(arrays_and_dtypes) == 0:
-        raise ValueError("at least one array or dtype is required")
-    else:
+    if len(arrays_and_dtypes) > 0:
         ret = _get_dtype(arrays_and_dtypes[0])
         for d in arrays_and_dtypes[1:]:
             dd = _get_dtype(arrays_and_dtypes[d])
@@ -173,4 +171,4 @@ def result_type(*arrays_and_dtypes):
             else:
                 raise TypeError("Unknown type promotion between {} and {}".format(ret, dd))
         return ret
-
+    raise ValueError("at least one array or dtype is required")

--- a/python/mxnet/numpy/utils.py
+++ b/python/mxnet/numpy/utils.py
@@ -23,9 +23,9 @@ import numpy as onp
 
 __all__ = ['float16', 'float32', 'float64', 'uint8', 'int32', 'int8', 'int64',
            'int16', 'uint16', 'uint32', 'uint64',
-           'bool', 'bool_', 'pi', 'inf', 'nan', 'PZERO', 'NZERO', 'newaxis', 'finfo',
+           'bool', 'bool_', 'pi', 'inf', 'nan', 'PZERO', 'NZERO', 'newaxis',
            'e', 'NINF', 'PINF', 'NAN', 'NaN',
-           '_STR_2_DTYPE_', '_DTYPE_2_STR_']
+           '_STR_2_DTYPE_', '_DTYPE_2_STR_', '_type_promotion_table']
 
 py_bool = bool
 
@@ -55,7 +55,6 @@ NAN = onp.NAN
 NaN = onp.NaN
 
 newaxis = None
-finfo = onp.finfo
 
 _STR_2_DTYPE_ = {'float16': float16, 'float32': float32, 'float64': float64, 'float': float64,
                  'int8': int8, 'int16': int16, 'int32': int32, 'int64': int64, 'int': int64,
@@ -77,3 +76,99 @@ def _get_np_op(name):
         if op is not None:
             return op
     raise ValueError('Operator `{}` is not supported by `mxnet.numpy`.'.format(name))
+
+
+_type_promotion_table = {
+    # signed integer type promotion
+    (int8, int8): int8,
+    (int8, int16): int16,
+    (int8, int32): int32,
+    (int8, int64): int64,
+    (int16, int16): int16,
+    (int16, int32): int32,
+    (int16, int64): int64,
+    (int32, int32): int32,
+    (int32, int64): int64,
+    (int64, int64): int64,
+    # unsigned integer type promotion
+    (uint8, uint8): uint8,
+    (uint8, uint16): uint16,
+    (uint8, uint32): uint32,
+    (uint8, uint64): uint64,
+    (uint16, uint16): uint16,
+    (uint16, uint32): uint32,
+    (uint16, uint64): uint64,
+    (uint32, uint32): uint32,
+    (uint32, uint64): uint64,
+    (uint64, uint64): uint64,
+    # mixed signed and unsigned integer type promotion
+    (int8, uint8): int16,
+    (int8, uint16): int32,
+    (int8, uint32): int64,
+    (int16, uint8): int16,
+    (int16, uint16): int32,
+    (int16, uint32): int64,
+    (int32, uint8): int32,
+    (int32, uint16): int32,
+    (int32, uint32): int64,
+    (int64, uint8): int64,
+    (int64, uint16): int64,
+    (int64, uint32): int64,
+    # float type promotion
+    (float16, float16): float16,
+    (float16, float32): float32,
+    (float16, float64): float64,
+    (float32, float32): float32,
+    (float32, float64): float64,
+    (float64, float64): float64,
+    # bool type promotion
+    (bool, bool): bool,
+    # mixed integer and float16 type promotion
+    (int8, float16): float16,
+    (int16, float16): float16,
+    (int32, float16): float16,
+    (int64, float16): float16,
+    (uint8, float16): float16,
+    (uint16, float16): float16,
+    (uint32, float16): float16,
+    (uint64, float16): float16,
+    # mixed integer and float16 type promotion
+    (int8, float32): float32,
+    (int16, float32): float32,
+    (int32, float32): float32,
+    (int64, float32): float32,
+    (uint8, float32): float32,
+    (uint16, float32): float32,
+    (uint32, float32): float32,
+    (uint64, float32): float32,
+    # mixed integer and float32 type promotion
+    (int8, float32): float32,
+    (int16, float32): float32,
+    (int32, float32): float32,
+    (int64, float32): float32,
+    (uint8, float32): float32,
+    (uint16, float32): float32,
+    (uint32, float32): float32,
+    (uint64, float32): float32,
+    # mixed integer and float64 type promotion
+    (int8, float64): float64,
+    (int16, float64): float64,
+    (int32, float64): float64,
+    (int64, float64): float64,
+    (uint8, float64): float64,
+    (uint16, float64): float64,
+    (uint32, float64): float32,
+    (uint64, float64): float64,
+    # mixed bool and other type promotion
+    (bool, int8): int8,
+    (bool, int16): int16,
+    (bool, int32): int32,
+    (bool, int64): int64,
+    (bool, uint8): uint8,
+    (bool, uint16): uint16,
+    (bool, uint32): uint32,
+    (bool, uint64): uint64,
+    (bool, float16): float16,
+    (bool, float32): float32,
+    (bool, float64): float64,
+}


### PR DESCRIPTION
## Description ##
can_cast, finfo, iinfo, type_result

- can_cast fall back to official numpy
- type_result is removed from fallback.py since we will have our own type promotion rules. 
- finfo, iinfo will follow the data-api-standard design. 

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
