### PR TITLE
[1.x] Fix 'module 'jinja2' has no attribute 'contextfilter''

### DIFF
--- a/julia/docs/Makefile
+++ b/julia/docs/Makefile
@@ -20,8 +20,9 @@ all:
 	  'using Pkg; \
 	   Pkg.develop(PackageSpec(name="MXNet", path = joinpath(pwd(), "..")))'
 	julia --color=yes --project=./ ./make.jl
-	pip install --user Markdown==3.1 \
-          mkdocs==1.0.4 \
+	pip install --user jinja2>=2.7.1,<3.1.0 \
+	  Markdown==3.1 \
+	  mkdocs==1.0.4 \
 	  mkdocs-material==4.6.0 \
 	  pygments==2.5.2 \
 	  pymdown-extensions==6.2.1 \

--- a/julia/docs/Makefile
+++ b/julia/docs/Makefile
@@ -20,7 +20,7 @@ all:
 	  'using Pkg; \
 	   Pkg.develop(PackageSpec(name="MXNet", path = joinpath(pwd(), "..")))'
 	julia --color=yes --project=./ ./make.jl
-	pip install --user jinja2>=2.7.1,<3.1.0 \
+	pip install --user jinja2==3.0.3 \
 	  Markdown==3.1 \
 	  mkdocs==1.0.4 \
 	  mkdocs-material==4.6.0 \

--- a/julia/docs/Makefile
+++ b/julia/docs/Makefile
@@ -20,7 +20,7 @@ all:
 	  'using Pkg; \
 	   Pkg.develop(PackageSpec(name="MXNet", path = joinpath(pwd(), "..")))'
 	julia --color=yes --project=./ ./make.jl
-	pip install --user jinja2==3.0.3 \
+	pip install --user "jinja2>=2.7.1,<3.1.0" \
 	  Markdown==3.1 \
 	  mkdocs==1.0.4 \
 	  mkdocs-material==4.6.0 \


### PR DESCRIPTION
## Description ##
Website CI on branch v1.x fails due to: 'module 'jinja2' has no attribute 'contextfilter''. According to https://jinja.palletsprojects.com/en/3.1.x/changes/#version-3-1-0 'contextfilter' has been replaced by pass_context in v3.1.0. This change ensures that the jinja2 is in lower version.

Fixes: https://github.com/apache/incubator-mxnet/issues/20991