### PR TITLE
[Feature] Add bfloat to oneDNN version of binary broadcast operators.

### DIFF
--- a/src/operator/nn/dnnl/dnnl_binary.cc
+++ b/src/operator/nn/dnnl/dnnl_binary.cc
@@ -69,7 +69,7 @@ bool SupportDNNLBinary(const std::vector<NDArray>& inputs) {
   auto ndim_1 = inputs[1].shape().ndim();
   return ndim_0 >= 1 && ndim_0 <= 6 && ndim_1 >= 1 && ndim_1 <= 6 &&
          inputs[0].shape().Size() != 0 && inputs[1].shape().Size() != 0 &&
-         dtype == mshadow::kFloat32 && dtype == inputs[1].dtype();
+         (dtype == mshadow::kFloat32 || dtype == mshadow::kBfloat16) && dtype == inputs[1].dtype();
 }
 
 }  // namespace op

--- a/tests/python/dnnl/test_bf16_operator.py
+++ b/tests/python/dnnl/test_bf16_operator.py
@@ -60,8 +60,7 @@ def check_operator_accuracy(sym_fp32, sym_bf16, data_shape, num_input_data=1, bf
     data_range = (0.0, 10.0)
     data_list_fp32 = list()
     data_list_bf16 = list()
-    for i, obj in enumerate(data_shape):
-        shape = data_shape[obj]
+    for i, (_, shape) in enumerate(data_shape.items()):
         data_list_fp32.append(mx.nd.random.uniform(low=data_range[0], high=data_range[1], shape=shape))
         data_list_bf16.append(mx.nd.amp_cast(data_list_fp32[i], dtype=bfloat16))
 


### PR DESCRIPTION
## Description ##
Binary broadcast operators such as broadcast_add are supported by oneDNN but not when inputs are of type bFloat16. Goal was to add those cases.

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented