### PR TITLE
[v2.0] [BUGFIX] Port #20940 (Upgrade numpy to <1.20.0 ...) from v1.9.x

### DIFF
--- a/ci/docker/install/requirements
+++ b/ci/docker/install/requirements
@@ -45,6 +45,7 @@ pytest-rerunfailures==10.2
 flaky==3.7.0
 setuptools==49.6.0  # https://github.com/pypa/setuptools/issues/2352
 wheel
+packaging
 
 # TVM dependencies
 decorator==4.4.0

--- a/tests/python/unittest/test_numpy_interoperability.py
+++ b/tests/python/unittest/test_numpy_interoperability.py
@@ -3345,8 +3345,6 @@ def check_interoperability(op_list):
         if name in ['shares_memory', 'may_share_memory', 'empty_like',
                     '__version__', 'dtype', '_NoValue']:  # skip list
             continue
-        if name in ['delete']: # https://github.com/apache/incubator-mxnet/issues/18600
-            continue
         if name in ['full_like', 'zeros_like', 'ones_like'] and \
                 StrictVersion(platform.python_version()) < StrictVersion('3.0.0'):
             continue

--- a/tests/python/unittest/test_numpy_interoperability.py
+++ b/tests/python/unittest/test_numpy_interoperability.py
@@ -1299,10 +1299,12 @@ def _add_workload_delete():
                 s = slice(start, stop, step)
                 OpArgMngr.add_workload('delete', a, s)
                 OpArgMngr.add_workload('delete', nd_a, s, axis=1)
-    OpArgMngr.add_workload('delete', a, np.array([]), axis=0)
+    # mxnet.numpy arrays, even 0-sized, have a float32 dtype.  Starting with numpy 1.19, the
+    # index array's of delete() must be of integer or boolean type, so we force that below.
+    OpArgMngr.add_workload('delete', a, np.array([], dtype='int32'), axis=0)
     OpArgMngr.add_workload('delete', a, 0)
-    OpArgMngr.add_workload('delete', a, np.array([]))
-    OpArgMngr.add_workload('delete', a, np.array([0, 1]))
+    OpArgMngr.add_workload('delete', a, np.array([], dtype='int32'))
+    OpArgMngr.add_workload('delete', a, np.array([0, 1], dtype='int32'))
     OpArgMngr.add_workload('delete', a, slice(1, 2))
     OpArgMngr.add_workload('delete', a, slice(1, -2))
     k = np.arange(10).reshape(2, 5)

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -5167,7 +5167,6 @@ def test_np_random_f():
 
 
 @use_np
-@pytest.mark.skip(reason='https://github.com/apache/incubator-mxnet/issues/18600')
 def test_np_random_chisquare():
     class TestRandomChisquare(HybridBlock):
         def __init__(self, size=None, dtype=None, device=None):

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -4488,7 +4488,6 @@ def test_np_swapaxes():
 
 
 @use_np
-@pytest.mark.skip(reason='https://github.com/apache/incubator-mxnet/issues/18600')
 def test_np_delete():
     class TestDelete(HybridBlock):
         def __init__(self, obj, axis=None):
@@ -5095,7 +5094,6 @@ def test_gamma_grad(shape, a, b):
 
 
 @use_np
-@pytest.mark.skip(reason='https://github.com/apache/incubator-mxnet/issues/18600')
 def test_np_random_beta():
     class TestRandomBeta(HybridBlock):
         def __init__(self, size=None, dtype=None, device=None):
@@ -5139,7 +5137,6 @@ def test_np_random_beta():
 
 
 @use_np
-@pytest.mark.skip(reason='https://github.com/apache/incubator-mxnet/issues/18600')
 def test_np_random_f():
     class TestRandomF(HybridBlock):
         def __init__(self, size=None):

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -30,6 +30,7 @@ import scipy.special as scipy_special
 import pytest
 import mxnet.ndarray.numpy._internal as _npi
 from functools import reduce
+from packaging.version import parse
 from mxnet import np, npx
 from mxnet.gluon import HybridBlock
 from mxnet.base import MXNetError
@@ -4536,6 +4537,12 @@ def test_np_delete():
             if type(obj) == list:
                 obj_mxnp = np.array(obj, dtype=objtype)
                 obj_onp = onp.array(obj, dtype=objtype)
