### PR TITLE
[v1.x] Update test_np_delete() to work with newer numpy versions

### DIFF
--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -3613,8 +3613,9 @@ def test_np_delete():
             for idx in range(-1 * GetDimSize(shp, ax), GetDimSize(shp, ax)):
                 config.append(tuple([shp, idx, ax]))
             #test ndarray indices
-            idx =  _np.random.randint(-1 * shp[ax], shp[ax] + 1, size = (4)).tolist()
-            config.append(tuple([shp, idx, ax]))
+            if shp[ax] > 0:
+                idx =  _np.random.randint(0, shp[ax], size = (4)).tolist()
+                config.append(tuple([shp, idx, ax]))
 
     for arr_shape, obj, axis in config:
         for objtype in ['int32', 'int64']:


### PR DESCRIPTION
Change test_np_delete() to stop testing negative and out-of-bounds indexes since the functionality was changed starting in numpy 1.19.0.

This fixes #20880. This was also brought up in #18600, where the unit test is disabled in master.