### PR TITLE
[BUGFIX] check shape size in reshape operator

### DIFF
--- a/src/operator/tensor/matrix_op-inl.h
+++ b/src/operator/tensor/matrix_op-inl.h
@@ -225,12 +225,10 @@ inline bool ReshapeShape(const nnvm::NodeAttrs& attrs,
            && ReverseReshapeInferShape(&(*in_attrs)[0], (*out_attrs)[0]);
   }
   ReverseReshapeInferShape(&dshape, oshape);
-#if 0
   CHECK_EQ(oshape.Size(), dshape.Size())
     << "Target shape size is different to source. "
     << "Target: " << oshape
     << "\nSource: " << dshape;
-#endif
   SHAPE_ASSIGN_CHECK(*out_attrs, 0, oshape);
   return ReverseReshapeInferShape(&(*in_attrs)[0], (*out_attrs)[0]);
 }


### PR DESCRIPTION
## Description ##
added an explicit check of shape size in reshape operator.
This improves the error message reported in issue #21017.