+                # To match mxnet.numpy's behavior of ignoring out-of-bounds indices,
+                # we may need to filter out indices that this numpy would not ignore.
+                onp_ignores_oob_indices = parse(onp.version.version) < parse('1.19')
+                if not onp_ignores_oob_indices:
+                    dim_size = GetDimSize(arr_shape,axis)
+                    obj_onp = obj_onp[((obj_onp>=0) & (obj_onp<dim_size))]
             elif type(obj) == slice:
                 obj_mxnp = obj
                 obj_onp = obj

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -5117,7 +5117,8 @@ def test_np_random_beta():
         smaller_than_one = onp.all(output < 1)
         return bigger_than_zero and smaller_than_one
 
-    shape_list = [(), (1,), (2, 3), (4, 0, 5), 6, (7, 8), None]
+    # Starting with numpy 1.19.0, output shape of () is no longer supported
+    shape_list = [(0,), (1,), (2, 3), (4, 0, 5), 6, (7, 8), None]
     # since fp16 might incur precision issue, the corresponding test is skipped
     dtype_list = [np.float32, np.float64]
     hybridize_list = [False, True]
@@ -5133,8 +5134,8 @@ def test_np_random_beta():
         mx_out = test_random_beta(mx_data, mx_data)
         mx_out_imperative = mx.np.random.beta(mx_data, mx_data, size=param_shape, dtype=out_dtype)
 
-        assert_almost_equal(np_out.shape, mx_out.shape)
-        assert_almost_equal(np_out.shape, mx_out_imperative.shape)
+        assert np_out.shape == mx_out.shape
+        assert np_out.shape == mx_out_imperative.shape
         assert _test_random_beta_range(mx_out.asnumpy()) == True
         assert _test_random_beta_range(mx_out_imperative.asnumpy()) == True
 
@@ -5153,7 +5154,8 @@ def test_np_random_f():
         def forward(self, dfnum, dfden):
             return np.random.f(dfnum, dfden, size=self._size)
 
-    shape_list = [(), (1,), (2, 3), (4, 0, 5), 6, (7, 8), None]
+    # Starting with numpy 1.19.0, output shape of () is no longer supported
+    shape_list = [(0,), (1,), (2, 3), (4, 0, 5), 6, (7, 8), None]
     hybridize_list = [False, True]
     df = np.array([1])
     for [param_shape, hybridize] in itertools.product(shape_list,
@@ -5169,8 +5171,8 @@ def test_np_random_f():
         mx_out = test_random_f(mx_df, mx_df)
         mx_out_imperative = mx.np.random.f(mx_df, mx_df, size=param_shape)
 
-        assert_almost_equal(np_out.shape, mx_out.shape)
-        assert_almost_equal(np_out.shape, mx_out_imperative.shape)
+        assert np_out.shape == mx_out.shape
+        assert np_out.shape == mx_out_imperative.shape
 
 
 @use_np
@@ -5185,7 +5187,8 @@ def test_np_random_chisquare():
         def forward(self, df):
             return np.random.chisquare(df, size=self._size, dtype=self._dtype, device=self._device)
 
-    shape_list = [(), (1,), (2, 3), (4, 0, 5), 6, (7, 8), None]
+    # Starting with numpy 1.19.0, output shape of () is no longer supported
+    shape_list = [(0,), (1,), (2, 3), (4, 0, 5), 6, (7, 8), None]
 
     dtype_list = [np.float16, np.float32, np.float64]
     hybridize_list = [False, True]
@@ -5203,8 +5206,8 @@ def test_np_random_chisquare():
         mx_out = test_random_chisquare(mx_df)
         mx_out_imperative = mx.np.random.chisquare(mx_df, size=param_shape, dtype=out_dtype)
 
-        assert_almost_equal(np_out.shape, mx_out.shape)
-        assert_almost_equal(np_out.shape, mx_out_imperative.shape)
+        assert np_out.shape == mx_out.shape
+        assert np_out.shape == mx_out_imperative.shape
 
 
 @use_np


### PR DESCRIPTION
## Description ##
This PR ports the unittest fixes of MXNet v1.x PR 20940 to MXNet 2.0.  MXNet v1.x used PR 20940 to advance its numpy version from 1.18.5 to numpy 1.19.  MXNet 2.0 has already advanced to use numpy 1.19, but did so by skipping the failing tests.  Thus, the plan with this PR is to first re-enable the skipped tests, to show them once again failing, then push the fixes to unittests test_np_delete and test_np_array_function_protocol from v1.x PR 20940.  In addition, the 3 tests test_np_random_{beta,f,chisquare} need a fix present in v1.x from a different PR.

## Checklist ##
### Essentials ###
- [X] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
- [X] Code is well-documented

