### PR TITLE
[BUGFIX] Fix mkldnn segfault in reshape operator 

### DIFF
--- a/src/operator/tensor/matrix_op-inl.h
+++ b/src/operator/tensor/matrix_op-inl.h
@@ -225,12 +225,12 @@ inline bool ReshapeShape(const nnvm::NodeAttrs& attrs,
            && ReverseReshapeInferShape(&(*in_attrs)[0], (*out_attrs)[0]);
   }
   ReverseReshapeInferShape(&dshape, oshape);
-#if 0
-  CHECK_EQ(oshape.Size(), dshape.Size())
-    << "Target shape size is different to source. "
-    << "Target: " << oshape
-    << "\nSource: " << dshape;
-#endif
+  if (shape_is_known(dshape) && shape_is_known(oshape)){
+    CHECK_EQ(oshape.Size(), dshape.Size())
+      << "Target shape size is different to source. "
+      << "Target: " << oshape
+      << "\nSource: " << dshape;
+  }
   SHAPE_ASSIGN_CHECK(*out_attrs, 0, oshape);
   return ReverseReshapeInferShape(&(*in_attrs)[0], (*out_attrs)[0]);
 }

--- a/src/operator/tensor/matrix_op-inl.h
+++ b/src/operator/tensor/matrix_op-inl.h
@@ -227,7 +227,7 @@ inline bool ReshapeShape(const nnvm::NodeAttrs& attrs,
   ReverseReshapeInferShape(&dshape, oshape);
   if (shape_is_known(dshape) && shape_is_known(oshape)) {
     CHECK_EQ(oshape.Size(), dshape.Size())
-        << "Target shape size is different to source. "
+        << "Target shape size is different to source.\n"
         << "Target: " << oshape << "\nSource: " << dshape;
   }
   SHAPE_ASSIGN_CHECK(*out_attrs, 0, oshape);

--- a/src/operator/tensor/matrix_op-inl.h
+++ b/src/operator/tensor/matrix_op-inl.h
@@ -225,11 +225,10 @@ inline bool ReshapeShape(const nnvm::NodeAttrs& attrs,
            && ReverseReshapeInferShape(&(*in_attrs)[0], (*out_attrs)[0]);
   }
   ReverseReshapeInferShape(&dshape, oshape);
-  if (shape_is_known(dshape) && shape_is_known(oshape)){
+  if (shape_is_known(dshape) && shape_is_known(oshape)) {
     CHECK_EQ(oshape.Size(), dshape.Size())
-      << "Target shape size is different to source. "
-      << "Target: " << oshape
-      << "\nSource: " << dshape;
+        << "Target shape size is different to source. "
+        << "Target: " << oshape << "\nSource: " << dshape;
   }
   SHAPE_ASSIGN_CHECK(*out_attrs, 0, oshape);
   return ReverseReshapeInferShape(&(*in_attrs)[0], (*out_attrs)[0]);


### PR DESCRIPTION
## Description ##
Fix segfault in reshape operator when output and input tensor sizes differ.

Fixes issue [#21017](https://github.com/apache/incubator-mxnet/issues/21017)