### PR TITLE
[master] Unified oneDNN implementation calls for quantized operators

### DIFF
--- a/src/operator/nn/dnnl/dnnl_base-inl.h
+++ b/src/operator/nn/dnnl/dnnl_base-inl.h
@@ -146,6 +146,10 @@ static inline bool SupportDNNL(const NDArray& input) {
   return SupportDNNL(input.dtype(), input.shape()) && SupportStorageDNNL(input.storage_type());
 }
 
+static inline bool SupportDNNLQuantize(const int out_type) {
+  return out_type == mshadow::kUint8 || out_type == mshadow::kInt8;
+}
+
 static inline bool DNNLEnvSet() {
   static bool is_dnnl_enabled = dmlc::GetEnv("MXNET_ONEDNN_ENABLED", true);
   return is_dnnl_enabled;

--- a/src/operator/quantization/dnnl/dnnl_quantize-inl.h
+++ b/src/operator/quantization/dnnl/dnnl_quantize-inl.h
@@ -67,9 +67,6 @@ static void DNNLQuantizeComputeKer(const std::vector<NDArray>& inputs,
   attr.set_output_scales(mask, scales);
   dnnl::engine cpu_engine = mxnet::CpuEngine::Get()->get_engine();
   NDArray in_buffer       = inputs[0];
-  if (inputs[0].IsView() && inputs[0].IsDNNLData())
-    in_buffer = inputs[0].Reorder2Default();
-
   auto i_mem    = in_buffer.GetDNNLData();
   auto i_desc   = i_mem->get_desc();
   size_t i_ndim = in_buffer.shape().ndim();

--- a/src/operator/quantization/quantize.cc
+++ b/src/operator/quantization/quantize.cc
@@ -106,7 +106,7 @@ where
     .set_attr<nnvm::FGradient>("FGradient", MakeZeroGradNodes)
 #if MXNET_USE_ONEDNN == 1
     .set_attr<bool>("TIsDNNL", true)
-    .set_attr<FComputeEx>("FComputeEx<cpu>", DNNLQuantizeCompute)
+    .set_attr<FComputeEx>("FComputeEx<cpu>", QuantizeComputeExCPU)
 #endif
     .set_attr<FCompute>("FCompute<cpu>", QuantizeCompute<cpu>)
     .add_argument("data", "NDArray-or-Symbol", "A ndarray/symbol of type `float32`")

--- a/src/operator/quantization/quantize.cc
+++ b/src/operator/quantization/quantize.cc
@@ -55,7 +55,7 @@ static void QuantizeComputeExCPU(const nnvm::NodeAttrs& attrs,
                                  const std::vector<NDArray>& outputs) {
   const QuantizeParam& param = nnvm::get<QuantizeParam>(attrs.parsed);
 
-  if (param.out_type == mshadow::kUint8 || param.out_type == mshadow::kInt8) {
+  if (SupportDNNLQuantize(param.out_type)) {
     DNNL_OPCHECK_INIT(false, outputs.size(), inputs, outputs);
     DNNLRun(DNNLQuantizeCompute, attrs, ctx, inputs, req, outputs);
     DNNL_OPCHECK_RUN(QuantizeCompute<cpu>, attrs, ctx, inputs, req, outputs);

--- a/src/operator/quantization/quantize_v2.cc
+++ b/src/operator/quantization/quantize_v2.cc
@@ -65,6 +65,22 @@ static OpStatePtr CreateQuantizeV2State(const nnvm::NodeAttrs& attrs,
   return state;
 }
 
+// DNNLRun doeas not support StatefullComputeEx
+// void QuantizeV2ForwardExCPU(const OpStatePtr& state,
+//                             const OpContext& ctx,
+//                             const std::vector<TBlob>& inputs,
+//                             const std::vector<OpReqType>& req,
+//                             const std::vector<TBlob>& outputs) {
+//   const ConvolutionParam& params = nnvm::get<ConvolutionParam>(attrs.parsed);
+//   if (SupportDNNLConv(params, inputs[0])) {
+//     DNNL_OPCHECK_INIT(false, outputs.size(), inputs, outputs);
+//     DNNLRun(SgDNNLQuantizeForward, state, ctx, inputs, req, outputs);
+//     DNNL_OPCHECK_RUN(QuantizeV2Forward<cpu>, attrs, ctx, inputs, req, outputs);
+//     return;
+//   }
+//   FallBackCompute(QuantizeV2Forward<cpu>, attrs, ctx, inputs, req, outputs);
+// }
+
 NNVM_REGISTER_OP(_contrib_quantize_v2)
     .add_alias("_npx_contrib_quantize_v2")
     .describe(R"code(Quantize a input tensor from float to `out_type`,

--- a/src/operator/quantization/quantize_v2.cc
+++ b/src/operator/quantization/quantize_v2.cc
@@ -65,22 +65,6 @@ static OpStatePtr CreateQuantizeV2State(const nnvm::NodeAttrs& attrs,
   return state;
 }
 
-// DNNLRun doeas not support StatefullComputeEx
-// void QuantizeV2ForwardExCPU(const OpStatePtr& state,
-//                             const OpContext& ctx,
-//                             const std::vector<TBlob>& inputs,
-//                             const std::vector<OpReqType>& req,
-//                             const std::vector<TBlob>& outputs) {
-//   const ConvolutionParam& params = nnvm::get<ConvolutionParam>(attrs.parsed);
-//   if (SupportDNNLConv(params, inputs[0])) {
-//     DNNL_OPCHECK_INIT(false, outputs.size(), inputs, outputs);
-//     DNNLRun(SgDNNLQuantizeForward, state, ctx, inputs, req, outputs);
-//     DNNL_OPCHECK_RUN(QuantizeV2Forward<cpu>, attrs, ctx, inputs, req, outputs);
-//     return;
-//   }
-//   FallBackCompute(QuantizeV2Forward<cpu>, attrs, ctx, inputs, req, outputs);
-// }
-
 NNVM_REGISTER_OP(_contrib_quantize_v2)
     .add_alias("_npx_contrib_quantize_v2")
     .describe(R"code(Quantize a input tensor from float to `out_type`,

--- a/src/operator/quantization/quantized_fully_connected.cc
+++ b/src/operator/quantization/quantized_fully_connected.cc
@@ -308,7 +308,6 @@ void QuantizedFullyConnectedForwardExCPU(const nnvm::NodeAttrs& attrs,
                                          const std::vector<NDArray>& inputs,
                                          const std::vector<OpReqType>& req,
                                          const std::vector<NDArray>& outputs) {
-  FullyConnectedParam param = nnvm::get<FullyConnectedParam>(attrs.parsed);
 
   DNNL_OPCHECK_INIT(false, outputs.size(), inputs, outputs);
   DNNLRun(DNNLQuantizedFullyConnectedForward, attrs, ctx, inputs, req, outputs);

--- a/src/operator/quantization/quantized_fully_connected.cc
+++ b/src/operator/quantization/quantized_fully_connected.cc
@@ -305,10 +305,14 @@ void QuantizedFullyConnectedForwardCPU(const nnvm::NodeAttrs& attrs,
 #if MXNET_USE_ONEDNN == 1
 void QuantizedFullyConnectedForwardExCPU(const nnvm::NodeAttrs& attrs,
                                          const OpContext& ctx,
-                                         const std::vector<NDArray>& in_data,
+                                         const std::vector<NDArray>& inputs,
                                          const std::vector<OpReqType>& req,
-                                         const std::vector<NDArray>& out_data) {
-  DNNLQuantizedFullyConnectedForward(attrs, ctx, in_data, req, out_data);
+                                         const std::vector<NDArray>& outputs) {
+  FullyConnectedParam param = nnvm::get<FullyConnectedParam>(attrs.parsed);
+
+  DNNL_OPCHECK_INIT(false, outputs.size(), inputs, outputs);
+  DNNLRun(DNNLQuantizedFullyConnectedForward, attrs, ctx, inputs, req, outputs);
+  DNNL_OPCHECK_RUN(QuantizedFullyConnectedForwardCPU, attrs, ctx, inputs, req, outputs);
 }
 #endif
 

--- a/src/operator/quantization/quantized_fully_connected.cc
+++ b/src/operator/quantization/quantized_fully_connected.cc
@@ -308,7 +308,6 @@ void QuantizedFullyConnectedForwardExCPU(const nnvm::NodeAttrs& attrs,
                                          const std::vector<NDArray>& inputs,
                                          const std::vector<OpReqType>& req,
                                          const std::vector<NDArray>& outputs) {
-
   DNNL_OPCHECK_INIT(false, outputs.size(), inputs, outputs);
   DNNLRun(DNNLQuantizedFullyConnectedForward, attrs, ctx, inputs, req, outputs);
   DNNL_OPCHECK_RUN(QuantizedFullyConnectedForwardCPU, attrs, ctx, inputs, req, outputs);

--- a/src/operator/quantization/requantize.cc
+++ b/src/operator/quantization/requantize.cc
@@ -37,9 +37,6 @@ void RequantizeForwardExCPU(const nnvm::NodeAttrs& attrs,
                             const std::vector<OpReqType>& req,
                             const std::vector<NDArray>& outputs) {
   const RequantizeParam& param = nnvm::get<RequantizeParam>(attrs.parsed);
-
-  // What checks should I do here?
-
   auto out_type = GetQuantizeOutputType(param);
 
   if (out_type == mshadow::kUint8 || out_type == mshadow::kInt8) {

--- a/src/operator/quantization/requantize.cc
+++ b/src/operator/quantization/requantize.cc
@@ -39,7 +39,7 @@ void RequantizeForwardExCPU(const nnvm::NodeAttrs& attrs,
   const RequantizeParam& param = nnvm::get<RequantizeParam>(attrs.parsed);
   auto out_type                = GetQuantizeOutputType(param);
 
-  if (out_type == mshadow::kUint8 || out_type == mshadow::kInt8) {
+  if (SupportDNNLQuantize(out_type)) {
     DNNL_OPCHECK_INIT(false, outputs.size(), inputs, outputs);
     DNNLRun(DNNLRequantizeForward, attrs, ctx, inputs, req, outputs);
     DNNL_OPCHECK_RUN(RequantizeForward<cpu>, attrs, ctx, inputs, req, outputs);

--- a/src/operator/quantization/requantize.cc
+++ b/src/operator/quantization/requantize.cc
@@ -37,7 +37,7 @@ void RequantizeForwardExCPU(const nnvm::NodeAttrs& attrs,
                             const std::vector<OpReqType>& req,
                             const std::vector<NDArray>& outputs) {
   const RequantizeParam& param = nnvm::get<RequantizeParam>(attrs.parsed);
-  auto out_type = GetQuantizeOutputType(param);
+  auto out_type                = GetQuantizeOutputType(param);
 
   if (out_type == mshadow::kUint8 || out_type == mshadow::kInt8) {
     DNNL_OPCHECK_INIT(false, outputs.size(), inputs, outputs);


### PR DESCRIPTION
## Description

In this PR I focused on unifying oneDNN implementation calls using `DNNLRun` method, so that all quantization operators would be consistent. Although some operators use  `FStatefulComputeEx` instead of `FComputeEx` which is not supported by the `DNNLRun` method and therefore they are unchanged.