### PR TITLE
[v1.x] Port #20941 from master

### DIFF
--- a/src/initialize.cc
+++ b/src/initialize.cc
@@ -102,7 +102,7 @@ LibraryInitializer::~LibraryInitializer() {
 }
 
 bool LibraryInitializer::lib_is_loaded(const std::string& path) const {
-  return loaded_libs.count(path) > 0;
+  return loaded_libs_.count(path) > 0;
 }
 
 /*!
@@ -132,9 +132,9 @@ void* LibraryInitializer::lib_load(const char* path) {
     }
 #endif  // _WIN32 or _WIN64 or __WINDOWS__
     // then store the pointer to the library
-    loaded_libs[path] = handle;
+    loaded_libs_[path] = handle;
   } else {
-    handle = loaded_libs.at(path);
+    handle = loaded_libs_.at(path);
   }
   return handle;
 }
@@ -143,15 +143,7 @@ void* LibraryInitializer::lib_load(const char* path) {
  * \brief Closes the loaded dynamic shared library file
  * \param handle library file handle
  */
-void LibraryInitializer::lib_close(void* handle) {
-  std::string libpath;
-  for (const auto& l : loaded_libs) {
-    if (l.second == handle) {
-      libpath = l.first;
-      break;
-    }
-  }
-  CHECK(!libpath.empty());
+void LibraryInitializer::lib_close(void* handle, const std::string& libpath) {
 #if defined(_WIN32) || defined(_WIN64) || defined(__WINDOWS__)
   FreeLibrary((HMODULE)handle);
 #else
@@ -160,7 +152,6 @@ void LibraryInitializer::lib_close(void* handle) {
         << " loaded from: '" << libpath << "': " << dlerror();
   }
 #endif  // _WIN32 or _WIN64 or __WINDOWS__
-  loaded_libs.erase(libpath);
 }
 
 /*!
@@ -235,9 +226,10 @@ void LibraryInitializer::install_signal_handlers() {
 }
 
 void LibraryInitializer::close_open_libs() {
-  for (const auto& l : loaded_libs) {
-    lib_close(l.second);
+  for (const auto& l : loaded_libs_) {
+    lib_close(l.second, l.first);
   }
+  loaded_libs_.clear();
 }
 
 /**

--- a/src/initialize.h
+++ b/src/initialize.h
@@ -68,7 +68,7 @@ class LibraryInitializer {
   // Library loading
   bool lib_is_loaded(const std::string& path) const;
   void* lib_load(const char* path);
-  void lib_close(void* handle);
+  void lib_close(void* handle, const std::string& libpath);
   static void get_sym(void* handle, void** func, char* name);
 
   /**
@@ -103,7 +103,7 @@ class LibraryInitializer {
 
   void close_open_libs();
 
-  loaded_libs_t loaded_libs;
+  loaded_libs_t loaded_libs_;
 };
 
 /*!


### PR DESCRIPTION
Avoid modifying loaded library map while iterating in lib_close() (#20941)

* Update close libs to not modify map while iterating over opened libraries, rename loaded_libs to loaded_libs_ to signify it is a private member.

* Clean up and simplify library close code.

* Fix clang-format.

