### PR TITLE
Remove first_quantization_pass FC property

### DIFF
--- a/src/operator/nn/dnnl/dnnl_fully_connected-inl.h
+++ b/src/operator/nn/dnnl/dnnl_fully_connected-inl.h
@@ -44,7 +44,6 @@ struct DNNLFCParam : public dmlc::Parameter<DNNLFCParam> {
   bool enable_float_output;
   bool with_eltwise;
   bool with_sum;
-  bool first_quantization_pass;  // True for operator created during first quantization pass
   dmlc::optional<float> min_calib_range;  // min float value calculated from calibration dataset
   dmlc::optional<float> max_calib_range;  // max float value calculated from calibration dataset
   dmlc::optional<bool> channel_wise_quantize;
@@ -59,9 +58,6 @@ struct DNNLFCParam : public dmlc::Parameter<DNNLFCParam> {
         .set_default(false)
         .describe("Whether there's a post with_eltwise after FullyConnected operator");
     DMLC_DECLARE_FIELD(with_sum).set_default(false).describe("Add post sum");
-    DMLC_DECLARE_FIELD(first_quantization_pass)
-        .set_default(false)
-        .describe("True for first quantization pass");
     DMLC_DECLARE_FIELD(min_calib_range)
         .set_default(dmlc::optional<float>())
         .describe(

--- a/src/operator/subgraph/dnnl/dnnl_fc_property.h
+++ b/src/operator/subgraph/dnnl/dnnl_fc_property.h
@@ -194,9 +194,6 @@ class SgDNNLFCProperty : public SubgraphProperty {
       auto& sub_name = node->op()->name;
       if (sub_name == "FullyConnected") {
         node_name << "fully_connected_";
-        if (HasAttr("quantize") && GetAttr<bool>("quantize")) {
-          n->attrs.dict["first_quantization_pass"] = "True";
-        }
       } else if (SupportDNNLFCEltwiseFusion(sub_name)) {
         node_name << "eltwise_";
         n->attrs.dict["with_eltwise"] = "True";


### PR DESCRIPTION
## Description ##
It turns out that first_quantization_pass FC property is not needed any longer. fc_param.dnnl_param.quantized is enough to distinguish phases of quantization

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [ ] Code is well-documented

