### PR TITLE
BUGFIX: Remove type `onp.bool`.

### DIFF
--- a/python/mxnet/numpy/utils.py
+++ b/python/mxnet/numpy/utils.py
@@ -23,7 +23,7 @@ import numpy as onp
 
 __all__ = ['float16', 'float32', 'float64', 'uint8', 'int32', 'int8', 'int64',
            'int16', 'uint16', 'uint32', 'uint64',
-           'bool', 'bool_', 'pi', 'inf', 'nan', 'PZERO', 'NZERO', 'newaxis',
+           'bool_', 'pi', 'inf', 'nan', 'PZERO', 'NZERO', 'newaxis',
            'e', 'NINF', 'PINF', 'NAN', 'NaN',
            '_STR_2_DTYPE_', '_DTYPE_2_STR_', '_type_promotion_table',
            'integer_dtypes', 'floating_dtypes', 'boolean_dtypes', 'numeric_dtypes']
@@ -38,7 +38,6 @@ int32 = onp.dtype(onp.int32)
 int8 = onp.dtype(onp.int8)
 int64 = onp.dtype(onp.int64)
 bool_ = onp.dtype(onp.bool_)
-bool = onp.dtype(onp.bool)
 int16 = onp.dtype(onp.int16)
 uint16 = onp.dtype(onp.uint16)
 uint32 = onp.dtype(onp.uint32)

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -2094,7 +2094,7 @@ def test_npi_boolean_assign():
                 if test_data.size == 0:
                     break
                 valid_num = int(mx_mask.asnumpy().sum())
-            np_mask = mx_mask.asnumpy().astype(onp.bool)
+            np_mask = mx_mask.asnumpy().astype(onp.bool_)
             vshape = []
             vshape_broadcast = []
             for i in range(len(dshape)):
@@ -5587,7 +5587,7 @@ def test_np_cumsum():
     for shape in shapes:
         for axis in [None] + [i for i in range(0, len(shape))]:
             for otype in [None, onp.int32, onp.int64]:
-                for itype in [onp.bool, onp.int8, onp.int32, onp.int64]:
+                for itype in [onp.bool_, onp.int8, onp.int32, onp.int64]:
                     x = rand_ndarray(shape).astype(itype).as_np_ndarray()
                     np_out = onp.cumsum(x.asnumpy(), axis=axis, dtype=otype)
                     mx_out = np.cumsum(x, axis=axis, dtype=otype)


### PR DESCRIPTION
I have to built mxnet locally on my M1 machine and then installed. But when I import the lib it threw `AttributeError` error with message `module 'numpy' has no attribute 'bool'`. This PR is a fix for the deprecation issue.

## Description ##

Remove type `onp.bool` as `np.bool` was a deprecated alias for the builtin `bool` with numpy version 1.20.

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
