### PR TITLE
Make convolution operator fully work with oneDNN v2.4+

### DIFF
--- a/src/operator/nn/dnnl/dnnl_convolution.cc
+++ b/src/operator/nn/dnnl/dnnl_convolution.cc
@@ -124,7 +124,7 @@ std::shared_ptr<dnnl::convolution_forward::primitive_desc> GetConvFwdImpl(
               // With the upgrade of oneDNN to version 2.4+
               // tests/python/dnnl/subgraphs/test_conv_subgraph.py::test_pos_conv_add[True-data_shape1]
               // started failing. Switching away from primitive with weight dnnl::format_tag
-              // ABcd4b16a4b is in place to temporairly fix the issue until full fix arrives.
+              // ABcd4b16a4b in order to temporarily fix the issue until full fix arrives.
               // Tracking issue: https://github.com/apache/incubator-mxnet/issues/20826.
               (param.dnnl_param.quantized && conv_pd->weights_desc().dims()[1] < 4 &&
                conv_pd->weights_desc().data.padded_dims[1] == 16)) {

--- a/tests/python/dnnl/subgraphs/subgraph_common.py
+++ b/tests/python/dnnl/subgraphs/subgraph_common.py
@@ -42,10 +42,7 @@ config =  {
   }
 }
 
-DATA_SHAPE=[(64, 4, 10, 10), (4, 4, 24, 24), (1, 16, 32, 32)]
-# Second shape has been temporairly changed from (4, 3, 24, 24) to (4, 4, 24, 24) due to
-# a bug regarding conv+sum fuse with the amount of input channels < 4. It will be reverted
-# as soon as the problem is fixed. Issue: https://github.com/apache/incubator-mxnet/issues/20826.
+DATA_SHAPE=[(64, 4, 10, 10), (4, 3, 24, 24), (1, 16, 32, 32)]
 
 # Helpers
 class RELU6(nn.HybridBlock):


### PR DESCRIPTION
## Description ##
With the upgrade of oneDNN to version 2.4+ tests/python/dnnl/subgraphs/test_conv_subgraph.py::test_pos_conv_add[True-data_shape1] started failing. During investigation of the problem it turned out that it regards only cases with amount of input channels lower than 4 and switching away from primitive with weight dnnl::format_tag ABcd4b16a4b fixes the issue. This change implements the switch in MXNet and restores the original shape in the failing test (adjusted here: https://github.com/apache/incubator-mxnet/pull/20662).

This is only temporary solution until the full fix arrives.

Problem tracking issue: https://github.com/apache/incubator-mxnet/issues/20826.

## Checklist ##
### Changes ###
- [x] Implement switching away from problematic primitive description
- [x] Restore original shape in failing test

