### PR TITLE
[BUGFIX] Fix remove Cast fuse

### DIFF
--- a/src/operator/subgraph/dnnl/dnnl_remove_casts_property.h
+++ b/src/operator/subgraph/dnnl/dnnl_remove_casts_property.h
@@ -95,7 +95,7 @@ class SgDNNLRemoveCastsSelector : public SubgraphSelectorV2 {
   }
 
   void Reset() override {
-    status_   = kFail;
+    status_   = kExpand;
     castDtype = -1;
   }
 };

--- a/src/operator/subgraph/dnnl/dnnl_remove_casts_property.h
+++ b/src/operator/subgraph/dnnl/dnnl_remove_casts_property.h
@@ -142,7 +142,7 @@ class SgDNNLRemoveCastsProperty : public SubgraphProperty {
                               std::vector<nnvm::NodeEntry*>* output_entries) const override {
     // Connect all extern output entries to output[0]
     for (size_t i = 0; i < output_entries->size(); ++i) {
-      *output_entries->at(i)     = nnvm::NodeEntry{subgraph_node, 0, 0};
+      *output_entries->at(i) = nnvm::NodeEntry{subgraph_node, 0, 0};
     }
   }
 };

--- a/src/operator/subgraph/dnnl/dnnl_remove_casts_property.h
+++ b/src/operator/subgraph/dnnl/dnnl_remove_casts_property.h
@@ -142,8 +142,7 @@ class SgDNNLRemoveCastsProperty : public SubgraphProperty {
                               std::vector<nnvm::NodeEntry*>* output_entries) const override {
     // Connect all extern output entries to output[0]
     for (size_t i = 0; i < output_entries->size(); ++i) {
-      auto entry_ptr = output_entries->at(i);
-      *entry_ptr     = nnvm::NodeEntry{subgraph_node, entry_ptr->index, 0};
+      *output_entries->at(i)     = nnvm::NodeEntry{subgraph_node, 0, 0};
     }
   }
 };

--- a/src/operator/subgraph/dnnl/dnnl_remove_casts_property.h
+++ b/src/operator/subgraph/dnnl/dnnl_remove_casts_property.h
@@ -105,7 +105,7 @@ class SgDNNLRemoveCastsProperty : public SubgraphProperty {
   SgDNNLRemoveCastsProperty() {}
 
   static SubgraphPropertyPtr Create() {
-    static const std::string& name = "Remove casts optimization pass";
+    static const std::string& name = "Remove Casts optimization pass";
     auto property                  = std::make_shared<SgDNNLRemoveCastsProperty>();
     property->SetAttr<std::string>("property_name", name);
     property->SetAttr<bool>("inference_only", true);
@@ -136,6 +136,15 @@ class SgDNNLRemoveCastsProperty : public SubgraphProperty {
   SubgraphSelectorV2Ptr CreateSubgraphSelectorV2() const override {
     auto selector = std::make_shared<SgDNNLRemoveCastsSelector>();
     return selector;
+  }
+
+  void ConnectSubgraphOutputs(const nnvm::ObjectPtr subgraph_node,
+                              std::vector<nnvm::NodeEntry*>* output_entries) const override {
+    // Connect all extern output entries to output[0]
+    for (size_t i = 0; i < output_entries->size(); ++i) {
+      auto entry_ptr = output_entries->at(i);
+      *entry_ptr     = nnvm::NodeEntry{subgraph_node, entry_ptr->index, 0};
+    }
   }
 };
 


### PR DESCRIPTION
## Description ##
This change fixes remove Casts fuse. The problem was caused by property trying to connect each output entry to subsequent subgraph outputs even though this fuse has only one output. This went unnoticed earlier as without EliminateCommonNodesPass all instances of the fuse had only one output entry.