### PR TITLE
[v1.9.x] Fix pip installation in containers

### DIFF
--- a/ci/docker/install/centos7_python.sh
+++ b/ci/docker/install/centos7_python.sh
@@ -30,4 +30,4 @@ yum -y install python36u
 curl "https://bootstrap.pypa.io/pip/3.6/get-pip.py" -o "get-pip.py"
 python3.6 get-pip.py
 # Restrict numpy version to < 1.19.0 due to https://github.com/apache/incubator-mxnet/issues/18600
-pip3 install nose pylint 'numpy>1.16.0,<1.19.0' nose-timer requests 'h5py<3' scipy==1.2.3
+python3.6 -m pip install nose pylint 'numpy>1.16.0,<1.19.0' nose-timer requests 'h5py<3' scipy==1.2.3

--- a/ci/docker/install/centos7_python.sh
+++ b/ci/docker/install/centos7_python.sh
@@ -27,7 +27,7 @@ yum -y install https://repo.ius.io/ius-release-el7.rpm
 yum -y install python36u
 
 # Install PIP
-curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py"
+curl "https://bootstrap.pypa.io/pip/3.6/get-pip.py" -o "get-pip.py"
 python3.6 get-pip.py
 # Restrict numpy version to < 1.19.0 due to https://github.com/apache/incubator-mxnet/issues/18600
 pip3 install nose pylint 'numpy>1.16.0,<1.19.0' nose-timer requests 'h5py<3' scipy==1.2.3

--- a/ci/docker/install/ubuntu_python.sh
+++ b/ci/docker/install/ubuntu_python.sh
@@ -32,5 +32,5 @@ ln -sf /usr/bin/python3.7 /usr/local/bin/python3
 
 # the version of the pip shipped with ubuntu may be too lower, install a recent version here
 wget -nv https://bootstrap.pypa.io/get-pip.py
-python3 get-pip.py
+/usr/local/bin/python3 get-pip.py
 pip3 install -r /work/requirements

--- a/ci/docker/install/ubuntu_python.sh
+++ b/ci/docker/install/ubuntu_python.sh
@@ -33,4 +33,4 @@ ln -sf /usr/bin/python3.7 /usr/local/bin/python3
 # the version of the pip shipped with ubuntu may be too lower, install a recent version here
 wget -nv https://bootstrap.pypa.io/get-pip.py
 /usr/local/bin/python3 get-pip.py
-pip3 install -r /work/requirements
+/usr/local/bin/python3 -m pip install -r /work/requirements


### PR DESCRIPTION
Update link to `get-pip.py` do we get a version that is supported with Python 3.6.