### PR TITLE
[DOC] Change of confusing Large Tensors documentation

### DIFF
--- a/config/linux.cmake
+++ b/config/linux.cmake
@@ -114,7 +114,7 @@ SET(EXTRA_OPERATORS "" CACHE PATH "EXTRA OPERATORS PATH")
 # Create C++ interface package
 set(USE_CPP_PACKAGE OFF CACHE BOOL "Build C++ Package")
 
-# Use int64_t type to represent the number of elements in a tensor
+# Use int64_t type to represent index and the number of elements in a tensor
 # This will cause performance degradation reported in issue #14496
 # Set to 1 for large tensor with tensor size greater than INT32_MAX i.e. 2147483647
 set(USE_INT64_TENSOR_SIZE ON CACHE BOOL "Use int64_t to represent the number of elements in a tensor")

--- a/config/linux.cmake
+++ b/config/linux.cmake
@@ -114,11 +114,10 @@ SET(EXTRA_OPERATORS "" CACHE PATH "EXTRA OPERATORS PATH")
 # Create C++ interface package
 set(USE_CPP_PACKAGE OFF CACHE BOOL "Build C++ Package")
 
-# Use int64_t type to represent the total number of elements in a tensor
+# Use int64_t type to represent the number of elements in a tensor
 # This will cause performance degradation reported in issue #14496
 # Set to 1 for large tensor with tensor size greater than INT32_MAX i.e. 2147483647
-# Note: the size of each dimension is still bounded by INT32_MAX
-set(USE_INT64_TENSOR_SIZE ON CACHE BOOL "Use int64_t to represent the total number of elements in a tensor")
+set(USE_INT64_TENSOR_SIZE ON CACHE BOOL "Use int64_t to represent the number of elements in a tensor")
 
 # Other GPU features
 set(USE_NCCL "Use NVidia NCCL with CUDA" OFF)


### PR DESCRIPTION
## Description ##
This PR makes a small changes in description of the behaviour of Large Tensors support. 
The description was misleading as currently individual tensor dimension can be greater than INT32_MAX.
This change is connected with https://github.com/apache/incubator-mxnet/issues/20807 issue
