### PR TITLE
[DOC] Fix wrong imports in Gluon Crash Course Step 4

### DIFF
--- a/docs/python_docs/python/tutorials/getting-started/crash-course/4-components.md
+++ b/docs/python_docs/python/tutorials/getting-started/crash-course/4-components.md
@@ -305,7 +305,7 @@ Before you can calculate the accuracy of your model, the metric (accuracy)
 should be instantiated before the training loop
 
 ```{.python .input}
-from mxnet.gluon.metric import Accuracy
+from mxnet.metric import Accuracy
 
 acc = Accuracy()
 ```
@@ -345,7 +345,7 @@ preds = np.array([0, 1, 1, 1, 1, 0, 0, 1, 0, 0, 0, 0])
 Next, define the custom metric class `precision` and instantiate it
 
 ```{.python .input}
-from mxnet.gluon.metric import EvalMetric
+from mxnet.metric import EvalMetric
 
 class precision(EvalMetric):
     def __init__(self):


### PR DESCRIPTION
`metric` is a submodule of `mxnet`, not of `mxnet.gluon`

## Description ##
In Step 4 of the Gluon Crash Course, metrics are imported from `mxnet.gluon.metric`, but should be imported from `mxnet.metric` instead. I update the documentation accordingly.

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [x] Updated documentation of Crash Course Step 4

## Comments ##
