### PR TITLE
[FEATURE] Add bytes conversion to NDArray

### DIFF
--- a/python/mxnet/ndarray/ndarray.py
+++ b/python/mxnet/ndarray/ndarray.py
@@ -4943,18 +4943,18 @@ def empty(shape, ctx=None, dtype=None):
 
 
 def from_buffer(buffer, dtype=mx_real_t, shape=None, zero_copy=True):
-    """Convert raw byte memory buffer to MXNet's ndarray.
+    """Convert raw byte memory buffer to mxnet.ndarray.NDarray.
 
     Parameters
     ----------
     buffer: bytes or bytearray or buffer_like object
-        The raw byte memory buffer.
+        The raw byte memory buffer we would like to copy from.
     dtype : str or numpy.dtype, optional
         The data type of the `NDArray`. The default datatype is `np.float32`.
     shape : int or tuple of int
         The shape of the returned array.
     zero_copy: bool
-        Whether we use DLPack's zero-copy conversion to convert to MXNet's NDArray.
+        Whether we use DLPack's zero-copy conversion to convert to mxnet.ndarray.NDArray.
 
     Returns
     -------


### PR DESCRIPTION
## Description ##
Add bytes conversion to NDArray.
The newly added NDArray's 'asbytes' and 'from_buffer' are completely equivalent to numpy's 'tobytes' and 'frombuffer', respectively.
These features make better use of NDArray.

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [x] Add 'asbytes' method to NDArray
- [x] Add 'from_buffer' function to NDArray

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
