### PR TITLE
Add support for bool data type for condition in where operator

### DIFF
--- a/src/operator/nn/dnnl/dnnl_base-inl.h
+++ b/src/operator/nn/dnnl/dnnl_base-inl.h
@@ -276,7 +276,7 @@ void DNNLMemorySum(const dnnl::memory& arr1, const dnnl::memory& arr2, const dnn
 
 static int GetTypeSize(int dtype) {
   int size = -1;
-  MSHADOW_TYPE_SWITCH(dtype, DType, { size = sizeof(DType); });
+  MSHADOW_TYPE_SWITCH_WITH_BOOL(dtype, DType, { size = sizeof(DType); });
   return size;
 }
 
@@ -298,6 +298,7 @@ static inline dnnl::memory::data_type get_dnnl_type(int dtype) {
     case mshadow::kInt8:
       return dnnl::memory::data_type::s8;
     case mshadow::kUint8:
+    case mshadow::kBool:
       return dnnl::memory::data_type::u8;
     default:
       LOG(FATAL) << "unknown type for oneDNN :" << static_cast<int>(dtype);

--- a/src/operator/nn/dnnl/dnnl_where.cc
+++ b/src/operator/nn/dnnl/dnnl_where.cc
@@ -37,8 +37,7 @@ bool SupportDNNLWhere(const std::vector<NDArray>& inputs) {
   if (inputs[0].dtype() == mshadow::kBool) {
     // oneDNN natively doesn't support bool data type, however this operator was written
     // to allow using bool datatype for 'condition' tensor - data will be treated as uint8
-    bool bool_support = SupportDNNLShape<1, 12>(inputs[0].shape());
-    return bool_support &&
+    return SupportDNNLShape<1, 12>(inputs[0].shape()) &&
            SupportDNNL<DNNLTypeMode::NoInt32, DNNLTensorsDtypes::AllSame>({inputs[1], inputs[2]});
   }
 

--- a/src/operator/nn/dnnl/dnnl_where.cc
+++ b/src/operator/nn/dnnl/dnnl_where.cc
@@ -107,7 +107,7 @@ static mxnet::TShape GetBroadcastableShape(const mxnet::TShape& in_shape,
  * \brief Create shape vector basing on two input shapes
  * \param first_shape first input shape
  * \param second_shape second input shape
- * \return deducted broadcasted shape basing on first_shape and second_shape
+ * \return deduced broadcasted shape based on first_shape and second_shape
  */
 static mxnet::TShape GetBroadcastedShape(const mxnet::TShape& first_shape,
                                          const mxnet::TShape& second_shape) {

--- a/src/operator/nn/dnnl/dnnl_where.cc
+++ b/src/operator/nn/dnnl/dnnl_where.cc
@@ -35,8 +35,8 @@ namespace op {
 // Support for https://oneapi-src.github.io/oneDNN/v2.6/dev_guide_binary.html
 bool SupportDNNLWhere(const std::vector<NDArray>& inputs) {
   if (inputs[0].dtype() == mshadow::kBool) {
-    // oneDNN natively doesn't support bool data type, however this operator was written
-    // to allow using bool datatype for 'condition' tensor - data will be treated as uint8
+    // oneDNN natively doesn't support bool type, however this operator was written
+    // to allow using bool type for 'condition' tensor - data will be treated as uint8
     return SupportDNNLShape<1, 12>(inputs[0].shape()) &&
            SupportDNNL<DNNLTypeMode::NoInt32, DNNLTensorsDtypes::AllSame>({inputs[1], inputs[2]});
   }


### PR DESCRIPTION
## Description ##
This change allows to utilize bool data type for condition tensor in oneDNN implementation of where operator

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
