### PR TITLE
[v1.9.x] Port #20482 from v1.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,6 +307,7 @@ if(USE_MKLDNN)
       # Also ACL_ROOT_DIR need to be set
       set(CMAKE_CXX_STANDARD 14)
       set(DNNL_AARCH64_USE_ACL ON CACHE INTERNAL "" FORCE)
+      add_definitions(-DDNNL_AARCH64_USE_ACL=1)
     endif()
     if (MKLDNN_USE_APL)
       # APL needs to be added to LD_LIBRARY_PATH

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -255,6 +255,7 @@ List of Contributors
 * [Zhaoqi Zhu](https://github.com/zha0q1)
 * [Harshit Sharma](https://github.com/harshitshrma)
 * [Andrzej Kotlowski](https://github.com/anko-intel)
+* [Crefeda Faviola Rodrigues](https://github.com/cfRod)
 
 Label Bot
 ---------

--- a/src/operator/operator_common.h
+++ b/src/operator/operator_common.h
@@ -625,6 +625,12 @@ class OpSignature {
       hash = hash * 2 + arr.dtype();
       eles.push_back(arr.dtype());
       AddSign(arr.shape());
+// Note:Temporary workaround for the accuracy issue noted here #20265.
+// Future releases of Compute Library will aim to fix this.
+#if DNNL_AARCH64_USE_ACL == 1
+      auto ival = reinterpret_cast<const uint64_t>(arr.storage_handle().dptr);
+      AddSign(ival);
+#endif
 #if MXNET_USE_MKLDNN == 1
     }
 #endif
@@ -644,6 +650,11 @@ class OpSignature {
   }
 
   void AddSign(int val) {
+    hash = hash * 2 + val;
+    eles.push_back(val);
+  }
+
+  void AddSign(uint64_t val) {
     hash = hash * 2 + val;
     eles.push_back(val);
   }


### PR DESCRIPTION
[BUGFIX] Fix reuse of primitives for MKLDNN-AArch64. Fixes #20265. (#20482)

This fix is a workaround for the accuracy issue observed when MXNet is built with Compute Library (ACL).
This change includes:
* Updating MXNet's AddSign function to generate unique hashes for MKLDNN-ACL backend.
* Adding DNNL_AARCH64_USE_ACL to CMakeLists.txt
* Adding Crefeda Rodrigues to the contributors list

Signed-off-by: cfRod <crefeda.rodrigues@arm.com>
