### PR TITLE
[FEATURE] Min and Max oneDNN primitive integration

### DIFF
--- a/src/operator/nn/dnnl/dnnl_reduce.cc
+++ b/src/operator/nn/dnnl/dnnl_reduce.cc
@@ -24,8 +24,8 @@
 
 #if MXNET_USE_ONEDNN == 1
 
-#include "./dnnl_reduce-inl.h"
-#include "../../numpy/np_broadcast_reduce_op.h"
+#include "operator/nn/dnnl/dnnl_reduce-inl.h"
+#include "operator/numpy/np_broadcast_reduce_op.h"
 
 namespace mxnet {
 namespace op {
@@ -58,6 +58,26 @@ NumpyReduceAxesParam ConvertReduceParamsToNumpy<ReduceAxesParam>(
   }
   numpy_param.keepdims = original_param.keepdims;
   numpy_param.dtype    = dmlc::optional<int>(output.dtype());
+  return numpy_param;
+}
+
+template <>
+NumpyReduceAxesParam ConvertReduceParamsToNumpy<NumpyReduceAxesNoDTypeParam>(
+    const NumpyReduceAxesNoDTypeParam& original_param,
+    const NDArray& input,
+    const NDArray& output) {
+  NumpyReduceAxesParam numpy_param;
+  numpy_param.axis = dmlc::optional<mxnet::Tuple<int>>();
+  if (original_param.axis.has_value()) {
+    mxnet::Tuple<int> axes(original_param.axis.value().begin(), original_param.axis.value().end());
+    std::sort(axes.begin(), axes.end());
+    numpy_param.axis = axes;
+  }
+  numpy_param.keepdims = original_param.keepdims;
+  if (original_param.initial.has_value()) {
+    numpy_param.initial = original_param.initial;
+  }
+  numpy_param.dtype = dmlc::optional<int>(output.dtype());
   return numpy_param;
 }
 

--- a/src/operator/nn/dnnl/dnnl_reduce.cc
+++ b/src/operator/nn/dnnl/dnnl_reduce.cc
@@ -112,7 +112,7 @@ bool SupportDNNLReduceImpl(const NumpyReduceAxesParam& param,
     auto axes    = CanonicalizeAndSortAxes(input, param, param.axis.value());
     int last_dim = *(axes.end() - 1);
     if (last_dim != input.shape().ndim() - 1) {
-      // oneDNN (v2.3.2) not optimized case
+      // oneDNN (v2.6.1) not optimized case
       return false;
     } else {
       for (int i = 0; i < axes.ndim(); i++) {

--- a/src/operator/nn/dnnl/dnnl_reduce.cc
+++ b/src/operator/nn/dnnl/dnnl_reduce.cc
@@ -24,6 +24,7 @@
 
 #if MXNET_USE_ONEDNN == 1
 
+#include <algorithm>
 #include "operator/nn/dnnl/dnnl_reduce-inl.h"
 #include "operator/numpy/np_broadcast_reduce_op.h"
 

--- a/src/operator/numpy/np_broadcast_reduce_op_value_max.cc
+++ b/src/operator/numpy/np_broadcast_reduce_op_value_max.cc
@@ -46,6 +46,12 @@ NNVM_REGISTER_OP(_npi_max)
     .add_argument("a", "NDArray-or-Symbol", "The input")
     .add_arguments(NumpyReduceAxesNoDTypeParam::__FIELDS__())
     .set_attr<FCompute>("FCompute<cpu>", NumpyReduceAxesNoDTypeCompute<cpu, mshadow::red::maximum>)
+#if MXNET_USE_ONEDNN == 1
+    .set_attr<FInferStorageType>("FInferStorageType", NumpyReduceAxesNoDTypeStorageType)
+    .set_attr<bool>("TIsDNNL", true)
+    .set_attr<FComputeEx>("FComputeEx<cpu>",
+                          DNNLReduceEx<NumpyReduceAxesNoDTypeParam, mshadow::red::maximum>)
+#endif
     .set_attr<FResourceRequest>("FResourceRequest",
                                 [](const NodeAttrs& attrs) {
                                   return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};

--- a/src/operator/numpy/np_broadcast_reduce_op_value_mean.cc
+++ b/src/operator/numpy/np_broadcast_reduce_op_value_mean.cc
@@ -43,11 +43,12 @@ NNVM_REGISTER_OP(_npi_mean)
                                      })
     .add_argument("a", "NDArray-or-Symbol", "The input")
     .add_arguments(NumpyReduceAxesParam::__FIELDS__())
-    .set_attr<FCompute>("FCompute<cpu>", NumpyReduceAxesCompute<cpu, mshadow_op::sum, true, true>)
+    .set_attr<FCompute>("FCompute<cpu>", NumpyReduceAxesCompute<cpu, mshadow::red::sum, true, true>)
 #if MXNET_USE_ONEDNN == 1
     .set_attr<FInferStorageType>("FInferStorageType", NumpyReduceAxesStorageType)
     .set_attr<bool>("TIsDNNL", true)
-    .set_attr<FComputeEx>("FComputeEx<cpu>", DNNLReduceEx<dnnl::algorithm::reduction_mean>)
+    .set_attr<FComputeEx>("FComputeEx<cpu>",
+                          DNNLReduceEx<NumpyReduceAxesParam, mshadow::red::sum, true>)
 #endif
     .set_attr<FResourceRequest>("FResourceRequest",
                                 [](const NodeAttrs& attrs) {

--- a/src/operator/numpy/np_broadcast_reduce_op_value_mean.cc
+++ b/src/operator/numpy/np_broadcast_reduce_op_value_mean.cc
@@ -43,12 +43,12 @@ NNVM_REGISTER_OP(_npi_mean)
                                      })
     .add_argument("a", "NDArray-or-Symbol", "The input")
     .add_arguments(NumpyReduceAxesParam::__FIELDS__())
-    .set_attr<FCompute>("FCompute<cpu>", NumpyReduceAxesCompute<cpu, mshadow::red::sum, true, true>)
+    .set_attr<FCompute>("FCompute<cpu>", NumpyReduceAxesCompute<cpu, mshadow_op::sum, true, true>)
 #if MXNET_USE_ONEDNN == 1
     .set_attr<FInferStorageType>("FInferStorageType", NumpyReduceAxesStorageType)
     .set_attr<bool>("TIsDNNL", true)
     .set_attr<FComputeEx>("FComputeEx<cpu>",
-                          DNNLReduceEx<NumpyReduceAxesParam, mshadow::red::sum, true>)
+                          DNNLReduceEx<NumpyReduceAxesParam, mshadow_op::sum, true>)
 #endif
     .set_attr<FResourceRequest>("FResourceRequest",
                                 [](const NodeAttrs& attrs) {

--- a/src/operator/numpy/np_broadcast_reduce_op_value_min.cc
+++ b/src/operator/numpy/np_broadcast_reduce_op_value_min.cc
@@ -46,6 +46,12 @@ NNVM_REGISTER_OP(_npi_min)
     .add_argument("a", "NDArray-or-Symbol", "The input")
     .add_arguments(NumpyReduceAxesNoDTypeParam::__FIELDS__())
     .set_attr<FCompute>("FCompute<cpu>", NumpyReduceAxesNoDTypeCompute<cpu, mshadow::red::minimum>)
+#if MXNET_USE_ONEDNN == 1
+    .set_attr<FInferStorageType>("FInferStorageType", NumpyReduceAxesNoDTypeStorageType)
+    .set_attr<bool>("TIsDNNL", true)
+    .set_attr<FComputeEx>("FComputeEx<cpu>",
+                          DNNLReduceEx<NumpyReduceAxesNoDTypeParam, mshadow::red::minimum>)
+#endif
     .set_attr<FResourceRequest>("FResourceRequest",
                                 [](const NodeAttrs& attrs) {
                                   return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};

--- a/src/operator/numpy/np_broadcast_reduce_op_value_sum.cc
+++ b/src/operator/numpy/np_broadcast_reduce_op_value_sum.cc
@@ -47,11 +47,11 @@ NNVM_REGISTER_OP(_npi_sum)
                                      })
     .add_argument("a", "NDArray-or-Symbol", "The input")
     .add_arguments(NumpyReduceAxesParam::__FIELDS__())
-    .set_attr<FCompute>("FCompute<cpu>", NumpyReduceAxesCompute<cpu, mshadow::red::sum, true>)
+    .set_attr<FCompute>("FCompute<cpu>", NumpyReduceAxesCompute<cpu, mshadow_op::sum, true>)
 #if MXNET_USE_ONEDNN == 1
     .set_attr<FInferStorageType>("FInferStorageType", NumpyReduceAxesStorageType)
     .set_attr<bool>("TIsDNNL", true)
-    .set_attr<FComputeEx>("FComputeEx<cpu>", DNNLReduceEx<NumpyReduceAxesParam, mshadow::red::sum>)
+    .set_attr<FComputeEx>("FComputeEx<cpu>", DNNLReduceEx<NumpyReduceAxesParam, mshadow_op::sum>)
 #endif
     .set_attr<FResourceRequest>("FResourceRequest",
                                 [](const NodeAttrs& attrs) {

--- a/src/operator/numpy/np_broadcast_reduce_op_value_sum.cc
+++ b/src/operator/numpy/np_broadcast_reduce_op_value_sum.cc
@@ -47,11 +47,11 @@ NNVM_REGISTER_OP(_npi_sum)
                                      })
     .add_argument("a", "NDArray-or-Symbol", "The input")
     .add_arguments(NumpyReduceAxesParam::__FIELDS__())
-    .set_attr<FCompute>("FCompute<cpu>", NumpyReduceAxesCompute<cpu, mshadow_op::sum, true>)
+    .set_attr<FCompute>("FCompute<cpu>", NumpyReduceAxesCompute<cpu, mshadow::red::sum, true>)
 #if MXNET_USE_ONEDNN == 1
     .set_attr<FInferStorageType>("FInferStorageType", NumpyReduceAxesStorageType)
     .set_attr<bool>("TIsDNNL", true)
-    .set_attr<FComputeEx>("FComputeEx<cpu>", DNNLReduceEx<dnnl::algorithm::reduction_sum>)
+    .set_attr<FComputeEx>("FComputeEx<cpu>", DNNLReduceEx<NumpyReduceAxesParam, mshadow::red::sum>)
 #endif
     .set_attr<FResourceRequest>("FResourceRequest",
                                 [](const NodeAttrs& attrs) {

--- a/src/operator/tensor/broadcast_reduce_minmax_value.cc
+++ b/src/operator/tensor/broadcast_reduce_minmax_value.cc
@@ -22,6 +22,7 @@
  * \brief CPU Implementation of broadcast and reduce min and max functions based on value.
  */
 #include "./broadcast_reduce_op.h"
+#include "../numpy/np_broadcast_reduce_op.h"
 
 namespace mxnet {
 namespace op {
@@ -33,7 +34,7 @@ MXNET_OPERATOR_REGISTER_MINMAX_REDUCE(max)
     #if MXNET_USE_ONEDNN == 1
     .set_attr<FInferStorageType>("FInferStorageType", ReduceAxesMinMaxOpForwardStorage)
     .set_attr<bool>("TIsDNNL", true)
-    .setattr_<FComputeEx>("FComputeEx<cpu>", ReduceAxesOpForwardEx<cpu, mshadow::red:maximum>)
+    .set_attr<FComputeEx>("FComputeEx<cpu>", ReduceAxesMinMaxOpForwardEx<cpu, mshadow::red::maximum>)
     #endif
     .set_attr<FResourceRequest>("FResourceRequest",
                                 [](const NodeAttrs& attrs) {
@@ -50,6 +51,11 @@ MXNET_OPERATOR_REGISTER_MINMAX_REDUCE(min)
     .add_alias("min_axis")
     .describe(get_reduce_axes_description("min", __LINE__))
     .set_attr<FCompute>("FCompute<cpu>", ReduceAxesCompute<cpu, mshadow::red::minimum>)
+    #if MXNET_USE_ONEDNN == 1
+    .set_attr<FInferStorageType>("FInferStorageType", ReduceAxesMinMaxOpForwardStorage)
+    .set_attr<bool>("TIsDNNL", true)
+    .set_attr<FComputeEx>("FComputeEx<cpu>", ReduceAxesMinMaxOpForwardEx<cpu, mshadow::red::minimum>)
+    #endif
     .set_attr<FResourceRequest>("FResourceRequest",
                                 [](const NodeAttrs& attrs) {
                                   return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};

--- a/src/operator/tensor/broadcast_reduce_minmax_value.cc
+++ b/src/operator/tensor/broadcast_reduce_minmax_value.cc
@@ -31,11 +31,12 @@ MXNET_OPERATOR_REGISTER_MINMAX_REDUCE(max)
     .add_alias("max_axis")
     .describe(get_reduce_axes_description("max", __LINE__))
     .set_attr<FCompute>("FCompute<cpu>", ReduceAxesCompute<cpu, mshadow::red::maximum>)
-    #if MXNET_USE_ONEDNN == 1
+#if MXNET_USE_ONEDNN == 1
     .set_attr<FInferStorageType>("FInferStorageType", ReduceAxesMinMaxOpForwardStorage)
     .set_attr<bool>("TIsDNNL", true)
-    .set_attr<FComputeEx>("FComputeEx<cpu>", ReduceAxesMinMaxOpForwardEx<cpu, mshadow::red::maximum>)
-    #endif
+    .set_attr<FComputeEx>("FComputeEx<cpu>",
+                          ReduceAxesMinMaxOpForwardEx<cpu, mshadow::red::maximum>)
+#endif
     .set_attr<FResourceRequest>("FResourceRequest",
                                 [](const NodeAttrs& attrs) {
                                   return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
@@ -51,11 +52,12 @@ MXNET_OPERATOR_REGISTER_MINMAX_REDUCE(min)
     .add_alias("min_axis")
     .describe(get_reduce_axes_description("min", __LINE__))
     .set_attr<FCompute>("FCompute<cpu>", ReduceAxesCompute<cpu, mshadow::red::minimum>)
-    #if MXNET_USE_ONEDNN == 1
+#if MXNET_USE_ONEDNN == 1
     .set_attr<FInferStorageType>("FInferStorageType", ReduceAxesMinMaxOpForwardStorage)
     .set_attr<bool>("TIsDNNL", true)
-    .set_attr<FComputeEx>("FComputeEx<cpu>", ReduceAxesMinMaxOpForwardEx<cpu, mshadow::red::minimum>)
-    #endif
+    .set_attr<FComputeEx>("FComputeEx<cpu>",
+                          ReduceAxesMinMaxOpForwardEx<cpu, mshadow::red::minimum>)
+#endif
     .set_attr<FResourceRequest>("FResourceRequest",
                                 [](const NodeAttrs& attrs) {
                                   return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};

--- a/src/operator/tensor/broadcast_reduce_minmax_value.cc
+++ b/src/operator/tensor/broadcast_reduce_minmax_value.cc
@@ -30,6 +30,11 @@ MXNET_OPERATOR_REGISTER_MINMAX_REDUCE(max)
     .add_alias("max_axis")
     .describe(get_reduce_axes_description("max", __LINE__))
     .set_attr<FCompute>("FCompute<cpu>", ReduceAxesCompute<cpu, mshadow::red::maximum>)
+    #if MXNET_USE_ONEDNN == 1
+    .set_attr<FInferStorageType>("FInferStorageType", )
+    .set_attr<bool>("TIsDNNL", true)
+    .setattr_<FComputeEx>("FComputeEx<cpu>", ReduceAxesOpForwardEx<cpu, mshadow::red:maximum>)
+    #endif
     .set_attr<FResourceRequest>("FResourceRequest",
                                 [](const NodeAttrs& attrs) {
                                   return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};

--- a/src/operator/tensor/broadcast_reduce_minmax_value.cc
+++ b/src/operator/tensor/broadcast_reduce_minmax_value.cc
@@ -31,7 +31,7 @@ MXNET_OPERATOR_REGISTER_MINMAX_REDUCE(max)
     .describe(get_reduce_axes_description("max", __LINE__))
     .set_attr<FCompute>("FCompute<cpu>", ReduceAxesCompute<cpu, mshadow::red::maximum>)
     #if MXNET_USE_ONEDNN == 1
-    .set_attr<FInferStorageType>("FInferStorageType", )
+    .set_attr<FInferStorageType>("FInferStorageType", ReduceAxesMinMaxOpForwardStorage)
     .set_attr<bool>("TIsDNNL", true)
     .setattr_<FComputeEx>("FComputeEx<cpu>", ReduceAxesOpForwardEx<cpu, mshadow::red:maximum>)
     #endif

--- a/src/operator/tensor/broadcast_reduce_op.h
+++ b/src/operator/tensor/broadcast_reduce_op.h
@@ -585,12 +585,30 @@ inline void BroadcastReduceShapeCompact(const mxnet::TShape& big,
   }
 }
 
+// infer storage function for min and max
+inline bool ReduceAxesMinMaxOpForwardStorage(const nnvm::NodeAttrs& attrs,
+                                             const int dev_mask,
+                                             DsipatchMode* dispatch_mode,
+                                             std::vector<int>* in_attrs,
+                                             std::vector<int>* out_attrs) {
+  CHECK_EQ(in_attrs->size(), 1U);
+  CHECK_EQ(out_attrs->size(), 1U);
+  const ReduceAxesParam& param = nnvm::get<ReduceAxesParam>(attrs.parsed);
+
+  bool onednn_dispatch = true;
+  if (param.dtype.has_value()) {
+    onednn_dispatch = param.dtype.value() == mshadow::kfloat32;
+  }
+
+  return DNNLStorageType(attrs, dev_mask, onednn_dispatch, dispatch_mode, in_attrs, out_attrs);
+}
+
 // infer storage function for sum(csr) and mean(csr)
-inline bool ReduceAxesOpForwardStorage(const nnvm::NodeAttrs& attrs,
-                                       const int dev_mask,
-                                       DispatchMode* dispatch_mode,
-                                       std::vector<int>* in_attrs,
-                                       std::vector<int>* out_attrs) {
+inline bool ReduceAxesSumMeanOpForwardStorage(const nnvm::NodeAttrs& attrs,
+                                              const int dev_mask,
+                                              DispatchMode* dispatch_mode,
+                                              std::vector<int>* in_attrs,
+                                              std::vector<int>* out_attrs) {
   CHECK_EQ(in_attrs->size(), 1U);
   CHECK_EQ(out_attrs->size(), 1U);
   const ReduceAxesParam& param = nnvm::get<ReduceAxesParam>(attrs.parsed);

--- a/src/operator/tensor/broadcast_reduce_op.h
+++ b/src/operator/tensor/broadcast_reduce_op.h
@@ -48,8 +48,18 @@ template <typename OP, bool normalize = false>
 struct DNNLReduceAlgorithm {};
 
 template <>
-struct DNNLReduceAlgorithm<mshadow::red::sum, false> {
+struct DNNLReduceAlgorithm<mshadow::red::sum> {
   static const dnnl::algorithm value = dnnl::algorithm::reduction_sum;
+};
+
+template <>
+struct DNNLReduceAlgorithm<mshadow_op::sum> {
+  static const dnnl::algorithm value = dnnl::algorithm::reduction_sum;
+};
+
+template <>
+struct DNNLReduceAlgorithm<mshadow_op::sum, true> {
+  static const dnnl::algorithm value = dnnl::algorithm::reduction_mean;
 };
 
 template <>

--- a/src/operator/tensor/broadcast_reduce_op.h
+++ b/src/operator/tensor/broadcast_reduce_op.h
@@ -43,7 +43,7 @@ namespace mxnet {
 namespace op {
 
 // template struct converting mshadow::red to dnnl::algorithm
-// normalize is false as a default, bacause onlu mean and sum use it
+// normalize is false as a default, bacause only mean and sum use it
 template <typename OP, bool normalize = false>
 struct DNNLReduceAlgorithm {};
 

--- a/src/operator/tensor/broadcast_reduce_op.h
+++ b/src/operator/tensor/broadcast_reduce_op.h
@@ -1114,8 +1114,7 @@ void ReduceAxesMinMaxOpForwardEx(const nnvm::NodeAttrs& attrs,
 
   if (SupportDNNLReduce<ReduceAxesParam>(attrs, inputs[0], outputs[0])) {
     const dnnl::algorithm alg = DNNLReduceAlgorithm<reducer>::value;
-    DNNLRun(DNNLReduceForward<ReduceAxesParam, alg>, attrs, ctx, inputs[0], req[0],
-    outputs[0]);
+    DNNLRun(DNNLReduceForward<ReduceAxesParam, alg>, attrs, ctx, inputs[0], req[0], outputs[0]);
   } else {
     FallBackCompute(ReduceAxesCompute<cpu, reducer, false>, attrs, ctx, inputs, req, outputs);
   }

--- a/src/operator/tensor/broadcast_reduce_op.h
+++ b/src/operator/tensor/broadcast_reduce_op.h
@@ -623,6 +623,7 @@ inline void BroadcastReduceShapeCompact(const mxnet::TShape& big,
   }
 }
 
+#if MXNET_USE_ONEDNN == 1
 // infer storage function for min and max
 inline bool ReduceAxesMinMaxOpForwardStorage(const nnvm::NodeAttrs& attrs,
                                              const int dev_mask,
@@ -633,6 +634,7 @@ inline bool ReduceAxesMinMaxOpForwardStorage(const nnvm::NodeAttrs& attrs,
   CHECK_EQ(out_attrs->size(), 1U);
   return DNNLStorageType(attrs, dev_mask, true, dispatch_mode, in_attrs, out_attrs);
 }
+#endif
 
 // infer storage function for sum(csr) and mean(csr)
 inline bool ReduceAxesSumMeanOpForwardStorage(const nnvm::NodeAttrs& attrs,

--- a/src/operator/tensor/broadcast_reduce_op.h
+++ b/src/operator/tensor/broadcast_reduce_op.h
@@ -30,10 +30,10 @@
 #include <vector>
 #include <utility>
 #include <algorithm>
-#include "../mshadow_op.h"
-#include "../elemwise_op_common.h"
-#include "./elemwise_binary_broadcast_op.h"
-#include "../mxnet_op.h"
+#include "operator/mshadow_op.h"
+#include "operator/elemwise_op_common.h"
+#include "operator/tensor/elemwise_binary_broadcast_op.h"
+#include "operator/mxnet_op.h"
 
 #if MXNET_USE_ONEDNN
 #include "../nn/dnnl/dnnl_reduce-inl.h"
@@ -42,6 +42,7 @@
 namespace mxnet {
 namespace op {
 
+#if MXNET_USE_ONEDNN
 // template struct converting mshadow::red to dnnl::algorithm
 // normalize is false as a default, bacause only mean and sum use it
 template <typename OP, bool normalize = false>
@@ -76,6 +77,7 @@ template <>
 struct DNNLReduceAlgorithm<mshadow::red::minimum> {
   static const dnnl::algorithm value = dnnl::algorithm::reduction_min;
 };
+#endif  // MXNET_USE_ONEDNN
 
 struct ReduceAxesParam : public dmlc::Parameter<ReduceAxesParam> {
   dmlc::optional<mxnet::TShape> axis;

--- a/src/operator/tensor/broadcast_reduce_sum_value.cc
+++ b/src/operator/tensor/broadcast_reduce_sum_value.cc
@@ -67,7 +67,7 @@ Example::
 )code" ADD_FILELINE)
     .set_attr<FCompute>("FCompute<cpu>", ReduceAxesCompute<cpu, mshadow::red::sum>)
     .set_attr<FComputeEx>("FComputeEx<cpu>", ReduceAxesOpForwardEx<cpu, mshadow::red::sum>)
-    .set_attr<FInferStorageType>("FInferStorageType", ReduceAxesOpForwardStorage)
+    .set_attr<FInferStorageType>("FInferStorageType", ReduceAxesSumMeanOpForwardStorage)
 #if MXNET_USE_ONEDNN == 1
     .set_attr<bool>("TIsMKLDNN", true)
 #endif
@@ -87,7 +87,7 @@ MXNET_ADD_SPARSE_OP_ALIAS(mean)
     .describe(get_reduce_axes_description("mean", __LINE__))
     .set_attr<FCompute>("FCompute<cpu>", ReduceAxesCompute<cpu, mshadow::red::sum, true>)
     .set_attr<FComputeEx>("FComputeEx<cpu>", ReduceAxesOpForwardEx<cpu, mshadow::red::sum, true>)
-    .set_attr<FInferStorageType>("FInferStorageType", ReduceAxesOpForwardStorage)
+    .set_attr<FInferStorageType>("FInferStorageType", ReduceAxesSumMeanOpForwardStorage)
 #if MXNET_USE_ONEDNN == 1
     .set_attr<bool>("TIsMKLDNN", true)
 #endif

--- a/src/operator/tensor/broadcast_reduce_sum_value.cc
+++ b/src/operator/tensor/broadcast_reduce_sum_value.cc
@@ -86,7 +86,8 @@ MXNET_OPERATOR_REGISTER_REDUCE(mean)
 MXNET_ADD_SPARSE_OP_ALIAS(mean)
     .describe(get_reduce_axes_description("mean", __LINE__))
     .set_attr<FCompute>("FCompute<cpu>", ReduceAxesCompute<cpu, mshadow::red::sum, true>)
-    .set_attr<FComputeEx>("FComputeEx<cpu>", ReduceAxesSumMeanOpForwardEx<cpu, mshadow::red::sum, true>)
+    .set_attr<FComputeEx>("FComputeEx<cpu>",
+                          ReduceAxesSumMeanOpForwardEx<cpu, mshadow::red::sum, true>)
     .set_attr<FInferStorageType>("FInferStorageType", ReduceAxesSumMeanOpForwardStorage)
 #if MXNET_USE_ONEDNN == 1
     .set_attr<bool>("TIsMKLDNN", true)

--- a/src/operator/tensor/broadcast_reduce_sum_value.cc
+++ b/src/operator/tensor/broadcast_reduce_sum_value.cc
@@ -66,7 +66,7 @@ Example::
 
 )code" ADD_FILELINE)
     .set_attr<FCompute>("FCompute<cpu>", ReduceAxesCompute<cpu, mshadow::red::sum>)
-    .set_attr<FComputeEx>("FComputeEx<cpu>", ReduceAxesOpForwardEx<cpu, mshadow::red::sum>)
+    .set_attr<FComputeEx>("FComputeEx<cpu>", ReduceAxesSumMeanOpForwardEx<cpu, mshadow::red::sum>)
     .set_attr<FInferStorageType>("FInferStorageType", ReduceAxesSumMeanOpForwardStorage)
 #if MXNET_USE_ONEDNN == 1
     .set_attr<bool>("TIsMKLDNN", true)
@@ -86,7 +86,7 @@ MXNET_OPERATOR_REGISTER_REDUCE(mean)
 MXNET_ADD_SPARSE_OP_ALIAS(mean)
     .describe(get_reduce_axes_description("mean", __LINE__))
     .set_attr<FCompute>("FCompute<cpu>", ReduceAxesCompute<cpu, mshadow::red::sum, true>)
-    .set_attr<FComputeEx>("FComputeEx<cpu>", ReduceAxesOpForwardEx<cpu, mshadow::red::sum, true>)
+    .set_attr<FComputeEx>("FComputeEx<cpu>", ReduceAxesSumMeanOpForwardEx<cpu, mshadow::red::sum, true>)
     .set_attr<FInferStorageType>("FInferStorageType", ReduceAxesSumMeanOpForwardStorage)
 #if MXNET_USE_ONEDNN == 1
     .set_attr<bool>("TIsMKLDNN", true)


### PR DESCRIPTION
## Description ##
Integration of oneDNN reduction primitives (min and max operators) for both nd and np interfaces.
It is worth to use oneDNN primitive only for reduction on the last axis of the array (oneDNN doesn't speedup reduction on other axes)

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

## Comments ##
![max_op_speedup](https://user-images.githubusercontent.com/71560847/184918968-6d4e4dae-43f5-4718-b622-06f977e48e3d.png)
Performance results for "min" operator are similar to those presented for "max" operator

