### PR TITLE
Port #20926 to v1.x

### DIFF
--- a/src/operator/quantization/quantized_elemwise_mul.cc
+++ b/src/operator/quantization/quantized_elemwise_mul.cc
@@ -198,7 +198,7 @@ void QuantizedElemwiseMulOpForward(const nnvm::NodeAttrs &attrs,
       }
     }
   } else {
-    typedef float_t out_type;
+    typedef float out_type;
     auto *out_data = outputs[quantized_elemwise_mul::kOut].dptr<out_type>();
 #if !defined(_MSC_VER)
 #pragma omp simd


### PR DESCRIPTION
## Description ##
float_t type on FreeBSD i386 is set to long double, for which there is no mshadow convertion available. This PR changes the output type of quantized_elemwise_mul operator to float, what fixes the compile error.