### PR TITLE
[master][clang-format] Add: break line entry before ternary operator

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -38,3 +38,4 @@ AlwaysBreakTemplateDeclarations: true
 BinPackArguments: false
 BinPackParameters: false
 SortIncludes: false
+BreakBeforeTernaryOperators: false


### PR DESCRIPTION
## Description ##
This pull-request solves a problem with ternary operators.
After:
```cpp
    const char* sevstr = (severity == Severity::kINTERNAL_ERROR ? "    BUG" :
                          severity == Severity::kERROR          ? "  ERROR" :
                          severity == Severity::kWARNING        ? "WARNING" :
                          severity == Severity::kINFO           ? "   INFO" :
                                                                  "UNKNOWN");
```
Before
```cpp
    const char* sevstr =
        (severity == Severity::kINTERNAL_ERROR ?
             "    BUG" :
             severity == Severity::kERROR ? "  ERROR" :
                                            severity == Severity::kWARNING ?
                                            "WARNING" :
                                            severity == Severity::kINFO ? "   INFO" : "UNKNOWN");
    (*_ostream) << "[" << buf << " " << sevstr << "] " << msg << std::endl;
  }
``` 

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
