### PR TITLE
[BUGFIX]Fix the regular expression in RTC code

### DIFF
--- a/python/mxnet/rtc.py
+++ b/python/mxnet/rtc.py
@@ -141,21 +141,22 @@ class CudaModule(object):
         is_ndarray = []
         is_const = []
         dtypes = []
-        pattern = re.compile(r"""^\s*(const)?\s*([\w_]+)\s*(\*)?\s*([\w_]+)?\s*$""")
+        pattern = re.compile(r"""^(const)?\s?([\w_]+)\s?(\*)?\s?([\w_]+)?$""")
         args = re.sub(r"\s+", " ", signature).split(",")
         for arg in args:
-            match = pattern.match(arg)
+            sanitized_arg = " ".join(arg.split())
+            match = pattern.match(sanitized_arg)
             if not match or match.groups()[1] == 'const':
                 raise ValueError(
                     'Invalid function prototype "%s". Must be in the '
-                    'form of "(const) type (*) (name)"'%arg)
+                    'form of "(const) type (*) (name)"'%sanitized_arg)
             is_const.append(bool(match.groups()[0]))
             dtype = match.groups()[1]
             is_ndarray.append(bool(match.groups()[2]))
             if dtype not in _DTYPE_CPP_TO_NP:
                 raise TypeError(
                     "Unsupported kernel argument type %s. Supported types are: %s."%(
-                        arg, ','.join(_DTYPE_CPP_TO_NP.keys())))
+                        sanitized_arg, ','.join(_DTYPE_CPP_TO_NP.keys())))
             dtypes.append(_DTYPE_NP_TO_MX[_DTYPE_CPP_TO_NP[dtype]])
 
         check_call(_LIB.MXRtcCudaKernelCreate(


### PR DESCRIPTION
## Description ##
This PR makes the regular expression in the legacy RTC code path more efficient.

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [x] Instead of checking for arbitrary number of whitespace character in the regular expression, I strip the input so that only a single whitespace is left between matched groups and modify the regular expression accordingly.

FYI @josephevans @szha @TristonC
