### PR TITLE
[FEATURE] Support bfloat and float mixed input in elemwise broadcast ops.

### DIFF
--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -900,6 +900,10 @@ inline bool is_float(const int dtype) {
   return dtype == mshadow::kFloat32 || dtype == mshadow::kFloat64 || dtype == mshadow::kFloat16;
 }
 
+inline bool is_bfloat(const int dtype) {
+  return dtype == mshadow::kBfloat16;
+}
+
 inline bool is_int(const int dtype) {
   return dtype == mshadow::kUint8 || dtype == mshadow::kInt8 || dtype == mshadow::kUint16 ||
          dtype == mshadow::kInt16 || dtype == mshadow::kUint32 || dtype == mshadow::kInt32 ||

--- a/src/operator/mshadow_op.h
+++ b/src/operator/mshadow_op.h
@@ -293,17 +293,19 @@ struct mixed_floor_divide {
 
   template <typename DType,
             typename std::enable_if<std::is_same<DType, mshadow::half::half_t>::value ||
+                                        std::is_same<DType, mshadow::bfloat::bf16_t>::value ||
                                         std::is_integral<DType>::value,
                                     int>::type = 0>
   MSHADOW_XINLINE static float Map(DType a, float b) {
     return ::floorf(a / static_cast<float>(b));
   }
 
-  template <typename DType,
-            typename std::enable_if<std::is_same<DType, mshadow::half::half_t>::value ||
-                                        std::is_same<DType, float>::value ||
-                                        std::is_integral<DType>::value,
-                                    int>::type = 0>
+  template <
+      typename DType,
+      typename std::enable_if<
+          std::is_same<DType, mshadow::half::half_t>::value || std::is_same<DType, float>::value ||
+              std::is_same<DType, mshadow::bfloat::bf16_t>::value || std::is_integral<DType>::value,
+          int>::type = 0>
   MSHADOW_XINLINE static double Map(DType a, double b) {
     return ::floor(a / static_cast<double>(b));
   }
@@ -317,17 +319,19 @@ struct mixed_rfloor_divide {
 
   template <typename DType,
             typename std::enable_if<std::is_same<DType, mshadow::half::half_t>::value ||
+                                        std::is_same<DType, mshadow::bfloat::bf16_t>::value ||
                                         std::is_integral<DType>::value,
                                     int>::type = 0>
   MSHADOW_XINLINE static float Map(DType a, float b) {
     return ::floorf(b / static_cast<float>(a));
   }
 
-  template <typename DType,
-            typename std::enable_if<std::is_same<DType, mshadow::half::half_t>::value ||
-                                        std::is_same<DType, float>::value ||
-                                        std::is_integral<DType>::value,
-                                    int>::type = 0>
+  template <
+      typename DType,
+      typename std::enable_if<
+          std::is_same<DType, mshadow::half::half_t>::value || std::is_same<DType, float>::value ||
+              std::is_same<DType, mshadow::bfloat::bf16_t>::value || std::is_integral<DType>::value,
+          int>::type = 0>
   MSHADOW_XINLINE static double Map(DType a, double b) {
     return ::floor(b / static_cast<double>(a));
   }
@@ -345,17 +349,19 @@ struct mixed_plus {
 
   template <typename DType,
             typename std::enable_if<std::is_same<DType, mshadow::half::half_t>::value ||
+                                        std::is_same<DType, mshadow::bfloat::bf16_t>::value ||
                                         std::is_integral<DType>::value,
                                     int>::type = 0>
   MSHADOW_XINLINE static float Map(DType a, float b) {
     return static_cast<float>(a) + b;
   }
 
-  template <typename DType,
-            typename std::enable_if<std::is_same<DType, mshadow::half::half_t>::value ||
-                                        std::is_same<DType, float>::value ||
-                                        std::is_integral<DType>::value,
-                                    int>::type = 0>
+  template <
+      typename DType,
+      typename std::enable_if<
+          std::is_same<DType, mshadow::half::half_t>::value || std::is_same<DType, float>::value ||
+              std::is_same<DType, mshadow::bfloat::bf16_t>::value || std::is_integral<DType>::value,
+          int>::type = 0>
   MSHADOW_XINLINE static double Map(DType a, double b) {
     return static_cast<double>(a) + b;
   }
@@ -369,17 +375,19 @@ struct mixed_minus {
 
   template <typename DType,
             typename std::enable_if<std::is_same<DType, mshadow::half::half_t>::value ||
+                                        std::is_same<DType, mshadow::bfloat::bf16_t>::value ||
                                         std::is_integral<DType>::value,
                                     int>::type = 0>
   MSHADOW_XINLINE static float Map(DType a, float b) {
     return static_cast<float>(a) - b;
   }
 
-  template <typename DType,
-            typename std::enable_if<std::is_same<DType, mshadow::half::half_t>::value ||
-                                        std::is_same<DType, float>::value ||
-                                        std::is_integral<DType>::value,
-                                    int>::type = 0>
+  template <
+      typename DType,
+      typename std::enable_if<
+          std::is_same<DType, mshadow::half::half_t>::value || std::is_same<DType, float>::value ||
+              std::is_same<DType, mshadow::bfloat::bf16_t>::value || std::is_integral<DType>::value,
+          int>::type = 0>
   MSHADOW_XINLINE static double Map(DType a, double b) {
     return static_cast<double>(a) - b;
   }
@@ -393,17 +401,19 @@ struct mixed_rminus {
 
   template <typename DType,
             typename std::enable_if<std::is_same<DType, mshadow::half::half_t>::value ||
+                                        std::is_same<DType, mshadow::bfloat::bf16_t>::value ||
                                         std::is_integral<DType>::value,
                                     int>::type = 0>
   MSHADOW_XINLINE static float Map(DType a, float b) {
     return b - static_cast<float>(a);
   }
 
-  template <typename DType,
-            typename std::enable_if<std::is_same<DType, mshadow::half::half_t>::value ||
-                                        std::is_same<DType, float>::value ||
-                                        std::is_integral<DType>::value,
-                                    int>::type = 0>
+  template <
+      typename DType,
+      typename std::enable_if<
+          std::is_same<DType, mshadow::half::half_t>::value || std::is_same<DType, float>::value ||
+              std::is_same<DType, mshadow::bfloat::bf16_t>::value || std::is_integral<DType>::value,
+          int>::type = 0>
   MSHADOW_XINLINE static double Map(DType a, double b) {
     return b - static_cast<double>(a);
   }
@@ -417,17 +427,19 @@ struct mixed_mul {
 
   template <typename DType,
             typename std::enable_if<std::is_same<DType, mshadow::half::half_t>::value ||
+                                        std::is_same<DType, mshadow::bfloat::bf16_t>::value ||
                                         std::is_integral<DType>::value,
                                     int>::type = 0>
   MSHADOW_XINLINE static float Map(DType a, float b) {
     return static_cast<float>(a) * b;
   }
 
-  template <typename DType,
-            typename std::enable_if<std::is_same<DType, mshadow::half::half_t>::value ||
-                                        std::is_same<DType, float>::value ||
-                                        std::is_integral<DType>::value,
-                                    int>::type = 0>
+  template <
+      typename DType,
+      typename std::enable_if<
+          std::is_same<DType, mshadow::half::half_t>::value || std::is_same<DType, float>::value ||
+              std::is_same<DType, mshadow::bfloat::bf16_t>::value || std::is_integral<DType>::value,
+          int>::type = 0>
   MSHADOW_XINLINE static double Map(DType a, double b) {
     return static_cast<double>(a) * b;
   }
@@ -441,17 +453,19 @@ struct mixed_power {
 
   template <typename DType,
             typename std::enable_if<std::is_same<DType, mshadow::half::half_t>::value ||
+                                        std::is_same<DType, mshadow::bfloat::bf16_t>::value ||
                                         std::is_integral<DType>::value,
                                     int>::type = 0>
   MSHADOW_XINLINE static float Map(DType a, float b) {
     return static_cast<float>(math::pow(a, b));
   }
 
-  template <typename DType,
-            typename std::enable_if<std::is_same<DType, mshadow::half::half_t>::value ||
-                                        std::is_same<DType, float>::value ||
-                                        std::is_integral<DType>::value,
-                                    int>::type = 0>
+  template <
+      typename DType,
+      typename std::enable_if<
+          std::is_same<DType, mshadow::half::half_t>::value || std::is_same<DType, float>::value ||
+              std::is_same<DType, mshadow::bfloat::bf16_t>::value || std::is_integral<DType>::value,
+          int>::type = 0>
   MSHADOW_XINLINE static double Map(DType a, double b) {
     return static_cast<double>(math::pow(a, b));
   }
@@ -465,17 +479,19 @@ struct mixed_rpower {
 
   template <typename DType,
             typename std::enable_if<std::is_same<DType, mshadow::half::half_t>::value ||
+                                        std::is_same<DType, mshadow::bfloat::bf16_t>::value ||
                                         std::is_integral<DType>::value,
                                     int>::type = 0>
   MSHADOW_XINLINE static float Map(DType a, float b) {
     return static_cast<float>(math::pow(b, a));
   }
 
-  template <typename DType,
-            typename std::enable_if<std::is_same<DType, mshadow::half::half_t>::value ||
-                                        std::is_same<DType, float>::value ||
-                                        std::is_integral<DType>::value,
-                                    int>::type = 0>
+  template <
+      typename DType,
+      typename std::enable_if<
+          std::is_same<DType, mshadow::half::half_t>::value || std::is_same<DType, float>::value ||
+              std::is_same<DType, mshadow::bfloat::bf16_t>::value || std::is_integral<DType>::value,
+          int>::type = 0>
   MSHADOW_XINLINE static double Map(DType a, double b) {
     return static_cast<double>(math::pow(b, a));
   }
@@ -1045,17 +1061,19 @@ struct mixed_mod {
 
   template <typename DType,
             typename std::enable_if<std::is_same<DType, mshadow::half::half_t>::value ||
+                                        std::is_same<DType, mshadow::bfloat::bf16_t>::value ||
                                         std::is_integral<DType>::value,
                                     int>::type = 0>
   MSHADOW_XINLINE static float Map(DType a, float b) {
     return mod::Map(static_cast<float>(a), b);
   }
 
-  template <typename DType,
-            typename std::enable_if<std::is_same<DType, mshadow::half::half_t>::value ||
-                                        std::is_same<DType, float>::value ||
-                                        std::is_integral<DType>::value,
-                                    int>::type = 0>
+  template <
+      typename DType,
+      typename std::enable_if<
+          std::is_same<DType, mshadow::half::half_t>::value || std::is_same<DType, float>::value ||
+              std::is_same<DType, mshadow::bfloat::bf16_t>::value || std::is_integral<DType>::value,
+          int>::type = 0>
   MSHADOW_XINLINE static double Map(DType a, double b) {
     return mod::Map(static_cast<double>(a), b);
   }
@@ -1069,17 +1087,19 @@ struct mixed_rmod {
 
   template <typename DType,
             typename std::enable_if<std::is_same<DType, mshadow::half::half_t>::value ||
+                                        std::is_same<DType, mshadow::bfloat::bf16_t>::value ||
                                         std::is_integral<DType>::value,
                                     int>::type = 0>
   MSHADOW_XINLINE static float Map(DType a, float b) {
     return mod::Map(b, static_cast<float>(a));
   }
 
-  template <typename DType,
-            typename std::enable_if<std::is_same<DType, mshadow::half::half_t>::value ||
-                                        std::is_same<DType, float>::value ||
-                                        std::is_integral<DType>::value,
-                                    int>::type = 0>
+  template <
+      typename DType,
+      typename std::enable_if<
+          std::is_same<DType, mshadow::half::half_t>::value || std::is_same<DType, float>::value ||
+              std::is_same<DType, mshadow::bfloat::bf16_t>::value || std::is_integral<DType>::value,
+          int>::type = 0>
   MSHADOW_XINLINE static double Map(DType a, double b) {
     return mod::Map(b, static_cast<double>(a));
   }

--- a/src/operator/mxnet_op.h
+++ b/src/operator/mxnet_op.h
@@ -933,6 +933,7 @@ struct op_with_req {
   /*! \brief inputs are two tensors with a float output tensor */
   template <typename DType,
             typename std::enable_if<std::is_same<DType, mshadow::half::half_t>::value ||
+                                        std::is_same<DType, mshadow::bfloat::bf16_t>::value ||
                                         std::is_integral<DType>::value,
                                     int>::type = 0>
   MSHADOW_XINLINE static void Map(index_t i, float* out, const DType* lhs, const float* rhs) {
@@ -942,6 +943,7 @@ struct op_with_req {
   /*! \brief inputs are two tensors with a double output tensor */
   template <typename DType,
             typename std::enable_if<std::is_same<DType, mshadow::half::half_t>::value ||
+                                        std::is_same<DType, mshadow::bfloat::bf16_t>::value ||
                                         std::is_same<DType, float>::value ||
                                         std::is_integral<DType>::value,
                                     int>::type = 0>

--- a/src/operator/nn/dnnl/dnnl_binary.cc
+++ b/src/operator/nn/dnnl/dnnl_binary.cc
@@ -64,12 +64,14 @@ void DNNLBinaryOpFwd::Execute(const std::vector<NDArray>& inputs,
 }
 
 bool SupportDNNLBinary(const std::vector<NDArray>& inputs) {
-  auto dtype  = inputs[0].dtype();
-  auto ndim_0 = inputs[0].shape().ndim();
-  auto ndim_1 = inputs[1].shape().ndim();
+  auto dtype_0 = inputs[0].dtype();
+  auto dtype_1 = inputs[1].dtype();
+  auto ndim_0  = inputs[0].shape().ndim();
+  auto ndim_1  = inputs[1].shape().ndim();
   return ndim_0 >= 1 && ndim_0 <= 6 && ndim_1 >= 1 && ndim_1 <= 6 &&
          inputs[0].shape().Size() != 0 && inputs[1].shape().Size() != 0 &&
-         (dtype == mshadow::kFloat32 || dtype == mshadow::kBfloat16) && dtype == inputs[1].dtype();
+         (dtype_0 == mshadow::kFloat32 || dtype_0 == mshadow::kBfloat16) &&
+         (dtype_1 == mshadow::kFloat32 || dtype_1 == mshadow::kBfloat16);
 }
 
 }  // namespace op

--- a/src/operator/numpy/np_true_divide-inl.h
+++ b/src/operator/numpy/np_true_divide-inl.h
@@ -115,7 +115,8 @@ void TrueDivideElemwiseCompute(const nnvm::NodeAttrs& attrs,
     }
   } else {
     // Case when types of the 2 input tensors are different
-    if (common::is_float(lhs.type_flag_) && common::is_float(rhs.type_flag_)) {
+    if ((common::is_float(lhs.type_flag_) || common::is_bfloat(lhs.type_flag_)) &&
+        (common::is_float(rhs.type_flag_) || common::is_bfloat(rhs.type_flag_))) {
       // both lhs and rhs are float types, output type is the more precise one
       TBlob temp_tblob;
       if (lhs.type_flag_ == out.type_flag_) {
@@ -238,7 +239,8 @@ void TrueDivideBroadcastCompute(const nnvm::NodeAttrs& attrs,
           });
         }
       } else {
-        if (common::is_float(lhs.type_flag_) && common::is_float(rhs.type_flag_)) {
+        if ((common::is_float(lhs.type_flag_) || common::is_bfloat(lhs.type_flag_)) &&
+            (common::is_float(rhs.type_flag_) || common::is_bfloat(rhs.type_flag_))) {
           // lhs and rhs have different float types, the output is the more precise one
           TBlob temp_tblob;
           if (lhs.type_flag_ == out.type_flag_) {


### PR DESCRIPTION
## Description ##
Elementwise binary broadcast operators such as add, subtract, multiply, divide in MXNet NumPy module support mixed inputs of float and integer type. Goal of this change is to add support of those operators for bfloat with fp32 and fp64 mixed input cases. Additionally oneDNN will be used when processing fp32 and bfloat cases.

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage

### Changes ###
- [x] Add support for bfloat16 and float32 through oneDNN primitive and without oneDNN.
- [x] Add support for bfloat16 and float64.