### PR TITLE
[submodule] Upgrade oneDNN to v2.5.2

### DIFF
--- a/tools/dependencies/README.md
+++ b/tools/dependencies/README.md
@@ -57,7 +57,7 @@ The dependencies could be categorized by several groups: BLAS libraries, CPU-bas
 | Dependencies  | MXNet Version |
 | :------------: |:-------------:| 
 |OpenBLAS| 0.3.9 |
-|oneDNN| 2.5.1 |
+|oneDNN| 2.5.2 |
 |CUDA| 10.1 |
 |cuDNN| 7.5.1 |
 |NCCL| 2.4.2 |


### PR DESCRIPTION
## Description ##
This change upgrades oneDNN used on master branch to v2.5.2.

## Checklist ##

### Changes ###
- [x] Change oneDNN tag to v2.5.2
