### PR TITLE
[BUGFIX] Fix threadsafety and shutdown issues with threaded_engine_perdevice

### DIFF
--- a/src/engine/threaded_engine_perdevice.cc
+++ b/src/engine/threaded_engine_perdevice.cc
@@ -21,8 +21,6 @@
  * \file threaded_engine_perdevice.cc
  * \brief ThreadedEngine that uses fix amount of thread for each device.
  */
-#include <unistd.h>
-#include <mutex>
 #include <dmlc/base.h>
 #include <dmlc/omp.h>
 #include <dmlc/logging.h>
@@ -30,6 +28,8 @@
 #include <dmlc/concurrency.h>
 #include <dmlc/thread_group.h>
 
+#include <unistd.h>
+#include <mutex>
 #include <memory>
 #include "../initialize.h"
 #include "./threaded_engine.h"

--- a/src/engine/threaded_engine_perdevice.cc
+++ b/src/engine/threaded_engine_perdevice.cc
@@ -76,8 +76,10 @@ class ThreadedEnginePerDevice : public ThreadedEngine {
     gpu_copy_workers_.Clear();
     cpu_normal_workers_.Clear();
     cpu_priority_worker_.reset(nullptr);
+#if MXNET_USE_CUDA
     streams_.clear();
     cuda_event_pool_per_worker_.clear();
+#endif
   }
 
   void Stop() override {

--- a/src/engine/threaded_engine_perdevice.cc
+++ b/src/engine/threaded_engine_perdevice.cc
@@ -28,7 +28,6 @@
 #include <dmlc/concurrency.h>
 #include <dmlc/thread_group.h>
 
-#include <unistd.h>
 #include <mutex>
 #include <memory>
 #include "../initialize.h"


### PR DESCRIPTION
## Description ##
This PR makes improvements in the handling of CUDA resources by the ThreadedEnginePerDevice, and this appears to have corrected certain CI failures of the GPU jobs on Windows (6 of 6 passing), as mentioned first in issue https://github.com/apache/incubator-mxnet/issues/20914 and more recently in PR https://github.com/apache/incubator-mxnet/pull/21107.

Background: As a general policy, a process should not have an active CUDA context, with unreleased CUDA resources like streams and events, prior to forking.  While it's even unclear whether this is guaranteed to work when the forked child process performs an immediate exec, in the absence of those assurances, the parent should definitely play it safe and release all CUDA resources prior to the fork. To help in that task, the following callback in initializer.cc is currently executed by the parent process prior to the fork:
```
void LibraryInitializer::atfork_prepare() {
  using op::custom::CustomOperator;
  CustomOperator::Get()->Stop();
  Engine::Get()->Stop();
}
```
The `Engine::Get()->Stop()` call then ultimately calls `ThreadedEnginePerDevice::StopNoWait()`.  This PR adds to `StopNoWait()` a release of CUDA resources introduced by the `async GPU dependency engine PR` https://github.com/apache/incubator-mxnet/pull/20331 (namely `streams_` and `cuda_event_pool_per_worker_`).  In addition, a thread safety issue is corrected that might occur during the initial construction of GPUWorkers.

## Checklist ##
### Essentials ###
- [X] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
