### PR TITLE
Use cuDNN for conv bias and bias grad

### DIFF
--- a/python/mxnet/amp/loss_scaler.py
+++ b/python/mxnet/amp/loss_scaler.py
@@ -46,14 +46,14 @@ class LossScaler(object):
         """Check gradients for overflow."""
         if is_np_array():
             all_finite_f = ndarray.numpy._internal.multi_all_finite
-            ones_f = ndarray.numpy.ones
+            ones_f = lambda ctx: ndarray.numpy.ones((1,), device=ctx)
         else:
             all_finite_f = ndarray.multi_all_finite
-            ones_f = ndarray.ones
+            ones_f = lambda ctx: ndarray.ones((1,), ctx=ctx)
         with ag.pause():
             chunk_size = 200
             valid_params = [p._grad[0] for p in params if p._grad is not None]
-            gpu_output = ones_f((1,), ctx=valid_params[0].context)
+            gpu_output = ones_f(valid_params[0].context)
             nb_params = len(valid_params)
             for idx in range(0, nb_params, chunk_size):
                 all_finite_f(*valid_params[idx:idx+chunk_size],

--- a/src/common/cuda/cudnn_cxx.cc
+++ b/src/common/cuda/cudnn_cxx.cc
@@ -112,15 +112,6 @@ std::vector<Descriptor> GetSomeAttrs(size_t max_n,
   return ret;
 }
 
-std::vector<int64_t> PackedStrides(const std::vector<size_t>& order,
-                                   const std::vector<int64_t>& dims) {
-  CHECK_EQ(order.size(), dims.size());
-  std::vector<int64_t> ret(dims.size(), 1);
-  for (size_t i = dims.size() - 1; i--;)
-    ret[order[i]] = dims[order[i + 1]] * ret[order[i + 1]];
-  return ret;
-}
-
 std::vector<Descriptor> GetPlans(cudnnBackendHeurMode_t h_mode,
                                  cudnnHandle_t handle,
                                  const Descriptor& op_graph,

--- a/src/common/cuda/cudnn_cxx.h
+++ b/src/common/cuda/cudnn_cxx.h
@@ -244,8 +244,14 @@ std::vector<Descriptor> GetSomeAttrs(size_t max_n,
                                      cudnnBackendDescriptorType_t type);
 
 // Order sets layout, as a permutation of dims, with N,C,<spacial dims> being identity.
-std::vector<int64_t> PackedStrides(const std::vector<size_t>& order,
-                                   const std::vector<int64_t>& dims);
+template <typename T>
+std::vector<T> PackedStrides(const std::vector<size_t>& order, const std::vector<T>& dims) {
+  CHECK_EQ(order.size(), dims.size());
+  std::vector<T> ret(dims.size(), 1);
+  for (size_t i = dims.size() - 1; i--;)
+    ret[order[i]] = dims[order[i + 1]] * ret[order[i + 1]];
+  return ret;
+}
 
 // Given an engine config's `notes`, return whether that config is compatible, i.e. does
 // the config have all of the required notes and none of the notes that are being excluded.

--- a/src/operator/cudnn_ops.cc
+++ b/src/operator/cudnn_ops.cc
@@ -758,6 +758,110 @@ void ConvWgrad::Exec(const cudnn_cxx::Descriptor& plan,
   CUDNN_CALL(cudnnBackendExecute(s->dnn_handle_, plan.get(), var_pack.get()));
 }
 
+struct LegacyTensorDestroyer {
+  using pointer = cudnnTensorDescriptor_t;
+
+  void operator()(cudnnTensorDescriptor_t desc) {
+    CUDNN_CALL_NONFATAL(cudnnDestroyTensorDescriptor(desc));
+  }
+};
+
+using LegacyTensor = std::unique_ptr<cudnnTensorDescriptor_t, LegacyTensorDestroyer>;
+
+LegacyTensor MakeLegacyTensor() {
+  cudnnTensorDescriptor_t desc{};
+  CUDNN_CALL(cudnnCreateTensorDescriptor(&desc));
+  return LegacyTensor(desc);
+}
+
+union ScalingParam {
+  double d;
+  float f;
+};
+
+std::pair<ScalingParam, ScalingParam> AlphaBeta(int type_flag, double init_a, double init_b) {
+  ScalingParam a, b;
+  switch (type_flag) {
+    case kFloat64:
+      a.d = init_a;
+      b.d = init_b;
+      break;
+    case kFloat32:  // fallthrough
+    case kFloat16:
+      a.f = init_a;
+      b.f = init_b;
+      break;
+    default:
+      LOG(FATAL) << "Unexpected type: " << type_flag;
+  }
+  return {a, b};
+}
+
+void SetLegacyTensor(cudnnTensorDescriptor_t desc, const TBlob& blob, const LayoutInfo& li) {
+  std::vector<int> dims(blob.shape_.ndim());
+  CHECK_EQ(dims.size(), li.n_space_dims + 2);
+  auto rev_order = ReverseOrder(li.Order());
+  for (size_t i = 0; i < dims.size(); ++i)
+    dims[i] = blob.shape_[rev_order[i]];
+  auto strides64 = li.Strides(std::vector<int64_t>(dims.begin(), dims.end()));
+  std::vector<int> strides(strides64.begin(), strides64.end());
+
+  auto type = static_cast<mshadow::TypeFlag>(blob.type_flag_);
+  CUDNN_CALL(cudnnSetTensorNdDescriptor(desc, CudnnType(type), dims.size(), &dims[0], &strides[0]));
+}
+
+void SetLegacyCTensorExpandDims(cudnnTensorDescriptor_t desc,
+                                const TBlob& blob,
+                                const LayoutInfo& li) {
+  std::vector<int> dims(li.n_space_dims + 2, 1);
+  dims[1] = blob.shape_[0];
+  std::vector<int> strides(dims.size(), 1);
+  strides[0] = blob.shape_[0];
+
+  auto type = static_cast<mshadow::TypeFlag>(blob.type_flag_);
+  CUDNN_CALL(cudnnSetTensorNdDescriptor(desc, CudnnType(type), dims.size(), &dims[0], &strides[0]));
+}
+
+bool LegacyAddBias(const OpContext& ctx, const LayoutInfo& li, const TBlob& y, const TBlob& b) {
+  thread_local auto y_desc = MakeLegacyTensor();
+  thread_local auto b_desc = MakeLegacyTensor();
+
+  auto s             = ctx.get_stream<gpu>();
+  auto [alpha, beta] = AlphaBeta(y.type_flag_, 1.0, 1.0);  // NOLINT(whitespace/braces)
+
+  SetLegacyTensor(y_desc.get(), y, li);
+  SetLegacyCTensorExpandDims(b_desc.get(), b, li);
+
+  auto err =
+      cudnnAddTensor(s->dnn_handle_, &alpha, b_desc.get(), b.dptr_, &beta, y_desc.get(), y.dptr_);
+  if (err == CUDNN_STATUS_NOT_SUPPORTED)
+    return false;
+  CHECK_EQ(err, CUDNN_STATUS_SUCCESS);
+  return true;
+}
+
+bool LegacyBiasGrad(const OpContext& ctx,
+                    const LayoutInfo& li,
+                    bool add_to,
+                    const TBlob& db,
+                    const TBlob& dy) {
+  thread_local auto db_desc = MakeLegacyTensor();
+  thread_local auto dy_desc = MakeLegacyTensor();
+
+  auto s             = ctx.get_stream<gpu>();
+  auto [alpha, beta] = AlphaBeta(dy.type_flag_, 1.0, add_to ? 1.0 : 0.0);  // NOLINT(*)
+
+  SetLegacyCTensorExpandDims(db_desc.get(), db, li);
+  SetLegacyTensor(dy_desc.get(), dy, li);
+
+  auto err = cudnnConvolutionBackwardBias(
+      s->dnn_handle_, &alpha, dy_desc.get(), dy.dptr_, &beta, db_desc.get(), db.dptr_);
+  if (err == CUDNN_STATUS_NOT_SUPPORTED)
+    return false;
+  CHECK_EQ(err, CUDNN_STATUS_SUCCESS);
+  return true;
+}
+
 }  // namespace cudnn
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/cudnn_ops.h
+++ b/src/operator/cudnn_ops.h
@@ -246,6 +246,14 @@ struct ConvWgrad {
                    const TBlob& dw);
 };
 
