### PR TITLE
[WIP] [BUGFIX] Fix flakey TemporaryDirectory() cleanup on Windows

### DIFF
--- a/python/mxnet/gluon/utils.py
+++ b/python/mxnet/gluon/utils.py
@@ -34,7 +34,7 @@ import requests
 import numpy as np
 
 from .. import ndarray
-from ..util import is_np_shape, is_np_array
+from ..util import is_np_shape, is_np_array, TemporaryDirectory
 from .. import numpy as _mx_np  # pylint: disable=reimported
 
 

--- a/python/mxnet/util.py
+++ b/python/mxnet/util.py
@@ -1373,7 +1373,7 @@ def TemporaryDirectory(*args, **kwargs):
     """A context wrapper of tempfile.TemporaryDirectory() that ignores cleanup errors on Windows.
     """
     dir = tempfile.TemporaryDirectory(*args, **kwargs)
-    yield dir
+    yield dir.name
     try:
         dir.cleanup()
     except PermissionError:

--- a/python/mxnet/util.py
+++ b/python/mxnet/util.py
@@ -1377,5 +1377,5 @@ def TemporaryDirectory(*args, **kwargs):
     try:
         dir.cleanup()
     except PermissionError:
-        if platform.system() == 'Windows':
-            pass
+        if platform.system() != 'Windows':
+            raise

--- a/python/mxnet/util.py
+++ b/python/mxnet/util.py
@@ -20,6 +20,9 @@ import ctypes
 import functools
 import inspect
 import threading
