### PR TITLE
Fix identity fuse for oneDNN

### DIFF
--- a/src/operator/subgraph/dnnl/dnnl_identity_property.h
+++ b/src/operator/subgraph/dnnl/dnnl_identity_property.h
@@ -82,7 +82,8 @@ class SgDNNLIdentitySelector : public SubgraphSelectorV2 {
 
   std::vector<BiDirectedNode*> Filter(const std::vector<BiDirectedNode*>& candidates) override {
     // candidates should contain only two nodes - custom node and identity node
-    if (candidates.size() == 2 && candidates.size() == matched_list_.size()) {
+    if (pattern_found && candidates.size() == matched_list_.size()) {
+      CHECK_EQ(candidates.size(), 2);
       return candidates;
     } else {
       return std::vector<BiDirectedNode*>(0);

--- a/src/operator/subgraph/dnnl/dnnl_identity_property.h
+++ b/src/operator/subgraph/dnnl/dnnl_identity_property.h
@@ -137,8 +137,10 @@ class SgDNNLIdentityProperty : public SubgraphProperty {
     // Create copy of original node
     nnvm::ObjectPtr n = nnvm::Node::Create();
     n->attrs          = org_node->attrs;
-    CHECK(n->op());
-    n->op()->attr_parser(&(n->attrs));
+    CHECK(n->op()) << "WRTF";
+    if (n->op()->attr_parser) {
+      n->op()->attr_parser(&(n->attrs));
+    }
     return n;
   }
 

--- a/src/operator/subgraph/dnnl/dnnl_identity_property.h
+++ b/src/operator/subgraph/dnnl/dnnl_identity_property.h
@@ -40,7 +40,7 @@ namespace op {
 class SgDNNLIdentitySelector : public SubgraphSelectorV2 {
  private:
   std::vector<const BiDirectedNode*> matched_list_;
-
+  bool pattern_found = false;
  public:
   bool Select(const BiDirectedNode& seed_node,
               const std::shared_ptr<NodeAttr>& node_attr) override {
@@ -65,10 +65,11 @@ class SgDNNLIdentitySelector : public SubgraphSelectorV2 {
   }
 
   bool SelectInput(const BiDirectedNode& n, const BiDirectedNode& input_node) override {
-    if (input_node.node->is_variable()) {
+    if (pattern_found || input_node.node->is_variable()) {
       return false;
     } else if (input_node.node->op()) {
       matched_list_.emplace_back(&input_node);
+      pattern_found = true;
       return true;
     }
     return false;

--- a/src/operator/subgraph/dnnl/dnnl_identity_property.h
+++ b/src/operator/subgraph/dnnl/dnnl_identity_property.h
@@ -41,6 +41,7 @@ class SgDNNLIdentitySelector : public SubgraphSelectorV2 {
  private:
   std::vector<const BiDirectedNode*> matched_list_;
   bool pattern_found = false;
+
  public:
   bool Select(const BiDirectedNode& seed_node,
               const std::shared_ptr<NodeAttr>& node_attr) override {


### PR DESCRIPTION
## Description ##
During testing https://github.com/dmlc/gluon-nlp/pull/1581 it occurred that identity fuse doesn't work properly on big graph, but works in unit test - that was caused by lack of stop condition in subgraph selector.

This PR fix this issue and expand test to cover such cases
