### PR TITLE
[API STD][SEARCH FUNC] Add keepdims=False to argmax/argmin

### DIFF
--- a/python/mxnet/ndarray/numpy/_op.py
+++ b/python/mxnet/ndarray/numpy/_op.py
@@ -5403,7 +5403,7 @@ def argmax(a, axis=None, out=None, keepdims=False):
     Notes
     -----
     ``keepdims`` param is part of request in data-api-standard
-    <https://data-apis.org/array-api/latest/API_specification/searching_functions.html#argmax-x-axis-none-keepdims-false`_,
+    <https://data-apis.org/array-api/latest/API_specification/searching_functions.html#argmax-x-axis-none-keepdims-false>`_,
     which is not the parameter in official NumPy
 
     In case of multiple occurrences of the maximum values, the indices
@@ -5480,7 +5480,7 @@ def argmin(a, axis=None, out=None, keepdims=False):
     Notes
     -----
     ``keepdims`` param is part of request in data-api-standard
-    <https://data-apis.org/array-api/latest/API_specification/searching_functions.html#argmax-x-axis-none-keepdims-false`_,
+    <https://data-apis.org/array-api/latest/API_specification/searching_functions.html#argmin-x-axis-none-keepdims-false>`_,
     which is not the parameter in official NumPy
 
     In case of multiple occurrences of the maximum values, the indices

--- a/python/mxnet/ndarray/numpy/_op.py
+++ b/python/mxnet/ndarray/numpy/_op.py
@@ -5402,7 +5402,7 @@ def argmax(a, axis=None, out=None, keepdims=False):
 
     Notes
     -----
-    ``keepdims`` param is part of request `in data-api-standard
+    ``keepdims`` param is part of request in data-api-standard
     <https://data-apis.org/array-api/latest/API_specification/searching_functions.html#argmax-x-axis-none-keepdims-false`_,
     which is not the parameter in official NumPy
 
@@ -5479,7 +5479,7 @@ def argmin(a, axis=None, out=None, keepdims=False):
 
     Notes
     -----
-    ``keepdims`` param is part of request `in data-api-standard
+    ``keepdims`` param is part of request in data-api-standard
     <https://data-apis.org/array-api/latest/API_specification/searching_functions.html#argmax-x-axis-none-keepdims-false`_,
     which is not the parameter in official NumPy
 

--- a/python/mxnet/ndarray/numpy/_op.py
+++ b/python/mxnet/ndarray/numpy/_op.py
@@ -5373,7 +5373,7 @@ def tril_indices(n, k=0, m=None):
 
 
 @set_module('mxnet.ndarray.numpy')
-def argmax(a, axis=None, out=None):
+def argmax(a, axis=None, out=None, keepdims=False):
     r"""
     Returns the indices of the maximum values along an axis.
 
@@ -5388,6 +5388,11 @@ def argmax(a, axis=None, out=None):
         A location into which the result is stored.
         If provided, it must have the same shape and dtype as input ndarray.
         If not provided or `None`, a freshly-allocated array is returned.
+    keepdims : bool
+        If True, the reduced axes (dimensions) must be included in the result as
+        singleton dimensions, and, accordingly, the result must be compatible with
+        the input array. Otherwise, if False, the reduced axes (dimensions) must
+        not be included in the result. Default: False .
 
     Returns
     -------
@@ -5397,6 +5402,10 @@ def argmax(a, axis=None, out=None):
 
     Notes
     -----
+    ``keepdims`` param is part of request `in data-api-standard
+    <https://data-apis.org/array-api/latest/API_specification/searching_functions.html#argmax-x-axis-none-keepdims-false`_,
+    which is not the parameter in official NumPy
+
     In case of multiple occurrences of the maximum values, the indices
     corresponding to the first occurrence are returned.
 
@@ -5438,11 +5447,11 @@ def argmax(a, axis=None, out=None):
     >>> b
     array([2., 2.])
     """
-    return _api_internal.argmax(a, axis, False, out)
+    return _api_internal.argmax(a, axis, keepdims, out)
 
 
 @set_module('mxnet.ndarray.numpy')
