### PR TITLE
Improve FC + add fusing

### DIFF
--- a/src/operator/nn/mkldnn/mkldnn_fully_connected-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_fully_connected-inl.h
@@ -45,7 +45,7 @@ struct MKLDNNFCParam : public dmlc::Parameter<MKLDNNFCParam> {
   bool enable_float_output;
   bool with_eltwise;
   bool with_sum;
-  bool for_quantization;  // True for operator created during first quantization pass
+  bool enable_fuse_add;
   float sum_scale = 1.0f;
   dmlc::optional<float> min_calib_range;  // min float value calculated from calibration dataset
   dmlc::optional<float> max_calib_range;  // max float value calculated from calibration dataset
@@ -64,9 +64,10 @@ struct MKLDNNFCParam : public dmlc::Parameter<MKLDNNFCParam> {
             "Whether there's a post with_eltwise after FullyConnected "
             "operator");
     DMLC_DECLARE_FIELD(with_sum).set_default(false).describe("Add post sum");
-    DMLC_DECLARE_FIELD(for_quantization)
-        .set_default(false)
-        .describe("True for first quantization pass");
+    DMLC_DECLARE_FIELD(enable_fuse_add)
+        .set_default(true)
+        .describe(
+            "True if fusing add should happened. Temporary set for false during quantization");
     DMLC_DECLARE_FIELD(min_calib_range)
         .set_default(dmlc::optional<float>())
         .describe(

--- a/src/operator/subgraph/mkldnn/mkldnn_fc_property.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_fc_property.h
@@ -193,9 +193,6 @@ class SgMKLDNNFCProperty : public SubgraphProperty {
       auto& sub_name = node->op()->name;
       if (sub_name == "FullyConnected") {
         node_name << "fully_connected_";
-        if (HasAttr("quantize") && GetAttr<bool>("quantize")) {
-          n->attrs.dict["for_quantization"] = "True";
-        }
       } else if (SupportMKLDNNFCEltwiseFusion(sub_name)) {
         node_name << "eltwise_";
         n->attrs.dict["with_eltwise"] = "True";


### PR DESCRIPTION
## Description ##
- Remove for_quantization flag from final graph,
- Rename for_quantization flag to enable_fuse_add and simplify the logics,
- Replace Node with BiDirectedNode to not fuse FC with elemwise add when
FC output is used also as an input of other operator,
- Do not fuse with add if already fused with other elemwise operation
for quantized model.

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
