### PR TITLE
[FEATURE] Dnnl sum primitive path

### DIFF
--- a/src/operator/tensor/elemwise_binary_broadcast_op_basic.cc
+++ b/src/operator/tensor/elemwise_binary_broadcast_op_basic.cc
@@ -42,7 +42,7 @@ void DNNLBinaryOpForward(const nnvm::NodeAttrs& attrs,
   // We can use more efficient sum kernel when there is no broadcast - when shapes are the same
   const bool same_shape = (inputs[0].shape() == inputs[1].shape());
 
-  if (same_shape) {
+  if (same_shape && alg == dnnl::algorithm::binary_add) {
     DNNLSumFwd& fwd = DNNLSumFwd::GetCached(inputs, outputs);
     fwd.Execute(ctx, inputs, req, outputs);
   } else {

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -9421,16 +9421,18 @@ def test_elementwise_ops_on_misaligned_input():
 def test_broadcast_ops_on_input_with_the_same_shape(dtype, ndim, max_dim_size):
     shape = list(rand_shape_nd(ndim, dim=max_dim_size))
     shape_size = np.product(shape)
-    a = mx.nd.arange(5000)
-    b = mx.nd.arange(5000)
-    e = mx.nd.arange(5000)
+    a = np.random.uniform(low=-100, high=100, size=5000)
+    b = np.random.uniform(low=-100, high=100, size=5000)
+    e = np.random.uniform(low=-100, high=100, size=5000)
     c = a[1:shape_size + 1].reshape(shape)
     d = b[1:shape_size + 1].reshape(shape)
     f = e[1:shape_size + 1].reshape(shape)
-    mx.nd.broadcast_add(c, d, out=f)
-    expected = c.asnumpy() + d.asnumpy()
+    expected = c + d
+    cm = mx.nd.array(c)
+    dm = mx.nd.array(d)
+    fm = cm + dm
     mx.nd.waitall()
-    assert_almost_equal(f, expected)
+    assert_almost_equal(fm, expected)
 
 @pytest.mark.parametrize('dtype', ['float16', 'float32', 'float64'])
 @pytest.mark.parametrize('lead_dim', [2, 3, 4, 6, 10])

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -9423,10 +9423,8 @@ def test_broadcast_ops_on_input_with_the_same_shape(dtype, ndim, max_dim_size):
     shape_size = np.product(shape)
     a = np.random.uniform(low=-100, high=100, size=5000)
     b = np.random.uniform(low=-100, high=100, size=5000)
-    e = np.random.uniform(low=-100, high=100, size=5000)
     c = a[1:shape_size + 1].reshape(shape)
     d = b[1:shape_size + 1].reshape(shape)
-    f = e[1:shape_size + 1].reshape(shape)
     expected = c + d
     cm = mx.nd.array(c)
     dm = mx.nd.array(d)

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -9414,6 +9414,24 @@ def test_elementwise_ops_on_misaligned_input():
     mx.nd.waitall()
     assert a[3].asscalar() == 4.0
 
+
+@pytest.mark.parametrize('dtype', ['float16', 'float32', 'float64'])
+@pytest.mark.parametrize('ndim', [1, 2, 3, 4, 5])
+@pytest.mark.parametrize('max_dim_size', [1, 2, 3, 4, 5])
+def test_broadcast_ops_on_input_with_the_same_shape(dtype, ndim, max_dim_size):
+    shape = list(rand_shape_nd(ndim, dim=max_dim_size))
+    shape_size = np.product(shape)
+    a = mx.nd.arange(5000)
+    b = mx.nd.arange(5000)
+    e = mx.nd.arange(5000)
+    c = a[1:shape_size + 1].reshape(shape)
+    d = b[1:shape_size + 1].reshape(shape)
+    f = e[1:shape_size + 1].reshape(shape)
+    mx.nd.broadcast_add(c, d, out=f)
+    expected = c.asnumpy() + d.asnumpy()
+    mx.nd.waitall()
+    assert_almost_equal(f, expected)
+
 @pytest.mark.parametrize('dtype', ['float16', 'float32', 'float64'])
 @pytest.mark.parametrize('lead_dim', [2, 3, 4, 6, 10])
 @pytest.mark.parametrize('both_ways', [False, True])

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -9420,17 +9420,14 @@ def test_elementwise_ops_on_misaligned_input():
 @pytest.mark.parametrize('max_dim_size', [1, 2, 3, 4, 5])
 def test_broadcast_ops_on_input_with_the_same_shape(dtype, ndim, max_dim_size):
     shape = list(rand_shape_nd(ndim, dim=max_dim_size))
-    shape_size = np.product(shape)
-    a = np.random.uniform(low=-100, high=100, size=5000)
-    b = np.random.uniform(low=-100, high=100, size=5000)
-    c = a[1:shape_size + 1].reshape(shape)
-    d = b[1:shape_size + 1].reshape(shape)
-    expected = c + d
-    cm = mx.nd.array(c)
-    dm = mx.nd.array(d)
-    fm = cm + dm
+    a = np.random.uniform(low=-100, high=100, size=shape)
+    b = np.random.uniform(low=-100, high=100, size=shape)
+    expected = a + b
+    am = mx.nd.array(a)
+    bm = mx.nd.array(b)
+    cm = am + bm
     mx.nd.waitall()
-    assert_almost_equal(fm, expected)
+    assert_almost_equal(cm, expected)
 
 @pytest.mark.parametrize('dtype', ['float16', 'float32', 'float64'])
 @pytest.mark.parametrize('lead_dim', [2, 3, 4, 6, 10])


### PR DESCRIPTION
Added path to DNNLSumFwd in broadcast binary add, when inputs' shapes are the same. Overall speedup is not noticeable, however, it is significant for some edge cases.

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
