### PR TITLE
[v1.9.x] Update website footer to include required Apache links

### DIFF
--- a/docs/static_site/src/_includes/footer.html
+++ b/docs/static_site/src/_includes/footer.html
@@ -1,7 +1,7 @@
 <footer class="site-footer h-card">
     <div class="wrapper">
         <div class="row">
-            <div class="col-4">
+            <div class="col-5">
                 <h4 class="footer-category-title">Resources</h4>
                 <ul class="contact-list">
                     <li><a href="{{'community/contribute#mxnet-dev-communications'|relative_url}}">Mailing lists</a></li>
@@ -10,15 +10,25 @@
                     <li><a href="https://github.com/apache/incubator-mxnet/labels/Roadmap">Github Roadmap</a></li>
                     <li><a href="https://discuss.mxnet.io">MXNet Discuss forum</a></li>
                     <li><a href="{{'community/contribute'|relative_url}}">Contribute To MXNet</a></li>
-
+                </ul>
+            </div>
+            <div class="col-5">
+                <h4 class="footer-category-title">Apache</h4>
+                <ul class="apache-list">
+                    <li><a href="https://www.apache.org/foundation/">Foundation</a></li>
+                    <li><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
+                    <li><a href="{{'/api/faq/security.html' | relative_url }}">Security</a></li>
+                    <li><a href="https://www.apache.org/licenses/">License</a></li>
+                    <li><a href="https://www.apache.org/events/current-event">Events</a></li>
+                    <li><a href="https://www.apache.org/foundation/thanks.html">Thanks</a></li>
                 </ul>
             </div>
 
-            <div class="col-4">
+            <div class="col-5">
                 {%- include social.html -%}
             </div>
 
-            <div class="col-4 footer-text">
+            <div class="col-5 footer-text">
                 <p>{{- site.description | escape -}}</p>
             </div>
         </div>
@@ -31,13 +41,13 @@
                 <img src="{{'/assets/img/apache_incubator_logo.png' | relative_url}}" class="footer-logo col-2">
             </div>
             <div class="footer-bottom-warning col-9">
-                <p>Apache MXNet is an effort undergoing incubation at The Apache Software Foundation (ASF), <span
+                <p>Apache MXNet is an effort undergoing incubation at <a href="http://www.apache.org/">The Apache Software Foundation</a> (ASF), <span
                         style="font-weight:bold">sponsored by the <i>Apache Incubator</i></span>. Incubation is required
                     of all newly accepted projects until a further review indicates that the infrastructure,
                     communications, and decision making process have stabilized in a manner consistent with other
                     successful ASF projects. While incubation status is not necessarily a reflection of the completeness
                     or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF.
-                </p><p>"Copyright © 2017-2018, The Apache Software Foundation Apache MXNet, MXNet, Apache, the Apache
+                </p><p>"Copyright © 2017-2022, The Apache Software Foundation Apache MXNet, MXNet, Apache, the Apache
                     feather, and the Apache MXNet project logo are either registered trademarks or trademarks of the
                     Apache Software Foundation."</p>
             </div>

--- a/docs/static_site/src/_includes/footer.html
+++ b/docs/static_site/src/_includes/footer.html
@@ -1,7 +1,7 @@
 <footer class="site-footer h-card">
     <div class="wrapper">
         <div class="row">
-            <div class="col-5">
+            <div class="col-3">
                 <h4 class="footer-category-title">Resources</h4>
                 <ul class="contact-list">
                     <li><a href="{{'community/contribute#mxnet-dev-communications'|relative_url}}">Mailing lists</a></li>
@@ -12,7 +12,7 @@
                     <li><a href="{{'community/contribute'|relative_url}}">Contribute To MXNet</a></li>
                 </ul>
             </div>
-            <div class="col-5">
+            <div class="col-3">
                 <h4 class="footer-category-title">Apache</h4>
                 <ul class="apache-list">
                     <li><a href="https://www.apache.org/foundation/">Foundation</a></li>
@@ -24,11 +24,11 @@
                 </ul>
             </div>
 
-            <div class="col-5">
+            <div class="col-3">
                 {%- include social.html -%}
             </div>
 
-            <div class="col-5 footer-text">
+            <div class="col-3 footer-text">
                 <p>{{- site.description | escape -}}</p>
             </div>
         </div>

--- a/docs/static_site/src/_sass/minima/_layout.scss
+++ b/docs/static_site/src/_sass/minima/_layout.scss
@@ -184,6 +184,7 @@
 }
 
 .contact-list,
+.apache-list,
 .social-media-list {
   list-style: none;
   margin-left: 0;

--- a/julia/docs/Makefile
+++ b/julia/docs/Makefile
@@ -20,8 +20,9 @@ all:
 	  'using Pkg; \
 	   Pkg.develop(PackageSpec(name="MXNet", path = joinpath(pwd(), "..")))'
 	julia --color=yes --project=./ ./make.jl
-	pip install --user Markdown==3.1 \
-          mkdocs==1.0.4 \
+	pip install --user jinja2>=2.7.1,<3.1.0 \
+	  Markdown==3.1 \
+	  mkdocs==1.0.4 \
 	  mkdocs-material==4.6.0 \
 	  pygments==2.5.2 \
 	  pymdown-extensions==6.2.1 \

--- a/julia/docs/Makefile
+++ b/julia/docs/Makefile
@@ -20,7 +20,7 @@ all:
 	  'using Pkg; \
 	   Pkg.develop(PackageSpec(name="MXNet", path = joinpath(pwd(), "..")))'
 	julia --color=yes --project=./ ./make.jl
-	pip install --user jinja2>=2.7.1,<3.1.0 \
+	pip install --user jinja2==3.0.3 \
 	  Markdown==3.1 \
 	  mkdocs==1.0.4 \
 	  mkdocs-material==4.6.0 \

--- a/julia/docs/Makefile
+++ b/julia/docs/Makefile
@@ -20,7 +20,7 @@ all:
 	  'using Pkg; \
 	   Pkg.develop(PackageSpec(name="MXNet", path = joinpath(pwd(), "..")))'
 	julia --color=yes --project=./ ./make.jl
-	pip install --user jinja2==3.0.3 \
+	pip install --user "jinja2>=2.7.1,<3.1.0" \
 	  Markdown==3.1 \
 	  mkdocs==1.0.4 \
 	  mkdocs-material==4.6.0 \


### PR DESCRIPTION
Going through the Apache MXNet (Incubating) [clutch status page](https://incubator.apache.org/clutch/mxnet.html) we were missing some required links to the ASF project, according to https://www.apache.org/foundation/marks/pmcs#navigation. This PR adds an "Apache" section to the footer which includes the ASF links.
