### PR TITLE
[master] CI/CD updates to be more stable

### DIFF
--- a/ci/build_windows.py
+++ b/ci/build_windows.py
@@ -118,7 +118,7 @@ CMAKE_FLAGS = {
         '-DUSE_BLAS=open '
         '-DUSE_LAPACK=ON '
         '-DUSE_DIST_KVSTORE=OFF '
-        '-DMXNET_CUDA_ARCH="5.2" '
+        '-DCMAKE_CUDA_ARCHITECTURES="52" '
         '-DCMAKE_BUILD_TYPE=Release')
 
     , 'WIN_GPU_ONEDNN': (
@@ -131,7 +131,7 @@ CMAKE_FLAGS = {
         '-DUSE_BLAS=open '
         '-DUSE_LAPACK=ON '
         '-DUSE_DIST_KVSTORE=OFF '
-        '-DMXNET_CUDA_ARCH="5.2" '
+        '-DCMAKE_CUDA_ARCHITECTURES="52" '
         '-DUSE_ONEDNN=ON '
         '-DCMAKE_BUILD_TYPE=Release')
 

--- a/ci/build_windows.py
+++ b/ci/build_windows.py
@@ -118,7 +118,7 @@ CMAKE_FLAGS = {
         '-DUSE_BLAS=open '
         '-DUSE_LAPACK=ON '
         '-DUSE_DIST_KVSTORE=OFF '
-        '-DCMAKE_CUDA_ARCHITECTURES="52" '
+        '-DMXNET_CUDA_ARCH="5.2 7.5" '
         '-DCMAKE_BUILD_TYPE=Release')
 
     , 'WIN_GPU_ONEDNN': (
@@ -131,7 +131,7 @@ CMAKE_FLAGS = {
         '-DUSE_BLAS=open '
         '-DUSE_LAPACK=ON '
         '-DUSE_DIST_KVSTORE=OFF '
-        '-DCMAKE_CUDA_ARCHITECTURES="52" '
+        '-DMXNET_CUDA_ARCH="5.2 7.5" '
         '-DUSE_ONEDNN=ON '
         '-DCMAKE_BUILD_TYPE=Release')
 

--- a/ci/docker/Dockerfile.build.ubuntu
+++ b/ci/docker/Dockerfile.build.ubuntu
@@ -91,7 +91,8 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         libb2-dev \
         libzstd-dev \
         gfortran && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    add-apt-repository -r "deb https://apt.repos.intel.com/oneapi all main"
 
 # Build OpenBLAS from source
 RUN export LIBRARY_PATH=$LIBRARY_PATH:/usr/lib/gcc/x86_64-linux-gnu/7/ && \

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -1355,7 +1355,6 @@ build_docs_beta() {
 push_docs() {
     folder_name=$1
     set -ex
-    pip3 install --user awscli
     export PATH=~/.local/bin:$PATH
     pushd docs/_build
     tar -xzf full_website.tgz --strip-components 1
@@ -1471,7 +1470,6 @@ cd_pypi_publish() {
 
 cd_s3_publish() {
     set -ex
-    pip3 install --upgrade --user awscli
     filepath=$(readlink -f wheel_build/dist/*.whl)
     filename=$(basename $filepath)
     variant=$(echo $filename | cut -d'-' -f1 | cut -d'_' -f2 -s)


### PR DESCRIPTION
This PR fixes a few issues with CI/CD:

1. When multiple processes are attempting to install a pip package at the same time, there is a race condition that causes them to fail intermittently. Since website s3 push and publish is not run inside a container, just use the awscli installed in the jenkins slave (which is up-to-date.) 
2. Remove the onednn repository after installing onednn. This change prevents all CI pipelines from failing in case the onednn repository gets corrupt (or sync issues), since any apt calls will fail. 
3. Update CUDA architectures built for Windows. Include 7.5 for Turing (which are on g4 instances,) so we can migrate to these instances for Windows CI.