+bool LegacyAddBias(const OpContext& ctx, const LayoutInfo& li, const TBlob& y, const TBlob& b);
+
+bool LegacyBiasGrad(const OpContext& ctx,
+                    const LayoutInfo& li,
+                    bool add_to,
+                    const TBlob& db,
+                    const TBlob& dy);
+
 }  // namespace cudnn
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/nn/convolution.cu
+++ b/src/operator/nn/convolution.cu
@@ -58,7 +58,7 @@ void ConvolutionCompute<gpu>(const nnvm::NodeAttrs& attrs,
       CHECK_EQ(inputs[conv::kBias].shape_.ndim(), 1);
       auto layout = static_cast<mshadow::LayoutFlag>(param.layout.value());
       auto li     = cudnn::GetLayoutInfo(layout);
-      if (dmlc::GetEnv("MXNET_NATIVE_ADD_BIAS", li.channel_last) ||
+      if (li.channel_last ||
           !cudnn::LegacyAddBias(ctx, li, outputs[conv::kOut], inputs[conv::kBias])) {
         int k  = inputs[conv::kBias].shape_.Size();
         auto b = inputs[conv::kBias].reshape(cudnn::ExpandChannelDims(layout, k));
@@ -143,7 +143,7 @@ void ConvolutionGradCompute<gpu>(const nnvm::NodeAttrs& attrs,
     if (ok && !param.no_bias && req[conv::kBias] != kNullOp) {
       auto li     = cudnn::GetLayoutInfo(static_cast<mshadow::LayoutFlag>(param.layout.value()));
       auto add_to = req[conv::kBias] == kAddTo;
-      if (dmlc::GetEnv("MXNET_NATIVE_BIAS_GRAD", li.channel_last) ||
+      if (li.channel_last ||
           !cudnn::LegacyBiasGrad(ctx, li, add_to, outputs[conv::kBias], inputs[0])) {
         if (li.channel_last) {
           // This kernel should be faster.

--- a/src/operator/nn/convolution.cu
+++ b/src/operator/nn/convolution.cu
@@ -58,7 +58,8 @@ void ConvolutionCompute<gpu>(const nnvm::NodeAttrs& attrs,
       CHECK_EQ(inputs[conv::kBias].shape_.ndim(), 1);
       auto layout = static_cast<mshadow::LayoutFlag>(param.layout.value());
       auto li     = cudnn::GetLayoutInfo(layout);
-      if (!cudnn::LegacyAddBias(ctx, li, outputs[conv::kOut], inputs[conv::kBias])) {
+      if (dmlc::GetEnv("MXNET_NATIVE_ADD_BIAS", li.channel_last) ||
+          !cudnn::LegacyAddBias(ctx, li, outputs[conv::kOut], inputs[conv::kBias])) {
         int k  = inputs[conv::kBias].shape_.Size();
         auto b = inputs[conv::kBias].reshape(cudnn::ExpandChannelDims(layout, k));
         BinaryBroadcastRTCCompute{"add"}(  // NOLINT(whitespace/braces)
@@ -142,7 +143,8 @@ void ConvolutionGradCompute<gpu>(const nnvm::NodeAttrs& attrs,
     if (ok && !param.no_bias && req[conv::kBias] != kNullOp) {
       auto li     = cudnn::GetLayoutInfo(static_cast<mshadow::LayoutFlag>(param.layout.value()));
       auto add_to = req[conv::kBias] == kAddTo;
-      if (!cudnn::LegacyBiasGrad(ctx, li, add_to, outputs[conv::kBias], inputs[0])) {
+      if (dmlc::GetEnv("MXNET_NATIVE_BIAS_GRAD", li.channel_last) ||
+          !cudnn::LegacyBiasGrad(ctx, li, add_to, outputs[conv::kBias], inputs[0])) {
         if (li.channel_last) {
           // This kernel should be faster.
           auto y_grad = FlattenAs2DHead<gpu, DType>(inputs[0], ctx);

--- a/src/operator/nn/deconvolution.cu
+++ b/src/operator/nn/deconvolution.cu
@@ -57,7 +57,7 @@ void DeconvolutionCompute<gpu>(const nnvm::NodeAttrs& attrs,
       CHECK_EQ(inputs[deconv::kBias].shape_.ndim(), 1);
       auto layout = static_cast<mshadow::LayoutFlag>(param.layout.value());
       auto li     = cudnn::GetLayoutInfo(layout);
-      if (dmlc::GetEnv("MXNET_NATIVE_ADD_BIAS", li.channel_last) ||
+      if (li.channel_last ||
           !cudnn::LegacyAddBias(ctx, li, outputs[deconv::kOut], inputs[deconv::kBias])) {
         int k  = inputs[deconv::kBias].shape_.Size();
         auto b = inputs[deconv::kBias].reshape(cudnn::ExpandChannelDims(layout, k));
@@ -121,7 +121,7 @@ void DeconvolutionGradCompute<gpu>(const nnvm::NodeAttrs& attrs,
     if (ok && !param.no_bias && req[deconv::kBias] != kNullOp) {
       auto li     = cudnn::GetLayoutInfo(static_cast<mshadow::LayoutFlag>(param.layout.value()));
       auto add_to = req[conv::kBias] == kAddTo;
-      if (dmlc::GetEnv("MXNET_NATIVE_BIAS_GRAD", li.channel_last) ||
+      if (li.channel_last ||
           !cudnn::LegacyBiasGrad(ctx, li, add_to, outputs[deconv::kBias], inputs[0])) {
         if (li.channel_last) {
           // This kernel should be faster.

--- a/src/operator/nn/deconvolution.cu
+++ b/src/operator/nn/deconvolution.cu
@@ -57,7 +57,8 @@ void DeconvolutionCompute<gpu>(const nnvm::NodeAttrs& attrs,
       CHECK_EQ(inputs[deconv::kBias].shape_.ndim(), 1);
       auto layout = static_cast<mshadow::LayoutFlag>(param.layout.value());
       auto li     = cudnn::GetLayoutInfo(layout);
-      if (!cudnn::LegacyAddBias(ctx, li, outputs[deconv::kOut], inputs[deconv::kBias])) {
+      if (dmlc::GetEnv("MXNET_NATIVE_ADD_BIAS", li.channel_last) ||
+          !cudnn::LegacyAddBias(ctx, li, outputs[deconv::kOut], inputs[deconv::kBias])) {
         int k  = inputs[deconv::kBias].shape_.Size();
         auto b = inputs[deconv::kBias].reshape(cudnn::ExpandChannelDims(layout, k));
         BinaryBroadcastRTCCompute{"add"}(  // NOLINT(whitespace/braces)
@@ -120,7 +121,8 @@ void DeconvolutionGradCompute<gpu>(const nnvm::NodeAttrs& attrs,
     if (ok && !param.no_bias && req[deconv::kBias] != kNullOp) {
       auto li     = cudnn::GetLayoutInfo(static_cast<mshadow::LayoutFlag>(param.layout.value()));
       auto add_to = req[conv::kBias] == kAddTo;
-      if (!cudnn::LegacyBiasGrad(ctx, li, add_to, outputs[deconv::kBias], inputs[0])) {
+      if (dmlc::GetEnv("MXNET_NATIVE_BIAS_GRAD", li.channel_last) ||
+          !cudnn::LegacyBiasGrad(ctx, li, add_to, outputs[deconv::kBias], inputs[0])) {
         if (li.channel_last) {
           // This kernel should be faster.
           auto y_grad = FlattenAs2DHead<gpu, DType>(inputs[0], ctx);

--- a/src/operator/nn/deconvolution.cu
+++ b/src/operator/nn/deconvolution.cu
@@ -56,14 +56,17 @@ void DeconvolutionCompute<gpu>(const nnvm::NodeAttrs& attrs,
     if (ok && !param.no_bias) {
       CHECK_EQ(inputs[deconv::kBias].shape_.ndim(), 1);
       auto layout = static_cast<mshadow::LayoutFlag>(param.layout.value());
-      int k       = inputs[deconv::kBias].shape_.Size();
-      auto b      = inputs[deconv::kBias].reshape(cudnn::ExpandChannelDims(layout, k));
-      BinaryBroadcastRTCCompute{"add"}(  // NOLINT(whitespace/braces)
-          attrs,
-          ctx,
-          {outputs[deconv::kOut], b},
-          {kWriteInplace},
-          {outputs[deconv::kOut]});
+      auto li     = cudnn::GetLayoutInfo(layout);
+      if (!cudnn::LegacyAddBias(ctx, li, outputs[deconv::kOut], inputs[deconv::kBias])) {
+        int k  = inputs[deconv::kBias].shape_.Size();
+        auto b = inputs[deconv::kBias].reshape(cudnn::ExpandChannelDims(layout, k));
+        BinaryBroadcastRTCCompute{"add"}(  // NOLINT(whitespace/braces)
+            attrs,
+            ctx,
+            {outputs[deconv::kOut], b},
+            {kWriteInplace},
+            {outputs[deconv::kOut]});
+      }
     }
     if (!ok) {
       if (!param.cudnn_off)
@@ -115,17 +118,24 @@ void DeconvolutionGradCompute<gpu>(const nnvm::NodeAttrs& attrs,
           cudnn::Exec<cudnn::ConvWgrad>(
               ctx, conv_param, inputs[0], inputs[1 + deconv::kData], outputs[deconv::kWeight]));
     if (ok && !param.no_bias && req[deconv::kBias] != kNullOp) {
-      auto li = cudnn::GetLayoutInfo(static_cast<mshadow::LayoutFlag>(param.layout.value()));
-      if (li.channel_last) {
-        // This kernel should be faster.
-        auto y_grad = FlattenAs2DHead<gpu, DType>(inputs[0], ctx);
-        AddBiasGrad(outputs[deconv::kBias], y_grad, req[deconv::kBias], param.num_filter, ctx);
-      } else {
-        TShape axes{static_cast<int>(li.ChannelIdx())};
-        TShape small =
-            ReduceAxesShapeImpl(inputs[0].shape_, dmlc::optional<mxnet::TShape>(axes), true, true);
-        ReduceAxesRTCComputeImpl(
-            ctx, {inputs[0]}, {req[deconv::kBias]}, {outputs[deconv::kBias]}, small, "red::sum{}");
+      auto li     = cudnn::GetLayoutInfo(static_cast<mshadow::LayoutFlag>(param.layout.value()));
+      auto add_to = req[conv::kBias] == kAddTo;
+      if (!cudnn::LegacyBiasGrad(ctx, li, add_to, outputs[deconv::kBias], inputs[0])) {
+        if (li.channel_last) {
+          // This kernel should be faster.
+          auto y_grad = FlattenAs2DHead<gpu, DType>(inputs[0], ctx);
+          AddBiasGrad(outputs[deconv::kBias], y_grad, req[deconv::kBias], param.num_filter, ctx);
+        } else {
+          TShape axes{static_cast<int>(li.ChannelIdx())};
+          TShape small = ReduceAxesShapeImpl(
+              inputs[0].shape_, dmlc::optional<mxnet::TShape>(axes), true, true);
+          ReduceAxesRTCComputeImpl(ctx,
+                                   {inputs[0]},
+                                   {req[deconv::kBias]},
+                                   {outputs[deconv::kBias]},
+                                   small,
+                                   "red::sum{}");
+        }
       }
     }
     if (!ok) {


### PR DESCRIPTION
## Description ##
This change uses cuDNN implementation of bias and bias gradient, if available. It mitigates performance regression in convolutional networks in 2.0 vs 1.x, as tested with ResNet training script.

## Checklist ##
### Essentials ###
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
- [X] Code is well-documented

## Other changes ##
- Fix AMP for ndarray.numpy