### PR TITLE
Fix multivariate normal bug

### DIFF
--- a/python/mxnet/numpy_op_fallback.py
+++ b/python/mxnet/numpy_op_fallback.py
@@ -182,7 +182,7 @@ class MultivariateNormal(operator.CustomOp):
             scale = _mx_np.linalg.cholesky(cov)
         #set context
         noise = _mx_np.random.normal(size=out_data[0].shape, dtype=loc.dtype, device=loc.device)
-        out = loc + _mx_np.einsum('...jk,...j->...k', scale, noise)
+        out = loc + _mx_np.einsum('...jk,...k->...j', scale, noise)
         self.assign(out_data[0], req[0], out)
 
     def backward(self, req, out_grad, in_data, out_data, in_grad, aux):


### PR DESCRIPTION
## Description ##
This PR fixes problem with `mxnet.np.random.multivariate_normal` producing unexpected results described in [this issue](https://github.com/apache/incubator-mxnet/issues/21095).

In the previous implementation, wrong columns were multiplied.

These are resulting plots
![image](https://user-images.githubusercontent.com/72540840/180416901-a78b5038-fe0a-43a8-9052-194a3a9933f7.png)
