### PR TITLE
[BUGFIX] Fix saved filename in `save`

### DIFF
--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -645,7 +645,7 @@ class Block:
         with open(prefix+'-model.json', 'w') as fp:
             json.dump(model, fp)
         # save params
-        self.save_parameters('MyModel-model.params')
+        self.save_parameters(prefix-'model.params')
 
     def load(self, prefix):
         """Load a model saved using the `save` API


### PR DESCRIPTION
## Description ##
The exported filename of params didn't use `prefix`, now it does

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
