### PR TITLE
Fix pip package description

### DIFF
--- a/tools/pip/setup.py
+++ b/tools/pip/setup.py
@@ -141,7 +141,7 @@ else:
 
 from mxnet.runtime import Features
 if Features().is_enabled("ONEDNN"):
-    libraries.append('ONEDNN')
+    libraries.append('oneDNN')
 
 short_description += ' This version uses {0}.'.format(' and '.join(libraries))
 


### PR DESCRIPTION
## Description ##
This PR fixes pip package description by changing wrong oneDNN inscription from 'ONEDNN' to 'oneDNN'.