### PR TITLE
[v1.x][BUGFIX] Fix tests/python/dnnl/subgraphs/test_conv_subgraph.py

### DIFF
--- a/src/operator/nn/mkldnn/mkldnn_convolution.cc
+++ b/src/operator/nn/mkldnn/mkldnn_convolution.cc
@@ -125,11 +125,11 @@ std::shared_ptr<mkldnn::convolution_forward::primitive_desc> GetConvFwdImpl(
                   conv_pd->weights_desc().get_size() != GetArraySize(weights)) ||
                  // With the upgrade of MKLDNN to version 2.4+
                  // tests/python/mkl/test_subgraph.py::test_pos_conv_add started failing. Switching
-                 // away from primitive with weight mkldnn::format_tag ABcd4b16a4b in order to
+                 // away from blocking weights in order to
                  // temporairly fix the issue until full fix arrives. Tracking issue:
                  // https://github.com/apache/incubator-mxnet/issues/20826.
                  (param.mkldnn_param.quantized && conv_pd->weights_desc().dims()[1] < 4 &&
-                  conv_pd->weights_desc().data.padded_dims[1] == 16)) {
+                  conv_pd->weights_desc().data.padded_dims[1] != conv_pd->weights_desc().dims()[1])) {
             // next_impl() will visit desc and engine, please make sure they are still alive here.
             CHECK(conv_pd->next_impl()) << "No convolution implementation for this request.";
           }

--- a/src/operator/nn/mkldnn/mkldnn_convolution.cc
+++ b/src/operator/nn/mkldnn/mkldnn_convolution.cc
@@ -109,41 +109,41 @@ std::shared_ptr<mkldnn::convolution_forward::primitive_desc> GetConvFwdImpl(
     int mask = (param.requantize_scales.size() > 1) ? 2 : 0;
     attr.set_output_scales(mask, param.requantize_scales);
   }
-  auto GetConvFwdPd =
-      [&param, &data, &weights, &output, &attr](const mkldnn::convolution_forward::desc& desc) {
-        auto engine = CpuEngine::Get()->get_engine();
-        try {
-          // MKLDNN introduced padded formats since 0.15 which require more memory compared to the
-          // actual size of the tensor. Currently, MKLDNN operators still reuse memory from memory
-          // planning, so here we need to select a suboptimal kernel for computation that has the
-          // expected memory size requirements
-          auto conv_pd =
-              std::make_shared<mkldnn::convolution_forward::primitive_desc>(desc, attr, engine);
-          while (conv_pd->dst_desc().get_size() != GetArraySize(output) ||
-                 conv_pd->src_desc().get_size() != GetArraySize(data) ||
-                 (!param.mkldnn_param.quantized &&
-                  conv_pd->weights_desc().get_size() != GetArraySize(weights)) ||
-                 // With the upgrade of MKLDNN to version 2.4+
-                 // tests/python/mkl/test_subgraph.py::test_pos_conv_add started failing. Switching
-                 // away from blocking weights in order to
-                 // temporairly fix the issue until full fix arrives. Tracking issue:
-                 // https://github.com/apache/incubator-mxnet/issues/20826.
-                 (param.mkldnn_param.quantized && conv_pd->weights_desc().dims()[1] < 4 &&
-                  conv_pd->weights_desc().data.padded_dims[1] != conv_pd->weights_desc().dims()[1])) {
-            // next_impl() will visit desc and engine, please make sure they are still alive here.
-            CHECK(conv_pd->next_impl()) << "No convolution implementation for this request.";
-          }
-          return conv_pd;
-        } catch (mkldnn::error& e) {
-          if (e.status == mkldnn_unimplemented && param.mkldnn_param.quantized) {
-            LOG(ERROR) << "AVX512-BW support or Intel(R) MKL dependency is "
-                          "required for int8 convolution";
-          } else {
-            LOG(ERROR) << e.message;
-          }
-          throw;
-        }
-      };
+  auto GetConvFwdPd = [&param, &data, &weights, &output, &attr](
+                          const mkldnn::convolution_forward::desc& desc) {
+    auto engine = CpuEngine::Get()->get_engine();
+    try {
+      // MKLDNN introduced padded formats since 0.15 which require more memory compared to the
+      // actual size of the tensor. Currently, MKLDNN operators still reuse memory from memory
+      // planning, so here we need to select a suboptimal kernel for computation that has the
+      // expected memory size requirements
+      auto conv_pd =
+          std::make_shared<mkldnn::convolution_forward::primitive_desc>(desc, attr, engine);
+      while (
+          conv_pd->dst_desc().get_size() != GetArraySize(output) ||
+          conv_pd->src_desc().get_size() != GetArraySize(data) ||
+          (!param.mkldnn_param.quantized &&
+           conv_pd->weights_desc().get_size() != GetArraySize(weights)) ||
+          // With the upgrade of MKLDNN to version 2.4+
+          // tests/python/mkl/test_subgraph.py::test_pos_conv_add started failing. Switching away
+          // from blocking weights in order to temporarily fix the issue until full fix arrives.
+          // Tracking issue: https://github.com/apache/incubator-mxnet/issues/20826.
+          (param.mkldnn_param.quantized && conv_pd->weights_desc().dims()[1] < 4 &&
+           conv_pd->weights_desc().data.padded_dims[1] != conv_pd->weights_desc().dims()[1])) {
+        // next_impl() will visit desc and engine, please make sure they are still alive here.
+        CHECK(conv_pd->next_impl()) << "No convolution implementation for this request.";
+      }
+      return conv_pd;
+    } catch (mkldnn::error& e) {
+      if (e.status == mkldnn_unimplemented && param.mkldnn_param.quantized) {
+        LOG(ERROR) << "AVX512-BW support or Intel(R) MKL dependency is "
+                      "required for int8 convolution";
+      } else {
+        LOG(ERROR) << e.message;
+      }
+      throw;
+    }
+  };
 
   if (param.conv_param.dilate.ndim() == 0 && bias_md_ptr == nullptr) {
     mkldnn::convolution_forward::desc desc(prop,


### PR DESCRIPTION
## Description ##
tests/python/dnnl/subgraphs/test_conv_subgraph.py::test_pos_conv_...[...-data_shape1] fail with oneDNN v2.4+ when the data_shape1 is (4, 3, 24, 24). After further investigation it turned out that the problem occurs for the amount of input channels (second dim) is lower than 4. There was a temporary fix in place: https://github.com/apache/incubator-mxnet/pull/20847 forcing blocking the weights by 8 instead of 16, but it turned out only to make the problem occur less often. Therefore until v2.6 of oneDNN arrives there will be no blocking the weights for convolutions with the amount of input channels lower than 4.