### PR TITLE
[v1.x] Reduce after quantization memory usage

### DIFF
--- a/python/mxnet/contrib/quantization.py
+++ b/python/mxnet/contrib/quantization.py
@@ -996,14 +996,20 @@ def quantize_net_v2(network, quantized_dtype='auto', quantize_mode='full', quant
         save_dict.update({('aux:%s' % k): v.as_in_context(cpu())
                           for k, v in aux_params.items()})
         nd_save(param_name, save_dict)
+        for k,v in net.collect_params().items():
+            v.grad_req = 'null'
         net.collect_params().load(param_name, cast_dtype=True, dtype_source='saved')
         net.collect_params().reset_ctx(ctx)
+
         if quantized_dtype == 'auto':
             mx.nd.waitall()
             net.optimize_for(x=data_nd, backend="MKLDNNShiftedQuantization")
             tmp_file = os.path.join(tmpdirname, 'model')
             net.export(tmp_file)
-            net = SymbolBlock.imports(tmp_file + '-symbol.json', data_names, tmp_file + '-0000.params')
+            net = SymbolBlock.imports(tmp_file + '-symbol.json', data_names)
+            for k,v in net.collect_params().items():
+                v.grad_req = 'null'
+            net.collect_params().load(tmp_file + '-0000.params', cast_dtype=True, dtype_source='saved')
     return net
 
 def quantize_net(network, quantized_dtype='auto', quantize_mode='full',

--- a/python/mxnet/contrib/quantization.py
+++ b/python/mxnet/contrib/quantization.py
@@ -996,7 +996,7 @@ def quantize_net_v2(network, quantized_dtype='auto', quantize_mode='full', quant
         save_dict.update({('aux:%s' % k): v.as_in_context(cpu())
                           for k, v in aux_params.items()})
         nd_save(param_name, save_dict)
-        for k,v in net.collect_params().items():
+        for _, v in net.collect_params().items():
             v.grad_req = 'null'
         net.collect_params().load(param_name, cast_dtype=True, dtype_source='saved')
         net.collect_params().reset_ctx(ctx)
@@ -1007,7 +1007,7 @@ def quantize_net_v2(network, quantized_dtype='auto', quantize_mode='full', quant
             tmp_file = os.path.join(tmpdirname, 'model')
             net.export(tmp_file)
             net = SymbolBlock.imports(tmp_file + '-symbol.json', data_names)
-            for k,v in net.collect_params().items():
+            for _, v in net.collect_params().items():
                 v.grad_req = 'null'
             net.collect_params().load(tmp_file + '-0000.params', cast_dtype=True, dtype_source='saved')
     return net


### PR DESCRIPTION
## Description ##
Port of https://github.com/apache/incubator-mxnet/pull/20894

Script:
```
import mxnet as mx
from mxnet.gluon.model_zoo import vision
import psutil
import os

def get_process_memory():
    process = psutil.Process(os.getpid())
    mem_info = process.memory_info()
    return mem_info.rss * 1e-6


batch_shape = (1, 3, 224, 224)
data = mx.nd.random.normal(shape=batch_shape)

print("memory before loading model: ", get_process_memory())
net = vision.resnet50_v1(pretrained=True)
print("memory after loading model: ", get_process_memory()) 
out = net(data)
out.wait_to_read()
print("memory after fp32 forward pass", get_process_memory())

indata = {'data':data}
label = {'label':mx.nd.zeros(shape=(1,))}
dataiter = mx.io.NDArrayIter(indata, label, 3, True, last_batch_handle='discard')
net_quantized = mx.contrib.quant.quantize_net(net, quantized_dtype='auto',
                                                quantize_mode="smart",
                                                calib_mode='naive',
                                                calib_data=dataiter,
                                                num_calib_examples=1,
                                                ctx=mx.current_context())

print("memory after quantization: ", get_process_memory())

outputs = net_quantized(data)
outputs.wait_to_read()
print("memory after int8 forward pass: ", get_process_memory())
```

Output before:
```
memory before loading model:  201.936896
memory after loading model:  433.41004799999996
memory after fp32 forward pass 523.698176
memory after quantization:  1308.803072
memory after int8 forward pass:  1313.349632
```

Output after:
```
memory before loading model:  202.502144
memory after loading model:  434.184192
memory after fp32 forward pass 520.986624
memory after quantization:  1136.570368
memory after int8 forward pass:  1141.485568
```