### PR TITLE
[1.x][submodule] Upgrade oneDNN to the top of rls-v2.4 branch

### DIFF
--- a/src/operator/nn/mkldnn/mkldnn_convolution.cc
+++ b/src/operator/nn/mkldnn/mkldnn_convolution.cc
@@ -123,13 +123,7 @@ std::shared_ptr<mkldnn::convolution_forward::primitive_desc> GetConvFwdImpl(
           conv_pd->dst_desc().get_size() != GetArraySize(output) ||
           conv_pd->src_desc().get_size() != GetArraySize(data) ||
           (!param.mkldnn_param.quantized &&
-           conv_pd->weights_desc().get_size() != GetArraySize(weights)) ||
-          // With the upgrade of MKLDNN to version 2.4+
-          // tests/python/mkl/test_subgraph.py::test_pos_conv_add started failing. Switching away
-          // from blocking weights in order to temporarily fix the issue until full fix arrives.
-          // Tracking issue: https://github.com/apache/incubator-mxnet/issues/20826.
-          (param.mkldnn_param.quantized && conv_pd->weights_desc().dims()[1] < 4 &&
-           conv_pd->weights_desc().data.padded_dims[1] != conv_pd->weights_desc().dims()[1])) {
+           conv_pd->weights_desc().get_size() != GetArraySize(weights))) {
         // next_impl() will visit desc and engine, please make sure they are still alive here.
         CHECK(conv_pd->next_impl()) << "No convolution implementation for this request.";
       }


### PR DESCRIPTION
## Description ##
This upgrade contains the fix to slim convolutions with blocked weights.
