### PR TITLE
Fix quantized_elemwise_add results

### DIFF
--- a/tests/python/quantization/test_quantization.py
+++ b/tests/python/quantization/test_quantization.py
@@ -55,6 +55,14 @@ def is_test_for_native_cpu():
             and os.environ.get('ENABLE_ONEDNN_QUANTIZATION_TEST') == None)
 
 
+def get_low_high(qtype):
+    """ Return low and high value for given integer type as float number"""
+    if qtype == 'uint8':
+        return 0.0, 255.0
+    else:
+        return -128.0, 127.0
+
+
 def test_quantize_float32_to_int8():
     shape = rand_shape_nd(4)
     data = rand_ndarray(shape, 'default', dtype='float32')
@@ -300,7 +308,7 @@ def test_quantized_conv():
                 max_weight = self.max_weight.data().to_device(device)
                 min_bias = self.min_bias.data().to_device(device) if self.use_bias else None
                 max_bias = self.max_bias.data().to_device(device) if self.use_bias else None
-                out = npx.quantized_conv(data=x, weight=weight, bias=bias, 
+                out = npx.quantized_conv(data=x, weight=weight, bias=bias,
                                          min_data=min_data, max_data=max_data,
                                          min_weight=min_weight, max_weight=max_weight,
                                          min_bias=min_bias, max_bias=max_bias,
@@ -348,11 +356,11 @@ def test_quantized_conv():
 
 @use_np
 def test_quantized_elemwise_add():
-    def check_quantized_elemwise_add(data_shape, qtype):
+    def check_quantized_elemwise_add(data_shape, qdtypeA, qdtypeB):
         if is_test_for_native_cpu():
             print('skipped testing quantized_elemwise_add for native cpu since it is not supported yet')
             return
-        elif qtype != 'uint8' and qtype != 'int8':
+        elif (qdtypeA != 'uint8' and qdtypeA != 'int8') or (qdtypeB != 'uint8' and qdtypeB != 'int8'):
             print('skipped testing quantized_elemwise_add for not supported data type')
             return
         elif is_test_for_gpu():
@@ -375,27 +383,25 @@ def test_quantized_elemwise_add():
 
         elemwise_add_fp32 = ElemwiseSumBlock()
 
-        if qtype == 'uint8':
-            data_low = 0.0
-            data_high = 255.0
-        else:
-            data_low = -127.0
-            data_high = 127.0
+        dataA_low, dataA_high = get_low_high(qdtypeA)
+        dataB_low, dataB_high = get_low_high(qdtypeB)
 
-        dataA_val = mx.np.random.uniform(low=data_low, high=data_high, size=data_shape).astype('int32').astype('float32')
-        dataB_val = mx.np.random.uniform(low=data_low, high=data_high, size=data_shape).astype('int32').astype('float32')
+        dataA_val = mx.np.random.uniform(low=dataA_low, high=dataA_high, size=data_shape).astype('int32').astype('float32')
+        dataB_val = mx.np.random.uniform(low=dataB_low, high=dataB_high, size=data_shape).astype('int32').astype('float32')
 
         output = elemwise_add_fp32(dataA_val, dataB_val)
+        mx.nd.waitall()
 
         #run quantized
         quantized_elemwise_add = QuantElemwiseSumBlock()
-        dataA_val_int8 = dataA_val.astype(qtype)
-        dataB_val_int8 = dataB_val.astype(qtype)
+        dataA_val_int8 = dataA_val.astype(qdtypeA)
+        dataB_val_int8 = dataB_val.astype(qdtypeB)
+
         quantized_range = 127.0
-        min_dataA = mx.np.array([data_low])
-        max_dataA = mx.np.array([data_high])
-        min_dataB = mx.np.array([data_low])
-        max_dataB = mx.np.array([data_high])
+        min_dataA = mx.np.array([dataA_low])
+        max_dataA = mx.np.array([dataA_high])
+        min_dataB = mx.np.array([dataB_low])
+        max_dataB = mx.np.array([dataB_high])
         qoutput, min_range, max_range = quantized_elemwise_add(dataA_val_int8, dataB_val_int8,
                                                                min_dataA, max_dataA,
                                                                min_dataB, max_dataB)
@@ -404,11 +410,10 @@ def test_quantized_elemwise_add():
         cond = mx.np.less(2, diff).sum().item()
         assert cond == 0
 
-    for qtype in ['int8', 'uint8']:
-        check_quantized_elemwise_add((4, 6), qtype)
-        check_quantized_elemwise_add((13, 74, 52), qtype)
-        check_quantized_elemwise_add((3, 4, 56, 56), qtype)
-        check_quantized_elemwise_add((32, 56, 64, 11), qtype)
+    check_quantized_elemwise_add((4, 6), 'uint8', 'int8')
+    check_quantized_elemwise_add((13, 74, 52), 'uint8', 'uint8')
+    check_quantized_elemwise_add((3, 4, 56, 56), 'int8', 'uint8')
+    check_quantized_elemwise_add((32, 56, 64, 11), 'int8', 'int8')
 
 
 @use_np
@@ -439,12 +444,7 @@ def test_quantized_elemwise_mul():
                 return npx.quantized_elemwise_mul(dataA, dataB, dataA_min, dataA_max, dataB_min, dataB_max)
 
         elemwise_mul_fp32 = ElemwiseMulBlock()
-        if qtype == 'uint8':
-            data_low = 0.0
-            data_high = 255.0
-        else:
-            data_low = -127.0
-            data_high = 127.0
+        data_low, data_high = get_low_high(qtype)
 
         dataA_val = mx.np.random.uniform(low=data_low, high=data_high, size=data_shape).astype('int32').astype('float32')
         dataB_val = mx.np.random.uniform(low=data_low, high=data_high, size=data_shape).astype('int32').astype('float32')
@@ -664,7 +664,7 @@ def test_quantized_fc():
                 max_weight = self.max_weight.data().to_device(device)
                 min_bias = self.min_bias.data().to_device(device) if self.use_bias else None
                 max_bias = self.max_bias.data().to_device(device) if self.use_bias else None
-                out = npx.quantized_fully_connected(data=x, weight=weight, bias=bias, 
+                out = npx.quantized_fully_connected(data=x, weight=weight, bias=bias,
                                                     min_data=min_data, max_data=max_data,
                                                     min_weight=min_weight, max_weight=max_weight,
                                                     min_bias=min_bias, max_bias=max_bias,
@@ -716,12 +716,7 @@ def test_quantized_fc():
 @use_np
 def test_quantized_transpose():
     def check_quantized_transpose(shape, qdtype, axes):
-        if qdtype == 'uint8':
-            data_low = 0.0
-            data_high = 255.0
-        else:
-            data_low = -127.0
-            data_high = 127.0
+        data_low, data_high = get_low_high(qdtype)
         data = mx.np.random.uniform(low=data_low, high=data_high, size=shape).astype(qdtype).astype('float32')
         min_data = mx.np.array([mx.np.min(data).astype('float32').item()])
         max_data = mx.np.array([mx.np.max(data).astype('float32').item()])
@@ -739,7 +734,6 @@ def test_quantized_transpose():
         check_quantized_transpose((7,3,9), qtype, (2,1,0))
         check_quantized_transpose((5,3,6,8), qtype, (2,3,0,1))
 
-        
 
 @use_np
 def test_quantized_embedding():
@@ -922,13 +916,7 @@ def test_quantized_bn():
             print('skipped testing quantize_bn for gpu since it is not supported yet')
             return
 
-        # qdtype = uint8
-        if qdtype == 'uint8':
-            data_low = 0.0
-            data_high = 255.0
-        else:
-            data_low = -127.0
-            data_high = 127.0
+        data_low, data_high = get_low_high(qdtype)
 
         # run fp32 bn
         bn_fp32 = mx.gluon.nn.BatchNorm(use_global_stats=True, scale=True)
@@ -937,7 +925,7 @@ def test_quantized_bn():
         bn_fp32.hybridize()
         bn_fp32(data)
         fp32_params = bn_fp32.collect_params()
-        
+
         data = mx.np.random.uniform(low=data_low, high=data_high, size=data_shape)
         gamma = mx.np.random.uniform(low=data_low, high=data_high, size=fp32_params['gamma'].shape)
         beta = mx.np.random.uniform(low=data_low, high=data_high, size=fp32_params['beta'].shape)
@@ -973,31 +961,26 @@ def test_quantized_bn():
 
 
 def test_quantized_reshape():
-    test_cases = [((2, 3, 5, 5),  (-2, -1),         False, (2, 75)), 
-                  ((2, 3, 5, 5),  (-2, -2, -1),     False, (2, 3, 25)), 
-                  ((5, 3, 4, 5),  (-2, -1, -2),     False, (5, 15, 4)), 
-                  ((2, 3, 5, 4),  (-1, -2, -2),     False, (8, 3, 5)), 
-                  ((2, 3, 5, 5),  (-2, -2, -2, -2), False, (2, 3, 5, 5)), 
-                  ((2, 1, 4, 5),  (-2, -3, -2, -2), False, (2, 4, 5)), 
-                  ((1, 1, 4, 1),  (-3, -3, -2, -2), False, (4, 1)), 
-                  ((1, 1, 1, 1),  (-3, -3, -3, -3), False, ()), 
-                  ((2, 4, 5, 3),  (-1, 2, 2, 1),    False, (30, 2, 2, 1)), 
-                  ((2, 3, 5, 6),  (-4,),            False, (2, 3, 5, 6)), 
-                  ((2, 3, 5, 6),  (6, 1, -4),       False, (6, 1, 5, 6)), 
-                  ((2, 3, 5, 6),  (-5, -5),         False, (6, 30)), 
-                  ((2, 3, 5, 6),  (-5, -1),         False, (6, 30)), 
-                  ((64,),         (-6, 16, 4),      False, (16, 4)), 
+    test_cases = [((2, 3, 5, 5),  (-2, -1),         False, (2, 75)),
+                  ((2, 3, 5, 5),  (-2, -2, -1),     False, (2, 3, 25)),
+                  ((5, 3, 4, 5),  (-2, -1, -2),     False, (5, 15, 4)),
+                  ((2, 3, 5, 4),  (-1, -2, -2),     False, (8, 3, 5)),
+                  ((2, 3, 5, 5),  (-2, -2, -2, -2), False, (2, 3, 5, 5)),
+                  ((2, 1, 4, 5),  (-2, -3, -2, -2), False, (2, 4, 5)),
+                  ((1, 1, 4, 1),  (-3, -3, -2, -2), False, (4, 1)),
+                  ((1, 1, 1, 1),  (-3, -3, -3, -3), False, ()),
+                  ((2, 4, 5, 3),  (-1, 2, 2, 1),    False, (30, 2, 2, 1)),
+                  ((2, 3, 5, 6),  (-4,),            False, (2, 3, 5, 6)),
+                  ((2, 3, 5, 6),  (6, 1, -4),       False, (6, 1, 5, 6)),
+                  ((2, 3, 5, 6),  (-5, -5),         False, (6, 30)),
+                  ((2, 3, 5, 6),  (-5, -1),         False, (6, 30)),
+                  ((64,),         (-6, 16, 4),      False, (16, 4)),
                   ((64,),         (-6, 16, -1),     False, (16, 4)),
-                  ((64, 1, 2, 3), (-6, 16, -1, -4), False, (16, 4, 1, 2, 3)), 
+                  ((64, 1, 2, 3), (-6, 16, -1, -4), False, (16, 4, 1, 2, 3)),
                   ((8, 5, 4, 6),  (-4, -1, 3, -6),  True,  (8, 5, 4, 2, 3))]
 
     def check_quantized_reshape(shape, qdtype, newshape, reverse, expected_ret_shape):
-        if qdtype == 'uint8':
-            data_low = 0.0
-            data_high = 255.0
-        else:
-            data_low = -127.0
-            data_high = 127.0
+        data_low, data_high = get_low_high(qdtype)
         qdata = mx.np.random.uniform(low=data_low, high=data_high, size=shape).astype(qdtype)
         min_data = mx.np.array([-1023.343], dtype='float32')
         max_data = mx.np.array([2343.324275], dtype='float32')
@@ -1442,7 +1425,7 @@ def test_rnn_quantization():
 
             def __iter__(self):
                 return self
-            
+
             def __next__(self):
                 return [self.data, self.states]
 


### PR DESCRIPTION
## Description ##
When inputs were different types results was wrong. Now unsigned input
tensor is converted to signed and later common path is used.
+ Modify test to check results for different input types + some cleanup.

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [ ] Code is well-documented
