### PR TITLE
[BUGFIX] Fix tests/python/dnnl/subgraphs/test_conv_subgraph.py

### DIFF
--- a/src/operator/nn/dnnl/dnnl_convolution.cc
+++ b/src/operator/nn/dnnl/dnnl_convolution.cc
@@ -118,17 +118,18 @@ std::shared_ptr<dnnl::convolution_forward::primitive_desc> GetConvFwdImpl(
       // suboptimal kernel for computation that has the expected memory size requirements
       auto conv_pd =
           std::make_shared<dnnl::convolution_forward::primitive_desc>(desc, attr, engine);
-      while (conv_pd->dst_desc().get_size() != GetArraySize(output) ||
-             conv_pd->src_desc().get_size() != GetArraySize(data) ||
-             (!param.dnnl_param.quantized &&
-              conv_pd->weights_desc().get_size() != GetArraySize(weights)) ||
-             // With the upgrade of oneDNN to version 2.4+
-             // tests/python/dnnl/subgraphs/test_conv_subgraph.py::test_pos_conv_add[True-data_shape1]
-             // started failing. Switching away from blocking weights in order to temporarily fix
-             // the issue until full fix arrives. Tracking issue:
-             // https://github.com/apache/incubator-mxnet/issues/20826.
-             (param.dnnl_param.quantized && conv_pd->weights_desc().dims()[1] < 4 &&
-              conv_pd->weights_desc().data.padded_dims[1] != conv_pd->weights_desc().dims()[1])) {
+      while (
+          conv_pd->dst_desc().get_size() != GetArraySize(output) ||
+          conv_pd->src_desc().get_size() != GetArraySize(data) ||
+          (!param.dnnl_param.quantized &&
+           conv_pd->weights_desc().get_size() != GetArraySize(weights)) ||
+          // With the upgrade of oneDNN to version 2.4+
+          // tests/python/dnnl/subgraphs/test_conv_subgraph.py::test_pos_conv_add[True-data_shape1]
+          // started failing. Switching away from blocking weights in order to temporarily fix
+          // the issue until full fix arrives. Tracking issue:
+          // https://github.com/apache/incubator-mxnet/issues/20826.
+          (param.dnnl_param.quantized && conv_pd->weights_desc().dims()[1] < 4 &&
+           conv_pd->weights_desc().data.padded_dims[1] != conv_pd->weights_desc().dims()[1])) {
         // next_impl() will visit desc and engine, please make sure they are still alive here.
         CHECK(conv_pd->next_impl()) << "No convolution implementation for this request.";
       }


### PR DESCRIPTION
## Description ##
tests/python/dnnl/subgraphs/test_conv_subgraph.py::test_pos_conv_...[...-data_shape1] fail with oneDNN v2.4+ when the data_shape1 is (4, 3, 24, 24). After further investigation it turned out that the problem occurs for the amount of input channels (second dim) is lower than 4. There was a temporary fix in place: https://github.com/apache/incubator-mxnet/pull/20847 forcing blocking the weights by 8 instead of 16, but it turned out only to make the problem occur less often. Therefore until v2.6 of oneDNN arrives there will be no blocking the weights for convolutions with the amount of input channels lower than 4.