-def argmin(a, axis=None, out=None):
+def argmin(a, axis=None, out=None, keepdims=False):
     r"""
     Returns the indices of the maximum values along an axis.
 
@@ -5456,6 +5465,11 @@ def argmin(a, axis=None, out=None):
     out : ndarray or None, optional
         If provided, the result will be inserted into this array. It should
         be of the appropriate shape and dtype.
+    keepdims : bool
+        If True, the reduced axes (dimensions) must be included in the result as
+        singleton dimensions, and, accordingly, the result must be compatible with
+        the input array. Otherwise, if False, the reduced axes (dimensions) must
+        not be included in the result. Default: False .
 
     Returns
     -------
@@ -5465,6 +5479,10 @@ def argmin(a, axis=None, out=None):
 
     Notes
     -----
+    ``keepdims`` param is part of request `in data-api-standard
+    <https://data-apis.org/array-api/latest/API_specification/searching_functions.html#argmax-x-axis-none-keepdims-false`_,
+    which is not the parameter in official NumPy
+
     In case of multiple occurrences of the maximum values, the indices
     corresponding to the first occurrence are returned.
 
@@ -5506,7 +5524,7 @@ def argmin(a, axis=None, out=None):
     >>> b
     array([0., 0.])
     """
-    return _api_internal.argmin(a, axis, False, out)
+    return _api_internal.argmin(a, axis, keepdims, out)
 
 
 @set_module('mxnet.ndarray.numpy')

--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -1568,10 +1568,10 @@ class ndarray(NDArray):  # pylint: disable=invalid-name
     def asscalar(self):
         raise AttributeError('mxnet.numpy.ndarray object has no attribute asscalar')
 
-    def argmax(self, axis=None, out=None):  # pylint: disable=arguments-differ
+    def argmax(self, axis=None, out=None, keepdims=False):  # pylint: disable=arguments-differ
         """Return indices of the maximum values along the given axis.
         Refer to `mxnet.numpy.argmax` for full documentation."""
-        return argmax(self, axis, out)
+        return argmax(self, axis, out, keepdims)
 
     def as_in_context(self, context):
         """This function has been deprecated. Please refer to ``ndarray.as_in_ctx``."""
@@ -1909,10 +1909,10 @@ class ndarray(NDArray):  # pylint: disable=invalid-name
         """
         raise AttributeError('mxnet.numpy.ndarray object has no attribute argmax_channel')
 
-    def argmin(self, axis=None, out=None):  # pylint: disable=arguments-differ
+    def argmin(self, axis=None, out=None, keepdims=False):  # pylint: disable=arguments-differ
         """Return indices of the minium values along the given axis.
         Refer to `mxnet.numpy.argmin` for full documentation."""
-        return argmin(self, axis, out)
+        return argmin(self, axis, out, keepdims)
 
     def clip(self, min=None, max=None, out=None):  # pylint: disable=arguments-differ
         """Return an array whose values are limited to [min, max].
@@ -7758,7 +7758,7 @@ def clip(a, a_min, a_max, out=None):
 
 
 @set_module('mxnet.numpy')
-def argmax(a, axis=None, out=None):
+def argmax(a, axis=None, out=None, keepdims=False):
     r"""
     Returns the indices of the maximum values along an axis.
 
@@ -7772,6 +7772,11 @@ def argmax(a, axis=None, out=None):
     out : ndarray or None, optional
         If provided, the result will be inserted into this array. It should
         be of the appropriate shape and dtype.
+    keepdims : bool
+        If True, the reduced axes (dimensions) must be included in the result as
+        singleton dimensions, and, accordingly, the result must be compatible with
+        the input array. Otherwise, if False, the reduced axes (dimensions) must
+        not be included in the result. Default: False .
 
     Returns
     -------
@@ -7780,6 +7785,10 @@ def argmax(a, axis=None, out=None):
         with the dimension along `axis` removed.
 
     .. note::
+       ``keepdims`` param is part of request `in data-api-standard
+       <https://data-apis.org/array-api/latest/API_specification/searching_functions.html#argmax-x-axis-none-keepdims-false`_,
+       which is not the parameter in official NumPy
+
        In case of multiple occurrences of the maximum values, the indices
        corresponding to the first occurrence are returned.
 
@@ -7823,11 +7832,11 @@ def argmax(a, axis=None, out=None):
     >>> b
     array([2., 2.])
     """
