### PR TITLE
[FEATURE][OP] Support FInplaceIdentity property for legacy operators

### DIFF
--- a/include/mxnet/operator.h
+++ b/include/mxnet/operator.h
@@ -357,6 +357,17 @@ class OperatorProperty {
     return std::vector<std::pair<int, void*> >();
   }
   /*!
+   * \brief Get if the forward inplace option is an identity.
+   * This function enables inplace optimization even when input reference count
+   * is greater than one.
+   *
+   * \return list of bool indicating whether corresponding pair from ForwardInplaceOption
+   *         is an identity.
+   */
+  virtual std::vector<bool> ForwardInplaceIdentity() const {
+    return std::vector<bool>();
+  }
+  /*!
    * \brief Get possible backward inplace options.
    *  This function enables optimization to reuse memory of inputs in output.
    *  Only override when necessary, by default in-place is disabled.
@@ -388,6 +399,17 @@ class OperatorProperty {
       const std::vector<int> &out_data,
       const std::vector<void*> &in_grad) const {
     return std::vector<std::pair<int, void*> >();
+  }
+  /*!
+   * \brief Get if the backward inplace option is an identity.
+   * This function enables inplace optimization even when input reference count
+   * is greater than one.
+   *
+   * \return list of bool indicating whether corresponding pair from BackwardInplaceOption
+   *         is an identity.
+   */
+  virtual std::vector<bool> BackwardInplaceIdentity() const {
+    return std::vector<bool>();
   }
   /*!
    * \brief Get Backward Input Dependency for generic types of data.

--- a/src/nnvm/legacy_op_util.cc
+++ b/src/nnvm/legacy_op_util.cc
@@ -280,6 +280,19 @@ std::vector<std::pair<int, int>> OpPropInplaceOption(const NodeAttrs& attrs) {
   return forward_inplace;
 }
 
+std::vector<bool> OpPropInplaceIdentity(const NodeAttrs& attrs) {
+  auto& prop = nnvm::get<ParsedOpProp>(attrs.parsed);
+  auto forward_inplace = OpPropInplaceOption(attrs);
+  auto forward_inplace_identity = prop.ptr->ForwardInplaceIdentity();
+  if (forward_inplace_identity.size() == 0UL) {
+    for (auto i = 0UL; i < forward_inplace.size(); ++i) {
+      forward_inplace_identity.push_back(false);
+    }
+  }
+  CHECK_EQ(forward_inplace.size(), forward_inplace_identity.size());
+  return forward_inplace_identity;
+}
+
 std::vector<ResourceRequest> OpPropResourceRequest(const NodeAttrs& attrs) {
   mxnet::ShapeVector ishape;
   auto& prop = nnvm::get<ParsedOpProp>(attrs.parsed);
@@ -409,6 +422,19 @@ std::vector<std::pair<int, int>> OpBackInplaceOption(const NodeAttrs& attrs) {
   return remap;
 }
 
+std::vector<bool> OpBackInplaceIdentity(const NodeAttrs& attrs) {
+  auto& prop = nnvm::get<ParsedOpProp>(attrs.parsed);
+  auto backward_inplace = OpBackInplaceOption(attrs);
+  auto backward_inplace_identity = prop.ptr->BackwardInplaceIdentity();
+  if (backward_inplace_identity.size() == 0UL) {
+    for (auto i = 0UL; i < backward_inplace.size(); ++i) {
+      backward_inplace_identity.push_back(false);
+    }
+  }
+  CHECK_EQ(backward_inplace.size(), backward_inplace_identity.size());
+  return backward_inplace_identity;
+}
+
 inline ExecType OpExecType(const NodeAttrs& attrs) {
   auto& prop = nnvm::get<ParsedOpProp>(attrs.parsed);
   return prop.ptr->exec_type();
@@ -442,6 +468,7 @@ void RegisterLegacyOpProp() {
     op.set_attr<nnvm::FInferType>("FInferType", OpPropInferType);
     op.set_attr<nnvm::FMutateInputs>("FMutateInputs", OpPropMutateInputs);
     op.set_attr<nnvm::FInplaceOption>("FInplaceOption", OpPropInplaceOption);
+    op.set_attr<nnvm::FInplaceIdentity>("FInplaceIdentity", OpPropInplaceIdentity);
     op.set_attr<FResourceRequest>("FResourceRequest", OpPropResourceRequest);
     op.set_attr<FExecType>("FExecType", OpExecType);
     op.set_attr<FCreateOpState>("FCreateOpState", OpPropCreateLayerOp);
@@ -463,6 +490,7 @@ void RegisterLegacyOpProp() {
     back_op.set_attr<nnvm::FListOutputNames>("FListOutputNames", OpBackListOutputNames);
     back_op.set_attr<nnvm::FMutateInputs>("FMutateInputs", OpBackMutateInputs);
     back_op.set_attr<nnvm::FInplaceOption>("FInplaceOption", OpBackInplaceOption);
+    back_op.set_attr<nnvm::FInplaceIdentity>("FInplaceIdentity", OpBackInplaceIdentity);
     back_op.set_attr<FResourceRequest>("FResourceRequest", OpBackResourceRequest);
     back_op.set_attr<bool>("TIsLayerOpBackward", true);
     back_op.set_attr<bool>("TIsBackward", true);


### PR DESCRIPTION
## Description ##
We notice that only nnvm operators support `FInplaceIdentity` property but legacy operators do not, which leads to `InplaceOption` failing when the storage reference count is large than 1. We add `FInplaceIdentity` support for legacy operators in this PR.

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
