### PR TITLE
[master] Fix issue with even number of channels in BatchNorm

### DIFF
--- a/src/operator/contrib/batch_norm_relu.cc
+++ b/src/operator/contrib/batch_norm_relu.cc
@@ -149,12 +149,11 @@ void BatchNormWithReLUComputeExCPU(const nnvm::NodeAttrs& attrs,
                                    const std::vector<NDArray>& outputs) {
   CHECK_EQ(inputs.size(), 5U);
   const BatchNormParam& param = nnvm::get<BatchNormParam>(attrs.parsed);
-  bool fuse_relu              = true;
   if (SupportDNNLBNReLU(inputs[0], param)) {
     CHECK_GT(outputs.size(), 3U);
     DNNL_OPCHECK_INIT(false, outputs.size(), inputs, outputs);
     DNNL_REAL_TYPE_SWITCH(inputs[0].dtype(), DTYPE, {
-      DNNLBatchNormForward<DTYPE>(attrs, ctx, inputs, req, outputs, fuse_relu);
+      DNNLRun(DNNLBatchNormForward<DTYPE, /*fuse_relu*/ true>, attrs, ctx, inputs, req, outputs);
     });
     return;
   }
@@ -167,11 +166,10 @@ void BatchNormWithReLUGradComputeExCPU(const nnvm::NodeAttrs& attrs,
                                        const std::vector<OpReqType>& req,
                                        const std::vector<NDArray>& outputs) {
   const BatchNormParam& param = nnvm::get<BatchNormParam>(attrs.parsed);
-  bool fuse_relu              = true;
   if (SupportDNNLBNReLU(inputs[0], param)) {
     CHECK_EQ(inputs.size(), 9U);
     DNNL_OPCHECK_INIT(true, outputs.size(), inputs, outputs);
-    DNNLBatchNormBackward<float>(attrs, ctx, inputs, req, outputs, fuse_relu);
+    DNNLRun(DNNLBatchNormBackward<float, /*fuse_relu*/ true>, attrs, ctx, inputs, req, outputs);
     return;
   }
   LOG(FATAL) << "BatchNormWithReLU operator only supports oneDNN Backend.";

--- a/src/operator/nn/batch_norm.cc
+++ b/src/operator/nn/batch_norm.cc
@@ -481,11 +481,10 @@ void BatchNormComputeExCPU(const nnvm::NodeAttrs& attrs,
                            const std::vector<NDArray>& outputs) {
   CHECK_EQ(inputs.size(), 5U);
   const BatchNormParam& param = nnvm::get<BatchNormParam>(attrs.parsed);
-  bool fuse_relu              = false;
   if (SupportDNNLBN(inputs[0], param)) {
     DNNL_OPCHECK_INIT(false, outputs.size(), inputs, outputs);
     DNNL_REAL_TYPE_SWITCH(inputs[0].dtype(), DTYPE, {
-      DNNLBatchNormForward<DTYPE>(attrs, ctx, inputs, req, outputs, fuse_relu);
+      DNNLRun(DNNLBatchNormForward<DTYPE, /*fuse_relu*/ false>, attrs, ctx, inputs, req, outputs);
     });
     DNNL_OPCHECK_RUN(BatchNormCompute<cpu>, attrs, ctx, inputs, req, outputs);
     return;
@@ -499,10 +498,9 @@ void BatchNormGradComputeExCPU(const nnvm::NodeAttrs& attrs,
                                const std::vector<OpReqType>& req,
                                const std::vector<NDArray>& outputs) {
   const BatchNormParam& param = nnvm::get<BatchNormParam>(attrs.parsed);
-  bool fuse_relu              = false;
   if (SupportDNNLBN(inputs[0], param)) {
     DNNL_OPCHECK_INIT(true, outputs.size(), inputs, outputs);
-    DNNLBatchNormBackward<float>(attrs, ctx, inputs, req, outputs, fuse_relu);
+    DNNLRun(DNNLBatchNormBackward<float, /*fuse_relu*/ false>, attrs, ctx, inputs, req, outputs);
     DNNL_OPCHECK_RUN(BatchNormGradCompute<cpu>, attrs, ctx, inputs, req, outputs);
     return;
   }

--- a/src/operator/nn/dnnl/dnnl_batch_norm-inl.h
+++ b/src/operator/nn/dnnl/dnnl_batch_norm-inl.h
@@ -146,11 +146,11 @@ static DNNLBNForward& GetBNForward(const BatchNormParam& param,
 
 template <typename DType>
 void DNNLBatchNormForwardImpl(const nnvm::NodeAttrs& attrs,
-                          const OpContext& ctx,
-                          const std::vector<NDArray>& inputs,
-                          const std::vector<OpReqType>& req,
-                          const std::vector<NDArray>& outputs,
-                          bool fuse_relu) {
+                              const OpContext& ctx,
+                              const std::vector<NDArray>& inputs,
+                              const std::vector<OpReqType>& req,
+                              const std::vector<NDArray>& outputs,
+                              bool fuse_relu) {
   const BatchNormParam& param = nnvm::get<BatchNormParam>(attrs.parsed);
   std::vector<NDArray> in_data(inputs.begin(), inputs.begin() + batchnorm::kInMovingMean);
 
@@ -263,10 +263,10 @@ void DNNLBatchNormForwardImpl(const nnvm::NodeAttrs& attrs,
 
 template <typename DType, bool fuse_relu>
 void DNNLBatchNormForward(const nnvm::NodeAttrs& attrs,
-                            const OpContext& ctx,
-                            const std::vector<NDArray>& inputs,
-                            const std::vector<OpReqType>& req,
-                            const std::vector<NDArray>& outputs) {
+                          const OpContext& ctx,
+                          const std::vector<NDArray>& inputs,
+                          const std::vector<OpReqType>& req,
+                          const std::vector<NDArray>& outputs) {
   DNNLBatchNormForwardImpl<DType>(attrs, ctx, inputs, req, outputs, fuse_relu);
 }
 
@@ -327,11 +327,11 @@ static DNNLBNBackward& GetBNBackward(const BatchNormParam& param,
 
 template <typename DType>
 void DNNLBatchNormBackwardImpl(const nnvm::NodeAttrs& attrs,
-                           const OpContext& ctx,
-                           const std::vector<NDArray>& inputs,
-                           const std::vector<OpReqType>& req,
-                           const std::vector<NDArray>& outputs,
-                           bool fuse_relu) {
+                               const OpContext& ctx,
+                               const std::vector<NDArray>& inputs,
+                               const std::vector<OpReqType>& req,
+                               const std::vector<NDArray>& outputs,
+                               bool fuse_relu) {
   if (fuse_relu) {
     CHECK_EQ(inputs.size(), 9U);
   } else {
@@ -492,12 +492,12 @@ void DNNLBatchNormBackwardImpl(const nnvm::NodeAttrs& attrs,
 }
 
 template <typename DType, bool fuse_relu>
-void DNNLBatchNormBackward(const nnvm::NodeAttrs &attrs, const OpContext &ctx,
-                             const std::vector<NDArray> &inputs,
-                             const std::vector<OpReqType> &req,
-                             const std::vector<NDArray> &outputs) {
-  DNNLBatchNormBackwardImpl<DType>(attrs, ctx, inputs, req, outputs,
-                                     fuse_relu);
+void DNNLBatchNormBackward(const nnvm::NodeAttrs& attrs,
+                           const OpContext& ctx,
+                           const std::vector<NDArray>& inputs,
+                           const std::vector<OpReqType>& req,
+                           const std::vector<NDArray>& outputs) {
+  DNNLBatchNormBackwardImpl<DType>(attrs, ctx, inputs, req, outputs, fuse_relu);
 }
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/nn/dnnl/dnnl_batch_norm-inl.h
+++ b/src/operator/nn/dnnl/dnnl_batch_norm-inl.h
@@ -145,7 +145,7 @@ static DNNLBNForward& GetBNForward(const BatchNormParam& param,
 }
 
 template <typename DType>
-void DNNLBatchNormForward(const nnvm::NodeAttrs& attrs,
+void DNNLBatchNormForwardImpl(const nnvm::NodeAttrs& attrs,
                           const OpContext& ctx,
                           const std::vector<NDArray>& inputs,
                           const std::vector<OpReqType>& req,
@@ -261,6 +261,15 @@ void DNNLBatchNormForward(const nnvm::NodeAttrs& attrs,
   }
 }
 
+template <typename DType, bool fuse_relu>
+void DNNLBatchNormForward(const nnvm::NodeAttrs& attrs,
+                            const OpContext& ctx,
+                            const std::vector<NDArray>& inputs,
+                            const std::vector<OpReqType>& req,
+                            const std::vector<NDArray>& outputs) {
+  DNNLBatchNormForwardImpl<DType>(attrs, ctx, inputs, req, outputs, fuse_relu);
+}
+
 class DNNLBNBackward {
   std::shared_ptr<dnnl::batch_normalization_backward> bwd;
   const std::shared_ptr<dnnl::memory> weight_m;
@@ -317,7 +326,7 @@ static DNNLBNBackward& GetBNBackward(const BatchNormParam& param,
 }
 
 template <typename DType>
-void DNNLBatchNormBackward(const nnvm::NodeAttrs& attrs,
+void DNNLBatchNormBackwardImpl(const nnvm::NodeAttrs& attrs,
                            const OpContext& ctx,
                            const std::vector<NDArray>& inputs,
                            const std::vector<OpReqType>& req,
@@ -480,6 +489,15 @@ void DNNLBatchNormBackward(const nnvm::NodeAttrs& attrs,
   } else {
     LOG(FATAL) << "oneDNN batch normalization backward: should not reach here ...";
   }
+}
+
+template <typename DType, bool fuse_relu>
+void DNNLBatchNormBackward(const nnvm::NodeAttrs &attrs, const OpContext &ctx,
+                             const std::vector<NDArray> &inputs,
+                             const std::vector<OpReqType> &req,
+                             const std::vector<NDArray> &outputs) {
+  DNNLBatchNormBackwardImpl<DType>(attrs, ctx, inputs, req, outputs,
+                                     fuse_relu);
 }
 }  // namespace op
 }  // namespace mxnet


### PR DESCRIPTION
## Description ##
Goal of this PR is to prevent bug with BatchNorm, that was seen on other versions ([here for instance](https://github.com/apache/incubator-mxnet/issues/20858)).    
Fix is done by calling oneDNN implementations via `DNNLRun` method, not directly.