### PR TITLE
[operator] Integrate oneDNN eltwise_tanh into _npi_tanh operator

### DIFF
--- a/src/operator/nn/dnnl/dnnl_base-inl.h
+++ b/src/operator/nn/dnnl/dnnl_base-inl.h
@@ -204,6 +204,7 @@ bool SupportDNNLReshape(const NDArray& input, const NDArray& output);
 bool SupportDNNLSplit(const NDArray& input);
 bool SupportDNNLStack(const std::vector<NDArray>& inputs);
 bool SupportDNNLBinary(const std::vector<NDArray>& inputs);
+bool SupportDNNLTanh(const NDArray& input, const NDArray& output);
 }  // namespace op
 
 static int GetTypeSize(int dtype) {

--- a/src/operator/nn/dnnl/dnnl_tanh-inl.h
+++ b/src/operator/nn/dnnl/dnnl_tanh-inl.h
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file dnnl_tanh-inl.h
+ */
+
+#ifndef MXNET_OPERATOR_NN_DNNL_DNNL_TANH_INL_H_
+#define MXNET_OPERATOR_NN_DNNL_DNNL_TANH_INL_H_
+
+#if MXNET_USE_ONEDNN == 1
+
+#include "operator/nn/dnnl/dnnl_base-inl.h"
+#include "operator/operator_common.h"
+
+namespace mxnet {
+namespace op {
+
+using eltwise_fwd_t    = dnnl::eltwise_forward;
+using eltwise_fwd_pd_t = dnnl::eltwise_forward::primitive_desc;
+
+class DNNLTanhFwd {
+ public:
+  typedef OpSignature DNNLTanhSignature;
+
+  static DNNLTanhFwd& GetTanhForward(const NDArray& input, const NDArray& output);
+
+  explicit DNNLTanhFwd(const NDArray& input);
+
+  void Execute(const NDArray& input, const OpReqType& req, const NDArray& output);
+
+ private:
+  std::shared_ptr<eltwise_fwd_t> fwd;
+  std::shared_ptr<eltwise_fwd_pd_t> fwd_pd;
+};
+
+inline void DNNLTanhForward(const nnvm::NodeAttrs& attrs,
+                            const OpContext& ctx,
+                            const NDArray& input,
+                            const OpReqType& req,
+                            const NDArray& output) {
+  DNNLTanhFwd& fwd = DNNLTanhFwd::GetTanhForward(input, output);
+  fwd.Execute(input, req, output);
+}
+
+}  // namespace op
+}  // namespace mxnet
+
+#endif  // MXNET_USE_ONEDNN == 1
+#endif  // MXNET_OPERATOR_NN_DNNL_DNNL_TANH_INL_H_

--- a/src/operator/nn/dnnl/dnnl_tanh.cc
+++ b/src/operator/nn/dnnl/dnnl_tanh.cc
@@ -29,14 +29,12 @@ namespace mxnet {
 namespace op {
 
 bool SupportDNNLTanh(const NDArray& input, const NDArray& output) {
-  auto commonChecks = [](const NDArray& tensor) {
-    return tensor.shape().ndim() > 0 && tensor.shape().ndim() <= 12 && tensor.shape().Size() > 0 &&
+  auto checkTensor = [](const NDArray& tensor) {
+    return (IsDNNLType(tensor.dtype()) || tensor.dtype() == mshadow::kInt32) &&
+           tensor.shape().ndim() > 0 && tensor.shape().ndim() <= 12 && tensor.shape().Size() > 0 &&
            SupportStorageDNNL(tensor.storage_type());
   };
-  const bool inputIsOK = IsDNNLType(input.dtype()) && commonChecks(input);
-  const bool outputIsOK =
-      (IsDNNLType(output.dtype()) || output.dtype() == mshadow::kInt32) && commonChecks(output);
-  return inputIsOK && outputIsOK;
+  return checkTensor(input) && checkTensor(output);
 }
 
 DNNLTanhFwd& DNNLTanhFwd::GetTanhForward(const NDArray& input, const NDArray& output) {

--- a/src/operator/nn/dnnl/dnnl_tanh.cc
+++ b/src/operator/nn/dnnl/dnnl_tanh.cc
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file dnnl_tanh.cc
+ */
+
+#if MXNET_USE_ONEDNN == 1
+
+#include "dnnl_tanh-inl.h"
+
+namespace mxnet {
+namespace op {
+
+bool SupportDNNLTanh(const NDArray& input, const NDArray& output) {
+  auto commonChecks = [](const NDArray& tensor) {
+    return tensor.shape().ndim() > 0 && tensor.shape().ndim() <= 12 && tensor.shape().Size() > 0 &&
+           SupportStorageDNNL(tensor.storage_type());
+  };
+  const bool inputIsOK = IsDNNLType(input.dtype()) && commonChecks(input);
+  const bool outputIsOK =
+      (IsDNNLType(output.dtype()) || output.dtype() == mshadow::kInt32) && commonChecks(output);
+  return inputIsOK && outputIsOK;
+}
+
+DNNLTanhFwd& DNNLTanhFwd::GetTanhForward(const NDArray& input, const NDArray& output) {
+#if DMLC_CXX11_THREAD_LOCAL
+  static thread_local std::unordered_map<DNNLTanhSignature, DNNLTanhFwd, OpHash> fwds;
+#else
+  static MX_THREAD_LOCAL std::unordered_map<DNNLTanhSignature, DNNLTanhFwd, OpHash> fwds;
+#endif
+  DNNLTanhSignature key;
+  key.AddSign(static_cast<int>(dnnl::algorithm::eltwise_tanh));
+  key.AddSign(input);
+  key.AddSign(output);
+
+  auto it = fwds.find(key);
+  if (it == fwds.end()) {
+    const DNNLTanhFwd fwd(input);
+    it = AddToCache(&fwds, key, fwd);
+  }
+  return it->second;
+}
+
+DNNLTanhFwd::DNNLTanhFwd(const NDArray& input) {
+  auto src_desc = input.GetDNNLData()->get_desc();
+  dnnl::eltwise_forward::desc fwd_desc(
+      dnnl::prop_kind::forward_scoring, dnnl::algorithm::eltwise_tanh, src_desc);
+  fwd_pd = std::make_shared<eltwise_fwd_pd_t>(fwd_desc, mxnet::CpuEngine::Get()->get_engine());
+  fwd    = std::make_shared<eltwise_fwd_t>(*fwd_pd);
+}
+
+void DNNLTanhFwd::Execute(const NDArray& input, const OpReqType& req, const NDArray& output) {
+  auto engine           = mxnet::CpuEngine::Get()->get_engine();
+  auto src              = input.GetDNNLData();
+  dnnl_output_t out_mem = CreateDNNLMem(output, fwd_pd->dst_desc(), req, &input);
+
+  dnnl_args_map_t args = {
+      {DNNL_ARG_SRC, *src},
+      {DNNL_ARG_DST, *out_mem.second},
+  };
+
+  DNNLStream::Get()->RegisterPrimArgs(*fwd, args);
+  CommitOutput(output, out_mem);
+  DNNLStream::Get()->Submit();
+}
+
+}  // namespace op
+}  // namespace mxnet
+
+#endif  // MXNET_USE_ONEDNN == 1

--- a/src/operator/numpy/np_elemwise_unary_op_basic.cc
+++ b/src/operator/numpy/np_elemwise_unary_op_basic.cc
@@ -22,8 +22,8 @@
  * \brief CPU Implementation of numpy elementwise unary function.
  */
 #include <mxnet/base.h>
-#include "../tensor/elemwise_unary_op.h"
-#include "../tensor/elemwise_binary_op.h"
+#include "operator/tensor/elemwise_unary_op.h"
+#include "operator/tensor/elemwise_binary_op.h"
 
 namespace mxnet {
 namespace op {
@@ -483,6 +483,10 @@ MXNET_OPERATOR_REGISTER_NUMPY_MIXED_TYPE_UNARY(_npi_tanh, "x", mshadow_op::tanh)
 .. math::
    tanh(x) = sinh(x) / cosh(x)
 )code" ADD_FILELINE)
+#if MXNET_USE_ONEDNN == 1
+    .set_attr<FComputeEx>("FComputeEx<cpu>", TanhComputeExCPU)
+    .set_attr<FInferStorageType>("FInferStorageType", TanhStorageType)
+#endif  // MXNET_USE_ONEDNN
     .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseInOut{"_backward_npi_tanh"});
 
 // arcsinh


### PR DESCRIPTION
## Description ##
Integrate oneDNN eltwise_tanh into _npi_tanh operator to improve its performance.

## Performance ##
Without dnnl:
![image](https://user-images.githubusercontent.com/59650839/159368913-9296fabb-d64f-48b0-bb32-0e1577735714.png)

With dnnl:
![image](https://user-images.githubusercontent.com/59650839/159368997-3a826089-46e1-4b4b-a5eb-4fb486736e55.png)

As it is visible from the screen shots, performance has improved over 10 times. Above benchmarks have been performed on a machine with Intel(R) Core(TM) i9-9940X CPU @ 3.30GHz processor. 