### PR TITLE
[BUGFIX] Reenable fwd conv engine 5 on test_group_conv2d_16c

### DIFF
--- a/src/common/cuda/cudnn_cxx.cc
+++ b/src/common/cuda/cudnn_cxx.cc
@@ -63,7 +63,7 @@ void SetAttr(const Descriptor& desc,
   std::vector<cudnnBackendDescriptor_t> raw(val.size());
   std::transform(val.begin(), val.end(), raw.begin(), [](const Descriptor& d) { return d.get(); });
   CUDNN_CALL(cudnnBackendSetAttribute(
-      desc.get(), name, CUDNN_TYPE_BACKEND_DESCRIPTOR, raw.size(), &raw[0]));
+      desc.get(), name, CUDNN_TYPE_BACKEND_DESCRIPTOR, raw.size(), raw.data()));
 }
 
 Descriptor GetAttr(const Descriptor& desc,

--- a/src/common/cuda/cudnn_cxx.h
+++ b/src/common/cuda/cudnn_cxx.h
@@ -162,14 +162,14 @@ void SetAttr(const Descriptor& desc, cudnnBackendAttributeName_t name, T val) {
 
 template <typename T>
 void SetAttr(const Descriptor& desc, cudnnBackendAttributeName_t name, const std::vector<T>& val) {
-  CUDNN_CALL(cudnnBackendSetAttribute(desc.get(), name, AttrType<T>::type, val.size(), &val[0]));
+  CUDNN_CALL(cudnnBackendSetAttribute(desc.get(), name, AttrType<T>::type, val.size(), val.data()));
 }
 
 template <typename T, size_t N>
 void SetAttr(const Descriptor& desc,
              cudnnBackendAttributeName_t name,
              const std::array<T, N>& val) {
-  CUDNN_CALL(cudnnBackendSetAttribute(desc.get(), name, AttrType<T>::type, val.size(), &val[0]));
+  CUDNN_CALL(cudnnBackendSetAttribute(desc.get(), name, AttrType<T>::type, val.size(), val.data()));
 }
 
 inline void SetAttrs(const Descriptor& desc) {}

--- a/src/operator/cudnn_ops.cc
+++ b/src/operator/cudnn_ops.cc
@@ -241,6 +241,17 @@ Descriptor MakeConvFwdOp(const Descriptor& conv,
   return ret;
 }
 
+Descriptor Conv::MakeConvFwdOp(const OpContext& ctx, const Param& param, const TBlob& x,
+                               const TBlob& w, const TBlob& y) {
+  auto dtype = static_cast<mshadow::TypeFlag>(x.type_flag_);
+  auto conv = MakeConvDesc(param, dtype);
+  auto li = GetLayoutInfo(static_cast<mshadow::LayoutFlag>(param.layout.value()));
+  auto x_desc = MakeTensorDesc(ID_X, x, li, true, false);
+  auto w_desc = MakeTensorDesc(ID_W, w, li, true, false);
+  auto y_desc = MakeTensorDesc(ID_Y, y, li, true, false);
+  return cudnn::MakeConvFwdOp(conv, x_desc, w_desc, y_desc, param.add_to);
+}
+
 Descriptor MakeConvDgradOp(const Descriptor& conv,
                            const Descriptor& w,
                            const Descriptor& dy,
@@ -270,6 +281,17 @@ Descriptor MakeConvDgradOp(const Descriptor& conv,
   }
   CUDNN_CALL(cudnnBackendFinalize(ret.get()));
   return ret;
+}
+
+Descriptor ConvDgrad::MakeConvDgradOp(const OpContext& ctx, const Param& param, const TBlob& w,
+                                      const TBlob& dy, const TBlob& dx) {
+  auto dtype = static_cast<mshadow::TypeFlag>(w.type_flag_);
+  auto conv = MakeConvDesc(param, dtype);
+  auto li = GetLayoutInfo(static_cast<mshadow::LayoutFlag>(param.layout.value()));
+  auto w_desc = MakeTensorDesc(ID_W, w, li, true, false);
+  auto dy_desc = MakeTensorDesc(ID_DY, dy, li, true, false);
+  auto dx_desc = MakeTensorDesc(ID_DX, dx, li, true, false);
+  return cudnn::MakeConvDgradOp(conv, w_desc, dy_desc, dx_desc, param.add_to);
 }
 
 Descriptor MakeConvWgradOp(const Descriptor& conv,
@@ -303,12 +325,53 @@ Descriptor MakeConvWgradOp(const Descriptor& conv,
   return ret;
 }
 
+Descriptor ConvWgrad::MakeConvWgradOp(const OpContext& ctx, const Param& param, const TBlob& x,
+                                      const TBlob& dy, const TBlob& dw) {
+  auto dtype = static_cast<mshadow::TypeFlag>(x.type_flag_);
+  auto conv = MakeConvDesc(param, dtype);
+  auto li = GetLayoutInfo(static_cast<mshadow::LayoutFlag>(param.layout.value()));
+  auto x_desc = MakeTensorDesc(ID_X, x, li, true, false);
+  auto dy_desc = MakeTensorDesc(ID_DY, dy, li, true, false);
+  auto dw_desc = MakeTensorDesc(ID_DW, dw, li, true, false);
+  return cudnn::MakeConvWgradOp(conv, x_desc, dy_desc, dw_desc, param.add_to);
+}
+
 Descriptor MakeOpGraph(cudnnHandle_t handle, const std::vector<Descriptor>& ops) {
   return MakeFinalized(CUDNN_BACKEND_OPERATIONGRAPH_DESCRIPTOR,
                        CUDNN_ATTR_OPERATIONGRAPH_HANDLE,
                        handle,
                        CUDNN_ATTR_OPERATIONGRAPH_OPS,
                        ops);
+}
+
+Descriptor MakeOpGraph(cudnnHandle_t handle, Descriptor op) {
+  std::vector<Descriptor> ops;
+  ops.push_back(std::move(op));
+  return MakeOpGraph(handle, ops);
+}
+
+Descriptor ClonePlan(cudnnHandle_t handle, Descriptor op_graph, const Descriptor& plan) {
+  auto cfg = GetAttr(plan, CUDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
+                     CUDNN_BACKEND_ENGINECFG_DESCRIPTOR);
+  auto engine = GetAttr(cfg, CUDNN_ATTR_ENGINECFG_ENGINE, CUDNN_BACKEND_ENGINE_DESCRIPTOR);
+
+  auto engine_idx = GetAttr<int64_t>(engine, CUDNN_ATTR_ENGINE_GLOBAL_INDEX);
+  auto choices = GetSomeAttrs(CUDNN_KNOB_TYPE_COUNTS, cfg, CUDNN_ATTR_ENGINECFG_KNOB_CHOICES,
+                              CUDNN_BACKEND_KNOB_CHOICE_DESCRIPTOR);
+
+  auto cloned_engine = MakeFinalized(CUDNN_BACKEND_ENGINE_DESCRIPTOR,
+                                     CUDNN_ATTR_ENGINE_GLOBAL_INDEX, engine_idx,
+                                     CUDNN_ATTR_ENGINE_OPERATION_GRAPH, op_graph);
+
+  auto cloned_cfg = MakeFinalized(CUDNN_BACKEND_ENGINECFG_DESCRIPTOR,
+                                  CUDNN_ATTR_ENGINECFG_ENGINE, cloned_engine,
+                                  CUDNN_ATTR_ENGINECFG_KNOB_CHOICES, choices);
+
+  auto cloned_plan = cudnn_cxx::Make(CUDNN_BACKEND_EXECUTION_PLAN_DESCRIPTOR,
+                                     CUDNN_ATTR_EXECUTION_PLAN_HANDLE, handle,
+                                     CUDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG, cloned_cfg);
+  CUDNN_CALL(cudnnBackendFinalize(cloned_plan.get()));
+  return cloned_plan;
 }
 
 ConvParam::ConvParam(const ConvolutionParam& p, bool add_to)
@@ -476,9 +539,7 @@ Descriptor SelectPlan(const OpContext& ctx,
                       int64_t out_size,
                       const std::string& excl_engines_var) {
   auto s = ctx.get_stream<gpu>();
-  std::vector<Descriptor> ops;
-  ops.push_back(std::move(op));
-  auto op_graph = MakeOpGraph(s->dnn_handle_, ops);
+  auto op_graph = MakeOpGraph(s->dnn_handle_, std::move(op));
 
   int verbose = dmlc::GetEnv("MXNET_CUDNN_ALGO_VERBOSE_LEVEL", 0);
   if (verbose > 0)
@@ -592,12 +653,7 @@ cudnn_cxx::Descriptor Conv::Make(const OpContext& ctx,
                                  const TBlob& x,
                                  const TBlob& w,
                                  const TBlob& y) {
-  auto conv     = MakeConvDesc(param, static_cast<mshadow::TypeFlag>(x.type_flag_));
-  auto li       = GetLayoutInfo(static_cast<mshadow::LayoutFlag>(param.layout.value()));
-  auto x_desc   = MakeTensorDesc(ID_X, x, li, true, false);
-  auto w_desc   = MakeTensorDesc(ID_W, w, li, true, false);
-  auto y_desc   = MakeTensorDesc(ID_Y, y, li, true, false);
-  auto conv_fwd = MakeConvFwdOp(conv, x_desc, w_desc, y_desc, param.add_to);
+  auto conv_fwd = MakeConvFwdOp(ctx, param, x, w, y);
 
   auto make_op_str = [&param, &x]() {
     std::ostringstream ss;
@@ -617,6 +673,19 @@ cudnn_cxx::Descriptor Conv::Make(const OpContext& ctx,
                     ptrs,
                     Size(y),
                     "MXNET_CUDNN_DISABLED_CONV_FWD_ENGINES");
+}
+
+cudnn_cxx::Descriptor Conv::Clone(const cudnn_cxx::Descriptor& plan,
+                                  const OpContext& ctx,
+                                  const Param& param,
+                                  const TBlob& x,
+                                  const TBlob& w,
+                                  const TBlob& y) {
+  auto conv_fwd = MakeConvFwdOp(ctx, param, x, w, y);
+  auto handle = ctx.get_stream<gpu>()->dnn_handle_;
+  auto op_graph = MakeOpGraph(handle, std::move(conv_fwd));
+  auto cloned_plan = ClonePlan(handle, std::move(op_graph), plan);
+  return cloned_plan;
 }
 
 void Conv::Exec(const cudnn_cxx::Descriptor& plan,
@@ -645,12 +714,7 @@ cudnn_cxx::Descriptor ConvDgrad::Make(const OpContext& ctx,
                                       const TBlob& w,
                                       const TBlob& dy,
                                       const TBlob& dx) {
-  auto conv    = MakeConvDesc(param, static_cast<mshadow::TypeFlag>(w.type_flag_));
-  auto li      = GetLayoutInfo(static_cast<mshadow::LayoutFlag>(param.layout.value()));
-  auto w_desc  = MakeTensorDesc(ID_W, w, li, true, false);
-  auto dy_desc = MakeTensorDesc(ID_DY, dy, li, true, false);
-  auto dx_desc = MakeTensorDesc(ID_DX, dx, li, true, false);
-  auto dgrad   = MakeConvDgradOp(conv, w_desc, dy_desc, dx_desc, param.add_to);
+  auto conv_dgrad = MakeConvDgradOp(ctx, param, w, dy, dx);
 
   auto make_op_str = [&param, &dx]() {
     std::ostringstream ss;
@@ -663,13 +727,26 @@ cudnn_cxx::Descriptor ConvDgrad::Make(const OpContext& ctx,
 
   return SelectPlan(ctx,
                     param,
-                    std::move(dgrad),
+                    std::move(conv_dgrad),
                     kMaxDgradFallbacks,
                     make_op_str,
                     ids,
                     ptrs,
                     Size(dx),
                     "MXNET_CUDNN_DISABLED_CONV_DGRAD_ENGINES");
+}
+
+cudnn_cxx::Descriptor ConvDgrad::Clone(const cudnn_cxx::Descriptor& plan,
+                                       const OpContext& ctx,
+                                       const Param& param,
+                                       const TBlob& w,
+                                       const TBlob& dy,
+                                       const TBlob& dx) {
+  auto conv_dgrad = MakeConvDgradOp(ctx, param, w, dy, dx);
+  auto handle = ctx.get_stream<gpu>()->dnn_handle_;
+  auto op_graph = MakeOpGraph(handle, std::move(conv_dgrad));
+  auto cloned_plan = ClonePlan(handle, std::move(op_graph), plan);
+  return cloned_plan;
 }
 
 void ConvDgrad::Exec(const cudnn_cxx::Descriptor& plan,
@@ -698,12 +775,7 @@ cudnn_cxx::Descriptor ConvWgrad::Make(const OpContext& ctx,
                                       const TBlob& x,
                                       const TBlob& dy,
                                       const TBlob& dw) {
-  auto conv    = MakeConvDesc(param, static_cast<mshadow::TypeFlag>(x.type_flag_));
-  auto li      = GetLayoutInfo(static_cast<mshadow::LayoutFlag>(param.layout.value()));
-  auto x_desc  = MakeTensorDesc(ID_X, x, li, true, false);
-  auto dy_desc = MakeTensorDesc(ID_DY, dy, li, true, false);
-  auto dw_desc = MakeTensorDesc(ID_DW, dw, li, true, false);
-  auto wgrad   = MakeConvWgradOp(conv, x_desc, dy_desc, dw_desc, param.add_to);
+  auto conv_wgrad = MakeConvWgradOp(ctx, param, x, dy, dw);
 
   auto make_op_str = [&param, &x]() {
     std::ostringstream ss;
@@ -716,13 +788,26 @@ cudnn_cxx::Descriptor ConvWgrad::Make(const OpContext& ctx,
 
   return SelectPlan(ctx,
                     param,
-                    std::move(wgrad),
+                    std::move(conv_wgrad),
                     kMaxWgradFallbacks,
                     make_op_str,
                     ids,
                     ptrs,
                     Size(dw),
                     "MXNET_CUDNN_DISABLED_CONV_WGRAD_ENGINES");
+}
+
+cudnn_cxx::Descriptor ConvWgrad::Clone(const cudnn_cxx::Descriptor& plan,
+                                       const OpContext& ctx,
+                                       const Param& param,
+                                       const TBlob& x,
+                                       const TBlob& dy,
+                                       const TBlob& dw) {
+  auto conv_wgrad = MakeConvWgradOp(ctx, param, x, dy, dw);
+  auto handle = ctx.get_stream<gpu>()->dnn_handle_;
+  auto op_graph = MakeOpGraph(handle, std::move(conv_wgrad));
+  auto cloned_plan = ClonePlan(handle, std::move(op_graph), plan);
+  return cloned_plan;
 }
 
 void ConvWgrad::Exec(const cudnn_cxx::Descriptor& plan,

--- a/src/operator/cudnn_ops.cc
+++ b/src/operator/cudnn_ops.cc
@@ -362,13 +362,13 @@ Descriptor MakeOpGraph(cudnnHandle_t handle, Descriptor op) {
 Descriptor ClonePlan(cudnnHandle_t handle, Descriptor op_graph, const Descriptor& plan) {
   auto cfg =
       GetAttr(plan, CUDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG, CUDNN_BACKEND_ENGINECFG_DESCRIPTOR);
-  auto engine = GetAttr(cfg, CUDNN_ATTR_ENGINECFG_ENGINE, CUDNN_BACKEND_ENGINE_DESCRIPTOR);
-
+  auto engine     = GetAttr(cfg, CUDNN_ATTR_ENGINECFG_ENGINE, CUDNN_BACKEND_ENGINE_DESCRIPTOR);
   auto engine_idx = GetAttr<int64_t>(engine, CUDNN_ATTR_ENGINE_GLOBAL_INDEX);
-  auto choices    = GetSomeAttrs(CUDNN_KNOB_TYPE_COUNTS,
-                                 cfg,
-                                 CUDNN_ATTR_ENGINECFG_KNOB_CHOICES,
-                                 CUDNN_BACKEND_KNOB_CHOICE_DESCRIPTOR);
+
+  auto choices = GetSomeAttrs(CUDNN_KNOB_TYPE_COUNTS,
+                              cfg,
+                              CUDNN_ATTR_ENGINECFG_KNOB_CHOICES,
+                              CUDNN_BACKEND_KNOB_CHOICE_DESCRIPTOR);
 
   auto cloned_engine = MakeFinalized(CUDNN_BACKEND_ENGINE_DESCRIPTOR,
                                      CUDNN_ATTR_ENGINE_GLOBAL_INDEX,

--- a/src/operator/cudnn_ops.cc
+++ b/src/operator/cudnn_ops.cc
@@ -241,11 +241,14 @@ Descriptor MakeConvFwdOp(const Descriptor& conv,
   return ret;
 }
 
-Descriptor Conv::MakeConvFwdOp(const OpContext& ctx, const Param& param, const TBlob& x,
-                               const TBlob& w, const TBlob& y) {
-  auto dtype = static_cast<mshadow::TypeFlag>(x.type_flag_);
-  auto conv = MakeConvDesc(param, dtype);
-  auto li = GetLayoutInfo(static_cast<mshadow::LayoutFlag>(param.layout.value()));
+Descriptor Conv::MakeConvFwdOp(const OpContext& ctx,
+                               const Param& param,
+                               const TBlob& x,
+                               const TBlob& w,
+                               const TBlob& y) {
+  auto dtype  = static_cast<mshadow::TypeFlag>(x.type_flag_);
+  auto conv   = MakeConvDesc(param, dtype);
+  auto li     = GetLayoutInfo(static_cast<mshadow::LayoutFlag>(param.layout.value()));
   auto x_desc = MakeTensorDesc(ID_X, x, li, true, false);
   auto w_desc = MakeTensorDesc(ID_W, w, li, true, false);
   auto y_desc = MakeTensorDesc(ID_Y, y, li, true, false);
@@ -283,12 +286,15 @@ Descriptor MakeConvDgradOp(const Descriptor& conv,
   return ret;
 }
 
-Descriptor ConvDgrad::MakeConvDgradOp(const OpContext& ctx, const Param& param, const TBlob& w,
-                                      const TBlob& dy, const TBlob& dx) {
-  auto dtype = static_cast<mshadow::TypeFlag>(w.type_flag_);
-  auto conv = MakeConvDesc(param, dtype);
-  auto li = GetLayoutInfo(static_cast<mshadow::LayoutFlag>(param.layout.value()));
-  auto w_desc = MakeTensorDesc(ID_W, w, li, true, false);
+Descriptor ConvDgrad::MakeConvDgradOp(const OpContext& ctx,
+                                      const Param& param,
+                                      const TBlob& w,
+                                      const TBlob& dy,
+                                      const TBlob& dx) {
+  auto dtype   = static_cast<mshadow::TypeFlag>(w.type_flag_);
+  auto conv    = MakeConvDesc(param, dtype);
+  auto li      = GetLayoutInfo(static_cast<mshadow::LayoutFlag>(param.layout.value()));
+  auto w_desc  = MakeTensorDesc(ID_W, w, li, true, false);
   auto dy_desc = MakeTensorDesc(ID_DY, dy, li, true, false);
   auto dx_desc = MakeTensorDesc(ID_DX, dx, li, true, false);
   return cudnn::MakeConvDgradOp(conv, w_desc, dy_desc, dx_desc, param.add_to);
@@ -325,12 +331,15 @@ Descriptor MakeConvWgradOp(const Descriptor& conv,
   return ret;
 }
 
-Descriptor ConvWgrad::MakeConvWgradOp(const OpContext& ctx, const Param& param, const TBlob& x,
-                                      const TBlob& dy, const TBlob& dw) {
-  auto dtype = static_cast<mshadow::TypeFlag>(x.type_flag_);
-  auto conv = MakeConvDesc(param, dtype);
-  auto li = GetLayoutInfo(static_cast<mshadow::LayoutFlag>(param.layout.value()));
-  auto x_desc = MakeTensorDesc(ID_X, x, li, true, false);
+Descriptor ConvWgrad::MakeConvWgradOp(const OpContext& ctx,
+                                      const Param& param,
+                                      const TBlob& x,
+                                      const TBlob& dy,
+                                      const TBlob& dw) {
+  auto dtype   = static_cast<mshadow::TypeFlag>(x.type_flag_);
+  auto conv    = MakeConvDesc(param, dtype);
+  auto li      = GetLayoutInfo(static_cast<mshadow::LayoutFlag>(param.layout.value()));
+  auto x_desc  = MakeTensorDesc(ID_X, x, li, true, false);
   auto dy_desc = MakeTensorDesc(ID_DY, dy, li, true, false);
   auto dw_desc = MakeTensorDesc(ID_DW, dw, li, true, false);
   return cudnn::MakeConvWgradOp(conv, x_desc, dy_desc, dw_desc, param.add_to);
@@ -351,25 +360,33 @@ Descriptor MakeOpGraph(cudnnHandle_t handle, Descriptor op) {
 }
 
 Descriptor ClonePlan(cudnnHandle_t handle, Descriptor op_graph, const Descriptor& plan) {
-  auto cfg = GetAttr(plan, CUDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
-                     CUDNN_BACKEND_ENGINECFG_DESCRIPTOR);
+  auto cfg =
+      GetAttr(plan, CUDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG, CUDNN_BACKEND_ENGINECFG_DESCRIPTOR);
   auto engine = GetAttr(cfg, CUDNN_ATTR_ENGINECFG_ENGINE, CUDNN_BACKEND_ENGINE_DESCRIPTOR);
 
   auto engine_idx = GetAttr<int64_t>(engine, CUDNN_ATTR_ENGINE_GLOBAL_INDEX);
-  auto choices = GetSomeAttrs(CUDNN_KNOB_TYPE_COUNTS, cfg, CUDNN_ATTR_ENGINECFG_KNOB_CHOICES,
-                              CUDNN_BACKEND_KNOB_CHOICE_DESCRIPTOR);
+  auto choices    = GetSomeAttrs(CUDNN_KNOB_TYPE_COUNTS,
+                                 cfg,
+                                 CUDNN_ATTR_ENGINECFG_KNOB_CHOICES,
+                                 CUDNN_BACKEND_KNOB_CHOICE_DESCRIPTOR);
 
   auto cloned_engine = MakeFinalized(CUDNN_BACKEND_ENGINE_DESCRIPTOR,
-                                     CUDNN_ATTR_ENGINE_GLOBAL_INDEX, engine_idx,
-                                     CUDNN_ATTR_ENGINE_OPERATION_GRAPH, op_graph);
+                                     CUDNN_ATTR_ENGINE_GLOBAL_INDEX,
+                                     engine_idx,
+                                     CUDNN_ATTR_ENGINE_OPERATION_GRAPH,
+                                     op_graph);
 
   auto cloned_cfg = MakeFinalized(CUDNN_BACKEND_ENGINECFG_DESCRIPTOR,
-                                  CUDNN_ATTR_ENGINECFG_ENGINE, cloned_engine,
-                                  CUDNN_ATTR_ENGINECFG_KNOB_CHOICES, choices);
+                                  CUDNN_ATTR_ENGINECFG_ENGINE,
+                                  cloned_engine,
+                                  CUDNN_ATTR_ENGINECFG_KNOB_CHOICES,
+                                  choices);
 
   auto cloned_plan = cudnn_cxx::Make(CUDNN_BACKEND_EXECUTION_PLAN_DESCRIPTOR,
-                                     CUDNN_ATTR_EXECUTION_PLAN_HANDLE, handle,
-                                     CUDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG, cloned_cfg);
+                                     CUDNN_ATTR_EXECUTION_PLAN_HANDLE,
+                                     handle,
+                                     CUDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
+                                     cloned_cfg);
   CUDNN_CALL(cudnnBackendFinalize(cloned_plan.get()));
   return cloned_plan;
 }
@@ -681,9 +698,9 @@ cudnn_cxx::Descriptor Conv::Clone(const cudnn_cxx::Descriptor& plan,
                                   const TBlob& x,
                                   const TBlob& w,
                                   const TBlob& y) {
-  auto conv_fwd = MakeConvFwdOp(ctx, param, x, w, y);
-  auto handle = ctx.get_stream<gpu>()->dnn_handle_;
-  auto op_graph = MakeOpGraph(handle, std::move(conv_fwd));
+  auto conv_fwd    = MakeConvFwdOp(ctx, param, x, w, y);
+  auto handle      = ctx.get_stream<gpu>()->dnn_handle_;
+  auto op_graph    = MakeOpGraph(handle, std::move(conv_fwd));
   auto cloned_plan = ClonePlan(handle, std::move(op_graph), plan);
   return cloned_plan;
 }
@@ -742,9 +759,9 @@ cudnn_cxx::Descriptor ConvDgrad::Clone(const cudnn_cxx::Descriptor& plan,
                                        const TBlob& w,
                                        const TBlob& dy,
                                        const TBlob& dx) {
-  auto conv_dgrad = MakeConvDgradOp(ctx, param, w, dy, dx);
-  auto handle = ctx.get_stream<gpu>()->dnn_handle_;
-  auto op_graph = MakeOpGraph(handle, std::move(conv_dgrad));
+  auto conv_dgrad  = MakeConvDgradOp(ctx, param, w, dy, dx);
+  auto handle      = ctx.get_stream<gpu>()->dnn_handle_;
+  auto op_graph    = MakeOpGraph(handle, std::move(conv_dgrad));
   auto cloned_plan = ClonePlan(handle, std::move(op_graph), plan);
   return cloned_plan;
 }
@@ -803,9 +820,9 @@ cudnn_cxx::Descriptor ConvWgrad::Clone(const cudnn_cxx::Descriptor& plan,
                                        const TBlob& x,
                                        const TBlob& dy,
                                        const TBlob& dw) {
-  auto conv_wgrad = MakeConvWgradOp(ctx, param, x, dy, dw);
-  auto handle = ctx.get_stream<gpu>()->dnn_handle_;
-  auto op_graph = MakeOpGraph(handle, std::move(conv_wgrad));
+  auto conv_wgrad  = MakeConvWgradOp(ctx, param, x, dy, dw);
+  auto handle      = ctx.get_stream<gpu>()->dnn_handle_;
+  auto op_graph    = MakeOpGraph(handle, std::move(conv_wgrad));
   auto cloned_plan = ClonePlan(handle, std::move(op_graph), plan);
   return cloned_plan;
 }

--- a/src/operator/cudnn_ops.h
+++ b/src/operator/cudnn_ops.h
@@ -112,6 +112,13 @@ struct LayoutInfo {
 
 LayoutInfo GetLayoutInfo(mshadow::LayoutFlag layout);
 
+cudnn_cxx::Descriptor MakeOpGraph(cudnnHandle_t handle,
+                                  cudnn_cxx::Descriptor op);
+
+// Make a copy of an existing execution plan with a new cuDNN handle.  Op graph re-supplied.
+cudnn_cxx::Descriptor ClonePlan(cudnnHandle_t handle, cudnn_cxx::Descriptor op_graph,
+                                const cudnn_cxx::Descriptor& plan);
+
 TShape ExpandChannelDims(mshadow::LayoutFlag layout, int c);
 
 void MaybeLogSelectedPlan(const cudnn_cxx::Descriptor& plan);
@@ -121,25 +128,40 @@ void MaybeLogSelectedPlan(const cudnn_cxx::Descriptor& plan);
 // Op::Param - a type, collecting all data, required to create cuDNN descriptor(s), but not needed
 //             for execution.
 // Op::MakeKey() - a static function, which maps its arguments to a tuple - a key in the op cache.
-// Op::Make() - a static function, creating the necessary cuDNN descriptor.
-// Op::Exec() - a static function, calling cudnnBackendExecute() with the prepared descriptor and
+// Op::Make() - a static function, creating all necessary cuDNN descriptors.
+// Op::Clone() - a static function, creating a copy of the op's descriptors with a new cudNN handle.
+// Op::Exec() - a static function, calling cudnnBackendExecute() with the prepared descriptor(s) and
 //              the passed arguments.
 template <typename Op, typename... Args>
 bool Exec(const OpContext& ctx, const typename Op::Param& param, Args&&... args) {
   auto key = std::tuple_cat(std::make_tuple(ctx.run_ctx.ctx.dev_id),
                             Op::MakeKey(param, std::forward<Args>(args)...));
-  static std::unordered_map<decltype(key), cudnn_cxx::Descriptor> op_map;
   static std::mutex mx;
   std::unique_lock<std::mutex> lk(mx);
-  auto it = op_map.find(key);
-  if (it == op_map.end()) {
-    auto op = Op::Make(ctx, param, std::forward<Args>(args)...);
-    it      = op_map.emplace(key, std::move(op)).first;
-  }
+  static std::unordered_multimap<decltype(key), const cudnn_cxx::Descriptor> op_map;
+  auto match_it = [&]() {
+    // Some cuDNN Op implementations require that the thread's cuDNN handle
+    // (used in cudnnBackendExecute()) matches the one used in making the plan.
+    const bool require_handle_match = true;
+    auto range = op_map.equal_range(key);
+    auto handle = ctx.get_stream<gpu>()->dnn_handle_;
+    for (auto it = range.first; it != range.second; ++it) {
+      if (!require_handle_match ||
+          handle == cudnn_cxx::GetAttr<cudnnHandle_t>(it->second,
+                                                      CUDNN_ATTR_EXECUTION_PLAN_HANDLE)) {
+          return it;
+      }
+    }
+    // No Op exists with this handle. Make a new op, cloning from an existing op if possible.
+    auto op = (range.first == range.second) ?
+        Op::Make(ctx, param, std::forward<Args>(args)...) :
+        Op::Clone(range.first->second, ctx, param, std::forward<Args>(args)...);
+    return op_map.emplace(key, std::move(op));
+  }();
   lk.unlock();
-  if (!it->second)
+  if (!match_it->second)
     return false;
-  Op::Exec(it->second, ctx, std::forward<Args>(args)...);
+  Op::Exec(match_it->second, ctx, std::forward<Args>(args)...);
   return true;
 }
 
@@ -189,11 +211,22 @@ struct Conv {
                                     const TBlob& w,
                                     const TBlob& y);
 
+  static cudnn_cxx::Descriptor Clone(const cudnn_cxx::Descriptor& plan,
+                                     const OpContext& ctx,
+                                     const Param& param,
+                                     const TBlob& x,
+                                     const TBlob& w,
+                                     const TBlob& y);
+
   static void Exec(const cudnn_cxx::Descriptor& plan,
                    const OpContext& ctx,
                    const TBlob& x,
                    const TBlob& w,
                    const TBlob& y);
+
+ private:
+  static cudnn_cxx::Descriptor MakeConvFwdOp(const OpContext& ctx, const Param& param,
+                                             const TBlob& x, const TBlob& w, const TBlob& y);
 };
 
 struct ConvDgrad {
@@ -223,11 +256,22 @@ struct ConvDgrad {
                                     const TBlob& dy,
                                     const TBlob& dx);
 
+  static cudnn_cxx::Descriptor Clone(const cudnn_cxx::Descriptor& plan,
+                                     const OpContext& ctx,
+                                     const Param& param,
+                                     const TBlob& x,
+                                     const TBlob& w,
+                                     const TBlob& y);
+
   static void Exec(const cudnn_cxx::Descriptor& plan,
                    const OpContext& ctx,
                    const TBlob& w,
                    const TBlob& dy,
                    const TBlob& dx);
+
+ private:
+  static cudnn_cxx::Descriptor MakeConvDgradOp(const OpContext& ctx, const Param& param,
+                                               const TBlob& w, const TBlob& dy, const TBlob& dx);
 };
 
 struct ConvWgrad {
@@ -257,11 +301,22 @@ struct ConvWgrad {
                                     const TBlob& dy,
                                     const TBlob& dw);
 
+  static cudnn_cxx::Descriptor Clone(const cudnn_cxx::Descriptor& plan,
+                                     const OpContext& ctx,
+                                     const Param& param,
+                                     const TBlob& x,
+                                     const TBlob& w,
+                                     const TBlob& y);
+
   static void Exec(const cudnn_cxx::Descriptor& plan,
                    const OpContext& ctx,
                    const TBlob& x,
                    const TBlob& dy,
                    const TBlob& dw);
+
+ private:
+  static cudnn_cxx::Descriptor MakeConvWgradOp(const OpContext& ctx, const Param& param,
+                                               const TBlob& x, const TBlob& dy, const TBlob& dw);
 };
 
 bool LegacyAddBias(const OpContext& ctx, const LayoutInfo& li, const TBlob& y, const TBlob& b);

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -1834,7 +1834,6 @@ def test_conv2d_16c(chn_num, kernel):
 @use_np
 @pytest.mark.parametrize('grp', [16])
 @pytest.mark.parametrize('kernel_size', [1, 3])
-@with_environment('MXNET_CUDNN_DISABLED_CONV_FWD_ENGINES', '5')  # eng:5 causes test failure on M60
 def test_group_conv2d_16c(grp, kernel_size):
     input_size_list = onp.random.randint(low=3, high=65, size=10).tolist()
     batch_size = 4


### PR DESCRIPTION
## Description ##
PR #20635, which began using the cuDNN v8 backend API for Convolution ops, includes the following line to avoid `test_gluon_gpu.py::test_group_conv2d_16c` failures that began occurring coincident with the PR:

```
@with_environment('MXNET_CUDNN_DISABLED_CONV_FWD_ENGINES', '5')  # eng:5 causes test failure on M60
```
This PR will remove that line by providing a different implementation of the "convolution plan cache" introduced with PR #20635 that is compatible with convolution engine 5.  The steps of this PR will be:

1. Reenable convolution engine 5, and demonstrate a return of `test_group_conv2d_16c` failures, then
2. Add the upgrade to the convolution plan cache so that `test_group_conv2d_16c` passes even with engine 5 use

Further detail:

The cuDNN v8 backend allows one to bypass a lot of CPU processing that might precede kernel launch by first building up and finalizing a convolution execution plan.  The plan, which includes a choice of convolution engine and 'knob settings', is then executed efficiently by the call `cudnnBackendExecute(cudnn_handle, plan, ...)`.  PR #20635 introduced a cache of plans so that autotuning does not need to be repeated for identically-parameterized convolutions, which are then handled by the same plan even if they exist multiple times in a model or are handled by different GPU workers.

The issue that was discovered for convolution engine 5 is that it caches a cuDNN handle provided during the plan's construction, and does not consider the handle passed as an argument of cudnnBackendExecute().  The result is that the engine's kernels are launched into the stream of the cached handle, and this would be the incorrect stream if the GPU worker executing the plan is different from the one that created the plan.  Without the proper stream synchronization, incorrect results may follow.

The contribution of this PR is to effectively include a GPU worker's cudnn handle as part of the key used in the cache lookup.  One aspect of the fix though is that if there's a plan cache miss, a plan made by a different worker for the same convolution can be 'cloned' with the proper handle without repeating the autotuning.

## Checklist ##
### Essentials ###
- [X] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
- [X] Code is well-documented

