### PR TITLE
[BUGFIX] Remove compilation warning

### DIFF
--- a/src/operator/quantization/mkldnn/mkldnn_quantized_elemwise_add.cc
+++ b/src/operator/quantization/mkldnn/mkldnn_quantized_elemwise_add.cc
@@ -125,6 +125,7 @@ static void MKLDNNQuantizedElemwiseAddForward(const nnvm::NodeAttrs& attrs,
   mkldnn::memory* rescaled_mem;
 
   // output default set as int32
+  // The impact of rounding in line below is negligible.
   float output_data_range = static_cast<float>(kInt32Range);
   auto output_data_type   = mkldnn::memory::data_type::s32;
   // dataA && dataB are uint8
@@ -134,10 +135,6 @@ static void MKLDNNQuantizedElemwiseAddForward(const nnvm::NodeAttrs& attrs,
   } else if (out_data[quantized_elemwise_add_enum::kOut].dtype() == mshadow::kUint8) {
     output_data_range = kUint8Range;
     output_data_type  = mkldnn::memory::data_type::u8;
-  } else {
-    // The impact of rounding in line below is negligible.
-    output_data_range = static_cast<float>(kInt32Range);
-    output_data_type  = mkldnn::memory::data_type::s32;
   }
 
   float output_min     = 0;

--- a/src/operator/quantization/mkldnn/mkldnn_quantized_elemwise_add.cc
+++ b/src/operator/quantization/mkldnn/mkldnn_quantized_elemwise_add.cc
@@ -125,7 +125,7 @@ static void MKLDNNQuantizedElemwiseAddForward(const nnvm::NodeAttrs& attrs,
   mkldnn::memory* rescaled_mem;
 
   // output default set as int32
-  float output_data_range = kInt32Range;
+  float output_data_range = static_cast<float>(kInt32Range);
   auto output_data_type   = mkldnn::memory::data_type::s32;
   // dataA && dataB are uint8
   if (out_data[quantized_elemwise_add_enum::kOut].dtype() == mshadow::kInt8) {
@@ -135,7 +135,8 @@ static void MKLDNNQuantizedElemwiseAddForward(const nnvm::NodeAttrs& attrs,
     output_data_range = kUint8Range;
     output_data_type  = mkldnn::memory::data_type::u8;
   } else {
-    output_data_range = kInt32Range;
+    // The impact of rounding in line below is negligible.
+    output_data_range = static_cast<float>(kInt32Range);
     output_data_type  = mkldnn::memory::data_type::s32;
   }
 

--- a/src/operator/quantization/quantized_elemwise_mul.cc
+++ b/src/operator/quantization/quantized_elemwise_mul.cc
@@ -139,7 +139,8 @@ void QuantizedElemwiseMulOpForward(const nnvm::NodeAttrs &attrs,
   float out_data_scale = 1.f;
   float out_scale = 1.f;
   if (!params.enable_float_output) {
-    float output_data_range = kInt32Range;
+    // The impact of rounding in line below is negligible
+    float output_data_range = static_cast<float>(kInt32Range);
     // dataA && dataB are int8
     if (outputs[quantized_elemwise_mul::kOut].type_flag_ == mshadow::kInt8) {
       output_data_range = kInt8Range;

--- a/src/operator/quantization/quantized_elemwise_mul.cc
+++ b/src/operator/quantization/quantized_elemwise_mul.cc
@@ -144,8 +144,6 @@ void QuantizedElemwiseMulOpForward(const nnvm::NodeAttrs &attrs,
     // dataA && dataB are int8
     if (outputs[quantized_elemwise_mul::kOut].type_flag_ == mshadow::kInt8) {
       output_data_range = kInt8Range;
-    } else {
-      output_data_range = kInt32Range;
     }
     if (params.max_calib_range.has_value() && params.min_calib_range.has_value()) {
       cached_output_min_ = params.min_calib_range.value();


### PR DESCRIPTION
## Description ##
It gets rid of compiltation warning:
'float' changes value from 2147483647 to 2147483648
for -Wimplicit-const-int-float-conversion flag
It fixes https://github.com/apache/incubator-mxnet/issues/20833

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