+import tempfile
+import platform
+from contextlib import contextmanager
 
 from struct import calcsize
 from .base import (_LIB, check_call, c_str, py_str,
@@ -1359,3 +1362,20 @@ def dtype_from_number(number):
     elif isinstance(number, _np.generic):
         return number.dtype
     raise TypeError('type {} not supported'.format(str(type(number))))
+
+# This is a wrapping of tempfile.TemporaryDirectory(), known to have cleanup issues on Windows.
+# The problem is partially handled as of Python 3.10 by the adding of a 'ignore_cleanup_errors'
+# parameter.  Once MXNet's Python version is forced to be >= 3.10, a simplification of this
+# function to use 'ignore_cleanup_errors' would be possible.  Until the fundamental Windows
+# issues are resolved, best to use this routine instead of tempfile.TemporaryDirectory().
+@contextmanager
+def TemporaryDirectory(*args, **kwargs):
+    """A context wrapper of tempfile.TemporaryDirectory() that ignores cleanup errors on Windows.
+    """
+    dir = tempfile.TemporaryDirectory(*args, **kwargs)
+    yield dir
+    try:
+        dir.cleanup()
+    except PermissionError:
+        if platform.system() == 'Windows':
+            pass

--- a/python/mxnet/util.py
+++ b/python/mxnet/util.py
@@ -1373,9 +1373,11 @@ def TemporaryDirectory(*args, **kwargs):
     """A context wrapper of tempfile.TemporaryDirectory() that ignores cleanup errors on Windows.
     """
     dir = tempfile.TemporaryDirectory(*args, **kwargs)
-    yield dir.name
     try:
-        dir.cleanup()
-    except PermissionError:
-        if platform.system() != 'Windows':
-            raise
+        yield dir.name
+    finally:
+        try:
+            dir.cleanup()
+        except PermissionError:
+            if platform.system() != 'Windows':
+                raise

--- a/tests/nightly/test_large_array.py
+++ b/tests/nightly/test_large_array.py
@@ -23,6 +23,7 @@ import numpy as np
 import mxnet as mx
 
 from mxnet.test_utils import rand_ndarray, assert_almost_equal, rand_coord_2d, default_device, check_symbolic_forward, create_2d_tensor
+from mxnet.util import TemporaryDirectory
 from mxnet import gluon, nd
 from common import with_seed
 import pytest
@@ -1028,7 +1029,7 @@ def test_tensor():
 
     def check_load_save():
         x = create_2d_tensor(SMALL_Y, LARGE_X)
-        with tempfile.TemporaryDirectory() as tmp:
+        with TemporaryDirectory() as tmp:
             tmpfile = os.path.join(tmp, 'large_tensor')
             nd.save(tmpfile, [x])
             y = nd.load(tmpfile)

--- a/tests/nightly/test_large_vector.py
+++ b/tests/nightly/test_large_vector.py
@@ -17,12 +17,12 @@
 
 import os
 import sys
-import tempfile
 import math
 import numpy as np
 import mxnet as mx
 
 from mxnet.test_utils import rand_ndarray, assert_almost_equal, rand_coord_2d, create_vector
+from mxnet.util import TemporaryDirectory
 from mxnet import gluon, nd
 from common import with_seed
 import pytest
@@ -374,7 +374,7 @@ def test_tensor():
 
     def check_load_save():
         x = create_vector(size=LARGE_X)
-        with tempfile.TemporaryDirectory() as tmp:
+        with TemporaryDirectory() as tmp:
             tmpfile = os.path.join(tmp, 'large_vector')
             nd.save(tmpfile, [x])
             y = nd.load(tmpfile)

--- a/tests/python/unittest/common.py
+++ b/tests/python/unittest/common.py
@@ -30,7 +30,7 @@ sys.path.insert(0, os.path.join(curr_path, '../../../python'))
 import models
 from contextlib import contextmanager
 import pytest
-from tempfile import TemporaryDirectory
+from mxnet.util import TemporaryDirectory
 import locale
 
 xfail_when_nonstandard_decimal_separator = pytest.mark.xfail(

--- a/tests/python/unittest/test_deferred_compute.py
+++ b/tests/python/unittest/test_deferred_compute.py
@@ -17,13 +17,13 @@
 
 import functools
 import operator
-import tempfile
 
 import numpy as np
 
 import mxnet as mx
 import mxnet._deferred_compute as dc
 from mxnet.base import MXNetError
+from mxnet.util import TemporaryDirectory
 import pytest
 
 
@@ -420,7 +420,7 @@ def _assert_dc_gluon(setup, net, setup_is_deterministic=True, numpy=True, autogr
 
     _all_same(ys_np, ys_hybrid_np)
 
-    with tempfile.TemporaryDirectory() as root:
+    with TemporaryDirectory() as root:
         with mx.util.np_shape(True), mx.util.np_array(True):
             net.export(root)
 

--- a/tests/python/unittest/test_gluon_event_handler.py
+++ b/tests/python/unittest/test_gluon_event_handler.py
@@ -78,8 +78,6 @@ def _get_batch_axis_test_data(in_size=32):
     data_arr = AxisArrayDataset(data, label)
     return mx.gluon.data.DataLoader(data_arr, batch_size=8)
 
-# Possible issue with bug in TemporaryDirectory() on Windows, as
-# mentioned in https://github.com/apache/incubator-mxnet/issues/20914
 @mx.util.use_np
 def test_checkpoint_handler():
     with TemporaryDirectory() as tmpdir:

--- a/tests/python/unittest/test_gluon_event_handler.py
+++ b/tests/python/unittest/test_gluon_event_handler.py
@@ -78,6 +78,8 @@ def _get_batch_axis_test_data(in_size=32):
     data_arr = AxisArrayDataset(data, label)
     return mx.gluon.data.DataLoader(data_arr, batch_size=8)
 
+# Possible issue with bug in TemporaryDirectory() on Windows, as
+# mentioned in https://github.com/apache/incubator-mxnet/issues/20914
 @mx.util.use_np
 def test_checkpoint_handler():
     with TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Description ##
On a recent PR of mine and in other PRs, I saw sporadic windows-gpu job failures, which I flagged awhile ago in issue https://github.com/apache/incubator-mxnet/issues/20914 .  I feel now the problem is due to flakiness of `tempfile.TemporaryDirectory()` on Windows, as described here: https://www.scivision.dev/python-tempfile-permission-error-windows/.  This PR starts with a non-functional commit to show that master is suffering this problem (which indeed failed with the expected "access violation": https://jenkins.mxnet-ci.com/blue/organizations/jenkins/mxnet-validation%2Fwindows-gpu/detail/PR-21107/1/pipeline).  This PR then adds a like-named context manager routine `mxnet.util.TemporaryDirectory()` that wraps `tempfile.TemporaryDirectory()`, but ignores its cleanup issues on Windows.  Finally, the PR changes all uses of `tempfile.TemporaryDirectory()` in the codebase to use the newly added `mxnet.util.TemporaryDirectory()`.

Update: I realize that this PR really targets a different error, namely "access is denied", as reported in this older issue: https://github.com/apache/incubator-mxnet/issues/17558

The "access violation" is a segfault in a backend thread, and so is likely a different issue.  This maybe a good PR to merge, if we are still seeing "access is denied".  But it won't correct the frequent windows GPU CI failures we are currently seeing.

## Checklist ##
### Essentials ###
- [X] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
- [X] Code is well-documented
