### PR TITLE
[BUGFIX] Fix mxnet.numpy.eye() handling of extreme k parameter values

### DIFF
--- a/.github/workflows/os_x_staticbuild.yml
+++ b/.github/workflows/os_x_staticbuild.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Test project
         env:
-          MXNET_ENFORCE_CYTHON: 1
+          MXNET_ENABLE_CYTHON: 1
         run: |
           python3 -m pytest -n 4 --durations=50 --verbose tests/python/unittest/ -k 'not test_operator and not (test_subgraph or test_custom_op or test_external_op or test_recordimage_dataset_with_data_loader_multiworker or test_multi_worker or test_multi_worker_shape or test_multi_worker_forked_data_loader or test_multi_worker_dataloader_release_pool)' -m 'not serial'
           MXNET_ENGINE_TYPE=NaiveEngine python3 -m pytest -n 4 --durations=50 --verbose tests/python/unittest/ -k 'test_operator and not (test_subgraph or test_custom_op or test_external_op or test_recordimage_dataset_with_data_loader_multiworker or test_multi_worker or test_multi_worker_shape or test_multi_worker_forked_data_loader or test_multi_worker_dataloader_release_pool)' -m 'not serial'
@@ -57,7 +57,7 @@ jobs:
 
       - name: Test Array API
         env:
-          MXNET_ENFORCE_CYTHON: 0
+          MXNET_ENABLE_CYTHON: 1
         run: |
           cd ..
           git clone https://github.com/data-apis/array-api-tests.git

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -878,9 +878,7 @@ unittest_array_api_standardization() {
     pushd /work/array-api-tests
     git checkout c1dba80a196a03f880d2e0a998a272fb3867b720
     export ARRAY_API_TESTS_MODULE=mxnet.numpy pytest
-    # OverflowError: Python int too large to convert to C long
-    # when cython is enabled
-    export MXNET_ENABLE_CYTHON=0
+    export MXNET_ENABLE_CYTHON=1
     export DMLC_LOG_STACK_TRACE_DEPTH=100
     python3 -m pytest --reruns 3 --durations=50 --cov-report xml:tests_api.xml --verbose array_api_tests/test_creation_functions.py
     python3 -m pytest --reruns 3 --durations=50 --cov-report xml:tests_api.xml --verbose array_api_tests/test_indexing.py

--- a/python/mxnet/ndarray/numpy/_op.py
+++ b/python/mxnet/ndarray/numpy/_op.py
@@ -1932,7 +1932,10 @@ def eye(N, M=None, k=0, dtype=float, **kwargs):
         dtype = _np.float64 if is_np_default_dtype() else _np.float32
     if dtype is not None and not isinstance(dtype, str):
         dtype = _np.dtype(dtype).name
-    k = minimum(k, N) if M is None else minimum(k, M)
+    # To avoid overflow errors, map large positive k values to the just-out-of-range "num_columns" value
+    k = minimum(k, M if M is not None else N)
+    # Similarly, map large negative k values to the just-out-of-range "-num_rows" value
+    k = maximum(k, -N)
     return _api_internal.eye(N, M, int(k), device, dtype)
 
 

--- a/python/mxnet/numpy/random.py
+++ b/python/mxnet/numpy/random.py
@@ -267,7 +267,7 @@ def lognormal(mean=0.0, sigma=1.0, size=None, dtype=None, device=None, out=None)
     .. [1] Limpert, E., Stahel, W. A., and Abbt, M., "Log-normal
            Distributions across the Sciences: Keys and Clues,"
            BioScience, Vol. 51, No. 5, May, 2001.
-           https://stat.ethz.ch/~stahel/lognormal/bioscience.pdf
+           http://www.statlit.org/pdf/2001-Limpert-Bioscience2.pdf
     .. [2] Reiss, R.D. and Thomas, M., "Statistical Analysis of Extreme
            Values," Basel: Birkhauser Verlag, 2001, pp. 31-32.
 


### PR DESCRIPTION
## Description ##
This PR supplies a missing check for extreme negative k values in the mxnet.numpy.eye() implementation.  I believe this was the reason why the array_api tests needed to be run with MXNET_ENABLE_CYTHON=0, since apparently Cython produced overflow errors for some eye() test cases where ctypes did not.  This PR re-enables Cython uniformly for both the centos and macosx jobs that perform the array_api testing.  This PR should resolve https://github.com/apache/incubator-mxnet/issues/20963 by supplying the root cause fix, not by disabling Cython as is discussed in the issue.

FYI @barry-jin 

## Checklist ##
### Essentials ###
- [X] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
- [X] Code is well-documented

