### PR TITLE
Use requested mem in dot op to reduce memory usage

### DIFF
--- a/src/operator/nn/dnnl/dnnl_dot-inl.h
+++ b/src/operator/nn/dnnl/dnnl_dot-inl.h
@@ -52,7 +52,8 @@ class DNNLDotFwd {
              const std::vector<NDArray>& outputs,
              const bool isNumpy);
 
-  void Execute(const std::vector<NDArray>& inputs,
+  void Execute(const OpContext& ctx,
+               const std::vector<NDArray>& inputs,
                const std::vector<OpReqType>& req,
                const std::vector<NDArray>& outputs,
                const bool isNumpy);
@@ -78,7 +79,7 @@ void DNNLDotForward(const nnvm::NodeAttrs& attrs,
     param = nnvm::get<DotParam>(attrs.parsed);
   }
   DNNLDotFwd& fwd = DNNLDotFwd::GetCached(param, inputs, outputs, isNumpy);
-  fwd.Execute(inputs, req, outputs, isNumpy);
+  fwd.Execute(ctx, inputs, req, outputs, isNumpy);
 }
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/nn/dnnl/dnnl_dot.cc
+++ b/src/operator/nn/dnnl/dnnl_dot.cc
@@ -116,9 +116,7 @@ void DNNLDotFwd::Execute(const OpContext& ctx,
       fwd_pd->src_desc(), engine, reinterpret_cast<void*>(inputs[DotIn::lhs].data().dptr_));
   auto ndimRhs                = inputs[DotIn::rhs].shape().ndim();
   const bool specialNumpyCase = isNumpy && ndimRhs > 2;
-  dnnl::memory rhs(
-      fwd_pd->weights_desc(),
-      engine,
+  auto rhsMemPointer =
       specialNumpyCase ?
           reinterpret_cast<void*>(
               ctx.requested[0]
@@ -126,7 +124,8 @@ void DNNLDotFwd::Execute(const OpContext& ctx,
                                                   GetTypeSize(inputs[DotIn::rhs].dtype())),
                                   ctx.get_stream<cpu>())
                   .dptr_) :
-          reinterpret_cast<void*>(inputs[DotIn::rhs].data().dptr_));
+          reinterpret_cast<void*>(inputs[DotIn::rhs].data().dptr_);
+  dnnl::memory rhs(fwd_pd->weights_desc(), engine, rhsMemPointer);
   if (specialNumpyCase) {
     // Necessity of this reorder is described in DNNLDotFwd constructor.
     auto tmp_rhs = inputs[DotIn::rhs].GetDNNLData();


### PR DESCRIPTION
## Description ##
This change aims to reduce memory footprint of dot operator by reusing once allocated memory buffer for future operator calls.
