### PR TITLE
fix slice_axis in ModulatedDeformableConvolution

### DIFF
--- a/python/mxnet/gluon/nn/conv_layers.py
+++ b/python/mxnet/gluon/nn/conv_layers.py
@@ -1647,8 +1647,8 @@ class ModulatedDeformableConvolution(HybridBlock):
             offset = npx.convolution(x, self.offset_weight.data(ctx),
                                      self.offset_bias.data(ctx), cudnn_off=True, **self._kwargs_offset)
 
-        offset_t = npx.slice_axis(offset, axis=1, begin=0, end=self.offset_split_index)
-        mask = npx.slice_axis(offset, axis=1, begin=self.offset_split_index, end=None)
+        offset_t = offset[:,0:self.offset_split_index,:, :]
+        mask = offset[:,self.offset_split_index:,:, :]
         mask = npx.sigmoid(mask) * 2
 
         if self.deformable_conv_bias is None:


### PR DESCRIPTION
## Description ##
slice_axis is not available in npx module, thus I try to achieve it using numpy slicing. 