### PR TITLE
[v1.9.x] Port #20941

### DIFF
--- a/src/initialize.h
+++ b/src/initialize.h
@@ -67,7 +67,7 @@ class LibraryInitializer {
   // Library loading
   bool lib_is_loaded(const std::string& path) const;
   void* lib_load(const char* path);
-  void lib_close(void* handle);
+  void lib_close(void* handle, const std::string& libpath);
   static void get_sym(void* handle, void** func, char* name);
 
   /**
@@ -102,7 +102,7 @@ class LibraryInitializer {
 
   void close_open_libs();
 
-  loaded_libs_t loaded_libs;
+  loaded_libs_t loaded_libs_;
 };
 
 /*!


### PR DESCRIPTION
Avoid modifying loaded library map while iterating in lib_close() (#20941)

* Update close libs to not modify map while iterating over opened libraries, rename loaded_libs to loaded_libs_ to signify it is a private member.

* Clean up and simplify library close code.

* Fix clang-format.
