### PR TITLE
[v1.9.x] Fix CD for pypi wheel version

### DIFF
--- a/ci/build.py
+++ b/ci/build.py
@@ -273,15 +273,10 @@ def container_run(platform: str,
         # mount mxnet/build for storing build
         '-v', "{}:/work/build".format(local_build_folder),
         '-v', "{}:/work/ccache".format(local_ccache_dir),
-        '-u', '{}:{}'.format(os.getuid(), os.getgid()),
-        '-e', 'CCACHE_MAXSIZE={}'.format(environment['CCACHE_MAXSIZE']),
-        # temp dir should be local and not shared
-        '-e', 'CCACHE_TEMPDIR={}'.format(environment['CCACHE_TEMPDIR']),
-        # this path is inside the container as /work/ccache is mounted
-        '-e', "CCACHE_DIR={}".format(environment['CCACHE_DIR']),
-        # a container-scoped log, useful for ccache verification.
-        '-e', "CCACHE_LOGFILE={}".format(environment['CCACHE_LOGFILE']),
+        '-u', '{}:{}'.format(os.getuid(), os.getgid())
     ]
+    for e in environment.keys():
+        docker_arg_list += ['-e', '{}={}'.format(e, environment[e])]
     docker_arg_list += [tag]
     docker_arg_list.extend(command)
 

--- a/tools/pip/setup.py
+++ b/tools/pip/setup.py
@@ -45,7 +45,7 @@ LIB_PATH = libinfo['find_lib_path']()
 __version__ = libinfo['__version__']
 
 # set by the CD pipeline
-is_release = os.environ.get("RELEASE_BUILD", "").strip()
+is_release = (os.environ.get("RELEASE_BUILD", "false").strip().lower() != "false")
 
 # set by the travis build pipeline
 travis_tag = os.environ.get("TRAVIS_TAG", "").strip()

--- a/tools/pip/setup.py
+++ b/tools/pip/setup.py
@@ -45,7 +45,7 @@ LIB_PATH = libinfo['find_lib_path']()
 __version__ = libinfo['__version__']
 
 # set by the CD pipeline
-is_release = (os.environ.get("RELEASE_BUILD", "false").strip().lower() != "false")
+is_release = (os.environ.get("RELEASE_BUILD", "false").strip().lower() == "true")
 
 # set by the travis build pipeline
 travis_tag = os.environ.get("TRAVIS_TAG", "").strip()

--- a/tools/pip/setup.py
+++ b/tools/pip/setup.py
@@ -45,7 +45,7 @@ LIB_PATH = libinfo['find_lib_path']()
 __version__ = libinfo['__version__']
 
 # set by the CD pipeline
-is_release = os.environ.get("IS_RELEASE", "").strip()
+is_release = os.environ.get("RELEASE_BUILD", "").strip()
 
 # set by the travis build pipeline
 travis_tag = os.environ.get("TRAVIS_TAG", "").strip()


### PR DESCRIPTION
The CD uses "RELEASE_BUILD" variable for signifying an actual release (vs nightly.) Change the setup.py script to check for this variable, instead of "IS_RELEASE" which was not set anywhere.