### PR TITLE
Fix CI in master

### DIFF
--- a/ci/docker/Dockerfile.build.ubuntu
+++ b/ci/docker/Dockerfile.build.ubuntu
@@ -159,6 +159,10 @@ SHELL ["/bin/bash", "-c"]
 # We need to redeclare ARG due to
 # https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
 ARG BASE_IMAGE
+RUN apt-get update && \
+        apt-get install -y --allow-change-held-packages libcudnn8 libcudnn8-dev && \
+        rm -rf /var/lib/apt/lists/*
+
 ARG TRT_VERSION
 RUN if [ ! -z "${TRT_VERSION}" ]; then \
         apt-get update && \

--- a/ci/docker/Dockerfile.build.ubuntu
+++ b/ci/docker/Dockerfile.build.ubuntu
@@ -160,15 +160,14 @@ SHELL ["/bin/bash", "-c"]
 # https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
 ARG BASE_IMAGE
 ARG TRT_VERSION
-RUN export SHORT_CUDA_VERSION=${CUDA_VERSION%.*} && \
-    apt-get update && \
-    apt-get install -y --allow-change-held-packages libcudnn8 libcudnn8-dev && \
-    if [ ! -z "${TRT_VERSION}" ]; then \
+RUN if [ ! -z "${TRT_VERSION}" ]; then \
+        apt-get update && \
         TRT_MAJOR_VERSION=$(echo $TRT_VERSION | cut -d. -f 1) && \
         apt-get install -y libnvinfer${TRT_MAJOR_VERSION}=${TRT_VERSION} \
                            libnvinfer-dev=${TRT_VERSION} \
                            libnvinfer-plugin${TRT_MAJOR_VERSION}=${TRT_VERSION} \
                            libnvinfer-plugin-dev=${TRT_VERSION}; \
-    fi && \
-    rm -rf /var/lib/apt/lists/*
+        rm -rf /var/lib/apt/lists/*; \
+    fi
+
 

--- a/ci/docker/Dockerfile.build.ubuntu
+++ b/ci/docker/Dockerfile.build.ubuntu
@@ -159,24 +159,13 @@ SHELL ["/bin/bash", "-c"]
 # We need to redeclare ARG due to
 # https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
 ARG BASE_IMAGE
+ARG TRT_VERSION
 RUN export SHORT_CUDA_VERSION=${CUDA_VERSION%.*} && \
     export OS_RELEASE="$(cat /etc/os-release)" && \
     apt-get update && \
     apt-get install -y --allow-change-held-packages libcudnn8 libcudnn8-dev && \
-    if [[ ${OS_RELEASE} == *"Bionic"* ]]; then \
-        if [ ${SHORT_CUDA_VERSION} = 11.0 ]; then \
-            TRT_VERSION="7.2.0-1+cuda11.0"; \
-            TRT_MAJOR_VERSION=7; \
-        elif [ ${SHORT_CUDA_VERSION} = 11.1 ]; then \
-            TRT_VERSION="7.2.1-1+cuda11.1"; \
-            TRT_MAJOR_VERSION=7; \
-        elif [ ${SHORT_CUDA_VERSION} = 11.4 ]; then \
-            TRT_VERSION="8.2.4-1+cuda11.4"; \
-            TRT_MAJOR_VERSION=8; \
-        else \
-            echo "ERROR: Cuda ${SHORT_CUDA_VERSION} not yet supported in Dockerfile.build.ubuntu"; \
-            exit 1; \
-        fi; \
+    if [ ! -z "${TRT_VERSION}" ]; then \
+        TRT_MAJOR_VERSION=$(echo $TRT_VERSION | cut -d. -f 1) && \
         apt-get install -y libnvinfer${TRT_MAJOR_VERSION}=${TRT_VERSION} \
                            libnvinfer-dev=${TRT_VERSION} \
                            libnvinfer-plugin${TRT_MAJOR_VERSION}=${TRT_VERSION} \

--- a/ci/docker/Dockerfile.build.ubuntu
+++ b/ci/docker/Dockerfile.build.ubuntu
@@ -170,6 +170,9 @@ RUN export SHORT_CUDA_VERSION=${CUDA_VERSION%.*} && \
         elif [ ${SHORT_CUDA_VERSION} = 11.1 ]; then \
             TRT_VERSION="7.2.1-1+cuda11.1"; \
             TRT_MAJOR_VERSION=7; \
+        elif [ ${SHORT_CUDA_VERSION} = 11.4 ]; then \
+            TRT_VERSION="8.2.4-1+cuda11.4"; \
+            TRT_MAJOR_VERSION=8; \
         else \
             echo "ERROR: Cuda ${SHORT_CUDA_VERSION} not yet supported in Dockerfile.build.ubuntu"; \
             exit 1; \

--- a/ci/docker/Dockerfile.build.ubuntu
+++ b/ci/docker/Dockerfile.build.ubuntu
@@ -161,7 +161,6 @@ SHELL ["/bin/bash", "-c"]
 ARG BASE_IMAGE
 ARG TRT_VERSION
 RUN export SHORT_CUDA_VERSION=${CUDA_VERSION%.*} && \
-    export OS_RELEASE="$(cat /etc/os-release)" && \
     apt-get update && \
     apt-get install -y --allow-change-held-packages libcudnn8 libcudnn8-dev && \
     if [ ! -z "${TRT_VERSION}" ]; then \

--- a/ci/docker/docker-compose.yml
+++ b/ci/docker/docker-compose.yml
@@ -105,7 +105,8 @@ services:
       dockerfile: Dockerfile.build.ubuntu
       target: gpu
       args:
-        BASE_IMAGE: nvidia/cuda:11.4.0-cudnn8-devel-ubuntu18.04
+        BASE_IMAGE: nvidia/cuda:11.4.0-cudnn8-devel-ubuntu20.04
+        TRT_VERSION: 8.2.4-1+cuda11.4
       cache_from:
         - ${DOCKER_CACHE_REGISTRY}/build.ubuntu_tensorrt_cu114:latest
   ubuntu_gpu_cu111:

--- a/ci/docker/docker-compose.yml
+++ b/ci/docker/docker-compose.yml
@@ -68,7 +68,7 @@ services:
       dockerfile: Dockerfile.build.centos7
       target: base
       args:
-        BASE_IMAGE: nvidia/cuda:11.0-cudnn8-devel-centos7
+        BASE_IMAGE: nvidia/cuda:11.0.3-cudnn8-devel-centos7
       cache_from:
         - ${DOCKER_CACHE_REGISTRY}/build.centos7_gpu_cu110:latest
   centos7_gpu_cu112:
@@ -105,7 +105,7 @@ services:
       dockerfile: Dockerfile.build.ubuntu
       target: gpu
       args:
-        BASE_IMAGE: nvidia/cuda:11.1-cudnn8-devel-ubuntu18.04
+        BASE_IMAGE: nvidia/cuda:11.1.1-cudnn8-devel-ubuntu18.04
       cache_from:
         - ${DOCKER_CACHE_REGISTRY}/build.ubuntu_tensorrt_cu111:latest
   ubuntu_gpu_cu111:
@@ -115,7 +115,7 @@ services:
       dockerfile: Dockerfile.build.ubuntu
       target: gpu
       args:
-        BASE_IMAGE: nvidia/cuda:11.1-cudnn8-devel-ubuntu20.04
+        BASE_IMAGE: nvidia/cuda:11.1.1-cudnn8-devel-ubuntu20.04
       cache_from:
         - ${DOCKER_CACHE_REGISTRY}/build.ubuntu_gpu_cu111:latest
   ###################################################################################################

--- a/ci/docker/docker-compose.yml
+++ b/ci/docker/docker-compose.yml
@@ -98,16 +98,16 @@ services:
         BASE_IMAGE: ubuntu:20.04
       cache_from:
         - ${DOCKER_CACHE_REGISTRY}/build.ubuntu_cpu:latest
-  ubuntu_tensorrt_cu111:
-    image: ${DOCKER_CACHE_REGISTRY}/build.ubuntu_tensorrt_cu111:latest
+  ubuntu_tensorrt_cu112:
+    image: ${DOCKER_CACHE_REGISTRY}/build.ubuntu_tensorrt_cu112:latest
     build:
       context: .
       dockerfile: Dockerfile.build.ubuntu
       target: gpu
       args:
-        BASE_IMAGE: nvidia/cuda:11.1.1-cudnn8-devel-ubuntu18.04
+        BASE_IMAGE: nvidia/cuda:11.2.1-cudnn8-devel-ubuntu18.04
       cache_from:
-        - ${DOCKER_CACHE_REGISTRY}/build.ubuntu_tensorrt_cu111:latest
+        - ${DOCKER_CACHE_REGISTRY}/build.ubuntu_tensorrt_cu112:latest
   ubuntu_gpu_cu111:
     image: ${DOCKER_CACHE_REGISTRY}/build.ubuntu_gpu_cu111:latest
     build:

--- a/ci/docker/docker-compose.yml
+++ b/ci/docker/docker-compose.yml
@@ -98,16 +98,16 @@ services:
         BASE_IMAGE: ubuntu:20.04
       cache_from:
         - ${DOCKER_CACHE_REGISTRY}/build.ubuntu_cpu:latest
-  ubuntu_tensorrt_cu112:
-    image: ${DOCKER_CACHE_REGISTRY}/build.ubuntu_tensorrt_cu112:latest
+  ubuntu_tensorrt_cu114:
+    image: ${DOCKER_CACHE_REGISTRY}/build.ubuntu_tensorrt_cu114:latest
     build:
       context: .
       dockerfile: Dockerfile.build.ubuntu
       target: gpu
       args:
-        BASE_IMAGE: nvidia/cuda:11.2.1-cudnn8-devel-ubuntu18.04
+        BASE_IMAGE: nvidia/cuda:11.4.0-cudnn8-devel-ubuntu18.04
       cache_from:
-        - ${DOCKER_CACHE_REGISTRY}/build.ubuntu_tensorrt_cu112:latest
+        - ${DOCKER_CACHE_REGISTRY}/build.ubuntu_tensorrt_cu114:latest
   ubuntu_gpu_cu111:
     image: ${DOCKER_CACHE_REGISTRY}/build.ubuntu_gpu_cu111:latest
     build:

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -551,7 +551,6 @@ build_ubuntu_gpu_tensorrt() {
     export PYBIN=$(which python3)
     PYVERFULL=$($PYBIN -V | awk '{print $2}')
     export PYVER=${PYVERFULL%.*}
-    echo "PYBIN=$PYBIN, PYVER=$PYVER"
 
     # Build ONNX
     pushd .

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -548,6 +548,10 @@ build_ubuntu_gpu_tensorrt() {
     export CC=gcc-7
     export CXX=g++-7
     export ONNX_NAMESPACE=onnx
+    export PYBIN=$(which python3)
+    PYVERFULL=$($PYBIN -V | awk '{print $2}')
+    export PYVER=${PYVERFULL%.*}
+    echo "PYBIN=$PYBIN, PYVER=$PYVER"
 
     # Build ONNX
     pushd .
@@ -556,7 +560,7 @@ build_ubuntu_gpu_tensorrt() {
     rm -rf build
     mkdir -p build
     cd build
-    cmake -DCMAKE_CXX_FLAGS=-I/usr/include/python${PYVER} -DBUILD_SHARED_LIBS=ON ..
+    cmake -DPYTHON_EXECUTABLE=$PYBIN -DCMAKE_CXX_FLAGS=-I/usr/include/python${PYVER} -DBUILD_SHARED_LIBS=ON ..
     make -j$(nproc)
     export LIBRARY_PATH=`pwd`:`pwd`/onnx/:$LIBRARY_PATH
     export CPLUS_INCLUDE_PATH=`pwd`:$CPLUS_INCLUDE_PATH
@@ -566,12 +570,12 @@ build_ubuntu_gpu_tensorrt() {
 
     # Build ONNX-TensorRT
     export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib
-    export CPLUS_INCLUDE_PATH=${CPLUS_INCLUDE_PATH}:/usr/local/cuda-10.2/targets/x86_64-linux/include/
+    export CPLUS_INCLUDE_PATH=${CPLUS_INCLUDE_PATH}:/usr/local/cuda/targets/x86_64-linux/include/
     pushd .
     cd 3rdparty/onnx-tensorrt/
     mkdir -p build
     cd build
-    cmake -DONNX_NAMESPACE=$ONNX_NAMESPACE ..
+    cmake -DPYTHON_EXECUTABLE=$PYBIN -DONNX_NAMESPACE=$ONNX_NAMESPACE ..
     make -j$(nproc)
     export LIBRARY_PATH=`pwd`:$LIBRARY_PATH
     popd
@@ -585,6 +589,7 @@ build_ubuntu_gpu_tensorrt() {
           -DUSE_CUDNN=1                           \
           -DUSE_OPENCV=1                          \
           -DUSE_TENSORRT=1                        \
+          -DUSE_INT64_TENSOR_SIZE=1               \
           -DUSE_OPENMP=0                          \
           -DUSE_BLAS=Open                         \
           -DUSE_ONEDNN=0                          \

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -28,6 +28,14 @@ CI_CMAKE_CUDA10_ARCH="5.2 7.5"
 # compute capabilities for CI instances supported by CUDA >= 11.1 (i.e. p3, g4, g5)
 CI_CMAKE_CUDA_ARCH="5.2 7.5 8.6"
 
+# On newer nvidia cuda containers, these environment variables
+#  are prefixed with NV_, so provide compatibility
+if [ ! -z "$NV_CUDNN_VERSION" ]; then
+    if [ -z "$CUDNN_VERSION" ]; then
+        export CUDNN_VERSION=$NV_CUDNN_VERSION
+    fi
+fi
+
 clean_repo() {
     set -ex
     git clean -xfd

--- a/ci/jenkins/Jenkins_steps.groovy
+++ b/ci/jenkins/Jenkins_steps.groovy
@@ -263,7 +263,7 @@ def compile_unix_tensorrt_gpu(lib_name) {
         ws('workspace/build-tensorrt') {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.init_git()
-            utils.docker_run('ubuntu_tensorrt_cu112', 'build_ubuntu_gpu_tensorrt', false)
+            utils.docker_run('ubuntu_tensorrt_cu114', 'build_ubuntu_gpu_tensorrt', false)
             utils.pack_lib(lib_name, mx_tensorrt_lib)
           }
         }

--- a/ci/jenkins/Jenkins_steps.groovy
+++ b/ci/jenkins/Jenkins_steps.groovy
@@ -263,7 +263,7 @@ def compile_unix_tensorrt_gpu(lib_name) {
         ws('workspace/build-tensorrt') {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.init_git()
-            utils.docker_run('ubuntu_tensorrt_cu111', 'build_ubuntu_gpu_tensorrt', false)
+            utils.docker_run('ubuntu_tensorrt_cu112', 'build_ubuntu_gpu_tensorrt', false)
             utils.pack_lib(lib_name, mx_tensorrt_lib)
           }
         }

--- a/src/operator/subgraph/tensorrt/onnx_to_tensorrt.cc
+++ b/src/operator/subgraph/tensorrt/onnx_to_tensorrt.cc
@@ -103,17 +103,32 @@ onnxToTrtCtx(const std::string& onnx_model,
     }
     throw dmlc::Error("Cannot parse ONNX into TensorRT Engine");
   }
+#if NV_TENSORRT_MAJOR >= 8
+  auto trt_config = InferObject(trt_builder->createBuilderConfig());
+#endif
   if (dmlc::GetEnv("MXNET_TENSORRT_USE_FP16", true)) {
     if (trt_builder->platformHasFastFp16()) {
+#if NV_TENSORRT_MAJOR >= 8
+      trt_config->setFlag(nvinfer1::BuilderFlag::kFP16);
+#else
       trt_builder->setFp16Mode(true);
+#endif
     } else {
       LOG(WARNING) << "TensorRT can't use fp16 on this platform";
     }
   }
   trt_builder->setMaxBatchSize(max_batch_size);
+#if NV_TENSORRT_MAJOR >= 8
+  trt_config->setMaxWorkspaceSize(max_workspace_size);
+  if (debug_builder) {
+    trt_config->setFlag(nvinfer1::BuilderFlag::kDEBUG);
+  }
+  auto trt_engine = InferObject(trt_builder->buildEngineWithConfig(*trt_network, *trt_config));
+#else
   trt_builder->setMaxWorkspaceSize(max_workspace_size);
   trt_builder->setDebugSync(debug_builder);
   auto trt_engine = InferObject(trt_builder->buildCudaEngine(*trt_network));
+#endif
   return std::make_tuple(std::move(trt_engine), std::move(trt_parser), std::move(trt_logger));
 }
 

--- a/src/operator/subgraph/tensorrt/onnx_to_tensorrt.h
+++ b/src/operator/subgraph/tensorrt/onnx_to_tensorrt.h
@@ -68,7 +68,11 @@ class TRT_Logger : public nvinfer1::ILogger {
  public:
   TRT_Logger(Severity verbosity = Severity::kWARNING, std::ostream& ostream = std::cout)  // NOLINT
       : _verbosity(verbosity), _ostream(&ostream) {}
+#if NV_TENSORRT_MAJOR >= 8
+  void log(Severity severity, const char* msg) noexcept override {
+#else
   void log(Severity severity, const char* msg) override {
+#endif
     if (severity <= _verbosity) {
       time_t rawtime = std::time(0);
       char buf[256];

--- a/src/operator/subgraph/tensorrt/onnx_to_tensorrt.h
+++ b/src/operator/subgraph/tensorrt/onnx_to_tensorrt.h
@@ -68,11 +68,7 @@ class TRT_Logger : public nvinfer1::ILogger {
  public:
   TRT_Logger(Severity verbosity = Severity::kWARNING, std::ostream& ostream = std::cout)  // NOLINT
       : _verbosity(verbosity), _ostream(&ostream) {}
-#if NV_TENSORRT_MAJOR >= 8
   void log(Severity severity, const char* msg) noexcept override {
-#else
-  void log(Severity severity, const char* msg) override {
-#endif
     if (severity <= _verbosity) {
       time_t rawtime = std::time(0);
       char buf[256];


### PR DESCRIPTION
Update minor versions of nvidia cuda containers to use that have the latest keys pre-installed, which prevents the error:

```
W: GPG error: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64  InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY A4B469963BF863CC
E: The repository 'https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64  InRelease' is not signed.
```

Also update TensorRT to 8.x, because the previous version we were building with is no longer available. 

@TristonC