### PR TITLE
Enable possibility of disabling particular graph pass

### DIFF
--- a/src/c_api/c_api_symbolic.cc
+++ b/src/c_api/c_api_symbolic.cc
@@ -1402,6 +1402,14 @@ int MXOptimizeForBackend(SymbolHandle sym_handle,
         mxnet::op::SubgraphBackendRegistry ::Get()->GetSubgraphBackend(backend_name);
     const auto& subgraph_prop_list = backend->GetSubgraphProperties();
     for (auto property : subgraph_prop_list) {
+      if (property->HasAttr("disable") && property->GetAttr<bool>("disable") == true) {
+        auto full_name = property->HasAttr("property_name") ?
+                             property->GetAttr<std::string>("property_name") :
+                             std::string();
+        LOG(INFO) << "subgraph property " << full_name << " from backend " << backend_name
+                  << " is disabled.";
+        continue;
+      }
       nnvm::Graph g = init_graph(s);
       property->PrePartition(g, options_map);
       g.attrs["subgraph_property"] = std::make_shared<nnvm::any>(property);


### PR DESCRIPTION
## Description ##
There was no possibility to disable particular fusing pass via
environment variable when use optimize_for function.

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [x] Code is well-documented
