### PR TITLE
[v1.9.x] Backport Add MKLDNN Deconvolution 1D and 3D support (#20137)

### DIFF
--- a/src/operator/nn/deconvolution-inl.h
+++ b/src/operator/nn/deconvolution-inl.h
@@ -219,7 +219,11 @@ class DeconvolutionOp {
     using namespace mshadow::expr;
 
     if (param_.kernel.ndim() > 2) {
-      LOG(FATAL) << "If not using CUDNN, only 1D or 2D Deconvolution is supported";
+      LOG(FATAL) << "Only 1D or 2D Deconvolution is natively supported. "
+                 << ((MXNET_USE_MKLDNN || MXNET_USE_CUDNN)
+                         ? "Fallback to native implementation (if occurred) is therefore "
+                           "impossible for 3D Deconvolution."
+                         : "");
     }
 
     CHECK_EQ(req[deconv::kOut], kWriteTo);

--- a/src/operator/nn/mkldnn/mkldnn_deconvolution.cc
+++ b/src/operator/nn/mkldnn/mkldnn_deconvolution.cc
@@ -29,7 +29,8 @@ namespace mxnet {
 namespace op {
 
 bool SupportMKLDNNDeconv(const DeconvolutionParam &params, const NDArray &input) {
-  return params.kernel.ndim() == 2 && input.shape().ndim() == 4 &&
+  return params.kernel.ndim() >= 1 && params.kernel.ndim() <= 3 &&
+         input.shape().ndim() == (params.kernel.ndim() + 2) &&
          (input.dtype() == mshadow::kFloat32 || input.dtype() == mshadow::kBfloat16);
 }
 
@@ -322,10 +323,10 @@ DeconvDescCreator::DeconvDescCreator(const DeconvolutionParam &param, const NDAr
       strides(param.stride.ndim()),
       padding(param.pad.ndim()),
       dilates(param.dilate.ndim()) {
-  // assuming only deconv2D is supported for now
   CHECK_EQ(param.stride.ndim(), param.pad.ndim());
   CHECK_EQ(param.stride.ndim(), param.dilate.ndim());
-  CHECK_EQ(param.stride.ndim(), 2);
+  CHECK_GE(param.stride.ndim(), 1);
+  CHECK_LE(param.stride.ndim(), 3);
   for (int i = 0; i < param.stride.ndim(); ++i) {
     strides[i] = param.stride[i];
     padding[i] = param.pad[i];

--- a/tests/python/mkl/test_mkldnn.py
+++ b/tests/python/mkl/test_mkldnn.py
@@ -471,8 +471,8 @@ def test_convolution():
 @with_seed()
 def test_Deconvolution():
     def check_Deconvolution_training(stype):
-        for shape in [(3, 3, 10, 10)]: # testing only 2D for now
-            data_tmp = np.random.randint(256, size=shape)
+        for shape in [(3, 3, 10), (3, 3, 10, 10), (3, 3, 10, 10, 10)]:
+            data_tmp = np.random.normal(-0.1, 1, size=shape)
             data = mx.symbol.Variable('data', stype=stype)
 
             if np.array(shape).shape[0] == 3:
@@ -481,6 +481,11 @@ def test_Deconvolution():
             elif np.array(shape).shape[0] == 4:
                 test = mx.symbol.Deconvolution(data=data, kernel=(3, 3), stride=(2, 2), num_filter=4)
                 weight_tmp = np.random.normal(-0.1, 0.1, size=(3, 4, 3, 3))
+            elif np.array(shape).shape[0] == 5 and stype == "default":
+                # Unable to test fallback to native implementation for non-default storage types
+                # as 3D deconvolution is not natively supported
+                test = mx.symbol.Deconvolution(data=data, kernel=(3,3,3), stride=(2,2,2), num_filter=4)
+                weight_tmp = np.random.normal(-0.1, 0.1, size=(3, 4, 3, 3, 3))
             else:
                 return 0
             bias_tmp = np.random.normal(0.1, 0.1, size=(4,))


### PR DESCRIPTION
## Description ##
Backport Add MKLDNN Deconvolution 1D and 3D support (#20137) to v1.9.x branch

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
