### PR TITLE
[master] Enabled tests using the whole batch for calibration

### DIFF
--- a/tests/python/dnnl/subgraphs/subgraph_common.py
+++ b/tests/python/dnnl/subgraphs/subgraph_common.py
@@ -162,9 +162,10 @@ def check_quantize(net_original, data_shapes, out_type, name='conv',
   dataArray= mx.gluon.data.ArrayDataset(*data)
 
   calib_data = mx.gluon.data.DataLoader(dataArray, batch_size=1)
-  # if test fails with only one batch used for calibration, it will be re-run with all batches:
-  for num_calib_batches in [1, None]:
-    for quantize_granularity in quantize_granularity_list:
+  for quantize_granularity in quantize_granularity_list:
+    # if test fails with only one batch used for calibration, it will be re-run with all batches
+    # to achieve better representatation of the whole data range:
+    for num_calib_batches in [1, None]:
       qnet = quantization.quantize_net(net_original,
                                        device=mx.cpu(),
                                        exclude_layers=None,
@@ -195,13 +196,13 @@ def check_quantize(net_original, data_shapes, out_type, name='conv',
       except AssertionError as err:
         if num_calib_batches==1:
           print("\nRerunning test with all batches used for calibration for more precise quantization scales!")
-          break
         else:
           raise err
       else:
         if num_calib_batches==None:
-          print("Test passed when all batches were used for calibration.")
-        return
+          print("Finally the test passed when all batches were used for calibration.")
+        else:
+          break # for num_calib_batches in [1, None]:
 
 
 


### PR DESCRIPTION
## Description ##
This PR fixes the tests by allowing them to use the whole batch of data for calibration of quantized model. 
Before, data was unnecessary divided into smaller parts and only one of them was used for calibration which resulted in worse representation of the whole data range and less precise quantization scales, as well as slower execution due to the overhead connected with dividing data. 
After this change, the whole batch is used to calculate quantization scales and loss in accuracy caused by too small calibration dataset will be avoided.