### PR TITLE
[v1.9.x] Fix aarch64 cd pipeline

### DIFF
--- a/ci/build.py
+++ b/ci/build.py
@@ -61,7 +61,7 @@ def get_docker_compose_platforms(path: str = get_dockerfiles_path()):
     return platforms
 
 
-def get_platforms(path: str = get_dockerfiles_path(), arch='x86_64') -> List[str]:
+def get_platforms(path: str = get_dockerfiles_path(), arch=machine()) -> List[str]:
     """Get a list of platforms given our dockerfiles"""
     dockerfiles = glob.glob(os.path.join(path, "Dockerfile.*"))
     dockerfiles = set(filter(lambda x: x[-1] != '~', dockerfiles))
@@ -301,7 +301,7 @@ def container_run(platform: str,
     return 0
 
 
-def list_platforms(arch='x86_64') -> str:
+def list_platforms(arch=machine()) -> str:
     return "\nSupported platforms:\n{}".format('\n'.join(get_platforms(arch=arch)))
 
 

--- a/ci/build.py
+++ b/ci/build.py
@@ -47,7 +47,7 @@ from util import *
 DOCKER_COMPOSE_FILES = set(['docker/build.centos7'])
 
 # keywords to identify arm-based dockerfiles
-AARCH_FILE_KEYWORDS = ['armv', 'aarch64']
+AARCH_FILE_KEYWORDS = ['aarch64']
 
 def get_dockerfiles_path():
     return "docker"

--- a/ci/build.py
+++ b/ci/build.py
@@ -34,7 +34,7 @@ import re
 import shutil
 import signal
 import subprocess
-import platform
+from platform import machine
 from itertools import chain
 from subprocess import check_call, check_output
 from typing import *
@@ -359,7 +359,7 @@ def main() -> int:
 
     parser.add_argument("-A", "--architecture",
                         help="Architecture of images to build (x86_64 or aarch64). Default is current machine type.",
-                        default=platform.machine(),
+                        default=machine(),
                         dest='architecture')
 
     parser.add_argument("-b", "--build-only",

--- a/ci/build.py
+++ b/ci/build.py
@@ -34,6 +34,7 @@ import re
 import shutil
 import signal
 import subprocess
+import platform
 from itertools import chain
 from subprocess import check_call, check_output
 from typing import *
@@ -60,7 +61,7 @@ def get_docker_compose_platforms(path: str = get_dockerfiles_path()):
     return platforms
 
 
-def get_platforms(path: str = get_dockerfiles_path(), arch='x86') -> List[str]:
+def get_platforms(path: str = get_dockerfiles_path(), arch='x86_64') -> List[str]:
     """Get a list of platforms given our dockerfiles"""
     dockerfiles = glob.glob(os.path.join(path, "Dockerfile.*"))
     dockerfiles = set(filter(lambda x: x[-1] != '~', dockerfiles))
@@ -68,7 +69,7 @@ def get_platforms(path: str = get_dockerfiles_path(), arch='x86') -> List[str]:
     files = files - DOCKER_COMPOSE_FILES
     files.update(["build."+x for x in get_docker_compose_platforms()])
     arm_files = set(filter(lambda x: any(y in x for y in AARCH_FILE_KEYWORDS), files))
-    if arch == 'x86':
+    if arch == 'x86_64':
         files = files - arm_files
     elif arch == 'aarch64':
         files = arm_files
@@ -300,7 +301,7 @@ def container_run(platform: str,
     return 0
 
 
-def list_platforms(arch='x86') -> str:
+def list_platforms(arch='x86_64') -> str:
     return "\nSupported platforms:\n{}".format('\n'.join(get_platforms(arch=arch)))
 
 
@@ -357,8 +358,8 @@ def main() -> int:
                         type=str)
 
     parser.add_argument("-A", "--architecture",
-                        help="Architecture of images to build (x86 or aarch64). Default is x86.",
-                        default='x86',
+                        help="Architecture of images to build (x86_64 or aarch64). Default is current machine type.",
+                        default=platform.machine(),
                         dest='architecture')
 
     parser.add_argument("-b", "--build-only",

--- a/ci/docker/install/requirements_aarch64
+++ b/ci/docker/install/requirements_aarch64
@@ -30,3 +30,4 @@ astroid==2.3.3  # pylint and astroid need to be aligned
 requests<2.19.0,>=2.18.4
 setuptools
 coverage
+wheel

--- a/ci/docker_cache.py
+++ b/ci/docker_cache.py
@@ -30,7 +30,7 @@ import os
 import subprocess
 import re
 import sys
-import platform
+from platform import machine
 from typing import *
 
 import build as build_util
@@ -226,7 +226,7 @@ def main() -> int:
 
     args = parser.parse_args()
 
-    platforms = build_util.get_platforms(arch=platform.machine())
+    platforms = build_util.get_platforms(arch=machine())
 
     if "dkr.ecr" in args.docker_registry:
         _ecr_login(args.docker_registry)

--- a/ci/docker_cache.py
+++ b/ci/docker_cache.py
@@ -30,6 +30,7 @@ import os
 import subprocess
 import re
 import sys
+import platform
 from typing import *
 
 import build as build_util
@@ -225,7 +226,7 @@ def main() -> int:
 
     args = parser.parse_args()
 
-    platforms = build_util.get_platforms()
+    platforms = build_util.get_platforms(arch=platform.machine())
 
     if "dkr.ecr" in args.docker_registry:
         _ecr_login(args.docker_registry)


### PR DESCRIPTION
We need to install the `wheel` package for the command `python3 setup.py bdist_wheel` to work in the aarch64 CD build pipeline.

Also extend the docker cache pipeline to work by default with current machine architecture.