### PR TITLE
Avoid modifying loaded library map while iterating in lib_close()

### DIFF
--- a/src/initialize.cc
+++ b/src/initialize.cc
@@ -103,7 +103,7 @@ LibraryInitializer::LibraryInitializer()
 LibraryInitializer::~LibraryInitializer() = default;
 
 bool LibraryInitializer::lib_is_loaded(const std::string& path) const {
-  return loaded_libs.count(path) > 0;
+  return loaded_libs_.count(path) > 0;
 }
 
 /*!
@@ -139,9 +139,9 @@ void* LibraryInitializer::lib_load(const char* path) {
     }
 #endif  // _WIN32 or _WIN64 or __WINDOWS__
     // then store the pointer to the library
-    loaded_libs[path] = handle;
+    loaded_libs_[path] = handle;
   } else {
-    handle = loaded_libs.at(path);
+    handle = loaded_libs_.at(path);
   }
   return handle;
 }
@@ -152,7 +152,7 @@ void* LibraryInitializer::lib_load(const char* path) {
  */
 void LibraryInitializer::lib_close(void* handle) {
   std::string libpath;
-  for (const auto& l : loaded_libs) {
+  for (const auto& l : loaded_libs_) {
     if (l.second == handle) {
       libpath = l.first;
       break;
@@ -167,7 +167,6 @@ void LibraryInitializer::lib_close(void* handle) {
                  << " loaded from: '" << libpath << "': " << dlerror();
   }
 #endif  // _WIN32 or _WIN64 or __WINDOWS__
-  loaded_libs.erase(libpath);
 }
 
 /*!
@@ -393,9 +392,10 @@ SIGNAL_HANDLER(SIGBUS, SIGBUSHandler, false);
 #endif
 
 void LibraryInitializer::close_open_libs() {
-  for (const auto& l : loaded_libs) {
+  for (const auto& l : loaded_libs_) {
     lib_close(l.second);
   }
+  loaded_libs_.clear();
 }
 
 /**

--- a/src/initialize.cc
+++ b/src/initialize.cc
@@ -150,15 +150,7 @@ void* LibraryInitializer::lib_load(const char* path) {
  * \brief Closes the loaded dynamic shared library file
  * \param handle library file handle
  */
-void LibraryInitializer::lib_close(void* handle) {
-  std::string libpath;
-  for (const auto& l : loaded_libs_) {
-    if (l.second == handle) {
-      libpath = l.first;
-      break;
-    }
-  }
-  CHECK(!libpath.empty());
+void LibraryInitializer::lib_close(void* handle, const std::string &libpath) {
 #if defined(_WIN32) || defined(_WIN64) || defined(__WINDOWS__)
   FreeLibrary((HMODULE)handle);
 #else
@@ -393,7 +385,7 @@ SIGNAL_HANDLER(SIGBUS, SIGBUSHandler, false);
 
 void LibraryInitializer::close_open_libs() {
   for (const auto& l : loaded_libs_) {
-    lib_close(l.second);
+    lib_close(l.second, l.first);
   }
   loaded_libs_.clear();
 }

--- a/src/initialize.cc
+++ b/src/initialize.cc
@@ -150,7 +150,7 @@ void* LibraryInitializer::lib_load(const char* path) {
  * \brief Closes the loaded dynamic shared library file
  * \param handle library file handle
  */
-void LibraryInitializer::lib_close(void* handle, const std::string &libpath) {
+void LibraryInitializer::lib_close(void* handle, const std::string& libpath) {
 #if defined(_WIN32) || defined(_WIN64) || defined(__WINDOWS__)
   FreeLibrary((HMODULE)handle);
 #else

--- a/src/initialize.h
+++ b/src/initialize.h
@@ -64,7 +64,7 @@ class LibraryInitializer {
   // Library loading
   bool lib_is_loaded(const std::string& path) const;
   void* lib_load(const char* path);
-  void lib_close(void* handle);
+  void lib_close(void* handle, const std::string& libpath);
   static void get_sym(void* handle, void** func, const char* name);
 
   /**

--- a/src/initialize.h
+++ b/src/initialize.h
@@ -104,7 +104,7 @@ class LibraryInitializer {
 
   void close_open_libs();
 
-  loaded_libs_t loaded_libs;
+  loaded_libs_t loaded_libs_;
 };
 
 /*!


### PR DESCRIPTION
Update close libs to not modify map while iterating over opened libraries, rename loaded_libs to loaded_libs_ to signify it is a private member.

This fixes a sporadic crash when closing MXNet (observed with MXNet and Neuron):

```
terminate called after throwing an instance of 'dmlc::Error'
  what():  [06:24:16] ../src/initialize.cc:154: Check failed: !libpath.empty(): 
```