### PR TITLE
[FEAUTURE] Fuses FC + elemwise_add operators  for oneDNN

### DIFF
--- a/src/operator/nn/dnnl/dnnl_fully_connected-inl.h
+++ b/src/operator/nn/dnnl/dnnl_fully_connected-inl.h
@@ -28,6 +28,8 @@
 
 #if MXNET_USE_ONEDNN == 1
 
+#include <memory>
+#include <unordered_map>
 #include <string>
 #include <vector>
 
@@ -41,6 +43,8 @@ struct DNNLFCParam : public dmlc::Parameter<DNNLFCParam> {
   bool quantized;
   bool enable_float_output;
   bool with_eltwise;
+  bool with_sum;
+  bool first_quantization_pass;  // True for operator created during first quantization pass
   dmlc::optional<float> min_calib_range;  // min float value calculated from calibration dataset
   dmlc::optional<float> max_calib_range;  // max float value calculated from calibration dataset
   dmlc::optional<bool> channel_wise_quantize;
@@ -54,6 +58,10 @@ struct DNNLFCParam : public dmlc::Parameter<DNNLFCParam> {
     DMLC_DECLARE_FIELD(with_eltwise)
         .set_default(false)
         .describe("Whether there's a post with_eltwise after FullyConnected operator");
+    DMLC_DECLARE_FIELD(with_sum).set_default(false).describe("Add post sum");
+    DMLC_DECLARE_FIELD(first_quantization_pass)
+        .set_default(false)
+        .describe("True for first quantization pass");
     DMLC_DECLARE_FIELD(min_calib_range)
         .set_default(dmlc::optional<float>())
         .describe(
@@ -76,7 +84,84 @@ struct DNNLFCFullParam {
   FullyConnectedParam default_param;
   DNNLFCParam dnnl_param;
   DNNLPostEltwiseParam eltwise_param;
+  float sum_scale                  = {1.0f};
   std::vector<float> output_scales = {0.0f};
+};
+
+static inline size_t GetInSumIndex(const DNNLFCFullParam& param) {
+  assert(param.dnnl_param.with_sum);
+  return fullc::kWeight + 1 + (param.default_param.no_bias ? 0 : 1);
+}
+
+class FCInputIndex {
+ public:
+  explicit FCInputIndex(const DNNLFCFullParam full_param) {
+    auto& dnnl_param     = full_param.dnnl_param;
+    const bool has_bias  = !full_param.default_param.no_bias;
+    const bool quantized = dnnl_param.quantized;
+    const bool sum_input_quantized =
+        quantized && dnnl_param.with_sum && !dnnl_param.enable_float_output;
+    const bool channel_wise = quantized && dnnl_param.channel_wise_quantize.has_value() &&
+                              dnnl_param.channel_wise_quantize.value();
+
+    // Calculate position of particular input in the input vector:
+    int index = 0;
+    data      = index++;
+    weight    = index++;
+    bias      = has_bias ? index++ : 0;
+    sum       = dnnl_param.with_sum ? index++ : 0;
+    num_base  = index;  // note number of base inputs
+
+    data_min   = quantized ? index++ : 0;
+    data_max   = quantized ? index++ : 0;
+    weight_min = (quantized && !channel_wise) ? index++ : 0;
+    weight_max = (quantized && !channel_wise) ? index++ : 0;
+    bias_min   = (quantized && !channel_wise && has_bias) ? index++ : 0;
+    bias_max   = (quantized && !channel_wise && has_bias) ? index++ : 0;
+    sum_min    = sum_input_quantized ? index++ : 0;
+    sum_max    = sum_input_quantized ? index++ : 0;
+    num_total  = index;  // note number of total inputs
+  }
+
+  // Returns true if sum input exists
+  bool IsSumExist() const {
+    return sum;
+  }
+
+  // Returns true if bias input exists
+  bool IsBiasExist() const {
+    return bias;
+  }
+
+  // Returns true if sum input exists and it is float number
+  bool IsSumInputFloat() const {
+    return (sum && !sum_min);
+  }
+  int GetTotal() const {
+    return num_total;
+  }
+  int GetBase() const {
+    return num_base;
+  }
+
+  // Represent index of particular input in the input vector:
+  int data;
+  int weight;
+  int bias;
+  int sum;
+  int data_min;
+  int data_max;
+  int weight_min;
+  int weight_max;
+  int bias_min;
+  int bias_max;
+  int sum_min;
+  int sum_max;
+
+ private:
+  int num_base;   // Number of standard inputs
+  int num_total;  // Number of total inputs: standard + additional needed for
+                  // quantization
 };
 
 dnnl::inner_product_forward::primitive_desc GetFCFwdImpl(const DNNLFCFullParam& full_param,

--- a/src/operator/nn/dnnl/dnnl_fully_connected.cc
+++ b/src/operator/nn/dnnl/dnnl_fully_connected.cc
@@ -53,6 +53,9 @@ dnnl::inner_product_forward::primitive_desc GetFCFwdImpl(const DNNLFCFullParam& 
                        full_param.eltwise_param.alpha,
                        full_param.eltwise_param.beta);
   }
+  if (full_param.dnnl_param.with_sum) {
+    ops.append_sum(full_param.sum_scale);
+  }
   attr.set_post_ops(ops);
 
   if (full_param.dnnl_param.quantized && full_param.output_scales.size()) {

--- a/src/operator/subgraph/build_subgraph.cc
+++ b/src/operator/subgraph/build_subgraph.cc
@@ -749,6 +749,17 @@ void CreateSubgraphNode(nnvm::Graph* g,
         for (BiDirectedNode* dest_node : subgraph_nodes) {
           sn->outputs.erase(dest_node->node);
         }
+      }
+    }
+
+    // Set outputs according to current inputs
+    for (size_t i = 0; i < n->inputs.size(); ++i) {
+      auto& e = n->inputs[i];
+      // update input entries' source simple nodes' outputs map
+      nnvm::Node* node = e.node.get();
+      if (indexed_graph.exist(node)) {
+        const auto nid     = indexed_graph.node_id(node);
+        BiDirectedNode* sn = simple_nodes[nid].get();
         sn->outputs[n.get()].push_back(i);
       }
     }

--- a/src/operator/subgraph/dnnl/dnnl_fc_property.h
+++ b/src/operator/subgraph/dnnl/dnnl_fc_property.h
@@ -193,6 +193,9 @@ class SgDNNLFCProperty : public SubgraphProperty {
       auto& sub_name = node->op()->name;
       if (sub_name == "FullyConnected") {
         node_name << "fully_connected_";
+        if (HasAttr("quantize") && GetAttr<bool>("quantize")) {
+          n->attrs.dict["first_quantization_pass"] = "True";
+        }
       } else if (SupportDNNLFCEltwiseFusion(sub_name)) {
         node_name << "eltwise_";
         n->attrs.dict["with_eltwise"] = "True";

--- a/src/operator/subgraph/dnnl/dnnl_fc_sum_fuse.h
+++ b/src/operator/subgraph/dnnl/dnnl_fc_sum_fuse.h
@@ -1,0 +1,293 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+  \file
+  \brief For fusing FullyConnected operator with element-wise add.
+
+  Element-wise add operator is replaced by DNNL FC "sum" post operator.
+  It adds FC results to existing values in output. For quantized integer version
+  this output is scaled to the proper range.
+*/
+
+#ifndef MXNET_OPERATOR_SUBGRAPH_DNNL_DNNL_FC_SUM_FUSE_H_
+#define MXNET_OPERATOR_SUBGRAPH_DNNL_DNNL_FC_SUM_FUSE_H_
+#if MXNET_USE_ONEDNN == 1
+
+#include <memory>
+#include <string>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "../../tensor/matrix_op-inl.h"
+#include "../common.h"
+#include "dnnl_fc-inl.h"
+#include "dnnl_subgraph_base-inl.h"
+
+namespace mxnet {
+namespace op {
+
+inline bool EndsWith(std::string const& value, std::string const& ending) {
+  if (ending.size() > value.size()) {
+    return false;
+  } else {
+    return std::equal(ending.rbegin(), ending.rend(), value.rbegin());
+  }
+}
+
+class SgDNNLFCSumFuseSelector : public SubgraphSelectorV2 {
+ private:
+  /*! \brief pattern match status */
+  enum SelectStatus {
+    kFail = 0,
+    kStart,
+    kSuccess,
+  };
+
+  bool quantized_;
+  SelectStatus status_ = kFail;
+  std::vector<const BiDirectedNode*> matched_list_;
+
+ public:
+  explicit SgDNNLFCSumFuseSelector(bool quantized) : quantized_(quantized) {}
+
+  bool Select(const BiDirectedNode& seed_node,
+              const std::shared_ptr<NodeAttr>& node_attr) override {
+    const auto n = seed_node.node;
+    if (n->op() == Op::Get("_sg_onednn_fully_connected") && SupportDNNLAttr(node_attr) &&
+        (seed_node.outputs.size() == 1)) {
+      auto const& fc_param = nnvm::get<DNNLFCFullParam>(n->attrs.parsed);
+      if ((!quantized_ && !fc_param.dnnl_param.first_quantization_pass) ||
+          fc_param.dnnl_param.quantized) {
+        // Start subgraph when fusing for floats (quantized_ is false for DNNL backend) or
+        // when FC is already quantized (second pass for DNNL_QUANTIZE).
+        status_ = kStart;
+        matched_list_.clear();
+        matched_list_.push_back(&seed_node);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  bool SelectInput(const BiDirectedNode& cur_node, const BiDirectedNode& input_node) override {
+    return false;
+  }
+
+  bool SelectOutput(const BiDirectedNode& cur_node, const BiDirectedNode& output_node) override {
+    const auto cur_n    = cur_node.node;
+    const auto output_n = output_node.node;
+    if (status_ == kFail || status_ == kSuccess || output_n->is_variable()) {
+      return false;
+    }
+    // If n isn't the last matched node, then we encoutered an internal
+    // branch, we should pop out the node behind n and stop fusion.
+    if (matched_list_.back() != &cur_node) {
+      if (std::find(matched_list_.begin(), matched_list_.end(), &cur_node) != matched_list_.end()) {
+        while (matched_list_.back() != &cur_node) {
+          matched_list_.pop_back();
+        }
+      }
+      status_ = kSuccess;
+      return false;
+    }
+
+    switch (status_) {
+      case kStart:
+        // Find _contrib_quantized_elemwise_add or elemwise_add
+        if (EndsWith(output_n->op()->name, "elemwise_add")) {
+          if (quantized_) {
+            auto const& fc_param = nnvm::get<DNNLFCFullParam>(cur_n->attrs.parsed);
+            if (!fc_param.dnnl_param.enable_float_output) {
+              // For quantized graph, when FC floating point output is not enabled
+              // elementwise add must also be quantized (min and max value have to be already stored
+              // in elementwise add).
+              CHECK_EQ(output_n->attrs.dict.count("min_calib_range"), 1);
+            }
+          }
+          matched_list_.push_back(&output_node);
+          status_ = kSuccess;
+          return true;
+        }
+      default:
+        status_ = kFail;
+        return false;
+    }
+  }
+
+  std::vector<BiDirectedNode*> Filter(const std::vector<BiDirectedNode*>& candidates) override {
+    if (status_ == kSuccess) {
+      return candidates;
+    } else {
+      return std::vector<BiDirectedNode*>(0);
+    }
+  }
+
+  void Reset() override {
+    CHECK_GE(matched_list_.size(), 1);
+    auto new_selector = SgDNNLFCSumFuseSelector(quantized_);
+    new_selector.Select(*matched_list_[0], nullptr);
+    *this = new_selector;
+  }
+};
+
+class SgDNNLFCSumFuseProperty : public SubgraphProperty {
+ public:
+  SgDNNLFCSumFuseProperty() {}
+
+  static SubgraphPropertyPtr Create() {
+    static const std::string& name = "DNNL fuse FullyConnected with sum";
+    auto property                  = std::make_shared<SgDNNLFCSumFuseProperty>();
+    property->SetAttr<std::string>("property_name", name);
+    property->SetAttr<bool>("inference_only", true);
+    if (dmlc::GetEnv("MXNET_DISABLE_DNNL_FC_SUM", 0)) {
+      property->SetAttr<bool>("disable", true);
+    }
+    return property;
+  }
+
+  nnvm::ObjectPtr CreateSubgraphNode(const nnvm::Symbol& sym,
+                                     const int subgraph_id = 0) const override {
+    nnvm::ObjectPtr fc_node     = nullptr;
+    nnvm::ObjectPtr ew_add_node = nullptr;
+
+    DFSVisit(sym.outputs, [&](const nnvm::ObjectPtr& node) {
+      if (node->is_variable()) {
+        return;
+      }
+      auto& sub_name = node->op()->name;
+      if (sub_name == "_sg_onednn_fully_connected") {
+        fc_node = node;
+      } else if (EndsWith(sub_name, "elemwise_add")) {
+        ew_add_node = node;
+      }
+    });
+
+    CHECK_NOTNULL(fc_node);
+    if (ew_add_node != nullptr) {
+      CHECK_NOTNULL(fc_node->attrs.subgraphs[0]);
+      auto fc_orginal = fc_node->attrs.subgraphs[0]->outputs[0].node;
+
+      if (fc_orginal->op() == Op::Get("FullyConnected")) {
+        nnvm::Symbol new_sym;
+        // Create a new elemwise_add node to not alter the original one.
+        // It is needed in subgraph to properly calculate InferShape.
+        nnvm::ObjectPtr n = nnvm::Node::Create();
+        n->attrs.op       = Op::Get("elemwise_add");
+        n->attrs.name     = ew_add_node->attrs.name;
+
+        if (ew_add_node->inputs[0].node == fc_node) {
+          n->inputs.emplace_back(fc_orginal);
+          n->inputs.emplace_back(ew_add_node->inputs[1]);
+        } else {
+          n->inputs.emplace_back(ew_add_node->inputs[0]);
+          n->inputs.emplace_back(fc_orginal);
+        }
+        new_sym.outputs.emplace_back(n);
+        fc_node->attrs.subgraphs.clear();
+        fc_node->attrs.subgraphs.emplace_back(std::make_shared<nnvm::Symbol>(new_sym));
+        fc_node->attrs.dict["with_sum"] = "True";
+        fc_node->attrs.dict.erase("first_quantization_pass");  // Removed as not needed any longer
+        fc_node->op()->attr_parser(&(fc_node->attrs));
+      }
+    }
+    return fc_node;
+  }
+
+  SubgraphSelectorV2Ptr CreateSubgraphSelectorV2() const override {
+    bool quantized = HasAttr("quantize") ? GetAttr<bool>("quantize") : false;
+    auto selector  = std::make_shared<SgDNNLFCSumFuseSelector>(quantized);
+    return selector;
+  }
+
+  void ConnectSubgraphOutputs(const nnvm::ObjectPtr n,
+                              std::vector<nnvm::NodeEntry*>* output_entries) const override {
+    // Connect all extern output entries to output[0]
+    for (size_t i = 0; i < output_entries->size(); ++i) {
+      auto entry_ptr = output_entries->at(i);
+      *entry_ptr     = nnvm::NodeEntry{n, entry_ptr->index, 0};
+    }
+  }
+
+  void ConnectSubgraphInputs(const nnvm::ObjectPtr n,
+                             std::vector<nnvm::NodeEntry*>* input_entries,
+                             std::vector<nnvm::NodeEntry>* orig_input_entries) const override {
+    auto sym             = n->attrs.subgraphs[0];
+    auto const& fc_param = nnvm::get<DNNLFCFullParam>(n->attrs.parsed);
+    std::unordered_set<const nnvm::Node*> node_sets;
+    DFSVisit(sym->outputs, [&](const nnvm::ObjectPtr& node) {
+      if (node->is_variable()) {
+        return;
+      }
+      node_sets.insert(node.get());
+      if (EndsWith(node->op()->name, "elemwise_add")) {
+        const size_t base_inputs = fc_param.default_param.no_bias ? 3 : 4;
+        // Make sure fc output is the left operand of the add operator, if not:
+        // - swap inputs of add operator
+        // - switch add operands sequence to ensure that
+        // the tensor (sum_tensor) to which FC output is added is the last input.
+        if (node_sets.count(node->inputs[1].node.get())) {
+          // Example of input_entries reordering for channel-wise quantized graph:
+          // sum_tensor.data    -->   fc.data
+          // fc.data            -->   fc.weight0
+          // fc.weight0         -->   fc.bias0
+          // fc.bias0           -->   sum_tensor.data
+          // fc_out.min         -->   fc_out.min
+          // fc_out.max         -->   fc_out.max
+          // sum_tensor.min     -->   sum_tensor.min
+          // sum_tensor.max     -->   sum_tensor.max
+          std::swap(node->inputs[0], node->inputs[1]);
+          std::rotate(input_entries->begin(),
+                      input_entries->begin() + 1,
+                      input_entries->begin() + base_inputs);
+          std::rotate(orig_input_entries->begin(),
+                      orig_input_entries->begin() + 1,
+                      orig_input_entries->begin() + base_inputs);
+        } else {
+          // Example of input_entries reordering for channel-wise quantized graph:
+          // fc.data            -->   fc.data
+          // fc.weight0         -->   fc.weight0
+          // fc.bias0           -->   fc.bias0
+          // fc_out.min         -->   sum_tensor.data
+          // fc_out.max         -->   fc_out.min
+          // sum_tensor.data    -->   fc_out.max
+          // sum_tensor.min     -->   sum_tensor.min
+          // sum_tensor.max     -->   sum_tensor.max
+          const int not_rotated_end =
+              (fc_param.dnnl_param.quantized && !fc_param.dnnl_param.enable_float_output) ? 2 : 0;
+
+          std::rotate(input_entries->begin() + base_inputs - 1,
+                      input_entries->end() - 1 - not_rotated_end,
+                      input_entries->end() - not_rotated_end);
+          std::rotate(orig_input_entries->begin() + base_inputs - 1,
+                      orig_input_entries->end() - 1 - not_rotated_end,
+                      orig_input_entries->end() - not_rotated_end);
+        }
+      }
+    });
+    n->inputs = *orig_input_entries;
+  }
+};
+
+}  // namespace op
+}  // namespace mxnet
+
+#endif  // if MXNET_USE_ONEDNN == 1
+#endif  // MXNET_OPERATOR_SUBGRAPH_DNNL_DNNL_FC_SUM_FUSE_H_

--- a/src/operator/subgraph/dnnl/dnnl_post_quantize_property.h
+++ b/src/operator/subgraph/dnnl/dnnl_post_quantize_property.h
@@ -44,6 +44,9 @@ const std::set<std::string> support_req_fusion_op = {"_contrib_quantized_elemwis
                                                      "_sg_onednn_selfatt_qk",
                                                      "_sg_onednn_selfatt_valatt",
                                                      "_sg_onednn_batch_dot"};
+
+const std::set<const Op*> no_enable_float_output = {Op::Get("_contrib_quantized_elemwise_add"),
+                                                    Op::Get("_sg_onednn_conv")};
 }  // namespace
 
 class SgDNNLPostQuantizeSelector : public SubgraphSelectorV2 {
@@ -109,7 +112,8 @@ class SgDNNLPostQuantizeSelector : public SubgraphSelectorV2 {
           if (param.min_calib_range.has_value() && param.max_calib_range.has_value()) {
             matched_list.emplace_back(&new_node);
             status = SelectStatus::kRequantize;
-            if (raw_node->op() == Op::Get("_sg_onednn_conv")) {
+            if ((raw_node->op() == Op::Get("_sg_onednn_conv")) ||
+                (raw_node->op() == Op::Get("_contrib_quantized_elemwise_add"))) {
               status = SelectStatus::kSuccess;
             }
             return true;
@@ -209,7 +213,7 @@ class SgDNNLPostQuantizeProperty : public SubgraphProperty {
 
     // When only fused quantized operator and requantize, set min/max_cablib_range,
     // When fused quantized operator + requantize + dequantize, set dequantize flag to true.
-    if (dequantize_node != nullptr) {
+    if ((dequantize_node != nullptr) && (no_enable_float_output.count(fuse_node->op()) == 0)) {
       fuse_node->attrs.dict["enable_float_output"] = "True";
     } else {
       fuse_node->attrs.dict["min_calib_range"] =

--- a/src/operator/subgraph/dnnl/dnnl_subgraph_property.cc
+++ b/src/operator/subgraph/dnnl/dnnl_subgraph_property.cc
@@ -28,6 +28,7 @@
 #include "dnnl_post_quantize_property.h"
 #include "dnnl_transformer_qk_property.h"
 #include "dnnl_transformer_valatt_property.h"
+#include "dnnl_fc_sum_fuse.h"
 
 namespace mxnet {
 namespace op {
@@ -43,6 +44,7 @@ MXNET_REGISTER_SUBGRAPH_PROPERTY(ONEDNN, SgDNNLBNReLUProperty);
 MXNET_REGISTER_SUBGRAPH_PROPERTY(ONEDNN, SgDNNLTransformerQKProperty);
 MXNET_REGISTER_SUBGRAPH_PROPERTY(ONEDNN, SgDNNLTransformerValAttProperty);
 MXNET_REGISTER_SUBGRAPH_PROPERTY(ONEDNN, SgDNNLBatchDotProperty);
+MXNET_REGISTER_SUBGRAPH_PROPERTY(ONEDNN, SgDNNLFCSumFuseProperty);
 
 MXNET_REGISTER_SUBGRAPH_BACKEND(ONEDNN_QUANTIZE).set_attr("context", Context::CPU());
 
@@ -55,6 +57,8 @@ MXNET_REGISTER_SUBGRAPH_PROPERTY(ONEDNN_QUANTIZE, SgDNNLBatchDotProperty)
     .set_attr("quantize", true);
 MXNET_REGISTER_SUBGRAPH_PROPERTY(ONEDNN_QUANTIZE, SgDNNLPostQuantizeProperty);
 MXNET_REGISTER_SUBGRAPH_PROPERTY(ONEDNN_QUANTIZE, SgDNNLPostQuantizeAlignScaleProperty);
+MXNET_REGISTER_SUBGRAPH_PROPERTY(ONEDNN_QUANTIZE, SgDNNLFCSumFuseProperty)
+    .set_attr("quantize", true);
 
 }  // namespace op
 }  // namespace mxnet

--- a/tests/python/dnnl/subgraphs/subgraph_common.py
+++ b/tests/python/dnnl/subgraphs/subgraph_common.py
@@ -111,8 +111,27 @@ def check_qsym_scale_align(qsym):
         assert max_calib_range == v['max_calib_range']
 
 
-def check_quantize(net_original, data_shape, out_type, name='conv',
-                   check_calibration=True, check_scale_align=False):
+def check_fusion_parameter(sym, attrs_dict):
+  for name, attrs in attrs_dict.items():
+    if name in config:
+      op_name = config[name][OP_NAME]
+    else:
+      op_name = name
+    assert ''.join(sym.get_internals().list_outputs()).find(op_name) != -1
+    if len(attrs):
+      found = False
+      for k, v in sym.attr_dict().items():
+        if k.find('_quantize') != -1:
+          continue
+        if k.find(op_name) != -1:
+          found = True
+          for attr_name, attr_value in attrs.items():
+            assert v[attr_name].lower() == attr_value.lower()
+      assert found
+
+def check_quantize(net_original, data_shapes, out_type, name='conv',
+                   check_calibration=True, check_scale_align=False, quantize_mode='full',
+                   attrs_dict={}):
   quantize_granularity_list = ['tensor-wise']
   if name == 'fc':
     quantize_granularity_list += ['channel-wise']
@@ -122,92 +141,108 @@ def check_quantize(net_original, data_shape, out_type, name='conv',
 
   net_original.initialize(init=mx.init.Normal(0.5), force_reinit=True)
   min_value = -1 if out_type != 'uint8' else 0
-  data = mx.np.random.uniform(min_value, 1.0, size=data_shape, dtype='float32', ctx=mx.current_device())
+  one_shape = isinstance(data_shapes, tuple)
+  if one_shape:
+    # replace one shape with list of shapes with one element inside to follow later the same schema
+    data_shapes=[data_shapes]
+  data = []
+  for shape in data_shapes:
+    data.append(mx.np.random.uniform(min_value, 1.0, size=shape, dtype='float32', device=mx.cpu()))
 
-  outputs = net_original(data)
+  outputs = net_original(*data)
   for output in outputs:
       output.wait_to_read()
   ref_out = outputs
 
-  calib_data = mx.gluon.data.DataLoader(data, batch_size=1)
+  dataArray= mx.gluon.data.ArrayDataset(*data)
+
+  calib_data = mx.gluon.data.DataLoader(dataArray, batch_size=1)
   for quantize_granularity in quantize_granularity_list:
     qnet = quantization.quantize_net(net_original,
-                                     ctx=mx.current_device(),
+                                     device=mx.cpu(),
                                      exclude_layers=None,
                                      exclude_operators=None,
                                      quantized_dtype=out_type,
                                      calib_mode='naive',
                                      calib_data=calib_data,
                                      num_calib_batches=1,
-                                     quantize_mode='full',
+                                     quantize_mode=quantize_mode,
                                      quantize_granularity=quantize_granularity)
     qsym, _ = qnet.export(None)
+    check_fusion_parameter(qsym, attrs_dict)
     if check_calibration:
       check_qsym_calibrated(qsym, out_type, name=name)
     if check_scale_align:
       check_qsym_scale_align(qsym)
 
-    quantized_out = qnet(data)
+    quantized_out = qnet(*data)
     for i in range(len(ref_out)):
       min_range = mx.np.min(ref_out[i]).item()
       max_range = mx.np.max(ref_out[i]).item()
       atol = 0.1 * max(abs(min_range), abs(max_range))
-      assert_almost_equal_with_err(quantized_out.asnumpy(), ref_out.asnumpy(), rtol=0.1, atol=atol, etol=0.2)
+      assert_almost_equal_with_err(quantized_out.asnumpy(), ref_out.asnumpy(),
+                                   rtol=0.1, atol=atol, etol=0.2)
 
 
-def check_fusion(net_original, data_shape, attrs_dict, check_fp32_fusion=True, check_quantization=True,
-                 out_types=['uint8', 'int8', 'auto'], dedup_subgraph=True):
+def check_fusion(net_original, data_shapes, attrs_dict, check_fp32_fusion=True,
+                 check_quantization=True, out_types=['uint8', 'int8', 'auto'], dedup_subgraph=True,
+                 quantize_mode='full'):
   net_original.initialize()
   net_original.hybridize(static_alloc=False, static_shape=False)
-  data = mx.np.random.uniform(size=data_shape, dtype='float32', ctx=mx.current_device())
-  net_original(data)
+  one_shape = isinstance(data_shapes, tuple)
+  data_min = -1.0
+  data_max = 1.0
+
+  if one_shape:
+    # replace one shape with list of shapes with one element to follow later the same schema
+    data_shapes=[data_shapes]
+  data = []
+  for shape in data_shapes:
+    data.append(mx.np.random.uniform(size=shape, dtype='float32', device=mx.cpu(),
+                low=data_min, high=data_max))
+  net_original(*data)
   net_fusion = copy.copy(net_original)
   sym, params = net_original.export(None)
 
   if check_fp32_fusion:
-    data_min = -1.0
-    data_max = 1.0
     if ''.join(sym.get_internals().list_outputs()).find('sqrt') != -1:
       check_quantization = False
       data_min = 0
 
     sym_sg = sym.optimize_for(SG_PASS_NAME, dedup_subgraph=dedup_subgraph, skip_infer=True)
-    for name, attrs in attrs_dict.items():
-      if name in config:
-        op_name = config[name][OP_NAME]
-      else:
-        op_name = name
-      assert ''.join(sym_sg.get_internals().list_outputs()).find(op_name) != -1
-      if len(attrs):
-          found = False
-          for k, v in sym_sg.attr_dict().items():
-            if k.find(op_name) != -1:
-              found = True
-              for attr_name, attr_value in attrs.items():
-                assert v[attr_name].lower() == attr_value.lower()
-          assert found
+    check_fusion_parameter(sym_sg, attrs_dict)
+    if data_min == 0 and mx.npx.is_np_default_dtype():
+      # regenerate inputs if they have different range or data type
+      data = []
+      for shape in data_shapes:
+        data.append(mx.np.random.uniform(size=shape, device=mx.cpu(), low=data_min, high=data_max))
+    out_unfused = net_original(*data)
 
-    data = mx.np.random.uniform(size=data_shape, low=data_min, high=data_max)
-    out_unfused = net_original(data)
-
-    net_fusion.optimize_for(data, backend=SG_PASS_NAME)
-    out_fused = net_fusion(data)
+    net_fusion.optimize_for(*data, backend=SG_PASS_NAME)
+    out_fused = net_fusion(*data)
 
     assert_almost_equal(out_unfused.asnumpy(), out_fused.asnumpy(), rtol=1e-3, atol=1e-1)
 
   if check_quantization:
     # fp32 to int8
     for out_type in out_types:
-      check_quantize(net_original, data_shape, out_type, name=name)
+      check_quantize(net_original, data_shapes, out_type, name=list(attrs_dict.keys())[0],
+                     quantize_mode=quantize_mode, attrs_dict=attrs_dict)
 
 def check_neg_fusion(net_original, attrs_name=None, excluded_attrs=None,
-                     data_shapes=(4,4,10,10), name='conv'):
+                     data_shapes=[(4,4,10,10)], name='conv'):
   op_name = config[name][OP_NAME]
+  one_shape = isinstance(data_shapes, tuple)
+  if one_shape:
+    # replace one shape with list of shapes with one element to follow later the same schema
+    data_shapes = [data_shapes]
+  data = []
+  for shape in data_shapes:
+    data.append(mx.np.random.uniform(size=shape))
 
-  data_nd = mx.np.random.uniform(size=data_shapes)
   net_original.initialize()
   net_original.hybridize()
-  net_original(data_nd)
+  net_original(*data)
 
   sym, _ = net_original.export(None)
   sym_sg = sym.optimize_for(SG_PASS_NAME, dedup_subgraph=True, skip_infer=True)
@@ -218,4 +253,41 @@ def check_neg_fusion(net_original, attrs_name=None, excluded_attrs=None,
       for attr in attrs_name:
         assert v[attr] == 'true'
       for exc_attr in excluded_attrs:
-        assert exc_attr not in v.keys()
+        assert exc_attr not in v.keys(), exc_attr + " atribute shouldn't exist"
+
+
+
+def check_neg_fusion_quantized(net_original, attrs_name=None, excluded_attrs=None,
+                     data_shapes=[(4,4,10,10)], name='conv'):
+  op_name = config[name][OP_NAME]
+  net_original.initialize(init=mx.init.Normal(0.5), force_reinit=True)
+  one_shape = isinstance(data_shapes, tuple)
+  if one_shape:
+    # replace one shape with list of shapes with one element inside to follow later the same schema
+    data_shapes=[data_shapes]
+  data = []
+  for shape in data_shapes:
+    data.append(mx.np.random.uniform(size=shape, dtype='float32', device=mx.cpu()))
+
+  dataArray= mx.gluon.data.ArrayDataset(*data)
+  calib_data = mx.gluon.data.DataLoader(dataArray, batch_size=1)
+
+  qnet = quantization.quantize_net(net_original,
+                                    device=mx.cpu(),
+                                    exclude_layers=None,
+                                    exclude_operators=None,
+                                    quantized_dtype='int8',
+                                    calib_mode='naive',
+                                    calib_data=calib_data,
+                                    num_calib_batches=1,
+                                    quantize_mode='full',
+                                    quantize_granularity='tensor-wise')
+  qsym, _ = qnet.export(None)
+  attrs_dict = qsym.attr_dict()
+  for k, v in attrs_dict.items():
+    if k.find(op_name) != -1:
+      for attr in attrs_name:
+        assert v[attr] == 'true'
+      for exc_attr in excluded_attrs:
+        assert exc_attr not in v.keys(), exc_attr + " atribute shouldn't exist"
+

--- a/tests/python/dnnl/subgraphs/test_conv_subgraph.py
+++ b/tests/python/dnnl/subgraphs/test_conv_subgraph.py
@@ -91,7 +91,7 @@ def test_pos_conv_add(use_bias, data_shape):
     
   attr = {'conv': {'with_sum': 'true'}}
   net = ConvAdd(use_bias=use_bias)
-  check_fusion(net, data_shape, attr)
+  check_fusion(net, data_shape, attr, check_quantization=False)
 
 
 @mx.util.use_np
@@ -112,14 +112,14 @@ def test_pos_conv_add2(no_bias, data_shape):
 
   attr = {'conv': {'with_sum': 'true'}}
   net = ConvAdd(use_bias=True)
-  check_fusion(net, data_shape, attr)
+  check_fusion(net, data_shape, attr, check_quantization=False)
 
 
 @mx.util.use_np
 @pytest.mark.parametrize('data_shape', DATA_SHAPE)
 @pytest.mark.parametrize('alg,quantize', [
     ("relu", False), #TODO(bgawrych): investigate
-    ("sigmoid", True),
+    ("sigmoid", False),
     ("log_sigmoid", False),
     ("mish", False),
     ("tanh", False), #TODO(bgawrych): investigate
@@ -162,11 +162,11 @@ def test_pos_conv_act_add(data_shape, alg, quantize, use_bias):
 @pytest.mark.parametrize('data_shape', DATA_SHAPE)
 @pytest.mark.parametrize('alg,quantize', [
     ("relu", True),
-    ("sigmoid", True),
-    ("log_sigmoid", True),
-    ("mish", True),
-    ("tanh", True),
-    ("softrelu", True),
+    ("sigmoid", False),
+    ("log_sigmoid", False),
+    ("mish", False),
+    ("tanh", False),
+    ("softrelu", False),
     ("relu6", True),
     ("leakyrelu", True),
     ("gelu", True)
@@ -200,14 +200,14 @@ def test_pos_conv_bn_act(use_bias, data_shape, alg, quantize):
 @mx.util.use_np
 @pytest.mark.parametrize('data_shape', DATA_SHAPE)
 @pytest.mark.parametrize('alg,quantize', [
-    ("relu", True),
-    ("sigmoid", True),
-    ("log_sigmoid", True),
-    ("mish", True),
-    ("tanh", True),
+    ("relu", False),
+    ("sigmoid", False),
+    ("log_sigmoid", False),
+    ("mish", False),
+    ("tanh", False),
     #("softrelu", True), #TODO(bgawrych): failing fusion check - difference in random single element
-    ("relu6", True),
-    ("leakyrelu", True),
+    ("relu6", False),
+    ("leakyrelu", False),
     ("gelu", False) #TODO: for True we get assert instead of not fusing pattern
 ])
 @pytest.mark.parametrize('use_bias', [True, False])
@@ -321,11 +321,11 @@ def test_pos_concat_scale_align(data_shape, out_type):
 @pytest.mark.parametrize('data_shape', DATA_SHAPE)
 @pytest.mark.parametrize('alg,quantize', [
     ("relu", True),
-    ("sigmoid", True),
-    ("log_sigmoid", True),
-    ("mish", True),
-    ("tanh", True),
-    ("softrelu", True),
+    ("sigmoid", False),
+    ("log_sigmoid", False),
+    ("mish", False),
+    ("tanh", False),
+    ("softrelu", False),
     ("relu6", True),
     ("leakyrelu", True),
     ("gelu", True)

--- a/tests/python/dnnl/subgraphs/test_fc_subgraph.py
+++ b/tests/python/dnnl/subgraphs/test_fc_subgraph.py
@@ -89,9 +89,11 @@ def test_fc_eltwise(data_shape, use_bias, flatten, alg):
         out = mx.np.clip(fc_out, 0, 1.0)
       return out
 
+  not_quant_fuze = ['sigmoid', 'log_sigmoid', 'softrelu', 'tanh', 'mish', 'square', 'square_root',
+                    'exp']
   attrs = {'fc': {'with_eltwise': 'true'}}
   net = FCEltwise(use_bias, flatten, alg)
-  check_fusion(net, data_shape, attrs, check_quantization=flatten)
+  check_fusion(net, data_shape, attrs, check_quantization=flatten and not alg in not_quant_fuze)
 
 
 @mx.util.use_np


### PR DESCRIPTION
## Description ##
This change fuses FullyConnected operator with elemwise_add after it if possible. It is done for both float and quantized path.

The change well optimize calculation on quantized graph with full quantization mode. Below are the measured results of the following command:
benchmark/python/dnnl/run.sh  benchmark/python/dnnl/fc_add.py
run before and after this PR. Measurements are done on AWS EC2 instance c6i.16xlarge (Xeon(R) Platinum 8375C CPU).

elemwise_add, float  

|    Shape    | Hidden | Before [ms] | After [ms] | Improvement |
|------------:|-------:|------------:|------------:|-----------:|
| (   1, 224) |    512 |     0.165 |     0.151 |   8%  |
| (   1, 224) |   4096 |     0.169 |     0.150 |  11%  |
| (  16,1024) |   1024 |     0.274 |     0.245 |  11%  |
| (  32,4096) |   1024 |     0.634 |     0.611 |   4%  |
| (  32,4096) |   4096 |     2.352 |     2.299 |   2%  |
| ( 512, 512) |   4096 |     1.517 |     1.414 |   7%  |


elemwise_add, mode = smart, granularity = tensor-wise  

|    Shape    | Hidden | Before [ms] | After [ms] | Improvement |
|------------:|-------:|------------:|------------:|-----------:|
| (   1, 224) |    512 |     0.182 |     0.173 |    5%  |
| (   1, 224) |   4096 |     0.184 |     0.169 |    8%  |
| (  16,1024) |   1024 |     0.246 |     0.235 |    4%  |
| (  32,4096) |   1024 |     0.328 |     0.317 |    3%  |
| (  32,4096) |   4096 |     0.573 |     0.571 |    0%  |
| ( 512, 512) |   4096 |     0.819 |     0.730 |   11%  |


elemwise_add, mode = smart, granularity = channel-wise  

|    Shape    | Hidden | Before [ms] | After [ms] | Improvement |
|------------:|-------:|------------:|------------:|-----------:|
| (   1, 224) |    512 |     0.164 |     0.138 |    16%  |
| (   1, 224) |   4096 |     0.152 |     0.143 |     6%  |
| (  16,1024) |   1024 |     0.213 |     0.199 |     7%  |
| (  32,4096) |   1024 |     0.300 |     0.285 |     5%  |
| (  32,4096) |   4096 |     0.545 |     0.542 |     1%  |
| ( 512, 512) |   4096 |     0.778 |     0.689 |    11%  |


elemwise_add, mode = full, granularity = tensor-wise  

|    Shape    | Hidden | Before* [ms] | After [ms] | Improvement |
|------------:|-------:|------------:|------------:|-----------:|
| (   1, 224) |    512 |     0.169 |     0.154 |     9%  |
| (   1, 224) |   4096 |     0.208 |     0.158 |    24%  |
| (  16,1024) |   1024 |     0.270 |     0.212 |    21%  |
| (  32,4096) |   1024 |     0.359 |     0.293 |    18%  |
| (  32,4096) |   4096 |     0.602 |     0.542 |    10%  |
| ( 512, 512) |   4096 |     0.873 |     0.652 |    25%  |


elemwise_add, mode = full, granularity = channel-wise  

|    Shape    | Hidden | Before* [ms] | After [ms] | Improvement |
|------------:|-------:|------------:|------------:|-----------:|
| (   1, 224) |    512 |     0.135 |     0.125 |    7%  |
| (   1, 224) |   4096 |     0.178 |     0.130 |   27%  |
| (  16,1024) |   1024 |     0.239 |     0.180 |   25%  |
| (  32,4096) |   1024 |     0.327 |     0.262 |   20%  |
| (  32,4096) |   4096 |     0.575 |     0.512 |   11%  |
| ( 512, 512) |   4096 |     0.852 |     0.625 |   27%  |

\* - before this PR fuzing FC with add in full quantize mode is broken, so results are taken from the first commit (https://github.com/apache/incubator-mxnet/pull/20821/commits/0c38ca7268a54664d8871890138cd021f49c4b55) of this PR which fix the issue

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

