### PR TITLE
[BUGFIX] Fix segfault at training exit

### DIFF
--- a/src/engine/threaded_engine.h
+++ b/src/engine/threaded_engine.h
@@ -426,6 +426,9 @@ class ThreadedEngine : public Engine {
     return bulk_size;
   }
 
+  /*! \brief whether it is during shutdown phase*/
+  std::atomic<bool> shutdown_phase_{false};
+
  private:
   /*! \brief structure for holding bulk execution status */
   struct BulkStatus {
@@ -555,8 +558,6 @@ class ThreadedEngine : public Engine {
   std::atomic<int> pending_{0};
   /*! \brief whether we want to kill the waiters */
   std::atomic<bool> kill_{false};
-  /*! \brief whether it is during shutdown phase*/
-  std::atomic<bool> shutdown_phase_{false};
   /*!\brief show more information from engine actions */
   bool engine_info_{false};
   /*! \brief debug information about wait for var. */

--- a/src/engine/threaded_engine_pooled.cc
+++ b/src/engine/threaded_engine_pooled.cc
@@ -54,7 +54,7 @@ class ThreadedEnginePooled : public ThreadedEngine {
   }
 
   void StopNoWait() {
-    streams_->Finalize();
+    streams_->Finalize(shutdown_phase_);
     task_queue_->SignalForKill();
     io_task_queue_->SignalForKill();
     task_queue_ = nullptr;


### PR DESCRIPTION
## Description ##
This provides an updated fix for issue https://github.com/apache/mxnet/issues/19379.  To understand this fix, a bit of history is needed:

- At some point (possibly the arrival of ubuntu 20.04) the destruction order at program exit of the CUDA context and MXNet's singleton engine became non-deterministic.  When the engine destruction occurred after the CUDA context destruction, a segfault would occur due to the release of CUDA resources to a non-existent context.
- @ptrendx supplied the fix of not destroying MXNet's Stream objects at exit in master PR https://github.com/apache/mxnet/pull/19378, which also was back-ported to v1.x.
- Since that time, improvements to CUDA have made it no longer susceptible to the problem, starting possibly with CUDA 11.2.  CUDA 10.2 and 11.0 are confirmed to be susceptible.
- A different issue https://github.com/apache/mxnet/issues/20959 was found to be due to the lack of CUDA resource cleanup at exit.  As a result, @ptrendx's PR was reverted (on the v1.9.x branch) here https://github.com/apache/mxnet/pull/20998.  Due to the improvements in CUDA, most users did not experience the return of the original segfault-at-exit problem.
- But clearly, for users still on CUDA 10.2 and 11.0, the segfault behavior has returned (see recent posts to issue https://github.com/apache/mxnet/issues/19379).

This PR resupplies the segfault fix of not destroying MXNet's Stream objects only to the parent process (detected by `shutdown_phase_ == true`). If the main process is exiting, the CUDA runtime will take care of the release of resources.  This PR does not effect the release of resources in the child threads (`shutdown_phase == false`).  Thus, the destruction of Streams in the dataloader child processes are not affected and the data memory leak problem of https://github.com/apache/mxnet/issues/20959 will not resurface.

## Checklist ##
### Essentials ###
- [X] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [X] Code is well-documented

Regarding testing, I was first able to repro the segfault on a DGX1V (8 V100's) running the mxnetci/build.ubuntu_gpu_cu110 container with the command sequence:
```
$ HOROVOD_WITH_MXNET=1 pip install horovod[mxnet]
$ python3 /work/mxnet/example/distributed_training-horovod/module_mnist.py
```

It is possible the segfault only occurs with horovod use.  I verified that the segfault occurred consistently with MXNET_ENGINE_TYPE set to all 3 possibilities: ThreadedEnginePerDevice, ThreadedEngine, and NaiveEngine.  After the fix of the PR was applied, the segfault did not appear for any of the engines.