-    return _mx_nd_np.argmax(a, axis, out)
+    return _mx_nd_np.argmax(a, axis, out, keepdims)
 
 
 @set_module('mxnet.numpy')
-def argmin(a, axis=None, out=None):
+def argmin(a, axis=None, out=None, keepdims=False):
     r"""
     Returns the indices of the minimum values along an axis.
 
@@ -7841,6 +7850,11 @@ def argmin(a, axis=None, out=None):
     out : ndarray or None, optional
         If provided, the result will be inserted into this array. It should
         be of the appropriate shape and dtype.
+    keepdims : bool
+        If True, the reduced axes (dimensions) must be included in the result as
+        singleton dimensions, and, accordingly, the result must be compatible with
+        the input array. Otherwise, if False, the reduced axes (dimensions) must
+        not be included in the result. Default: False .
 
     Returns
     -------
@@ -7849,6 +7863,10 @@ def argmin(a, axis=None, out=None):
         with the dimension along `axis` removed.
 
     .. note::
+       ``keepdims`` param is part of request `in data-api-standard
+       <https://data-apis.org/array-api/latest/API_specification/searching_functions.html#argmax-x-axis-none-keepdims-false`_,
+       which is not the parameter in official NumPy
+
        In case of multiple occurrences of the minimum values, the indices
        corresponding to the first occurrence are returned.
 
@@ -7892,7 +7910,7 @@ def argmin(a, axis=None, out=None):
     >>> b
     array([0., 0.])
     """
-    return _mx_nd_np.argmin(a, axis, out)
+    return _mx_nd_np.argmin(a, axis, out, keepdims)
 
 
 @set_module('mxnet.numpy')

--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -7785,7 +7785,7 @@ def argmax(a, axis=None, out=None, keepdims=False):
         with the dimension along `axis` removed.
 
     .. note::
-       ``keepdims`` param is part of request `in data-api-standard
+       ``keepdims`` param is part of request in data-api-standard
        <https://data-apis.org/array-api/latest/API_specification/searching_functions.html#argmax-x-axis-none-keepdims-false`_,
        which is not the parameter in official NumPy
 
@@ -7863,7 +7863,7 @@ def argmin(a, axis=None, out=None, keepdims=False):
         with the dimension along `axis` removed.
 
     .. note::
-       ``keepdims`` param is part of request `in data-api-standard
+       ``keepdims`` param is part of request in data-api-standard
        <https://data-apis.org/array-api/latest/API_specification/searching_functions.html#argmax-x-axis-none-keepdims-false`_,
        which is not the parameter in official NumPy
 

--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -7786,7 +7786,7 @@ def argmax(a, axis=None, out=None, keepdims=False):
 
     .. note::
        ``keepdims`` param is part of request in data-api-standard
-       <https://data-apis.org/array-api/latest/API_specification/searching_functions.html#argmax-x-axis-none-keepdims-false`_,
+       <https://data-apis.org/array-api/latest/API_specification/searching_functions.html#argmax-x-axis-none-keepdims-false>`_,
        which is not the parameter in official NumPy
 
        In case of multiple occurrences of the maximum values, the indices
@@ -7864,7 +7864,7 @@ def argmin(a, axis=None, out=None, keepdims=False):
 
     .. note::
        ``keepdims`` param is part of request in data-api-standard
-       <https://data-apis.org/array-api/latest/API_specification/searching_functions.html#argmax-x-axis-none-keepdims-false`_,
+       <https://data-apis.org/array-api/latest/API_specification/searching_functions.html#argmin-x-axis-none-keepdims-false>`_,
        which is not the parameter in official NumPy
 
        In case of multiple occurrences of the minimum values, the indices

