### PR TITLE
[master] New version of clang-format

### DIFF
--- a/ci/docker/Dockerfile.build.ubuntu
+++ b/ci/docker/Dockerfile.build.ubuntu
@@ -57,7 +57,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         libprotobuf-dev \
         default-jdk \
         clang-6.0 \
-        clang-format \
+        clang-format-11 \
         python-yaml \
         clang-10 \
         clang-tidy-10 \

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -738,11 +738,11 @@ sanity_clang() {
     
     tools/lint/clang_format_ci.sh "${BASE_SHA}"
     GIT_DIFFERENCE=$(git diff)
+    clang-format-11 --version
     if [[ -z $GIT_DIFFERENCE ]]; then
         git remote remove "${GITHUB_RUN_ID}" # temporary remote is removed
         return
     fi
-    clang-format-11 --version
     echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     echo "| Clang-format failures found! Run: "
     echo "|    tools/lint/clang_format_ci.sh ${BASE_SHA} "

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -742,11 +742,12 @@ sanity_clang() {
         git remote remove "${GITHUB_RUN_ID}" # temporary remote is removed
         return
     fi
-
+    clang-format-11 --version
     echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     echo "| Clang-format failures found! Run: "
     echo "|    tools/lint/clang_format_ci.sh ${BASE_SHA} "
     echo "| to fix this error. "
+    echo "| Clang-format minimum version: 11. "
     echo "| For more info, see: https://mxnet.apache.org/versions/master/community/clang_format_guide"
     echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 


### PR DESCRIPTION
## Description ##
The clang-format tool is bumped up to v11.

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
