### PR TITLE
CI fixes

### DIFF
--- a/docs/python_docs/requirements
+++ b/docs/python_docs/requirements
@@ -17,7 +17,7 @@
 
 numpy>=1.17,<1.20.0
 jupyter
-Jinja2==2.11.3
+Jinja2==3.0.3
 sphinx==2.4.0
 matplotlib
 notebook


### PR DESCRIPTION
## Description ##
The CI is failing due to Jinja version being unsupported:
https://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/mxnet-validation%2Fwebsite/detail/PR-20899/1/pipeline/
Pinned the new version of the package to fix the issue.

Related issue:
https://github.com/pallets/jinja/issues/1585

