### PR TITLE
[BUGFIX] Fix DNNL requantize operator overflow error

### DIFF
--- a/src/operator/quantization/dnnl/dnnl_requantize-inl.h
+++ b/src/operator/quantization/dnnl/dnnl_requantize-inl.h
@@ -132,7 +132,7 @@ static void DNNLRequantizeForward(const nnvm::NodeAttrs& attrs,
         data_min = data_mins[i];
     }
     float src_range     = MinAbs(MinValue<SrcDType>(), MaxValue<SrcDType>());
-    // It doesn't use MaxAbs as it convert data to float which could cause overflow errors
+    // MaxAbs is not used here as it converts data to float what could cause overflow errors.
     SrcDType data_range = std::max(std::abs(data_min), std::abs(data_max));
     float data_scale    = MaxAbs(*inputs[1].data().dptr<float>(), *inputs[2].data().dptr<float>());
     real_range          = data_range * data_scale / src_range;

--- a/src/operator/quantization/dnnl/dnnl_requantize-inl.h
+++ b/src/operator/quantization/dnnl/dnnl_requantize-inl.h
@@ -132,7 +132,8 @@ static void DNNLRequantizeForward(const nnvm::NodeAttrs& attrs,
         data_min = data_mins[i];
     }
     float src_range     = MinAbs(MinValue<SrcDType>(), MaxValue<SrcDType>());
-    SrcDType data_range = MaxAbs(data_min, data_max);
+    // It doesn't use MaxAbs as it convert data to float which could cause overflow errors
+    SrcDType data_range = std::max(std::abs(data_min), std::abs(data_max));
     float data_scale    = MaxAbs(*inputs[1].data().dptr<float>(), *inputs[2].data().dptr<float>());
     real_range          = data_range * data_scale / src_range;
   }


### PR DESCRIPTION
## Description ##
It fixes overflow issue which sometimes happenes giving negative scales.

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

## Note ##
Simple way to reproduce the bug: 
MXNET_TEST_SEED=970044477 pytest tests/python/dnnl/subgraphs/test_fc_subgraph.py::test_add_quantized[ele_add-no_broadc-nore-full-none-int8]
but with modyfied shape to 
 ` data_shape = (4,6)`