### PR TITLE
AMP improvements + enable bf16 input for quantize_v2

### DIFF
--- a/python/mxnet/amp/lists/symbol_bf16.py
+++ b/python/mxnet/amp/lists/symbol_bf16.py
@@ -45,6 +45,7 @@ BF16_FP32_FUNCS = [
     'sqrt',
     'square',
     'tanh',
+    '_contrib_quantize_v2',
 ]
 
 # Functions that when running with Bfloat16, the params that still need float32.
@@ -97,7 +98,6 @@ FP32_FUNCS = [
     '_contrib_index_copy',
     '_contrib_quadratic',
     '_contrib_quantize',
-    '_contrib_quantize_v2',
     '_contrib_quantized_concat',
     '_contrib_quantized_conv',
     '_contrib_quantized_flatten',

--- a/python/mxnet/ndarray/ndarray.py
+++ b/python/mxnet/ndarray/ndarray.py
@@ -2653,6 +2653,8 @@ fixed-size items.
         array([[1, 1, 1],
                [1, 1, 1]], dtype=int32)
         """
+        if self.dtype == bfloat16:
+            return self.astype(np.float32).asnumpy()
         data = np.empty(self.shape, dtype=self.dtype)
         check_call(_LIB.MXNDArraySyncCopyToCPU(
             self.handle,

--- a/src/operator/quantization/quantize_v2-inl.h
+++ b/src/operator/quantization/quantize_v2-inl.h
@@ -151,8 +151,18 @@ static inline bool QuantizeV2Type(const nnvm::NodeAttrs& attrs,
   CHECK_EQ(in_attrs->size(), 1U);
   CHECK_EQ(out_attrs->size(), 3U);
   const QuantizeV2Param& param = nnvm::get<QuantizeV2Param>(attrs.parsed);
-  CHECK(in_attrs->at(0) == mshadow::kFloat32 || in_attrs->at(0) == mshadow::kUint8 ||
-        in_attrs->at(0) == mshadow::kInt8);
+
+#if MXNET_USE_ONEDNN == 1
+  if (param.min_calib_range.has_value() && param.max_calib_range.has_value()) {
+    CHECK(in_attrs->at(0) == mshadow::kFloat32 || in_attrs->at(0) == mshadow::kBfloat16 ||
+          in_attrs->at(0) == mshadow::kUint8 || in_attrs->at(0) == mshadow::kInt8);
+  } else
+#endif
+  {
+    CHECK(in_attrs->at(0) == mshadow::kFloat32 || in_attrs->at(0) == mshadow::kUint8 ||
+          in_attrs->at(0) == mshadow::kInt8);
+  }
+
   auto out_type = GetQuantizeOutputType(param);
   if (out_type == mshadow::kUint8) {
     TYPE_ASSIGN_CHECK(*out_attrs, 0, mshadow::kUint8);


### PR DESCRIPTION
### Changes ###
- [ ] Fix `asnumpy()` for bfloat16 dtype
- [ ] Relaxed some AMP assumptions, added more checks
- [ ] Fixed an issue with ops from [`LP16_FP32_FUNCS`](https://github.com/apache/incubator-mxnet/blob/master/python/mxnet/amp/lists/symbol_bf16.py#L36) list, for which order of visited nodes during graph pass could affect whether an op is converted (to low precision) or not.
- [ ] Enabled bf16 input for calibrated quantize_v2 ops (removes need for `amp_cast` before `quantize_v2` for quantized models)