--- a/src/operator/numpy/np_broadcast_reduce_op.cc
+++ b/src/operator/numpy/np_broadcast_reduce_op.cc
@@ -66,7 +66,11 @@ void NumpyArgMinMaxRTCCompute::operator()(const nnvm::NodeAttrs& attrs,
     axes = dmlc::optional<mxnet::Tuple<int>>(t);
   }
   TShape small;
-  small = NumpyReduceAxesShapeImpl(in.shape_, axes, true);
+  if (param.keepdims) {
+    small = outputs[0].shape_;
+  } else {
+    small = NumpyReduceAxesShapeImpl(in.shape_, axes, true);
+  }
   mxnet::TShape src_shape, dst_shape;
   BroadcastReduceShapeCompact(in.shape_, small, &src_shape, &dst_shape);
   const TBlob in_data = in.reshape(src_shape);

--- a/src/operator/numpy/np_broadcast_reduce_op.h
+++ b/src/operator/numpy/np_broadcast_reduce_op.h
@@ -550,7 +550,11 @@ void NumpyArgMinMaxCompute(const nnvm::NodeAttrs& attrs,
     axes = dmlc::optional<mxnet::Tuple<int>>(t);
   }
   TShape small;
-  small = NumpyReduceAxesShapeImpl(in.shape_, axes, true);
+  if (param.keepdims) {
+    small = outputs[0].shape_;
+  } else {
+    small = NumpyReduceAxesShapeImpl(in.shape_, axes, true);
+  }
   mxnet::TShape src_shape, dst_shape;
   BroadcastReduceShapeCompact(in.shape_, small, &src_shape, &dst_shape);
   const TBlob in_data = in.reshape(src_shape);

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -4437,28 +4437,28 @@ def test_np_delete():
 
 
 @use_np
-def test_np_argmin_argmax():
-    workloads = [
-        ((), 0, False),
-        ((), -1, False),
-        ((), 1, True),
-        ((5, 3), None, False),
-        ((5, 3), -1, False),
-        ((5, 3), 1, False),
-        ((5, 3), 3, True),
-        ((5, 0, 3), 0, False),
-        ((5, 0, 3), -1, False),
-        ((5, 0, 3), None, True),
-        ((5, 0, 3), 1, True),
-        ((3, 5, 7), None, False),
-        ((3, 5, 7), 0, False),
-        ((3, 5, 7), 1, False),
-        ((3, 5, 7), 2, False),
-        ((3, 5, 7, 9, 11), -3, False),
-    ]
-    dtypes = ['float16', 'float32', 'float64', 'bool', 'int32']
-    ops = ['argmin', 'argmax']
-
+@pytest.mark.parametrize('shape,axis,throw_exception', [
+    ((), 0, False),
+    ((), -1, False),
+    ((), 1, True),
+    ((5, 3), None, False),
+    ((5, 3), -1, False),
+    ((5, 3), 1, False),
+    ((5, 3), 3, True),
+    ((5, 0, 3), 0, False),
+    ((5, 0, 3), -1, False),
+    ((5, 0, 3), None, True),
+    ((5, 0, 3), 1, True),
+    ((3, 5, 7), None, False),
+    ((3, 5, 7), 0, False),
+    ((3, 5, 7), 1, False),
+    ((3, 5, 7), 2, False),
+    ((3, 5, 7, 9, 11), -3, False),
+])
+@pytest.mark.parametrize('dtype', ['float16', 'float32', 'float64', 'bool', 'int32'])
+@pytest.mark.parametrize('op_name', ['argmin', 'argmax'])
+@pytest.mark.parametrize('keepdims', [True, False])
+def test_np_argmin_argmax(shape, axis, throw_exception, dtype, op_name, keepdims):
     class TestArgExtreme(HybridBlock):
         def __init__(self, op_name, axis=None, keepdims=False):
             super(TestArgExtreme, self).__init__()
@@ -4469,49 +4469,52 @@ def test_np_argmin_argmax():
         def forward(self, x):
             return getattr(x, self._op_name)(self._axis, keepdims=self.keepdims)
 
