### PR TITLE
[website] Update requirements

### DIFF
--- a/docs/python_docs/requirements
+++ b/docs/python_docs/requirements
@@ -25,6 +25,7 @@ nbconvert==5.6.1
 jupyter-client<=6.1.12
 nbsphinx==0.4.3
 recommonmark==0.6.0
+markupsafe==2.0.1
 notedown==1.5.1
 pypandoc==1.4
 breathe==4.13.1


### PR DESCRIPTION
## Description ##
Due to a breaking change in one of the dependecy pacakges `markupsafe`, we are getting this error 
```ImportError: cannot import name 'soft_unicode' from 'markupsafe'```
in the website build pipeline https://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/restricted-website-build-master/detail/restricted-website-build-master/3553/pipeline

More information about this issue: https://github.com/pallets/markupsafe/issues/284