### PR TITLE
[DOC] Large tensors documentation update

### DIFF
--- a/docs/static_site/src/pages/api/faq/large_tensor_support.md
+++ b/docs/static_site/src/pages/api/faq/large_tensor_support.md
@@ -26,10 +26,9 @@ permalink: /api/faq/large_tensor_support
 # Using MXNet with Large Tensor Support
 
 ## What is large tensor support?
-When creating a network that uses large amounts of data, as in a deep graph problem, you may need large tensor support. This is a relatively new feature as tensors are indexed in MXNet using INT32 indices by default. Now MXNet build with Large Tensor supports INT64 indices.
+When creating a network that uses large amounts of data, as in a deep graph problem, you may need large tensor support. This means tensors indexed using INT64, not INT32 indices.
 
-It is MXNet built with an additional flag *USE_INT64_TENSOR_SIZE=1*
-in CMAKE it is built using *USE_INT64_TENSOR_SIZE:“ON”*
+This feature is enabled when MXNet is built with a flag *USE_INT64_TENSOR_SIZE=1* or with CMAKE using *USE_INT64_TENSOR_SIZE:“ON”*, which is now a default setting. You can also make MXNet use INT32 indices by changing these flags.
 
 ## When do you need it?
 1. When you are creating NDArrays of size larger than 2^31 elements.
@@ -71,8 +70,8 @@ The following are the cases for large tensor usage where you must specify `dtype
 * _randint():_
 
 ```python
-low_large_value = 2*32*
-*high_large_value = 2*34
+low_large_value = 2**32
+high_large_value = 2**34
 # dtype is explicitly specified since default type is int32 for randint
 a = nd.random.randint(low_large_value, high_large_value, dtype=np.int64)
 ```
@@ -141,15 +140,14 @@ Backward pass is partially supported and not completely tested, so it is conside
 
 Not supported:
 
-* GPU and oneDNN. 
+* GPU. 
 * Windows, ARM or any operating system other than Ubuntu
-* Any permutation of MXNet wheel that contains oneDNN. 
 * Other language bindings like Scala, Java, R,  and Julia.
 
 
 ## Other known Issues:
-Randint operator is flaky: https://github.com/apache/incubator-mxnet/issues/16172
-dgemm operations using BLAS libraries currently don’t support int64.
+Randint operator is flaky: https://github.com/apache/incubator-mxnet/issues/16172.  
+dgemm operations using BLAS libraries currently don’t support int64.  
 linspace() is not supported.
 
 ```python

--- a/docs/static_site/src/pages/api/faq/large_tensor_support.md
+++ b/docs/static_site/src/pages/api/faq/large_tensor_support.md
@@ -26,9 +26,9 @@ permalink: /api/faq/large_tensor_support
 # Using MXNet with Large Tensor Support
 
 ## What is large tensor support?
-When creating a network that uses large amounts of data, as in a deep graph problem, you may need large tensor support. This means tensors indexed using INT64, not INT32 indices.
+When creating a network that uses large amounts of data, as in a deep graph problem, you may need large tensor support. This means tensors are indexed using INT64, instead of INT32 indices.
 
-This feature is enabled when MXNet is built with a flag *USE_INT64_TENSOR_SIZE=1* or with CMAKE using *USE_INT64_TENSOR_SIZE:“ON”*, which is now a default setting. You can also make MXNet use INT32 indices by changing these flags.
+This feature is enabled when MXNet is built with a flag *USE_INT64_TENSOR_SIZE=1*, which is now a default setting. You can also make MXNet use INT32 indices by changing this flag.
 
 ## When do you need it?
 1. When you are creating NDArrays of size larger than 2^31 elements.

--- a/docs/static_site/src/pages/api/faq/large_tensor_support.md
+++ b/docs/static_site/src/pages/api/faq/large_tensor_support.md
@@ -146,9 +146,9 @@ Not supported:
 
 
 ## Other known Issues:
-Randint operator is flaky: https://github.com/apache/incubator-mxnet/issues/16172.  
-dgemm operations using BLAS libraries currently don’t support int64.  
-linspace() is not supported.
+* Randint operator is flaky: https://github.com/apache/incubator-mxnet/issues/16172.
+* dgemm operations using BLAS libraries currently don’t support int64.
+* linspace() is not supported.
 
 ```python
 a = mx.sym.Variable('a')


### PR DESCRIPTION
## Description ##
This PR updates the documentation regarding the use of Large Tensors Support for MXNet.

## Comments ##
According to MXNet linux.cmake, building with large tensors is a default behaviour now: https://github.com/apache/incubator-mxnet/blob/e9840b89f3305c446e4bab0402232abc68bde6dc/config/linux.cmake#L121

Added also small sanity fixes.