-    for op_name in ops:
-        for keepdims in (True, False):
-            for shape, axis, throw_exception in workloads:
-                for dtype in dtypes:
-                    a = np.random.uniform(low=0, high=100, size=shape).astype(dtype)
-                    if throw_exception:
-                        # Cannot use assert_exception because sometimes the main thread
-                        # proceeds to `assert False` before the exception is thrown
-                        # in the worker thread. Have to use mx.nd.waitall() here
-                        # to block the main thread.
-                        try:
-                            getattr(np, op_name)(a, axis)
-                            mx.nd.waitall()
-                            assert False
-                        except mx.MXNetError:
-                            pass
-                    else:
-                        mx_ret = getattr(np, op_name)(a, axis=axis, keepdims=keepdims)
-                        np_ret = getattr(onp, op_name)(a.asnumpy(), axis=axis)
-                        assert mx_ret.dtype == np_ret.dtype
-                        if keepdims:
-                            assert same(np.squeeze(mx_ret, axis=axis).asnumpy(), np_ret)
-                        else:
-                            assert same(mx_ret.asnumpy(), np_ret)
+    a = np.random.uniform(low=0, high=100, size=shape).astype(dtype)
+    if throw_exception:
+        # Cannot use assert_exception because sometimes the main thread
+        # proceeds to `assert False` before the exception is thrown
+        # in the worker thread. Have to use mx.nd.waitall() here
+        # to block the main thread.
+        try:
+            getattr(np, op_name)(a, axis)
+            mx.nd.waitall()
+            assert False
+        except mx.MXNetError:
+            pass
+    else:
+        mx_ret = getattr(np, op_name)(a, axis=axis, keepdims=keepdims)
+        np_ret = getattr(onp, op_name)(a.asnumpy(), axis=axis)
+        assert mx_ret.dtype == np_ret.dtype
+        if keepdims:
+            # if shape == ():
+            #     assert mx_ret.shape == shape
+            # # elif not axis:
+            # #     assert mx_ret.size == 0
+            # else:
+            #     print(mx_ret.shape, np_ret.shape, shape, axis)
+            assert same(np.squeeze(mx_ret, axis=axis).asnumpy(), np_ret)
+            # assert same(mx_ret.asnumpy(), np_ret.reshape((mx_ret.shape)))
+        else:
+            assert same(mx_ret.asnumpy(), np_ret)
 
-                    for hybridize in [False, True]:
-                        net = TestArgExtreme(op_name, axis, keepdims)
-                        if hybridize:
-                            net.hybridize()
-                        if throw_exception:
-                            try:
-                                net(a)
-                                mx.nd.waitall()
-                                assert False
-                            except mx.MXNetError:
-                                pass
-                        else:
-                            mx_ret = net(a)
-                            assert mx_ret.dtype == np_ret.dtype
-                            if keepdims:
-                                assert same(np.squeeze(mx_ret, axis=axis).asnumpy(), np_ret)
-                            else:
-                                assert same(mx_ret.asnumpy(), np_ret)
+    for hybridize in [False, True]:
+        net = TestArgExtreme(op_name, axis, keepdims)
+        if hybridize:
+            net.hybridize()
+        if throw_exception:
+            try:
+                net(a)
+                mx.nd.waitall()
+                assert False
+            except mx.MXNetError:
+                pass
+        else:
+            mx_ret = net(a)
+            assert mx_ret.dtype == np_ret.dtype
+            if keepdims:
+                assert same(np.squeeze(mx_ret, axis=axis).asnumpy(), np_ret)
+            else:
+                assert same(mx_ret.asnumpy(), np_ret)
 
 
 @use_np


### PR DESCRIPTION
## Description ##
Standardize [argmax](https://data-apis.org/array-api/latest/API_specification/searching_functions.html#argmax-x-axis-none-keepdims-false)/[argmin](https://data-apis.org/array-api/latest/API_specification/searching_functions.html#argmin-x-axis-none-keepdims-false) by adding keepdims param. Update argmin/argmax tests.  


## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
